### PR TITLE
Handler infrastructure for incoming block announcements in Blockchain

### DIFF
--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -163,6 +163,14 @@ impl<B: BlockConfig> Blockchain<B> {
         use chain_core::property::Settings;
         self.state.settings.read().unwrap().tip()
     }
+
+    pub fn handle_block_announcement(
+        &mut self,
+        _header: B::BlockHeader,
+    ) -> Result<(), storage::Error> {
+        info!("received block announcement, handling not implemented yet");
+        Ok(())
+    }
 }
 
 /*

--- a/src/blockchain/process.rs
+++ b/src/blockchain/process.rs
@@ -21,14 +21,6 @@ pub fn process<Chain>(
     <Chain::Leader as property::LeaderSelection>::Update: Clone,
 {
     let res = match bquery {
-        BlockMsg::NetworkBlock(block) => {
-            debug!("received block from the network: {:#?}", block.header());
-            let res = blockchain.write().unwrap().handle_incoming_block(block);
-            if res.is_ok() {
-                stats_counter.add_block_recv_cnt(1);
-            }
-            res
-        }
         BlockMsg::LeadershipBlock(block) => {
             let header = block.header();
             debug!("received block from the leadership: {:#?}", header);
@@ -40,6 +32,17 @@ pub fn process<Chain>(
             let rx = network_broadcast.add_rx();
             reply.send(rx);
             Ok(())
+        }
+        BlockMsg::AnnouncedBlock(header) => {
+            debug!("received block header from the network: {:#?}", header);
+            let res = blockchain
+                .write()
+                .unwrap()
+                .handle_block_announcement(header);
+            if res.is_ok() {
+                stats_counter.add_block_recv_cnt(1);
+            }
+            res
         }
     };
     if let Err(e) = res {

--- a/src/intercom.rs
+++ b/src/intercom.rs
@@ -368,12 +368,12 @@ where
 
 /// General Block Message for the block task
 pub enum BlockMsg<B: BlockConfig> {
-    /// A untrusted Block has been received from the network task
-    NetworkBlock(B::Block),
     /// A trusted Block has been received from the leadership task
     LeadershipBlock(B::Block),
     /// The network task has a subscription to add
     Subscribe(SubscriptionHandle<B::BlockHeader>),
+    /// A untrusted block Header has been received from the network task
+    AnnouncedBlock(B::BlockHeader),
 }
 
 impl<B> Debug for BlockMsg<B>
@@ -384,9 +384,9 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use BlockMsg::*;
         match self {
-            NetworkBlock(block) => f.debug_tuple("NetworkBlock").field(block).finish(),
             LeadershipBlock(block) => f.debug_tuple("LeadershipBlock").field(block).finish(),
             Subscribe(_) => f.debug_tuple("Subscribe").finish(),
+            AnnouncedBlock(header) => f.debug_tuple("AnnouncedBlock").field(header).finish(),
         }
     }
 }

--- a/src/network/grpc/server.rs
+++ b/src/network/grpc/server.rs
@@ -30,7 +30,7 @@ pub fn run_listen_socket<B>(
 where
     B: BlockConfig + 'static,
 {
-    let state = ConnectionState::new_listen(&state, listen_to);
+    let state = ConnectionState::new_listen(&state, &listen_to);
 
     info!(
         "start listening and accepting gRPC connections on {}",

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -161,7 +161,7 @@ impl<B: BlockConfig> ConnectionState<B> {
         }
     }
 
-    fn new_peer(global: &GlobalState<B>, peer: Peer) -> Self {
+    fn new_peer(global: &GlobalState<B>, peer: &Peer) -> Self {
         ConnectionState {
             global_network_configuration: global.config.clone(),
             channels: global.channels.clone(),

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -149,7 +149,7 @@ impl<B: BlockConfig> Clone for ConnectionState<B> {
 }
 
 impl<B: BlockConfig> ConnectionState<B> {
-    fn new_listen(global: &GlobalState<B>, listen: Listen) -> Self {
+    fn new_listen(global: &GlobalState<B>, listen: &Listen) -> Self {
         ConnectionState {
             global_network_configuration: global.config.clone(),
             channels: global.channels.clone(),


### PR DESCRIPTION
Added a new `BlockMsg` variant, `AnnouncedBlock`, carrying a block header.
Currently it can be received from block subscription, and in the future
it may also be received from p2p block announcements.
`BlockMsg::NetworkBlock` is no more.

The method `Blockchain::handle_block_announcement` will process
incoming block announcements, but is introduced here as a noisy stub.