### PR TITLE
Gossip about self

### DIFF
--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -155,7 +155,7 @@ pub fn run(
         let state = state.clone();
         grpc::connect(addr, conn_state, conn_channels.clone()).map(
             move |(node_id, mut prop_handles)| {
-                debug!("connected to {:?} at {}", node_id, addr);
+                debug!("connected to {} at {}", node_id, addr);
                 let gossip = Gossip::from_nodes(iter::once(state.node.clone()));
                 match prop_handles.try_send_gossip(gossip) {
                     Ok(()) => state.propagation_peers.insert_peer(node_id, prop_handles),

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -79,7 +79,8 @@ impl GlobalState {
         node.add_message_subscription(p2p_topology::InterestLevel::High);
         node.add_block_subscription(p2p_topology::InterestLevel::High);
 
-        let topology = P2pTopology::new(node.clone());
+        let mut topology = P2pTopology::new(node.clone());
+        topology.set_poldercast_modules();
 
         GlobalState {
             config,

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -30,7 +30,7 @@ use futures::prelude::*;
 use futures::stream;
 use tokio::timer::Interval;
 
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{iter, net::SocketAddr, sync::Arc, time::Duration};
 
 type Connection = SocketAddr;
 
@@ -153,8 +153,18 @@ pub fn run(
         let conn_state = ConnectionState::new(state.clone(), &peer);
         let state = state.clone();
         grpc::connect(addr, conn_state, conn_channels.clone()).map(
-            move |(node_id, prop_handles)| {
-                state.propagation_peers.insert_peer(node_id, prop_handles);
+            move |(node_id, mut prop_handles)| {
+                debug!("connected to {:?} at {}", node_id, addr);
+                let gossip = Gossip::from_nodes(iter::once(state.node.clone()));
+                match prop_handles.try_send_gossip(gossip) {
+                    Ok(()) => state.propagation_peers.insert_peer(node_id, prop_handles),
+                    Err(e) => {
+                        info!(
+                            "gossiping to peer {} failed just after connection: {:?}",
+                            node_id, e
+                        );
+                    }
+                }
             },
         )
     });

--- a/src/network/subscription.rs
+++ b/src/network/subscription.rs
@@ -28,6 +28,7 @@ where
     tokio::spawn(
         inbound
             .for_each(move |gossip| {
+                debug!("received gossip: {:?}", gossip);
                 state.topology.update(gossip.into_nodes());
                 Ok(())
             })


### PR DESCRIPTION
After connecting to trusted peers, the nodes send initial gossip about themselves.
This is needed to start gossiping among the initial peers.