### PR TITLE
Update demo scripts.

### DIFF
--- a/demo/Readme.md
+++ b/demo/Readme.md
@@ -11,11 +11,11 @@ This code will allow you to setup a demo instance of jormnugndr with a configura
 
 First you need to create the environment to run jormungandr
 
-`./setup.sh <folder> <nodecount> <genesis-file> <cardano-cli-path> `
+`./setup.sh <folder> <nodecount> <genesis-file> <node-config> <cardano-cli-path>`
 
-This will create the required environment in a folder. 
+This will create the required environment in a folder.
 
-## Running 
+## Running
 
 ### Starting nodes
 

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -64,7 +64,7 @@ echo "Building Jormungandr"
 echo
 cd ..
 cargo build
-cd tools  
+cd demo
 echo
 echo "Build finished"
 echo
@@ -94,23 +94,24 @@ while [ $counter -lt $nodes ]; do
     mkdir -p $node_folder
     cd $node_folder
     
-		let counter=$counter+1			
-		
-		stub='node_'$counter
-		privkey=$node_folder/$stub'.xprv'
-		pubkey=$node_folder/$stub'.xpub'
+    let counter=$counter+1
+    stub='node_'$counter
+    privkey=$stub'.xprv'
+    pubkey=$stub'.xpub'
 
-		echo "Making keys for $stub"
-		echo "PRIV = $privkey"
+    echo "Making keys for $stub"
+    echo "PRIV = $privkey"
     echo "PUB  = $pubkey"
 
+    echo "$cli debug generate-xprv $privkey"
     $cli debug generate-xprv $privkey
+    echo "$cli debug xprv-to-xpub $privkey $pubkey"
     $cli debug xprv-to-xpub $privkey $pubkey
 
-		echo "Adding key to global config"
-		pubkeycontents=`cat $pubkey` 
-		echo "    - $pubkeycontents" >> $folder'/config.yaml'
-		echo
+    echo "Adding key to global config"
+    pubkeycontents=`cat $pubkey` 
+    echo "    - $pubkeycontents" >> '../../config.yaml'
+    echo
 done  
 
 echo "Setup is complete"


### PR DESCRIPTION
Add additional parameter to the documentation and update setup script so  it works.

There were few problems in the script for me:
1. after going to the top-level folder to call `cargo` script was returning to the `./tools` directory
instead of `popd` or `cd ./demo`, so script appear to be running in the wrong directory;
2. `$cli debug generate-xprv $privkey` was running in node folder already, but the `path` included that folder, so istead of writing to `$base/node/1/key` it was writing to `$base/node/1/1/key` and that call failed.
3. configuration was written to the `$base/node/1/node/config.yaml` instead of `$base/config.yaml`.