### PR TITLE
Fix infinite recursion in impl ledger::Transaction

### DIFF
--- a/src/blockcfg/chain/cardano.rs
+++ b/src/blockcfg/chain/cardano.rs
@@ -48,6 +48,6 @@ impl ledger::Transaction for Transaction {
     type Output = cardano::tx::TxOut;
     type Id = TransactionId;
     fn id(&self) -> Self::Id {
-        self.id()
+        self.tx.id()
     }
 }


### PR DESCRIPTION
The implementation of method `id` of the `Transaction` trait for `TxAux` erroneously calls the trait method recursively.