### PR TITLE
Initial utxos

### DIFF
--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -68,7 +68,7 @@ impl State<Mockchain> {
         };
 
         State {
-            ledger: ledger::Ledger::new(Default::default()),
+            ledger: ledger::Ledger::new(genesis.initial_utxos()),
             settings: setting::Settings {
                 last_block_id: last_block_hash,
                 max_number_of_transactions_per_block: 100, // TODO: add this in the genesis data ?


### PR DESCRIPTION
make sure to connect the initial outputs from the genesis file into the initial state.

To do so we create virtual transaction without inputs that cannot have more than 255 outputs at a time. These will be the initial utxos.