### PR TITLE
network: Rationalize shared connection state

### DIFF
--- a/src/network/grpc/server.rs
+++ b/src/network/grpc/server.rs
@@ -1,21 +1,17 @@
-use crate::network::{service::NodeServer, ConnectionState, GlobalState};
-use crate::settings::start::network::Listen;
+use super::super::{service::NodeServer, Channels, ConnectionState};
 
 use network_grpc::server::{listen, Server};
 
-use futures::future;
-use futures::prelude::*;
 use tokio::executor::DefaultExecutor;
+use tokio::prelude::*;
 
 use std::net::SocketAddr;
 
 pub fn run_listen_socket(
     sockaddr: SocketAddr,
-    listen_to: Listen,
-    state: GlobalState,
+    state: ConnectionState,
+    channels: Channels,
 ) -> impl Future<Item = (), Error = ()> {
-    let state = ConnectionState::new_listen(&state, &listen_to);
-
     info!(
         "start listening and accepting gRPC connections on {}",
         sockaddr
@@ -27,7 +23,7 @@ pub fn run_listen_socket(
             unimplemented!()
         }
         Ok(listener_stream) => {
-            let node_server = NodeServer::new(state);
+            let node_server = NodeServer::new(state, channels);
             let server = Server::new(node_server, DefaultExecutor::current());
 
             listener_stream

--- a/src/network/propagate.rs
+++ b/src/network/propagate.rs
@@ -6,8 +6,6 @@ use network_core::{error::Error, gossip::Gossip};
 use futures::prelude::*;
 use futures::sync::mpsc;
 
-use std::sync::{Arc, Mutex};
-
 // Buffer size determines the number of stream items pending processing that
 // can be buffered before back pressure is applied to the inbound half of
 // a gRPC subscription stream.
@@ -89,20 +87,17 @@ enum SubscriptionState<T> {
 
 /// Propagation subscription handles for all stream types that a peer can
 /// be subscribed to.
+#[derive(Default)]
 pub struct PeerHandles {
     pub blocks: PropagationHandle<Header>,
     pub messages: PropagationHandle<Message>,
     pub gossip: PropagationHandle<Gossip<Node>>,
 }
 
-pub type PeerHandlesR = Arc<Mutex<PeerHandles>>;
-
 impl PeerHandles {
-    pub fn new() -> PeerHandlesR {
-        Arc::new(Mutex::new(PeerHandles {
-            blocks: Default::default(),
-            messages: Default::default(),
-            gossip: Default::default(),
-        }))
+    pub fn new() -> PeerHandles {
+        PeerHandles {
+            ..Default::default()
+        }
     }
 }

--- a/src/settings/start/network.rs
+++ b/src/settings/start/network.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, net::SocketAddr, str, time::Duration};
 use crate::settings::start::config::{Address, InterestLevel, Topic};
 
 /// Protocol to use for a connection.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Protocol {
     Ntt,
     Grpc,
@@ -62,8 +62,8 @@ impl Peer {
             timeout: Duration::from_micros(DEFAULT_TIMEOUT_MICROSECONDS),
         }
     }
-    pub fn address(&self) -> &SocketAddr {
-        &self.connection
+    pub fn address(&self) -> SocketAddr {
+        self.connection
     }
 }
 
@@ -76,7 +76,7 @@ impl Listen {
         }
     }
 
-    pub fn address(&self) -> &SocketAddr {
-        &self.connection
+    pub fn address(&self) -> SocketAddr {
+        self.connection
     }
 }


### PR DESCRIPTION
Make global state members shared under `Arc` without cloning.
Per-connection state is also put under `Arc` because it needs to be shared between Tokio task closures and client/server instances.
Mutable leaf parts of the state are protected by mutexes.
Channels are not `Sync`, so they are moved out of state structs and passed down as clones separately.

Other sympathetic changes:

* Centralized building of an origin URI into an utility function.
* Improved copyability of data structures in network settings.