### PR TITLE
Task future improvements

### DIFF
--- a/src/utils/task.rs
+++ b/src/utils/task.rs
@@ -131,16 +131,10 @@ impl Services {
     /// the service will stop once there is no more input to read: the function
     /// will be called one last time with `Input::Shutdown` and then will return
     ///
-    pub fn spawn_with_inputs<F, Msg>(
-        &mut self,
-        name: &'static str,
-        // mut b: B,
-        mut f: F,
-    ) -> TaskMessageBox<Msg>
+    pub fn spawn_with_inputs<F, Msg>(&mut self, name: &'static str, mut f: F) -> TaskMessageBox<Msg>
     where
         F: FnMut(&ThreadServiceInfo, Input<Msg>) -> (),
         F: Send + 'static,
-        // B: Send + 'static,
         Msg: Send + 'static,
     {
         let (tx, rx) = mpsc::channel::<Msg>();


### PR DESCRIPTION
Deduplicates code in `utils::task`, replaces magic numbers with constants.