### PR TITLE
Remove the links key from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ description = """
 Midgard Serpent
 """
 build = "tests/build/deploy_tests_resources.rs"
-links = "fs_extra"
 
 [dependencies]
 dirs = "1.0"


### PR DESCRIPTION
`fs_extra` is used by the build script, it's wrong to use the key meant for binding to foreign libraries.