### PR TITLE
Implement response to block subscription

### DIFF
--- a/src/blockchain/process.rs
+++ b/src/blockchain/process.rs
@@ -36,7 +36,11 @@ pub fn process<Chain>(
             network_broadcast.send_broadcast(header);
             res
         }
-        BlockMsg::Subscribe(_reply) => unimplemented!(),
+        BlockMsg::Subscribe(reply) => {
+            let rx = network_broadcast.add_rx();
+            reply.send(rx);
+            Ok(())
+        }
     };
     if let Err(e) = res {
         error!("error processing an incoming block: {:?}", e);

--- a/src/utils/task.rs
+++ b/src/utils/task.rs
@@ -1,6 +1,6 @@
 use crate::log_wrapper::logger::update_thread_logger;
 
-use tokio_bus::Bus;
+use tokio_bus::{Bus, BusReader};
 
 use std::clone::Clone;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -91,6 +91,10 @@ pub struct TaskBroadcastBox<T: Clone + Sync>(Bus<T>);
 impl<T: Clone + Sync> TaskBroadcastBox<T> {
     pub fn new(len: usize) -> Self {
         TaskBroadcastBox(Bus::new(len))
+    }
+
+    pub fn add_rx(&mut self) -> BusReader<T> {
+        self.0.add_rx()
     }
 
     pub fn send_broadcast(&mut self, val: T) {


### PR DESCRIPTION
The last piece of the puzzle needed to send notifications of new blocks
to the gRPC clients which have their subscription streams open.