### PR TITLE
Readme fixes

### DIFF
--- a/doc/cli_address.md
+++ b/doc/cli_address.md
@@ -10,7 +10,7 @@ for debugging addresses and for testing.
 To display an address and verify it is in a valid format you can utilise:
 
 ```
-$  jcli  address  info ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
+$ jcli address info ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
 discrimination: testing
 public key: ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
 ```
@@ -18,7 +18,7 @@ public key: ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3j
 or for example:
 
 ```
-$  jcli address \
+$ jcli address \
     info \
     ca1qsy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxz8ah8dldkhvwfghn77se8dp76uguavzyxh5cccek9epryr7mkkr8n7kgx
 discrimination: production
@@ -63,7 +63,7 @@ but it is also possible to utilise them as a wallet.
 To create an account:
 
 ```
-$  jcli address \
+$ jcli address \
     account ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
 ca1q5y0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvx6g5gwu
 ```

--- a/doc/cli_address.md
+++ b/doc/cli_address.md
@@ -10,8 +10,7 @@ for debugging addresses and for testing.
 To display an address and verify it is in a valid format you can utilise:
 
 ```
-$ cargo run --bin jcli -- address \
-    info ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
+$  jcli  address  info ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
 discrimination: testing
 public key: ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
 ```
@@ -19,7 +18,7 @@ public key: ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3j
 or for example:
 
 ```
-$ cargo run --bin jcli -- address \
+$  jcli address \
     info \
     ca1qsy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxz8ah8dldkhvwfghn77se8dp76uguavzyxh5cccek9epryr7mkkr8n7kgx
 discrimination: production
@@ -38,7 +37,7 @@ a testnet environment. To create an address for testing simply add the flag `--t
 You can create a bootstrap era address utilising the following command.
 
 ```
-$ cargo run --bin jcli -- address \
+$ jcli address \
     single ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
 ca1qvy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvx5c3cy4
 ```
@@ -49,7 +48,7 @@ desired.
 To add the delegation, simply add the delegation key as a second parameter of the command:
 
 ```
-$ cargo run --bin jcli -- address \
+$ jcli address \
     single \
     ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a \
     ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
@@ -64,7 +63,7 @@ but it is also possible to utilise them as a wallet.
 To create an account:
 
 ```
-$ cargo run --bin jcli -- address \
+$  jcli address \
     account ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
 ca1q5y0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvx6g5gwu
 ```

--- a/doc/cli_rest.md
+++ b/doc/cli_rest.md
@@ -2,7 +2,7 @@
 
 Jormungandr comes with a CLI client for manual communication with nodes over HTTP.
 
-## Convention
+## Conventions
 
 Many CLI commands have common arguments:
 
@@ -60,7 +60,7 @@ YAML printed on success
 Posts a signed, hex-encoded transaction
 
 ```
-jcli rest v0 transaction post <options>
+jcli rest v0 message post <options>
 ```
 
 The options are

--- a/doc/cli_transaction.md
+++ b/doc/cli_transaction.md
@@ -40,3 +40,11 @@ ed25519extended_public key.
 bech32-encoded ed25519extended_secret. Required one for every input.
 
 Value outputted to stdout on success is transaction message encoded as hex.
+
+
+### Example
+
+```
+jcli transaction build --input f7f1b60d6033bf72409f5fca14fea21f657a0cee19729146351a698d2b6a853e:0:100  \
+--output ta1sv5er2j6vpvhqsj0yy248tmdrxwz0c6u2uvays27ujqhk697dyk6csdzwvm:70 -s key.private
+```

--- a/doc/starting_bft_blockchain.md
+++ b/doc/starting_bft_blockchain.md
@@ -28,8 +28,8 @@ blockchain_configuration:
   - [ discrimination, test ]
 initial_setting:
   allow_account_creation: true
-  slot-duration: 15
-  epoch-stability-depth: 2600
+  slot_duration: 15
+  epoch_stability_depth: 2600
   linear_fees:
     constant: 0
     coefficient: 0


### PR DESCRIPTION
Fixing docs:

- conventions section is not anchored
- IMHO in cli_address.md there is no need to add cargo run in each command
- rest transaction -> message since` jcli rest v0 transaction post <options>` does not exists
- starting bft: prameters should be underscored not dashed