### PR TITLE
Add propagation among subscribed peers

### DIFF
--- a/src/network/p2p_topology.rs
+++ b/src/network/p2p_topology.rs
@@ -7,6 +7,7 @@ use network_core::gossip::{self, Node as _};
 use poldercast::topology::{Cyclon, Module, Rings, Topology, Vicinity};
 use poldercast::Subscription;
 pub use poldercast::{Address, InterestLevel};
+
 use std::{collections::BTreeMap, error, fmt, io, net::SocketAddr, sync::RwLock};
 
 pub const NEW_MESSAGES_TOPIC: u32 = 0u32;
@@ -94,6 +95,12 @@ impl NodeId {
     }
 }
 
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0.as_u128())
+    }
+}
+
 /// object holding the P2pTopology of the Node
 pub struct P2pTopology {
     lock: RwLock<Topology>,
@@ -159,10 +166,15 @@ impl P2pTopology {
         topology.add_module(Cyclon::new());
     }
 
-    /// this is the list of neighbors to contact for event dissemination
-    pub fn view(&self) -> Vec<Node> {
+    /// Returns a list of neighbors selected in this turn
+    /// to contact for event dissemination.
+    pub fn view_ids(&self) -> Vec<NodeId> {
         let topology = self.lock.read().unwrap();
-        topology.view().into_iter().map(Node).collect()
+        topology
+            .view()
+            .into_iter()
+            .map(|node| NodeId(*node.id()))
+            .collect()
     }
 
     /// this is the function to utilise when we receive a gossip in order

--- a/src/network/propagate.rs
+++ b/src/network/propagate.rs
@@ -6,7 +6,10 @@ use network_core::{error::Error, gossip::Gossip};
 use futures::prelude::*;
 use futures::sync::mpsc;
 
-use std::{collections::HashMap, sync::RwLock};
+use std::{
+    collections::{hash_map, HashMap},
+    sync::Mutex,
+};
 
 // Buffer size determines the number of stream items pending processing that
 // can be buffered before back pressure is applied to the inbound half of
@@ -106,10 +109,10 @@ impl PeerHandles {
 
 /// The map of peer nodes currently subscribed to chain or network updates.
 ///
-/// This map object uses internal read-write locking and is shared between
+/// This map object uses internal locking and is shared between
 /// all network connection tasks.
 pub struct PropagationMap {
-    lock: RwLock<HashMap<p2p::NodeId, PeerHandles>>,
+    mutex: Mutex<HashMap<p2p::NodeId, PeerHandles>>,
 }
 
 fn ensure_propagation_peer<'a>(
@@ -122,25 +125,56 @@ fn ensure_propagation_peer<'a>(
 impl PropagationMap {
     pub fn new() -> Self {
         PropagationMap {
-            lock: RwLock::new(HashMap::new()),
+            mutex: Mutex::new(HashMap::new()),
         }
     }
 
     pub fn subscribe_to_blocks(&self, id: p2p::NodeId) -> Subscription<Header> {
-        let mut map = self.lock.write().unwrap();
+        let mut map = self.mutex.lock().unwrap();
         let handles = ensure_propagation_peer(&mut map, id);
         handles.blocks.subscribe()
     }
 
     pub fn subscribe_to_messages(&self, id: p2p::NodeId) -> Subscription<Message> {
-        let mut map = self.lock.write().unwrap();
+        let mut map = self.mutex.lock().unwrap();
         let handles = ensure_propagation_peer(&mut map, id);
         handles.messages.subscribe()
     }
 
     pub fn subscribe_to_gossip(&self, id: p2p::NodeId) -> Subscription<Gossip<p2p::Node>> {
-        let mut map = self.lock.write().unwrap();
+        let mut map = self.mutex.lock().unwrap();
         let handles = ensure_propagation_peer(&mut map, id);
         handles.gossip.subscribe()
+    }
+
+    fn propagate_with<F>(&self, ids: &[p2p::NodeId], f: F)
+    where
+        F: Fn(&mut PeerHandles) -> Result<(), PropagateError>,
+    {
+        let mut map = self.mutex.lock().unwrap();
+        for id in ids {
+            if let hash_map::Entry::Occupied(mut entry) = map.entry(id.clone()) {
+                f(entry.get_mut()).unwrap_or_else(|e| {
+                    info!("propagation stream error: {:?}", e);
+                    debug!("unsubscribing peer {}", id);
+                    entry.remove_entry();
+                });
+            } else {
+                // TODO: connect asynchronously and deliver the item
+                // once subscribed
+            }
+        }
+    }
+
+    pub fn propagate_block(&self, ids: &[p2p::NodeId], header: Header) {
+        self.propagate_with(ids, |handles| handles.blocks.try_send(header.clone()))
+    }
+
+    pub fn propagate_message(&self, ids: &[p2p::NodeId], message: Message) {
+        self.propagate_with(ids, |handles| handles.messages.try_send(message.clone()))
+    }
+
+    pub fn propagate_gossip(&self, ids: &[p2p::NodeId], gossip: Gossip<p2p::Node>) {
+        self.propagate_with(ids, |handles| handles.gossip.try_send(gossip.clone()))
     }
 }

--- a/src/network/propagate.rs
+++ b/src/network/propagate.rs
@@ -155,7 +155,7 @@ impl PropagationMap {
         for id in ids {
             if let hash_map::Entry::Occupied(mut entry) = map.entry(id.clone()) {
                 f(entry.get_mut()).unwrap_or_else(|e| {
-                    info!("propagation stream error: {:?}", e);
+                    info!("propagation to peer {} failed: {:?}", id, e);
                     debug!("unsubscribing peer {}", id);
                     entry.remove_entry();
                 });


### PR DESCRIPTION
Propagate blocks and messages announced by their respective service tasks.

Currently propagation is only expected to work among the peers who have subscribed. On-demand client propagation toward peers discovered via gossip is not yet implemented.