### PR TITLE
Fix deadlock that happens during local logger update.

### DIFF
--- a/src/log_wrapper/logger.rs
+++ b/src/log_wrapper/logger.rs
@@ -89,7 +89,9 @@ where
 /// that were defined for the threads earlier.
 pub fn set_global_logger(logger: slog::Logger) {
     let logger2 = logger.clone();
-    let ref_cell = TOP_LOGGER.lock().unwrap();
-    ref_cell.replace(logger);
+    {
+        let ref_cell = TOP_LOGGER.lock().unwrap();
+        ref_cell.replace(logger);
+    }
     update_thread_logger(|_| logger2.clone());
 }


### PR DESCRIPTION
In the `update_local_logger` function `lock` on the top level logger was held for too long.
So function tried to take that lock twice and deadlocked in the end.