### PR TITLE
Plug block propagation stream into network client

### DIFF
--- a/src/network/grpc/client.rs
+++ b/src/network/grpc/client.rs
@@ -1,4 +1,4 @@
-use super::super::{BlockConfig, ConnectionState, GlobalState};
+use super::super::{propagate, BlockConfig, ConnectionState, GlobalState};
 use crate::{intercom::BlockMsg, settings::start::network::Peer};
 
 use network_core::client::block::BlockService;
@@ -7,13 +7,13 @@ use network_grpc::{client::Client, peer as grpc_peer};
 use bytes::Bytes;
 use futures::future;
 use futures::prelude::*;
-use tokio::{executor::DefaultExecutor, sync::mpsc};
+use tokio::executor::DefaultExecutor;
 
-pub fn run_connect_socket(peer: Peer, state: GlobalState) -> impl Future<Item = (), Error = ()> {
-    let mut state = ConnectionState::new_peer(&state, &peer);
-
-    // TODO: plug in the outbound stream
-    let (block_sender, block_receiver) = mpsc::unbounded_channel();
+pub fn run_connect_socket(
+    peer: Peer,
+    state: GlobalState,
+) -> (impl Future<Item = (), Error = ()>, propagate::PeerHandlesR) {
+    let state = ConnectionState::new_peer(&state, &peer);
 
     info!("connecting to subscription peer {}", peer.connection);
     info!("address: {}", peer.address());
@@ -28,29 +28,31 @@ pub fn run_connect_socket(peer: Peer, state: GlobalState) -> impl Future<Item = 
         .path_and_query("/")
         .build()
         .unwrap();
+    let propagation = state.propagation.clone();
+    let mut block_box = state.channels.block_box;
 
-    Client::connect(peer, DefaultExecutor::current(), origin)
+    let fut = Client::connect(peer, DefaultExecutor::current(), origin)
         .map_err(move |err| {
             error!("Error connecting to peer {}: {:?}", addr, err);
         })
-        .and_then(|mut client: Client<BlockConfig, _, _>| {
+        .and_then(move |mut client: Client<BlockConfig, _, _>| {
+            let mut sub_handles = propagation.lock().unwrap();
             client
-                .block_subscription(block_receiver)
+                .block_subscription(sub_handles.blocks.subscribe())
                 .map_err(move |err| {
                     error!("BlockSubscription request failed: {:?}", err);
                 })
         })
-        .and_then(|subscription| {
+        .and_then(move |subscription| {
             subscription
                 .for_each(move |header| {
-                    state
-                        .channels
-                        .block_box
-                        .send(BlockMsg::AnnouncedBlock(header));
+                    block_box.send(BlockMsg::AnnouncedBlock(header));
                     future::ok(())
                 })
                 .map_err(|err| {
                     error!("Block subscription failed: {:?}", err);
                 })
-        })
+        });
+
+    (fut, state.propagation)
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -190,7 +190,8 @@ pub fn run(
         .collect::<Vec<_>>();
     let connections = stream::iter_ok(addrs).for_each(move |addr| {
         let peer = Peer::new(addr, Protocol::Grpc);
-        grpc::run_connect_socket(peer, state_connection.clone())
+        let (conn, _propagation) = grpc::run_connect_socket(peer, state_connection.clone());
+        conn // TODO: manage propagation peers in a map
     });
 
     let propagate = propagate_input


### PR DESCRIPTION
Client connections can now establish outbound streams to propagate blocks.

Ran some experiments (partially recorded in tower-rs/tower-grpc#150) to verify that the `Client` instance does not need to live for the client connection to be open, as long as the subscription streams are alive.