### PR TITLE
Introduce new shim logger.

### DIFF
--- a/src/log_wapper/mod.rs
+++ b/src/log_wapper/mod.rs
@@ -1,0 +1,91 @@
+pub use log::log;
+use log::Level;
+
+/// Logs a message at the debug level.
+///
+/// ```rust
+/// let (err_info, port) = ("No connection", 22);
+///
+/// debug!("Error: {} on port {}", err_info, port);
+/// debug!("App Error: {}, Port: {}", err_info, 22 ; user = "user1", thread = "17");
+/// ```
+#[macro_export]
+macro_rules!debug  {
+    ($($arg:tt)*) => { log!(level: log::Level::Debug, $($arg)*)};
+}
+
+/// Logs a message at the error level.
+///
+/// ```rust
+/// let (err_info, port) = ("No connection", 22);
+///
+/// error!("Error: {} on port {}", err_info, port);
+/// error!("App Error: {}, Port: {}", err_info, 22 ; user = "user1", thread = "17");
+/// ```
+#[macro_export]
+macro_rules!error {
+    ($($arg:tt)*) => { log!(level: log::Level::Error, $($arg)*)};
+}
+
+/// Logs a message at the info level.
+///
+/// ```rust
+/// let (err_info, port) = ("No connection", 22);
+///
+/// info!("Error: {} on port {}", err_info, port);
+/// info!("App Error: {}, Port: {}", err_info, 22 ; user = "user1", thread = "17");
+/// ```
+#[macro_export]
+macro_rules!info{
+    ($($arg:tt)*) => { log!(level: log::Level::Info, $($arg)*)};
+}
+
+/// Logs a message at the trace level.
+///
+/// ```rust
+/// let (err_info, port) = ("No connection", 22);
+///
+/// trace!("Error: {} on port {}", err_info, port);
+/// trace!("App Error: {}, Port: {}", err_info, 22 ; user = "user1", thread = "17");
+/// ```
+#[macro_export]
+macro_rules!trace {
+    ($($arg:tt)*) => { log!(level: log::Level::Trace, $($arg)*)};
+}
+
+/// Logs a message at the warn level.
+///
+/// ```rust
+/// let (err_info, port) = ("No connection", 22);
+///
+/// warn!("Error: {} on port {}", err_info, port);
+/// warn!("App Error: {}, Port: {}", err_info, 22 ; user = "user1", thread = "17");
+/// ```
+#[macro_export]
+macro_rules!warn {
+    ($($arg:tt)*) => { log!(level: log::Level::Warn, $($arg)*)};
+}
+
+/// Standard logging macros.
+/// ```rust
+/// let (err_info, port) = ("No connection", 22);
+///
+/// log!(level: log::Level::Error, "Error: {} on port {}", err_info, port;
+///   user = "Loki"
+///   location = "Fólkvangr"
+///   );
+/// ```
+#[macro_export]
+macro_rules!log {
+    (level: $lvl:expr, $msg:expr ; $($name:ident = $val:expr),+ ) =>
+        { log::log!($lvl, concat!(concat!($("[",stringify!($name),"= {:#?} ]",)+),$msg),$($val),+ ) };
+    (level: $lvl:expr, $msg:expr, $($params:expr),+ ; $($name:ident = $val:expr),+ ) =>
+        { log::log!($lvl, concat!(concat!($("[",stringify!($name),"=","{:?}","]",)+),$msg), $($val,)+ $($params,)* ) };
+    (level: $lvl:expr, $msg:expr, $($params:expr),+) =>
+        { log::log!($lvl, $msg, $( $params,)+ ) };
+    (level: $lvl:expr, $msg:expr, $($params:expr),+ , ) =>
+        { log::log!($lvl, $msg, $( $params,)+ ) };
+    (level: $lvl:expr, $msg:expr) =>
+        { log::log!($lvl, $msg ) };
+
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ extern crate clap;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_yaml;
-#[macro_use]
 extern crate log;
 extern crate rand;
 extern crate env_logger;
@@ -39,6 +38,9 @@ extern crate tower_util;
 extern crate test;
 #[cfg(test)]
 extern crate quickcheck;
+
+#[macro_use]
+mod log_wapper;
 
 pub mod clock;
 pub mod blockchain;


### PR DESCRIPTION
Introduce a new logger interface that allows
to update the logger being used. New interface
uses simple macros that allow to update implementation
and change the command beign called.
This implementation does not try to generalize logger
in use or easily switch between then in runtime. Real
logger still needs to be initialized in the program.
However this approach allows to change the implementation
by only changing macros definition and logger initialization.

closes #80 