### PR TITLE
Propagate on demand

### DIFF
--- a/src/intercom.rs
+++ b/src/intercom.rs
@@ -285,7 +285,7 @@ impl Debug for BlockMsg {
 }
 
 /// Message to propagate to the connected peers.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum NetworkPropagateMsg {
     Block(Header),
     Message(Message),

--- a/src/network/grpc/client.rs
+++ b/src/network/grpc/client.rs
@@ -1,9 +1,7 @@
-use super::{
-    super::{
-        p2p_topology as p2p, propagate, subscription, BlockConfig, Channels, ConnectionState,
-        GlobalStateR,
-    },
-    origin_authority,
+use super::origin_authority;
+use crate::network::{
+    p2p_topology as p2p, propagate, subscription, BlockConfig, Channels, ConnectionState,
+    GlobalStateR,
 };
 
 use network_core::{

--- a/src/network/grpc/mod.rs
+++ b/src/network/grpc/mod.rs
@@ -14,7 +14,7 @@ use network_grpc::peer::TcpPeer;
 
 use std::net::SocketAddr;
 
-pub use self::client::run_connect_socket;
+pub use self::client::connect;
 pub use self::server::run_listen_socket;
 
 impl network_grpc::client::ProtocolConfig for BlockConfig {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -147,7 +147,10 @@ pub fn run(
     let connections = stream::iter_ok(addrs).for_each(move |addr| {
         let peer = Peer::new(addr, Protocol::Grpc);
         let conn_state = ConnectionState::new(state.clone(), &peer);
-        grpc::run_connect_socket(addr, conn_state, channels.clone())
+        let state = state.clone();
+        grpc::connect(addr, conn_state, channels.clone()).map(move |(node_id, prop_handles)| {
+            state.propagation_peers.insert_peer(node_id, prop_handles);
+        })
     });
 
     let state = global_state.clone();

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -24,6 +24,8 @@ use crate::utils::{
 use self::p2p_topology::{self as p2p, P2pTopology};
 use self::propagate::PropagationMap;
 
+use network_core::gossip::Node;
+
 use futures::prelude::*;
 use futures::stream;
 
@@ -144,34 +146,88 @@ pub fn run(
         .filter_map(|paddr| paddr.to_socketaddr())
         .collect::<Vec<_>>();
     let state = global_state.clone();
+    let conn_channels = channels.clone();
     let connections = stream::iter_ok(addrs).for_each(move |addr| {
         let peer = Peer::new(addr, Protocol::Grpc);
         let conn_state = ConnectionState::new(state.clone(), &peer);
         let state = state.clone();
-        grpc::connect(addr, conn_state, channels.clone()).map(move |(node_id, prop_handles)| {
-            state.propagation_peers.insert_peer(node_id, prop_handles);
-        })
+        grpc::connect(addr, conn_state, conn_channels.clone()).map(
+            move |(node_id, prop_handles)| {
+                state.propagation_peers.insert_peer(node_id, prop_handles);
+            },
+        )
     });
 
-    let state = global_state.clone();
-    let propagate = propagate_input
-        .for_each(move |msg| {
-            let node_ids = state.topology.view_ids();
-            match msg {
-                NetworkPropagateMsg::Block(header) => {
-                    state.propagation_peers.propagate_block(&node_ids, header);
-                }
-                NetworkPropagateMsg::Message(message) => {
-                    state
-                        .propagation_peers
-                        .propagate_message(&node_ids, message);
-                }
-            }
-            Ok(())
-        })
-        .map_err(|_| {});
+    let propagate = handle_propagation(propagate_input, channels.clone(), global_state.clone());
 
     tokio::run(connections.join(propagate).join(listener).map(|_| ()));
+}
+
+fn handle_propagation(
+    input: MessageQueue<NetworkPropagateMsg>,
+    channels: Channels,
+    state: GlobalStateR,
+) -> impl Future<Item = (), Error = ()> {
+    input
+        .for_each(move |msg| {
+            let channels = channels.clone();
+            let state = state.clone();
+            let nodes = state.topology.view().collect();
+            let res = match msg {
+                NetworkPropagateMsg::Block(ref header) => state
+                    .propagation_peers
+                    .propagate_block(nodes, header.clone()),
+                NetworkPropagateMsg::Message(ref message) => state
+                    .propagation_peers
+                    .propagate_message(nodes, message.clone()),
+            };
+            // If any nodes selected for propagation are not in the
+            // active subscriptions map, connect to them and deliver
+            // the item.
+            res.map_err(move |unreached_nodes| {
+                for (node_id, addr) in unreached_nodes
+                    .iter()
+                    .filter_map(|node| node.address().map(|addr| (node.id(), addr)))
+                {
+                    let peer = Peer::new(addr, Protocol::Grpc);
+                    let conn_state = ConnectionState::new(state.clone(), &peer);
+                    let msg = msg.clone();
+                    let state = state.clone();
+                    let cf = grpc::connect(addr, conn_state, channels.clone()).map(
+                        move |(connected_node_id, mut handles)| {
+                            if connected_node_id == node_id {
+                                let res = match msg {
+                                    NetworkPropagateMsg::Block(header) => {
+                                        handles.try_send_block(header)
+                                    }
+                                    NetworkPropagateMsg::Message(message) => {
+                                        handles.try_send_message(message)
+                                    }
+                                };
+                                match res {
+                                    Ok(()) => (),
+                                    Err(e) => {
+                                        info!("propagation to peer {} failed just after connection: {:?}", connected_node_id, e);
+                                        return;
+                                    }
+                                }
+                            } else {
+                                info!(
+                                    "peer at {} responded with different node id: {}",
+                                    addr, connected_node_id
+                                );
+                            };
+
+                            state
+                                .propagation_peers
+                                .insert_peer(connected_node_id, handles);
+                        },
+                    );
+                    tokio::spawn(cf);
+                }
+            })
+        })
+        .map_err(|_| {})
 }
 
 pub fn bootstrap(config: &Configuration, blockchain: BlockchainR) {

--- a/src/network/p2p_topology.rs
+++ b/src/network/p2p_topology.rs
@@ -168,13 +168,9 @@ impl P2pTopology {
 
     /// Returns a list of neighbors selected in this turn
     /// to contact for event dissemination.
-    pub fn view_ids(&self) -> Vec<NodeId> {
+    pub fn view(&self) -> impl Iterator<Item = Node> {
         let topology = self.lock.read().unwrap();
-        topology
-            .view()
-            .into_iter()
-            .map(|node| NodeId(*node.id()))
-            .collect()
+        topology.view().into_iter().map(Node)
     }
 
     /// this is the function to utilise when we receive a gossip in order


### PR DESCRIPTION
When there are peer nodes selected for propagation that are not currently
subscribed, connect to them, follow through with propagating the item,
and add them to the map.