### PR TITLE
Allow unchecked transactions

### DIFF
--- a/src/bin/jormungandr_cli_app/block/mod.rs
+++ b/src/bin/jormungandr_cli_app/block/mod.rs
@@ -53,7 +53,6 @@ fn add_to_block(argument: AddArgs) {
     let block = builder.make_genesis_block();
     let file = open_file_write(&argument.common.block);
     block.serialize(file).unwrap();
-    println!("{:#?}", block);
 }
 
 #[derive(StructOpt)]


### PR DESCRIPTION
This is useful for the block0 creation. The option is not documented on purpose in the doc/*.md on purpose (this is not something for day to day use)