### PR TITLE
Fix get_tip() crash

### DIFF
--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -46,8 +46,8 @@ impl Blockchain {
     }
 
     /// return the current tip hash and date
-    pub fn get_tip(&self) -> (BlockHash, BlockDate) {
-        (self.chain_state.last_block.clone(), self.chain_state.last_date.unwrap())
+    pub fn get_tip(&self) -> BlockHash {
+        self.chain_state.last_block.clone()
     }
 
     pub fn get_storage(&self) -> &Storage {

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,7 +25,7 @@ fn handle_get_block_tip(
     blockchain: &BlockchainR
 ) -> Result<Header, Error> {
     let blockchain = blockchain.read().unwrap();
-    let tip = blockchain.get_tip().0;
+    let tip = blockchain.get_tip();
     match block_read(blockchain.get_storage(), &tip) {
         None => {
             Err(format!("Cannot read block '{}'", tip).into())

--- a/src/leadership/process.rs
+++ b/src/leadership/process.rs
@@ -74,12 +74,12 @@ pub fn leadership_task(secret: NodeSecret, selection: Arc<Selection>, tpool: TPo
             // * get the transactions to put in the transactions
             // * mint the block
             // * sign it
-            let (latest_tip, latest_tip_date) = {
+            let latest_tip = {
                 let b = blockchain.read().unwrap();
                 b.get_tip()
             };
 
-            info!("leadership create tpool={} transactions tip={} ({})", len, latest_tip, latest_tip_date);
+            info!("leadership create tpool={} transactions tip={}", len, latest_tip);
 
             let epochslot = EpochSlotId { epoch: epoch.0 as u64, slotid: idx as u16 };
             let block = make_block(&secret, &my_pub, &latest_tip, epochslot, &[]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,7 @@ fn block_task(blockchain: BlockchainR, selection: Arc<Selection>, clock: clock::
 }
 
 fn startup_info(gd: &GenesisData, blockchain: &Blockchain, settings: &Settings) {
-    let (tip, tip_date) = blockchain.get_tip();
-    println!("protocol magic={} prev={} k={} tip={} ({})", gd.protocol_magic, gd.genesis_prev, gd.epoch_stability_depth, tip, tip_date);
+    println!("protocol magic={} prev={} k={} tip={}", gd.protocol_magic, gd.genesis_prev, gd.epoch_stability_depth, blockchain.get_tip());
     println!("consensus: {:?}", settings.consensus);
 }
 


### PR DESCRIPTION
get_tip() no longer returns a date since the chain might be at the genesis hash, in which case there is no date.