### PR TITLE
remove non needed consensus parameter in the initial setting

### DIFF
--- a/doc/cli_address.md
+++ b/doc/cli_address.md
@@ -12,7 +12,7 @@ To display an address and verify it is in a valid format you can utilise:
 ```
 $ jcli address info ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
 discrimination: testing
-public key: ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
+public key: ed25519e_pk1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtpsx9rnmx
 ```
 
 or for example:
@@ -22,8 +22,8 @@ $ jcli address \
     info \
     ca1qsy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxz8ah8dldkhvwfghn77se8dp76uguavzyxh5cccek9epryr7mkkr8n7kgx
 discrimination: production
-public key: ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
-group key:  ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
+public key: ed25519e_pk1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtpsx9rnmx
+group key:  ed25519e_pk1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtpsx9rnmx
 ```
 
 ## Creating an address
@@ -38,8 +38,8 @@ You can create a bootstrap era address utilising the following command.
 
 ```
 $ jcli address \
-    single ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
-ca1qvy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvx5c3cy4
+    single ed25519e_pk1jnlhwdgzv3c9frknyv7twsv82su26qm30yfpdmvkzyjsdgw80mfqduaean
+ca1qw207ae4qfj8q4yw6v3ned6psa2r3tgrw9u3y9hdjcgj2p4pcaldyukyka8
 ```
 
 This kind of address are useful when running in the BFT era or if delegation is not
@@ -50,9 +50,9 @@ To add the delegation, simply add the delegation key as a second parameter of th
 ```
 $ jcli address \
     single \
-    ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a \
-    ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
-ca1qsy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdv8zhm7zx62sx36q9p24hdk7v5dndgujtk6jlnjj6g0m5mdgs8d653lpq5dq
+    ed25519e_pk1fxvudq6j7mfxvgk986t5f3f258sdtw89v4n3kr0fm6mpe4apxl4q0vhp3k \
+    ed25519e_pk1as03wxmy2426ceh8nurplvjmauwpwlcz7ycwj7xtl9gmx9u5gkqscc5ylx
+ca1q3yen35r2tmdye3zc5lfw3x992s7p4dcu4jkwxcda80tv8xh5ym74mqlzudkg42443nw08cxr7e9hmcuzals9ufsa9uvh723kvteg3vpvrcxcq
 ```
 
 ### Address for Account
@@ -64,6 +64,6 @@ To create an account:
 
 ```
 $ jcli address \
-    account ed25519extended_public1pr7mnklkmtk8y5tel0gvnksldwywwkpzrt6vvvvmzus3jpldmtps3t9h3a
-ca1q5y0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvx6g5gwu
+    account ed25519e_pk1c4yq3hflulynn8fef0hdq92579n3c49qxljasrl9dnuvcksk84gs9sqvc2
+ca1qhz5szxa8lnujwva8997a5q42nckw8z55qm7tkq0u4k03nz6zc74ze780qe
 ```

--- a/doc/cli_transaction.md
+++ b/doc/cli_transaction.md
@@ -26,7 +26,7 @@ FLAGS:
 OPTIONS:
 - -c, --change <change> change address. Value taken from inputs and not spent on outputs
 or fees will be returned to this address. If not provided, the change will go to treasury.
-Must be bech32-encoded ed25519extended_public key.
+Must be bech32-encoded ed25519e_pk key.
 - -b, --fee-base <fee-base> fee base which will be always added to the transaction
 - -a, --fee-per-addr <fee-per-addr> fee which will be added to the transaction for every
 input and output
@@ -34,10 +34,10 @@ input and output
 - -i, --input <input>... transaction input. Must have format
 `<hex-encoded-transaction-id>:<output-index>:<value>`. E.g. `1234567890abcdef:2:535`.
 - -o, --output <output>... transaction output. Must have format `<address>:<value>`.
-E.g. `ed25519extended_public1abcdef1234567890:501`. The address must be bech32-encoded
+E.g. `ed25519e_pk1abcdef1234567890:501`. The address must be bech32-encoded
 ed25519extended_public key.
 - -s, --spending-key <spending-key>... file with transaction spending keys. Must be
-bech32-encoded ed25519extended_secret. Required one for every input.
+bech32-encoded ed25519e_sk. Required one for every input.
 
 Value outputted to stdout on success is transaction message encoded as hex.
 

--- a/doc/genesis_file.md
+++ b/doc/genesis_file.md
@@ -24,7 +24,6 @@ initial_setting:
   bootstrap_key_slots_percentage: ~
   slot_duration: 15
   epoch_stability_depth: 10
-  consensus: bft
   bft_leaders:
     - ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
     - ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
@@ -55,7 +54,7 @@ There are multiple _parts_ in the genesis file:
 |:-------|:-------|:------------|
 | `block0_date` | number | the official start time of the blockchain, in seconds since UNIX EPOCH |
 | `discrimination` | string | `production` or `test` |
-| `block0_genesis` | string | `bft` |
+| `block0_consensus` | string | `bft` |
 
 ### initial settings
 
@@ -65,7 +64,6 @@ There are multiple _parts_ in the genesis file:
 | `bootstrap_key_slots_percentage` | number | placeholder, do not use |
 | `slot_duration` | number | the number of seconds between the creation of 2 blocks |
 | `epoch_stability_depth` | number | allowed size of a fork (in number of block) |
-| `consensus` | string | the consensus version at the startup of the blockchain (`bft` for BFT) |
 | `allow_account_creation` | boolean | allow creating accounts without publishing certificate |
 | `linear_fee` | object | linear fee settings, set the fee for transaction and certificate publishing |
 | `bft_leaders` | array | the list of the BFT leader at the beginning of the blockchain |

--- a/doc/genesis_file.md
+++ b/doc/genesis_file.md
@@ -25,8 +25,8 @@ initial_setting:
   slot_duration: 15
   epoch_stability_depth: 10
   bft_leaders:
-    - ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
-    - ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
+    - ed25519e_pk1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
+    - ed25519e_pk13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
   allow_account_creation: true
   linear_fee:
     constant: 2

--- a/doc/genesis_file.md
+++ b/doc/genesis_file.md
@@ -32,10 +32,10 @@ initial_setting:
     constant: 2
     coefficient: 1
     certificate: 4
-initial_utxos:
+initial_funds:
   - address: ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
     value: 10000
-legacy_utxos: ~
+legacy_funds: ~
 ```
 
 There are multiple _parts_ in the genesis file:
@@ -71,7 +71,7 @@ There are multiple _parts_ in the genesis file:
 _for more information about the BFT leaders in the genesis file, see
 [Starting a BFT Blockchain](./starting_bft_blockchain.md)_
 
-### The initial UTxO
+### The initial Funds
 
 This is a list of the initial token present in the blockchain. It can be:
 
@@ -79,14 +79,14 @@ This is a list of the initial token present in the blockchain. It can be:
 * an account (if `allow_account_creation` is set to true): an
   [account address](./cli_address.md#address-for-account) and a value
 
-### The legacy UTxO
+### The legacy Funds
 
 This is a list of legacy cardano addresses and associated credited value.
 
 Example:
 
 ```yaml
-legacy_utxos:
+legacy_funds:
   - address: Ae2tdPwUPEZCEhYAUVU7evPfQCJjyuwM6n81x6hSjU9TBMSy2YwZEVydssL
     value: 2000
 ```

--- a/doc/jormungandr_keys.md
+++ b/doc/jormungandr_keys.md
@@ -14,12 +14,12 @@ There is a command line parameter to generate this keys:
 
 ```
 $ jcli key generate --type=Ed25519
-ed25519_secret1sx3vjuc733mmlfm86xc2ufrjx6hltas57yj6pklra3s2n03yfv2svckr67
+ed25519_sk1cvac48ddf2rpk9na94nv2zqhj74j0j8a99q33gsqdvalkrz6ar9srnhvmt
 ```
 
 and to extract the associated public key:
 
 ```
-$ echo ed25519_secret1sx3vjuc733mmlfm86xc2ufrjx6hltas57yj6pklra3s2n03yfv2svckr67 | jcli key to-public
-ed25519_public1zkt4e7yufvf4es45u4wc0kztzkfr0n3wa6ks04z6kltsxdalafxqp7m2ca
+$ echo ed25519_sk1cvac48ddf2rpk9na94nv2zqhj74j0j8a99q33gsqdvalkrz6ar9srnhvmt | jcli key to-public
+ed25519_pk1z2ffur59cq7t806nc9y2g64wa60pg5m6e9cmrhxz9phppaxk5d4sn8nsqg
 ```

--- a/doc/starting_bft_blockchain.md
+++ b/doc/starting_bft_blockchain.md
@@ -31,7 +31,6 @@ initial_setting:
   allow_account_creation: true
   slot_duration: 15
   epoch_stability_depth: 2600
-  consensus: bft
   linear_fees:
     constant: 0
     coefficient: 0

--- a/doc/starting_bft_blockchain.md
+++ b/doc/starting_bft_blockchain.md
@@ -39,7 +39,7 @@ initial_setting:
   bft_leaders:
     - ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
     - ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
-initial_utxos:
+initial_funds:
   - address: ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
     value: 10000
 ```

--- a/doc/starting_bft_blockchain.md
+++ b/doc/starting_bft_blockchain.md
@@ -37,8 +37,8 @@ initial_setting:
     certificate: 0
   block_version: 1
   bft_leaders:
-    - ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
-    - ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
+    - ed25519e_pk1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
+    - ed25519e_pk13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
 initial_funds:
   - address: ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
     value: 10000

--- a/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
+++ b/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
@@ -66,7 +66,7 @@ initial_setting:
 # The initial deposits present in the blockchain.
 #
 # It can be UTxO addresses or account (if allow_account_creation is set).
-initial_utxos:
+initial_funds:
   # this is the personal address of the developers, have a good heart and
   # leave a good initial deposit for them
   - address: ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
@@ -74,4 +74,4 @@ initial_utxos:
 
 # the initial deposits present in the blockchain but utilising the
 # legacy cardano address format
-legacy_utxos: ~
+legacy_funds: ~

--- a/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
+++ b/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
@@ -44,8 +44,8 @@ initial_setting:
   # A list of Ed25519 Extended PublicKey that represents the
   # BFT leaders. The order in the list matters.
   bft_leaders:
-    - ed25519e_pk1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
-    - ed25519e_pk13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
+    - ed25519e_pk1else5uqslegj6n5rxnrayz2x99cel6m2g492ac6tpv76kns0dwlqpjnh0l
+    - ed25519e_pk1xuqdxht6f0kkh0lf3ck3gfyvnpk33s09du92w6740mfmxl6hsfpsp8grmk
 
   # Allow the creation of accounts from the output of a transaction
   #

--- a/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
+++ b/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
@@ -44,8 +44,8 @@ initial_setting:
   # A list of Ed25519 Extended PublicKey that represents the
   # BFT leaders. The order in the list matters.
   bft_leaders:
-    - ed25519extended_public1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
-    - ed25519extended_public13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
+    - ed25519e_pk1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
+    - ed25519e_pk13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
 
   # Allow the creation of accounts from the output of a transaction
   #

--- a/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
+++ b/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
@@ -41,12 +41,6 @@ initial_setting:
   # The number of blocks (*10) per epoch
   epoch_stability_depth: 10
 
-  # The consensus version:
-  #
-  # * BFT consensus: bft
-  # * Genesis Praos consensus: genesis
-  consensus: bft
-
   # A list of Ed25519 Extended PublicKey that represents the
   # BFT leaders. The order in the list matters.
   bft_leaders:

--- a/src/bin/jcli_app/block/genesis/yaml.rs
+++ b/src/bin/jcli_app/block/genesis/yaml.rs
@@ -10,7 +10,6 @@ use chain_impl_mockchain::{
     transaction,
     value::Value,
 };
-use jcli_app::utils::serde_with_string;
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 
@@ -59,8 +58,6 @@ pub struct BlockchainConfiguration {
 pub struct Update {
     max_number_of_transactions_per_block: Option<u32>,
     bootstrap_key_slots_percentage: Option<u8>,
-    #[serde(with = "serde_with_string")]
-    consensus: ConsensusVersion,
     bft_leaders: Option<Vec<String>>,
     allow_account_creation: Option<bool>,
     linear_fee: Option<InitialLinearFee>,
@@ -321,7 +318,7 @@ impl Update {
         let update = UpdateProposal {
             max_number_of_transactions_per_block: self.max_number_of_transactions_per_block,
             bootstrap_key_slots_percentage: self.bootstrap_key_slots_percentage,
-            consensus_version: Some(self.consensus),
+            consensus_version: None,
             bft_leaders: self.bft_leaders.clone().map(|leaders| {
                 leaders
                     .iter()
@@ -348,9 +345,6 @@ impl Update {
             max_number_of_transactions_per_block: update_proposal
                 .max_number_of_transactions_per_block,
             bootstrap_key_slots_percentage: update_proposal.bootstrap_key_slots_percentage,
-            consensus: update_proposal
-                .consensus_version
-                .unwrap_or(ConsensusVersion::Bft),
             bft_leaders: update_proposal.bft_leaders.clone().map(|leaders| {
                 leaders
                     .iter()

--- a/src/bin/jcli_app/block/genesis/yaml.rs
+++ b/src/bin/jcli_app/block/genesis/yaml.rs
@@ -27,8 +27,8 @@ pub struct Genesis {
 
     pub initial_setting: Update,
 
-    pub initial_utxos: Option<Vec<InitialUTxO>>,
-    pub legacy_utxos: Option<Vec<LegacyUTxO>>,
+    pub initial_funds: Option<Vec<InitialUTxO>>,
+    pub legacy_funds: Option<Vec<LegacyUTxO>>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -119,12 +119,12 @@ impl Genesis {
         Genesis {
             blockchain_configuration,
             initial_setting: initial_setting,
-            initial_utxos: if initial_utxos.is_empty() {
+            initial_funds: if initial_utxos.is_empty() {
                 None
             } else {
                 Some(initial_utxos)
             },
-            legacy_utxos: if legacy_utxos.is_empty() {
+            legacy_funds: if legacy_utxos.is_empty() {
                 None
             } else {
                 Some(legacy_utxos)
@@ -160,7 +160,7 @@ impl Genesis {
 
     fn to_initial_messages(&self, max_output_per_message: usize) -> Vec<Message> {
         let mut messages = Vec::new();
-        if let Some(initial_utxos) = &self.initial_utxos {
+        if let Some(initial_utxos) = &self.initial_funds {
             let mut utxo_iter = initial_utxos.iter();
 
             while let Some(utxo) = utxo_iter.next() {
@@ -196,7 +196,7 @@ impl Genesis {
     }
     fn to_legacy_messages(&self, max_output_per_message: usize) -> Vec<Message> {
         let mut messages = Vec::new();
-        if let Some(legacy_utxos) = &self.legacy_utxos {
+        if let Some(legacy_utxos) = &self.legacy_funds {
             let mut utxo_iter = legacy_utxos.iter();
 
             while let Some(utxo) = utxo_iter.next() {

--- a/src/bin/jcli_app/key.rs
+++ b/src/bin/jcli_app/key.rs
@@ -6,10 +6,7 @@ use jcli_app::utils::io;
 use rand::{rngs::EntropyRng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::{io::Read as _, path::PathBuf};
-use structopt::{
-    clap::{_clap_count_exprs, arg_enum},
-    StructOpt,
-};
+use structopt::{clap::arg_enum, StructOpt};
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "genesis", rename_all = "kebab-case")]

--- a/tests/resources/genesis/genesis.yaml
+++ b/tests/resources/genesis/genesis.yaml
@@ -12,8 +12,8 @@ initial_setting:
     certificate: 0
   block_version: 1
   bft_leaders:
-    - ed25519e_pk1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
-    - ed25519e_pk13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
+    - ed25519e_pk1else5uqslegj6n5rxnrayz2x99cel6m2g492ac6tpv76kns0dwlqpjnh0l
+    - ed25519e_pk1xuqdxht6f0kkh0lf3ck3gfyvnpk33s09du92w6740mfmxl6hsfpsp8grmk
 initial_funds:
   - address: ta1svaengshtf3f0mc3qrq76c7autjpyxeuyfkn9h5r0vr9qrek6e0y6zpe8ls
     value: 100

--- a/tests/resources/genesis/genesis.yaml
+++ b/tests/resources/genesis/genesis.yaml
@@ -14,7 +14,7 @@ initial_setting:
   bft_leaders:
     -  ed25519extended_public1nhnr6nfff3uhuky94evw9ejfxx9h5yhk6zk97kd5mssezlhlpryqy5xljp
     -  ed25519extended_public1gl7rvurvvsllkmp4xmt250s6jl85e0fprw3mk4e7fwuv5kmu7vtsftgku8
-initial_utxos:
+initial_funds:
   - address: ta1svaengshtf3f0mc3qrq76c7autjpyxeuyfkn9h5r0vr9qrek6e0y6zpe8ls
     value: 100
   - address: ta1sv5er2j6vpvhqsj0yy248tmdrxwz0c6u2uvays27ujqhk697dyk6csdzwvm

--- a/tests/resources/genesis/genesis.yaml
+++ b/tests/resources/genesis/genesis.yaml
@@ -3,7 +3,6 @@ blockchain_configuration:
   discrimination: test
   block0_consensus: bft
 initial_setting:
-  consensus: bft
   allow_account_creation: true
   slot_duration: 15
   epoch_stability_depth: 2600

--- a/tests/resources/genesis/genesis.yaml
+++ b/tests/resources/genesis/genesis.yaml
@@ -12,8 +12,8 @@ initial_setting:
     certificate: 0
   block_version: 1
   bft_leaders:
-    -  ed25519extended_public1nhnr6nfff3uhuky94evw9ejfxx9h5yhk6zk97kd5mssezlhlpryqy5xljp
-    -  ed25519extended_public1gl7rvurvvsllkmp4xmt250s6jl85e0fprw3mk4e7fwuv5kmu7vtsftgku8
+    - ed25519e_pk1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
+    - ed25519e_pk13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
 initial_funds:
   - address: ta1svaengshtf3f0mc3qrq76c7autjpyxeuyfkn9h5r0vr9qrek6e0y6zpe8ls
     value: 100


### PR DESCRIPTION
* remove non needed consensus parameter in the initial setting;
* clean up the jcli address command interfaces (use structopt procedural macro helper);
* update the doc and APIs referring to the new key prefixes