### PR TITLE
fix the grpc server spawn issue

### DIFF
--- a/src/network/grpc/server.rs
+++ b/src/network/grpc/server.rs
@@ -26,7 +26,7 @@ pub fn run_listen_socket<B>(
     sockaddr: SocketAddr,
     listen_to: Listen,
     state: GlobalState<B>,
-) -> tokio::executor::Spawn
+) -> impl Future<Item = (), Error = ()>
 where
     B: BlockConfig + 'static,
 {
@@ -37,35 +37,40 @@ where
         sockaddr
     );
 
-    let node_services = ConnectionServices::new(state);
-    let server = Server::new(node_services, DefaultExecutor::current());
+    match listen(&sockaddr) {
+        Err(error) => {
+            error!("Error while listening to {}", error ; sockaddr = sockaddr);
+            unimplemented!()
+        }
+        Ok(listener_stream) => {
+            let node_services = ConnectionServices::new(state);
+            let server = Server::new(node_services, DefaultExecutor::current());
 
-    let listener = listen(&sockaddr)
-        .unwrap() // TODO, handle on error to provide better error message
-        .map_err(move |err| {
-            // error while receiving an incoming connection
-            // here we might need to log the error and try
-            // to listen again on the sockaddr
-            error!(
-                "Error while accepting connection on {}: {:?}",
-                sockaddr, err
-            );
-        })
-        .fold(server, |mut server, stream| {
-            // received incoming connection
-            info!(
-                "{} connected to {}",
-                stream.peer_addr().unwrap(),
-                stream.local_addr().unwrap(),
-            );
+            listener_stream
+                .map_err(move |err| {
+                    // error while receiving an incoming connection
+                    // here we might need to log the error and try
+                    // to listen again on the sockaddr
+                    error!(
+                        "Error while accepting connection on {}: {:?}",
+                        sockaddr, err
+                    );
+                })
+                .fold(server, |mut server, stream| {
+                    // received incoming connection
+                    info!(
+                        "{} connected to {}",
+                        stream.peer_addr().unwrap(),
+                        stream.local_addr().unwrap(),
+                    );
 
-            let conn = server.serve(stream);
+                    let conn = server.serve(stream);
 
-            tokio::spawn(conn.map_err(|e| error!("server error: {:?}", e)));
+                    tokio::spawn(conn.map_err(|e| error!("server error: {:?}", e)));
 
-            future::ok(server)
-        })
-        .map(|_| ());
-
-    tokio::spawn(listener)
+                    future::ok(server)
+                })
+                .map(|_| ())
+        }
+    }
 }


### PR DESCRIPTION
The real change here is that instead of returning the Spawn handler we are returning the future. This allows the future to run within the new Tokio Executor instead of the current new thread (which does not have an executor yet because the current new thread is not the global state -- note the subtility here).