### PR TITLE
Print settings initialization error on stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,10 @@ fn main() {
     //
     // parse the command line arguments, the config files supplied
     // and setup the initial values
-    let settings = Settings::load();
+    let settings = Settings::load().unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    });
 
     settings.log_settings.apply();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,15 +104,16 @@ fn startup_info(gd: &GenesisData, blockchain: &Blockchain<Cardano>, settings: &S
     println!("consensus: {:?}", settings.consensus);
 }
 
-fn main() {
+// Expand the type with more variants
+// when it becomes necessary to represent different error cases.
+type Error = settings::Error;
+
+fn run() -> Result<(), Error> {
     // # load parameters & config
     //
     // parse the command line arguments, the config files supplied
     // and setup the initial values
-    let settings = Settings::load().unwrap_or_else(|e| {
-        eprintln!("{}", e);
-        std::process::exit(1);
-    });
+    let settings = Settings::load()?;
 
     settings.log_settings.apply();
 
@@ -173,6 +174,8 @@ fn main() {
     let tpool_data: TPool<TransactionId, Transaction> = TPool::new();
     let tpool = Arc::new(RwLock::new(tpool_data));
 
+    // Validation of consensus settings should make sure that we always have
+    // non-empty selection data.
     let selection_data =
         leadership::selection::prepare(&secret.to_public(), &settings.consensus).unwrap();
     let selection = Arc::new(selection_data);
@@ -251,4 +254,16 @@ fn main() {
 
     // FIXME some sort of join so that the main thread does something ...
     tasks.join();
+
+    Ok(())
+}
+
+fn main() {
+    match run() {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("jormungandr error: {}", e);
+            std::process::exit(1);
+        }
+    }
 }


### PR DESCRIPTION
Make sure any fatal error from parsing command line arguments
or the settings files is printed on the standard error stream before
the program exits.

Fixes #111