### PR TITLE
Fixed genesis config example spelling

### DIFF
--- a/doc/genesis_file.md
+++ b/doc/genesis_file.md
@@ -13,8 +13,8 @@ start_time: 1552990378
 slot_duration: 15
 epoch_stability_depth: 10
 allow_account_creation: true
-address_discimination: Production
-linear_fee:
+address_discrimination: Production
+linear_fees:
   constant: 2
   coefficient: 1
   certificate: 4


### PR DESCRIPTION
In _genesis_file.md_ the example configuration for the _genesis.yaml_ has two spelling errors which cause errors when the config is used with jormungandr.