### PR TITLE
Add storage to config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ grpc_listen:
        - "127.0.0.1:8081"
 legacy_peers:
        - "127.0.0.1:9000"
+storage:
+       - "/tmp/storage"
 ```
 
-`legacy_listen` and `grpc_listen` fields are optional and can be omitted.
+`legacy_listen`, `grpc_listen` and `storage` fields are optional and can be omitted.

--- a/src/settings/command_arguments.rs
+++ b/src/settings/command_arguments.rs
@@ -42,7 +42,7 @@ pub struct CommandArguments {
 
     /// Path to the blockchain pool storage directory
     #[structopt(long = "storage", parse(from_os_str))]
-    pub storage: PathBuf,
+    pub storage: Option<PathBuf>,
 
     /// Set the node config (in YAML format) to use as general configuration
     #[structopt(long = "config", parse(from_os_str))]

--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub legacy_listen: Option<Vec<SocketAddr>>,
     pub grpc_listen: Option<Vec<SocketAddr>>,
     pub legacy_peers: Option<Vec<SocketAddr>>,
+    pub storage: Option<PathBuf>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -84,8 +84,15 @@ impl Settings {
             }
         };
 
+        let storage = match command_arguments.storage.as_ref() {
+              Some(path) => path.clone(),
+              None => config.storage
+                .expect("Storage is needed for persistently saving the blocks of the blockchain")
+                .clone(),
+        };
+
         Settings {
-            storage: command_arguments.storage.clone(),
+            storage: storage,
             genesis_data_config: command_arguments.genesis_data_config.clone(),
             secret_config: command_arguments.secret.clone().or(config.secret_file).expect("secret config unspecified"),
             network: network,


### PR DESCRIPTION
Storage option allows the user to define where to
keep the storage for the blocks. Now, this parameter
can be omitted from the command line.

N.B. if the parameter is not passed in the command line,
and read from the configuration file, unwrap() is called.
As a result error message may be not nice in that case.

Closes #63 