### PR TITLE
Update node secret

### DIFF
--- a/doc/starting_bft_blockchain.md
+++ b/doc/starting_bft_blockchain.md
@@ -68,8 +68,9 @@ Now that the blockchain is initialized, you need to start your node.
 Write you private key in a file on your HD:
 
 ```
-$ cat private.key
-ed25519extended_secret1vzpkw6lqk5sfaa0rtp64s28s7zcegpwqte0psqneum5w9mcgafd0gwexmfn7s96lqja5sv520zx6hx5hd0qsgahp3ta8grrrxkd8n0cjmaqre
+$ cat node_secret.yaml
+bft:
+  signing_key: ed25519extended_secret1vzpkw6lqk5sfaa0rtp64s28s7zcegpwqte0psqneum5w9mcgafd0gwexmfn7s96lqja5sv520zx6hx5hd0qsgahp3ta8grrrxkd8n0cjmaqre
 ```
 
 Configure your Node (config.yml) and run the following command:
@@ -77,5 +78,5 @@ Configure your Node (config.yml) and run the following command:
 ```
 $ jormungandr --genesis-block block-0.bin \
     --config example.config \
-    --secret private.key
+    --secret node_secret.yaml
 ```

--- a/src/start_up/error.rs
+++ b/src/start_up/error.rs
@@ -1,4 +1,4 @@
-use crate::{blockcfg, blockchain, settings};
+use crate::{blockcfg, blockchain, secure, settings};
 use chain_storage::error::Error as StorageError;
 use std::io;
 
@@ -15,6 +15,7 @@ custom_error! {pub Error
     StorageError { source: StorageError } = "Storage error",
     Blockchain { source: blockchain::LoadError } = "Error while loading the blockchain state",
     Block0 { source: blockcfg::Block0Error } = "Error in the genesis-block",
+    NodeSecrets { source: secure::NodeSecretFromFileError} = "Error while loading the node's secrets."
 }
 
 impl Error {
@@ -34,6 +35,7 @@ impl Error {
             Error::StorageError { source: _ } => 5,
             Error::Blockchain { source: _ } => 6,
             Error::Block0 { source: _ } => 7,
+            Error::NodeSecrets { source: _ } => 8,
         }
     }
 }


### PR DESCRIPTION
Merging this PR will generate the following change in the format of the node's secret file:

```yaml
bft:
    signing_key: ed25519extended_secretbech32...
```

There is an _undocumented part_ (for now) about starting the node in genesis (stake pool):

```yaml
genesis:
    vrf_key: curve25519_2hashdh_secretbech32...
    sig_key: fakemmm_secretbech32...
    node_id: aa7215b6bb9d0b85f77bb0452c0b2e5543eb57981f1d99cc1ea62927dcba1bc2
```