### PR TITLE
Updated doc to reflect new changes to jormungandr/genesis config

### DIFF
--- a/doc/starting_bft_blockchain.md
+++ b/doc/starting_bft_blockchain.md
@@ -26,10 +26,16 @@ Utilising a Round Robin algorithm.
 start_time: 1550822014
 slot_duration: 15
 epoch_stability_depth: 2600
+allow_account_creation: true
+address_discrimination: Production 
 initial_utxos: []
-obft_leaders:
-  - ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
-  - ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
+linear_fees:
+        constant: 2
+        coefficient: 1
+        certificate: 4
+bft_leaders:
+          - ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
+          - ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
 ```
 
 Or you can generate it with the following command line:
@@ -37,7 +43,8 @@ Or you can generate it with the following command line:
 ```
 jormungandr init \
     --bft-leader=ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3 \
-    --bft-leader=ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en > genesis.yaml
+    --bft-leader=ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en \
+    --discrimination production > genesis.yaml
 ```
 
 more information regarding the [genesis file here](./genesis_file.md).


### PR DESCRIPTION
The doc provided a genesis config example with fields with old names, lacking new required fields, and the init command provided lacked the required ```--discrimination``` flag.