### PR TITLE
Add client side outbound subscription handles to the propagation map

### DIFF
--- a/src/network/grpc/client.rs
+++ b/src/network/grpc/client.rs
@@ -45,9 +45,9 @@ fn subscribe(
     channels: Channels,
 ) -> impl Future<Item = (), Error = ()> {
     let block_box = channels.block_box;
-    let mut sub_handles = propagate::PeerHandles::new();
-    let block_sub = client.block_subscription(sub_handles.blocks.subscribe());
-    let gossip_sub = client.gossip_subscription(sub_handles.gossip.subscribe());
+    let mut prop_handles = propagate::PeerHandles::new();
+    let block_sub = client.block_subscription(prop_handles.blocks.subscribe());
+    let gossip_sub = client.gossip_subscription(prop_handles.gossip.subscribe());
     block_sub
         .join(gossip_sub)
         .map_err(move |err| {
@@ -61,6 +61,9 @@ fn subscribe(
                 );
                 return Err(());
             }
+            global_state
+                .propagation_peers
+                .insert_peer(node_id, prop_handles);
             subscription::process_blocks(block_sub, block_box);
             subscription::process_gossip(gossip_sub, global_state);
             Ok(())

--- a/src/network/grpc/client.rs
+++ b/src/network/grpc/client.rs
@@ -61,8 +61,8 @@ fn subscribe(
                 );
                 return Err(());
             }
-            tokio::spawn(subscription::process_blocks(block_sub, block_box));
-            tokio::spawn(subscription::process_gossip(gossip_sub, global_state));
+            subscription::process_blocks(block_sub, block_box);
+            subscription::process_gossip(gossip_sub, global_state);
             Ok(())
         })
 }

--- a/src/network/grpc/client.rs
+++ b/src/network/grpc/client.rs
@@ -1,19 +1,20 @@
 use super::{
-    super::{BlockConfig, Channels, ConnectionState},
+    super::{propagate, subscription, BlockConfig, Channels, ConnectionState, GlobalStateR},
     origin_authority,
 };
-use crate::intercom::BlockMsg;
 
-use network_core::{client::block::BlockService, gossip::Node};
+use network_core::{
+    client::{block::BlockService, gossip::GossipService},
+    gossip::Node,
+};
 use network_grpc::{
     client::{Connect, Connection},
     peer as grpc_peer,
 };
 
-use futures::future;
 use futures::prelude::*;
 use http::uri;
-use tokio::executor::DefaultExecutor;
+use tokio::{executor::DefaultExecutor, net::TcpStream};
 use tower_service::Service as _;
 
 use std::net::SocketAddr;
@@ -27,7 +28,6 @@ pub fn run_connect_socket(
     info!("address: {}", addr);
     let peer = grpc_peer::TcpPeer::new(addr);
     let origin = origin_authority(addr);
-    let mut block_box = channels.block_box;
 
     Connect::new(peer, DefaultExecutor::current())
         .origin(uri::Scheme::HTTP, origin)
@@ -36,22 +36,33 @@ pub fn run_connect_socket(
         .map_err(move |err| {
             error!("Error connecting to peer {}: {:?}", addr, err);
         })
-        .and_then(move |mut client: Connection<BlockConfig, _, _>| {
-            let mut sub_handles = state.propagation.lock().unwrap();
-            client
-                .block_subscription(sub_handles.blocks.subscribe())
-                .map_err(move |err| {
-                    error!("BlockSubscription request failed: {:?}", err);
-                })
+        .and_then(move |client| subscribe(client, state.global, channels))
+}
+
+fn subscribe(
+    mut client: Connection<BlockConfig, TcpStream, DefaultExecutor>,
+    global_state: GlobalStateR,
+    channels: Channels,
+) -> impl Future<Item = (), Error = ()> {
+    let block_box = channels.block_box;
+    let mut sub_handles = propagate::PeerHandles::new();
+    let block_sub = client.block_subscription(sub_handles.blocks.subscribe());
+    let gossip_sub = client.gossip_subscription(sub_handles.gossip.subscribe());
+    block_sub
+        .join(gossip_sub)
+        .map_err(move |err| {
+            error!("Subscription request failed: {:?}", err);
         })
-        .and_then(move |(subscription, _node_id)| {
-            subscription
-                .for_each(move |header| {
-                    block_box.send(BlockMsg::AnnouncedBlock(header));
-                    future::ok(())
-                })
-                .map_err(|err| {
-                    error!("Block subscription failed: {:?}", err);
-                })
+        .and_then(move |((block_sub, node_id), (gossip_sub, node_id_1))| {
+            if node_id != node_id_1 {
+                warn!(
+                    "peer subscription IDs do not match: {} != {}",
+                    node_id, node_id_1
+                );
+                return Err(());
+            }
+            tokio::spawn(subscription::process_blocks(block_sub, block_box));
+            tokio::spawn(subscription::process_gossip(gossip_sub, global_state));
+            Ok(())
         })
 }

--- a/src/network/grpc/server.rs
+++ b/src/network/grpc/server.rs
@@ -1,4 +1,4 @@
-use super::super::{service::NodeService, Channels, GlobalState};
+use super::super::{service::NodeService, Channels, GlobalStateR};
 use crate::settings::start::network::Listen;
 
 use network_grpc::server::{self, Server};
@@ -6,11 +6,9 @@ use network_grpc::server::{self, Server};
 use tokio::executor::DefaultExecutor;
 use tokio::prelude::*;
 
-use std::sync::Arc;
-
 pub fn run_listen_socket(
     listen: Listen,
-    state: Arc<GlobalState>,
+    state: GlobalStateR,
     channels: Channels,
 ) -> impl Future<Item = (), Error = ()> {
     let sockaddr = listen.address();

--- a/src/network/propagate.rs
+++ b/src/network/propagate.rs
@@ -129,6 +129,11 @@ impl PropagationMap {
         }
     }
 
+    pub fn insert_peer(&self, id: p2p::NodeId, handles: PeerHandles) {
+        let mut map = self.mutex.lock().unwrap();
+        map.insert(id, handles);
+    }
+
     pub fn subscribe_to_blocks(&self, id: p2p::NodeId) -> Subscription<Header> {
         let mut map = self.mutex.lock().unwrap();
         let handles = ensure_propagation_peer(&mut map, id);

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1,9 +1,7 @@
-use super::{p2p_topology as p2p, propagate::Subscription, Channels, GlobalState};
+use super::{p2p_topology as p2p, propagate::Subscription, subscription, Channels, GlobalStateR};
 
 use crate::blockcfg::{Block, BlockDate, Header, HeaderHash, Message, MessageId};
-use crate::intercom::{
-    self, stream_reply, unary_reply, BlockMsg, ClientMsg, ReplyFuture, ReplyStream,
-};
+use crate::intercom::{self, stream_reply, unary_reply, ClientMsg, ReplyFuture, ReplyStream};
 
 use network_core::{
     error as core_error,
@@ -19,16 +17,14 @@ use network_core::{
 use futures::future::{self, FutureResult};
 use futures::prelude::*;
 
-use std::sync::Arc;
-
 #[derive(Clone)]
 pub struct NodeService {
     channels: Channels,
-    global_state: Arc<GlobalState>,
+    global_state: GlobalStateR,
 }
 
 impl NodeService {
-    pub fn new(channels: Channels, global_state: Arc<GlobalState>) -> Self {
+    pub fn new(channels: Channels, global_state: GlobalStateR) -> Self {
         NodeService {
             channels,
             global_state,
@@ -146,17 +142,10 @@ impl BlockService for NodeService {
     where
         In: Stream<Item = Self::Header, Error = core_error::Error> + Send + 'static,
     {
-        let mut block_box = self.channels.block_box.clone();
-        tokio::spawn(
-            inbound
-                .for_each(move |header| {
-                    block_box.send(BlockMsg::AnnouncedBlock(header));
-                    future::ok(())
-                })
-                .map_err(|err| {
-                    error!("Block subscription failed: {:?}", err);
-                }),
-        );
+        tokio::spawn(subscription::process_blocks(
+            inbound,
+            self.channels.block_box.clone(),
+        ));
 
         let subscription = self
             .global_state
@@ -212,17 +201,10 @@ impl GossipService for NodeService {
     where
         In: Stream<Item = Gossip<Self::Node>, Error = core_error::Error> + Send + 'static,
     {
-        let global_state = self.global_state.clone();
-        tokio::spawn(
-            inbound
-                .for_each(move |gossip| {
-                    global_state.topology.update(gossip.into_nodes());
-                    Ok(())
-                })
-                .map_err(|err| {
-                    error!("gossip subscription inbound stream error: {:?}", err);
-                }),
-        );
+        tokio::spawn(subscription::process_gossip(
+            inbound,
+            self.global_state.clone(),
+        ));
 
         let subscription = self
             .global_state

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -142,10 +142,7 @@ impl BlockService for NodeService {
     where
         In: Stream<Item = Self::Header, Error = core_error::Error> + Send + 'static,
     {
-        tokio::spawn(subscription::process_blocks(
-            inbound,
-            self.channels.block_box.clone(),
-        ));
+        subscription::process_blocks(inbound, self.channels.block_box.clone());
 
         let subscription = self
             .global_state
@@ -201,10 +198,7 @@ impl GossipService for NodeService {
     where
         In: Stream<Item = Gossip<Self::Node>, Error = core_error::Error> + Send + 'static,
     {
-        tokio::spawn(subscription::process_gossip(
-            inbound,
-            self.global_state.clone(),
-        ));
+        subscription::process_gossip(inbound, self.global_state.clone());
 
         let subscription = self
             .global_state

--- a/src/network/subscription.rs
+++ b/src/network/subscription.rs
@@ -5,33 +5,34 @@ use network_core::{error as core_error, gossip::Gossip};
 
 use futures::prelude::*;
 
-pub fn process_blocks<S>(
-    inbound: S,
-    mut block_box: MessageBox<BlockMsg>,
-) -> impl Future<Item = (), Error = ()>
+pub fn process_blocks<S>(inbound: S, mut block_box: MessageBox<BlockMsg>) -> tokio::executor::Spawn
 where
-    S: Stream<Item = Header, Error = core_error::Error>,
+    S: Stream<Item = Header, Error = core_error::Error> + Send + 'static,
 {
-    inbound
-        .for_each(move |header| {
-            block_box.send(BlockMsg::AnnouncedBlock(header));
-            Ok(())
-        })
-        .map_err(|err| {
-            error!("block subscription stream failure: {:?}", err);
-        })
+    tokio::spawn(
+        inbound
+            .for_each(move |header| {
+                block_box.send(BlockMsg::AnnouncedBlock(header));
+                Ok(())
+            })
+            .map_err(|err| {
+                error!("block subscription stream failure: {:?}", err);
+            }),
+    )
 }
 
-pub fn process_gossip<S>(inbound: S, state: GlobalStateR) -> impl Future<Item = (), Error = ()>
+pub fn process_gossip<S>(inbound: S, state: GlobalStateR) -> tokio::executor::Spawn
 where
-    S: Stream<Item = Gossip<Node>, Error = core_error::Error>,
+    S: Stream<Item = Gossip<Node>, Error = core_error::Error> + Send + 'static,
 {
-    inbound
-        .for_each(move |gossip| {
-            state.topology.update(gossip.into_nodes());
-            Ok(())
-        })
-        .map_err(|err| {
-            info!("gossip subscription stream failure: {:?}", err);
-        })
+    tokio::spawn(
+        inbound
+            .for_each(move |gossip| {
+                state.topology.update(gossip.into_nodes());
+                Ok(())
+            })
+            .map_err(|err| {
+                info!("gossip subscription stream failure: {:?}", err);
+            }),
+    )
 }

--- a/src/network/subscription.rs
+++ b/src/network/subscription.rs
@@ -16,7 +16,7 @@ where
                 Ok(())
             })
             .map_err(|err| {
-                error!("block subscription stream failure: {:?}", err);
+                info!("block subscription stream failure: {:?}", err);
             }),
     )
 }

--- a/src/network/subscription.rs
+++ b/src/network/subscription.rs
@@ -1,0 +1,37 @@
+use super::{p2p_topology::Node, GlobalStateR};
+use crate::{blockcfg::Header, intercom::BlockMsg, utils::async_msg::MessageBox};
+
+use network_core::{error as core_error, gossip::Gossip};
+
+use futures::prelude::*;
+
+pub fn process_blocks<S>(
+    inbound: S,
+    mut block_box: MessageBox<BlockMsg>,
+) -> impl Future<Item = (), Error = ()>
+where
+    S: Stream<Item = Header, Error = core_error::Error>,
+{
+    inbound
+        .for_each(move |header| {
+            block_box.send(BlockMsg::AnnouncedBlock(header));
+            Ok(())
+        })
+        .map_err(|err| {
+            error!("block subscription stream failure: {:?}", err);
+        })
+}
+
+pub fn process_gossip<S>(inbound: S, state: GlobalStateR) -> impl Future<Item = (), Error = ()>
+where
+    S: Stream<Item = Gossip<Node>, Error = core_error::Error>,
+{
+    inbound
+        .for_each(move |gossip| {
+            state.topology.update(gossip.into_nodes());
+            Ok(())
+        })
+        .map_err(|err| {
+            info!("gossip subscription stream failure: {:?}", err);
+        })
+}


### PR DESCRIPTION
When client-side subscriptions are established and the remote node ID is received, register the peer and its outbound propagation handles in the propagation map.