### PR TITLE
Clean test code  removing warnings due to unused code

### DIFF
--- a/tests/common/configuration/genesis_model.rs
+++ b/tests/common/configuration/genesis_model.rs
@@ -1,4 +1,7 @@
-use common::serde_derive::{Deserialize, Serialize};
+#![allow(dead_code)]
+
+extern crate serde_derive;
+use self::serde_derive::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::vec::Vec;
 

--- a/tests/common/configuration/mod.rs
+++ b/tests/common/configuration/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use super::file_utils;
 use std::env;
 use std::path::PathBuf;
@@ -38,11 +40,12 @@ pub fn get_jcli_app() -> PathBuf {
 }
 
 /// Gets working directory
+/// Uses std::env::current_exe() for this purpose.
+/// Current exe directory is ./target/{profile}/deps/{app_name}.exe
+/// Function returns ./target/{profile}
 fn get_working_directory() -> PathBuf {
     let mut output_directory: PathBuf = std::env::current_exe().unwrap().into();
 
-    /// current exe directory is ./target/{profile}/deps/{app_name}.exe
-    /// We would like to navigate to ./target/{profile}
     output_directory.pop();
     output_directory.pop();
     output_directory

--- a/tests/common/configuration/node_config_model.rs
+++ b/tests/common/configuration/node_config_model.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 extern crate rand;
 extern crate serde_derive;
 use self::rand::Rng;

--- a/tests/common/file_assert.rs
+++ b/tests/common/file_assert.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::fs::metadata;
 use std::path::Path;
 

--- a/tests/common/file_utils.rs
+++ b/tests/common/file_utils.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 extern crate mktemp;
 
 use std::fs::File;

--- a/tests/common/jcli_wrapper/jcli_commands.rs
+++ b/tests/common/jcli_wrapper/jcli_commands.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use super::configuration;
 use super::file_utils;
 use std::path::PathBuf;
@@ -41,7 +43,8 @@ pub fn get_genesis_hash_command(path_to_output_block: &PathBuf) -> Command {
     command
 }
 
-/// Get rest stat command. Uses [default host and port](super::test_const::JORMUNGANDR_ADDRESS)
+
+/// Get rest stats command.
 pub fn get_rest_stats_command(host: &str) -> Command {
     let mut command = Command::new(configuration::get_jcli_app().as_os_str());
     command
@@ -55,7 +58,7 @@ pub fn get_rest_stats_command(host: &str) -> Command {
     command
 }
 
-/// Get utxo get command. Uses [default host and port](super::test_const::JORMUNGANDR_ADDRESS)
+/// Get utxo get command.
 pub fn get_rest_utxo_get_command(host: &str) -> Command {
     let mut command = Command::new(configuration::get_jcli_app().as_os_str());
     command
@@ -133,7 +136,7 @@ pub fn get_post_transaction_command(transaction_hash: &str, host: &str) -> Comma
 /// Get key generate command
 pub fn get_key_generate_command_default() -> Command {
     let deafult_extended_key_type = "Ed25519Extended";
-    let mut command = get_key_generate_command(&deafult_extended_key_type);
+    let command = get_key_generate_command(&deafult_extended_key_type);
     command
 }
 

--- a/tests/common/jcli_wrapper/jcli_commands.rs
+++ b/tests/common/jcli_wrapper/jcli_commands.rs
@@ -43,7 +43,6 @@ pub fn get_genesis_hash_command(path_to_output_block: &PathBuf) -> Command {
     command
 }
 
-
 /// Get rest stats command.
 pub fn get_rest_stats_command(host: &str) -> Command {
     let mut command = Command::new(configuration::get_jcli_app().as_os_str());

--- a/tests/common/jcli_wrapper/jcli_transaction_wrapper.rs
+++ b/tests/common/jcli_wrapper/jcli_transaction_wrapper.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use super::configuration;
 use super::file_utils;
 use super::process_assert;

--- a/tests/common/jcli_wrapper/mod.rs
+++ b/tests/common/jcli_wrapper/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub mod jcli_commands;
 pub mod jcli_transaction_wrapper;
 pub mod utxo;
@@ -10,7 +12,6 @@ use super::process_utils;
 use super::process_utils::output_extensions::ProcessOutput;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::process::Command;
 
 pub fn assert_genesis_encode(
     genesis_yaml_file_path: &PathBuf,

--- a/tests/common/jormungandr_wrapper.rs
+++ b/tests/common/jormungandr_wrapper.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::path::PathBuf;
 use std::process::Command;
 

--- a/tests/common/process_assert.rs
+++ b/tests/common/process_assert.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 extern crate regex;
 
 use self::regex::Regex;
@@ -61,7 +63,7 @@ pub fn assert_process_exited_successfully(output: Output) {
     );
 }
 
-pub fn assert_process_failed_and_contains_message(mut command: Command, expected_part: &str) {
+pub fn assert_process_failed_and_contains_message(command: Command, expected_part: &str) {
     let output = process_utils::run_process_and_get_output(command);
     let actual = output.err_as_single_line();
 

--- a/tests/common/process_utils/mod.rs
+++ b/tests/common/process_utils/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 extern crate serde_yaml;
 
 pub mod output_extensions;

--- a/tests/common/process_utils/process_guard.rs
+++ b/tests/common/process_utils/process_guard.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::process::Child;
 
 /// Struct ensures child process is killed if leaves given scope

--- a/tests/common/startup/mod.rs
+++ b/tests/common/startup/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::path::PathBuf;
 
 use super::configuration::genesis_model::GenesisYaml;

--- a/tests/jcli_address_test.rs
+++ b/tests/jcli_address_test.rs
@@ -1,14 +1,7 @@
 mod common;
 
-extern crate bytes;
-use bytes::Bytes;
-use common::configuration::genesis_model::GenesisYaml;
-use common::file_utils;
 use common::jcli_wrapper;
 use common::process_assert;
-use common::process_utils;
-use common::process_utils::output_extensions::ProcessOutput;
-use common::startup;
 
 #[test]
 #[cfg(feature = "integration-test")]
@@ -19,8 +12,8 @@ pub fn test_utxo_address_made_of_ed25519_extended_key() {
     let public_key = jcli_wrapper::assert_key_to_public_default(&private_key);
     println!("public key: {}", &public_key);
 
-    let utxoAddress = jcli_wrapper::assert_address_single_default(&public_key);
-    assert_ne!(utxoAddress, "", "generated utxo address is empty");
+    let utxo_address = jcli_wrapper::assert_address_single_default(&public_key);
+    assert_ne!(utxo_address, "", "generated utxo address is empty");
 }
 
 #[test]
@@ -32,8 +25,8 @@ pub fn test_account_address_made_of_ed25519_extended_key() {
     let public_key = jcli_wrapper::assert_key_to_public_default(&private_key);
     println!("public key: {}", &public_key);
 
-    let accountAddress = jcli_wrapper::assert_address_account_default(&public_key);
-    assert_ne!(accountAddress, "", "generated account address is empty");
+    let account_address = jcli_wrapper::assert_address_account_default(&public_key);
+    assert_ne!(account_address, "", "generated account address is empty");
 }
 
 #[test]
@@ -52,10 +45,10 @@ pub fn test_delegation_address_made_of_ed25519_extended_seed_key() {
     let delegation_key = jcli_wrapper::assert_key_to_public_default(&private_key);
     println!("delegation key: {}", &delegation_key);
 
-    let delegationAddress =
+    let delegation_address =
         jcli_wrapper::assert_address_delegation_default(&public_key, &delegation_key);
     assert_ne!(
-        delegationAddress, "",
+        delegation_address, "",
         "generated delegation adress is empty"
     );
 }
@@ -71,10 +64,10 @@ pub fn test_delegation_address_is_the_same_as_public() {
     let public_key = jcli_wrapper::assert_key_to_public_default(&private_key);
     println!("public key: {}", &public_key);
 
-    let delegationAddress =
+    let delegation_address =
         jcli_wrapper::assert_address_delegation_default(&public_key, &public_key);
     assert_ne!(
-        delegationAddress, "",
+        delegation_address, "",
         "generated delegation adress is empty"
     );
 }

--- a/tests/jcli_key_tests.rs
+++ b/tests/jcli_key_tests.rs
@@ -1,14 +1,9 @@
 mod common;
 
 extern crate bytes;
-use bytes::Bytes;
-use common::configuration::genesis_model::GenesisYaml;
 use common::file_utils;
 use common::jcli_wrapper;
 use common::process_assert;
-use common::process_utils;
-use common::process_utils::output_extensions::ProcessOutput;
-use common::startup;
 
 #[test]
 #[cfg(feature = "integration-test")]


### PR DESCRIPTION
There is an issue in cargo which incorrectly warns about dead code:

https://github.com/rust-lang/rust/issues/46379

This pr contains fix + some minor warning clean ups