### PR TITLE
Pregenerated Genesis File

### DIFF
--- a/doc/genesis_file.md
+++ b/doc/genesis_file.md
@@ -8,6 +8,12 @@ Example of a BFT genesis file with an initial address UTxO and an account UTxO.
 More info regarding [starting a BFT blockchain here](./starting_bft_blockchain.md)
 and [regarding addresses there](./cli_address.md).
 
+You can generate a documented pre-generated genesis file:
+
+```
+jcli genesis init
+```
+
 ```yaml
 blockchain_configuration:
   - [ block0-date, 1552990378 ]

--- a/src/bin/jcli_app/block/genesis.rs
+++ b/src/bin/jcli_app/block/genesis.rs
@@ -22,7 +22,10 @@ impl Genesis {
 }
 
 fn init_genesis_yaml() {
-    unimplemented!()
+    let path: Option<&'static str> = None;
+    let out = io::open_file_write(&path);
+
+    yaml::documented_example(out, std::time::SystemTime::now()).unwrap()
 }
 
 fn encode_block_0(argument: Common) {

--- a/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
+++ b/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
@@ -1,0 +1,76 @@
+# The Blockchain Configuration defines the different settings
+# of the blockchain that cannot be changed once the blockchain
+# is started.
+blockchain_configuration:
+
+  # The block0-date defines the date the blockchain starts
+  # expected value in seconds since UNIX_EPOCH
+  - [ block0-date, {now} ]
+
+  # This is the type of dicrimination of the blockchain
+  # of this blockchain is meant for production then
+  # use the following instead
+  # - [ discrimination, proudction ]
+  #
+  # otherwise leave as this
+  - [ discrimination, test ]
+
+# The Initial settings defines the settings than may change during
+# the life time of the blockchain.
+initial_setting:
+
+  # This is hte max number of messages allowed in a given Block
+  max_number_of_transactions_per_block: 255
+
+  # This is the `d` parameter when running in BFT/genesis praos
+  # compatibility mode
+  #
+  bootstrap_key_slots_percentage: ~
+
+  # The slot duration, in seconds, is the time between the creation
+  # of 2 blocks
+  slot_duration: 15
+
+  # The number of blocks (*10) per epoch
+  epoch_stability_depth: 10
+
+  # The block version:
+  #
+  # * BFT consensus: 1
+  # * Genesis Praos consensus: 2
+  block_version: 1
+
+  # A list of Ed25519 Extended PublicKey that represents the
+  # BFT leaders. The order in the list matters.
+  bft_leaders:
+    - ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
+    - ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
+
+  # Allow the creation of accounts from the output of a transaction
+  #
+  # if set to false, account based wallet will not be created without
+  # publishing a stake certificat.
+  # if set to true, simply adding the account in the output of a transaction
+  # will allow the account to exist in the blockchain.
+  allow_account_creation: true
+
+  # The fee calculations settings
+  #
+  # fee(num_bytes, has_certificate) = constant + num_bytes * coefficient + has_certificate * certificate
+  linear_fee:
+    constant: 2
+    coefficient: 1
+    certificate: 4
+
+# The initial deposits present in the blockchain.
+#
+# It can be UTxO addresses or account (if allow_account_creation is set).
+initial_utxos:
+  # this is the personal address of the developers, have a good heart and
+  # leave a good initial deposit for them
+  - address: ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
+    value: 10000
+
+# the initial deposits present in the blockchain but utilising the
+# legacy cardano address format
+legacy_utxos: ~

--- a/src/bin/jcli_app/block/genesis/yaml.rs
+++ b/src/bin/jcli_app/block/genesis/yaml.rs
@@ -49,6 +49,7 @@ pub struct Update {
     bft_leaders: Option<Vec<String>>,
     allow_account_creation: Option<bool>,
     linear_fee: Option<InitialLinearFee>,
+    slot_duration: u8,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -268,6 +269,7 @@ impl Update {
                 coefficient: linear_fee.coefficient,
                 certificate: linear_fee.certificate,
             }),
+            slot_duration: Some(self.slot_duration),
         };
         Message::Update(update)
     }
@@ -294,6 +296,9 @@ impl Update {
                     coefficient: linear_fee.coefficient,
                     certificate: linear_fee.certificate,
                 }),
+            slot_duration: update_proposal
+                .slot_duration
+                .expect("slot_duration is mandatory"),
         }
     }
 }
@@ -575,4 +580,18 @@ impl<'de> serde::de::Deserialize<'de> for InitialUTxO {
         }
         deserializer.deserialize_struct("InitialUTxO", FIELDS, InitialUTxOVisitor)
     }
+}
+
+pub fn documented_example<W>(mut writer: W, now: std::time::SystemTime) -> std::io::Result<()>
+where
+    W: std::io::Write,
+{
+    writeln!(
+        writer,
+        include_str!("DOCUMENTED_EXAMPLE.yaml"),
+        now = now
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    )
 }

--- a/src/bin/jcli_app/block/genesis/yaml.rs
+++ b/src/bin/jcli_app/block/genesis/yaml.rs
@@ -50,6 +50,7 @@ pub struct Update {
     allow_account_creation: Option<bool>,
     linear_fee: Option<InitialLinearFee>,
     slot_duration: u8,
+    epoch_stability_depth: u32,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -270,6 +271,7 @@ impl Update {
                 certificate: linear_fee.certificate,
             }),
             slot_duration: Some(self.slot_duration),
+            epoch_stability_depth: Some(self.epoch_stability_depth as u32),
         };
         Message::Update(update)
     }
@@ -299,6 +301,9 @@ impl Update {
             slot_duration: update_proposal
                 .slot_duration
                 .expect("slot_duration is mandatory"),
+            epoch_stability_depth: update_proposal
+                .epoch_stability_depth
+                .expect("epoch_stability_depth is mandatory"),
         }
     }
 }

--- a/src/blockcfg/mod.rs
+++ b/src/blockcfg/mod.rs
@@ -20,6 +20,18 @@ fn block_0_get_initial(block: &Block) -> &InitialEnts {
     panic!("Invalid Block0: missing the initial blockchain settings");
 }
 
+pub fn block_0_get_slot_duration(block: &Block) -> std::time::Duration {
+    let mut duration = None;
+    for message in block.messages() {
+        if let Message::Update(proposal) = message {
+            duration = proposal.slot_duration;
+        }
+    }
+
+    let duration = duration.expect("Slot Duration is a mandatory setting of the block 0");
+    std::time::Duration::from_secs(duration as u64)
+}
+
 pub fn block_0_get_start_time(block: &Block) -> std::time::SystemTime {
     let ents = block_0_get_initial(block);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,10 +130,11 @@ fn start(settings: settings::start::Settings) -> Result<(), Error> {
     let block_0 = settings.load_block_0();
 
     let start_time = blockcfg::block_0_get_start_time(&block_0);
+    let slot_duration = blockcfg::block_0_get_slot_duration(&block_0);
 
     let clock = {
         let initial_epoch = clock::ClockEpochConfiguration {
-            slot_duration: std::time::Duration::from_secs(2),
+            slot_duration: slot_duration,
             slots_per_epoch: 10 * 10,
         };
         clock::Clock::new(start_time, initial_epoch)


### PR DESCRIPTION
The command

`jcli genesis init` will generate the following documented genesis file:

```yaml
# The Blockchain Configuration defines the different settings
# of the blockchain that cannot be changed once the blockchain
# is started.
blockchain_configuration:

  # The block0-date defines the date the blockchain starts
  # expected value in seconds since UNIX_EPOCH
  - [ block0-date, 1553770395 ]

  # This is the type of dicrimination of the blockchain
  # of this blockchain is meant for production then
  # use the following instead
  # - [ discrimination, proudction ]
  #
  # otherwise leave as this
  - [ discrimination, test ]

# The Initial settings defines the settings than may change during
# the life time of the blockchain.
initial_setting:

  # This is hte max number of messages allowed in a given Block
  max_number_of_transactions_per_block: 255

  # This is the `d` parameter when running in BFT/genesis praos
  # compatibility mode
  #
  bootstrap_key_slots_percentage: ~

  # The slot duration, in seconds, is the time between the creation
  # of 2 blocks
  slot_duration: 15

  # The number of blocks (*10) per epoch
  epoch_stability_depth: 10

  # The block version:
  #
  # * BFT consensus: 1
  # * Genesis Praos consensus: 2
  block_version: 1

  # A list of Ed25519 Extended PublicKey that represents the
  # BFT leaders. The order in the list matters.
  bft_leaders:
    - ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
    - ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en

  # Allow the creation of accounts from the output of a transaction
  #
  # if set to false, account based wallet will not be created without
  # publishing a stake certificat.
  # if set to true, simply adding the account in the output of a transaction
  # will allow the account to exist in the blockchain.
  allow_account_creation: true

  # The fee calculations settings
  #
  # fee(num_bytes, has_certificate) = constant + num_bytes * coefficient + has_certificate * certificate
  linear_fee:
    constant: 2
    coefficient: 1
    certificate: 4

# The initial deposits present in the blockchain.
#
# It can be UTxO addresses or account (if allow_account_creation is set).
initial_utxos:
  # this is the personal address of the developers, have a good heart and
  # leave a good initial deposit for them
  - address: ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
    value: 10000

# the initial deposits present in the blockchain but utilising the
# legacy cardano address format
legacy_utxos: ~
```