### PR TITLE
improve the private key generation doc and parsing of the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,15 @@ In order to start a leader node you need to generate key pairs using
 `jormungandr`:
 
 ```
-jormungandr generate-keys
-signing_key: 90167eccc5db6ab75c643e33901ec727be847aa51f16890df06ec6fa401e9958
-public_key: 77d0edad4553bbb66115ce1ed78ca0e752534a0d2faa707d4356ea567a586475
+$ jormungandr generate-priv-key --type Ed25519Extended
+ed25519extended_secret1vzpkw6lqk5sfaa0rtp64s28s7zcegpwqte0psqneum5w9mcgafd0gwexmfn7s96lqja5sv520zx6hx5hd0qsgahp3ta8grrrxkd8n0cjmaqre
+
+$ echo ed25519extended_secret1vzpkw6lqk5sfaa0rtp64s28s7zcegpwqte0psqneum5w9mcgafd0gwexmfn7s96lqja5sv520zx6hx5hd0qsgahp3ta8grrrxkd8n0cjmaqre \
+  | cargo run -- generate-pub-key
+ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
 ```
 
-`singing_key` is your private key you can put it in key.xprv file,
-note that there should be no EOL in that file. If you expect your
+This is your private key you can put it in key.xprv file. If you expect your
 node to be a leader, put your public_key in the `genesis.yaml` leader.
 
 Then you should start node using:

--- a/src/secure/mod.rs
+++ b/src/secure/mod.rs
@@ -23,6 +23,7 @@ impl NodeSecret {
     pub fn load_from_file(path: &Path) -> NodeSecret {
         let file_string = fs::read_to_string(path).unwrap();
         let bech32: Bech32 = file_string
+            .trim()
             .parse()
             .expect("Private key file should be bech32 encoded");
         if bech32.hrp() != Ed25519Extended::SECRET_BECH32_HRP {

--- a/src/settings/command_arguments.rs
+++ b/src/settings/command_arguments.rs
@@ -100,6 +100,8 @@ pub struct InitArguments {
 #[derive(StructOpt, Debug)]
 pub struct GeneratePrivKeyArguments {
     /// Type of a private key
+    ///
+    /// value values are: ed25519, ed25510bip32, ed25519extended, curve25519_2hashdh
     #[structopt(long = "type")]
     pub key_type: GenPrivKeyType,
 }


### PR DESCRIPTION
This PR will mainly improve the way we parse the `--secret key` file when we start a new node (so we don't have to worry about trailing white spaces)