### PR TITLE
Simplify configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,8 @@ Running the command above will generate (WARNING: this is temporary, the genesis
 
 ```yaml
 ---
-start_time:
-  secs_since_epoch: 1550822014
-  nanos_since_epoch: 930587000
-slot_duration:
-  secs: 15
-  nanos: 0
+start_time: 1550822014
+slot_duration: 15
 epoch_stability_depth: 2600
 initial_utxos:
   - address: ca1qvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqxuzx4s
@@ -101,10 +97,10 @@ obft_leaders:
 You store this in a genesis.yaml file, you can the modify/tune your genesis data.
 
 Configuration fields meaning:
-  - *start_time*: when the blockchain starts
-  - *slot_duration*: amount of time each slot is running.
+  - *start_time*: when the blockchain starts (seconds since epoch).
+  - *slot_duration*: amount of time each slot is running (seconds).
   - *epoch_stability_depth*: allowed size of the fork (in blocks).
-  - *initial_utuxos*:
+  - *initial_utuxos*: list of initial unspent outputs.
 
 ### Node Configuration
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,9 @@ use chain_impl_mockchain::{
 };
 use futures::Future;
 
-use blockcfg::{genesis_data::GenesisData, mock::Mockchain as Cardano};
+use blockcfg::{
+    genesis_data::ConfigGenesisData, genesis_data::GenesisData, mock::Mockchain as Cardano,
+};
 //use state::State;
 use blockchain::{Blockchain, BlockchainR};
 use intercom::BlockMsg;
@@ -307,13 +309,13 @@ fn main() {
             println!("public_key: {}", hex::encode(public_key.as_ref()));
         }
         Command::Init(init_settings) => {
-            let genesis = GenesisData {
+            let genesis = ConfigGenesisData::from_genesis(GenesisData {
                 start_time: init_settings.blockchain_start,
                 slot_duration: init_settings.slot_duration,
                 epoch_stability_depth: init_settings.epoch_stability_depth,
                 initial_utxos: init_settings.initial_utxos,
                 bft_leaders: init_settings.bft_leaders,
-            };
+            });
 
             serde_yaml::to_writer(std::io::stdout(), &genesis).unwrap();
         }


### PR DESCRIPTION
In the configuration simplify `start_since` and slot
duration options, so the no longer require to set
nanoseconds.

Closes #127 