### PR TITLE
update the blockchain's leadership support

### DIFF
--- a/src/leadership/leaderships.rs
+++ b/src/leadership/leaderships.rs
@@ -1,0 +1,63 @@
+use crate::blockcfg::{ChainLength, Header, HeaderHash};
+use chain_core::property::Header as _;
+use chain_impl_mockchain::multiverse::{GCRoot, Multiverse};
+use std::collections::{BTreeMap, HashSet};
+
+pub use chain_impl_mockchain::leadership::Leadership;
+
+/// TODO: get the type from the chain-impl-mockchain
+type Epoch = u32;
+
+/// structure containing the leaderships at different
+/// time of the blockchain.
+pub struct Leaderships {
+    multiverse: Multiverse<Leadership>,
+
+    anchors: BTreeMap<Epoch, HashSet<HeaderHash>>,
+
+    pub tip: GCRoot,
+}
+
+impl Leaderships {
+    /// Leadership object need to be construction with initial data
+    pub fn new(block_0_header: &Header, initial: Leadership) -> Self {
+        let mut multiverse = Multiverse::new();
+        let mut anchors = BTreeMap::new();
+
+        let gc_root =
+            multiverse.insert(block_0_header.chain_length(), block_0_header.id(), initial);
+
+        anchors.entry(0).or_insert(HashSet::new()).insert(*gc_root);
+
+        Leaderships {
+            multiverse: multiverse,
+            anchors: anchors,
+            tip: gc_root,
+        }
+    }
+
+    pub fn get(&self, epoch: Epoch) -> Option<impl Iterator<Item = (&HeaderHash, &Leadership)>> {
+        self.anchors.get(&epoch).map(|set| {
+            set.iter()
+                .map(move |h| (h, self.multiverse.get(h).unwrap()))
+        })
+    }
+
+    pub fn add(
+        &mut self,
+        epoch: Epoch,
+        chain_length: ChainLength,
+        header_hash: HeaderHash,
+        leadership: Leadership,
+    ) -> GCRoot {
+        let gc_root = self
+            .multiverse
+            .insert(chain_length, header_hash, leadership);
+
+        self.anchors
+            .entry(epoch)
+            .or_insert(HashSet::new())
+            .insert(*gc_root);
+        gc_root
+    }
+}

--- a/src/leadership/mod.rs
+++ b/src/leadership/mod.rs
@@ -1,3 +1,5 @@
+pub mod leaderships;
 pub mod process;
 
+pub use self::leaderships::*;
 pub use self::process::leadership_task;

--- a/src/leadership/process.rs
+++ b/src/leadership/process.rs
@@ -1,7 +1,5 @@
 use crate::{
-    blockcfg::{
-        BlockBuilder, BlockDate, ChainLength, HeaderHash, Leader, LeaderOutput, Leadership,
-    },
+    blockcfg::{BlockBuilder, BlockDate, ChainLength, HeaderHash, Leader, LeaderOutput},
     clock,
     intercom::BlockMsg,
     transaction::TPoolR,
@@ -34,8 +32,7 @@ pub fn leadership_task(
         let b = blockchain.lock_read();
         let (last_block, _last_block_info) = b.get_block_tip().unwrap();
         let chain_length = last_block.chain_length().next();
-        let state = b.multiverse.get_from_root(&b.tip);
-        let leadership = Leadership::new(epoch.0, state);
+        let leadership = b.leaderships.get(epoch.0).unwrap().next().unwrap().1;
         let parent_id = &*b.tip;
 
         // let am_leader = leadership.get_leader_at(date.clone()).unwrap() == leader_id;


### PR DESCRIPTION
1. hold multiple version of the leadership for different epochs;
2. don't re-compute the leadership at every tick of the block.