### PR TITLE
Sync with the rust-cardano unify-proposals-and-initial-config branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix_derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -62,7 +62,7 @@ dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-net 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -87,7 +87,7 @@ dependencies = [
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -111,9 +111,9 @@ name = "actix_derive"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -254,12 +254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -344,8 +344,8 @@ dependencies = [
  "cbor_event 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-core 0.1.0",
  "cryptoxide 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -399,7 +399,7 @@ dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-bip32 0.1.0",
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -416,6 +416,7 @@ dependencies = [
  "chain-core 0.1.0",
  "chain-crypto 0.1.0",
  "chain-storage 0.1.0",
+ "chain-time 0.1.0",
  "custom_error 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "imhamt 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -445,6 +446,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "chain-time"
+version = "0.1.0"
+
+[[package]]
 name = "chrono"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,7 +476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -492,7 +497,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -528,8 +533,8 @@ dependencies = [
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -626,7 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "curve25519-dalek"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -786,7 +791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -804,9 +809,9 @@ name = "failure_derive"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -871,7 +876,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -983,12 +988,21 @@ dependencies = [
 [[package]]
 name = "http-body"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http#9a3b77d07fdbd355bfe9f89157886d39f2e13a05"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http-connection"
+version = "0.1.0"
+source = "git+https://github.com/hyperium/http-connection#351d472c1b4722accf5e103862d382d79eb33242"
+dependencies = [
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1099,7 +1113,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1172,8 +1186,8 @@ dependencies = [
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1196,7 +1210,7 @@ dependencies = [
  "chain-crypto 0.1.0",
  "chain-impl-mockchain 0.1.0",
  "custom_error 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1409,9 +1423,9 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1449,8 +1463,8 @@ dependencies = [
  "network-core 0.1.0-dev",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=b67569b5aace78595b2813b25ab7feacc28311b7)",
- "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=b67569b5aace78595b2813b25ab7feacc28311b7)",
+ "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=62be26fd6cd6757d1ea0a2edc48d93c0937b36d5)",
+ "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=62be26fd6cd6757d1ea0a2edc48d93c0937b36d5)",
  "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
  "tower-request-modifier 0.1.0 (git+https://github.com/tower-rs/tower-http)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1481,9 +1495,9 @@ name = "num-derive"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1519,15 +1533,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
-version = "0.10.21"
+version = "0.10.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1537,7 +1551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.45"
+version = "0.9.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1637,7 +1651,7 @@ dependencies = [
  "multiaddr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1668,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1708,9 +1722,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1755,7 +1769,7 @@ name = "quote"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1964,7 +1978,7 @@ dependencies = [
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1991,7 +2005,7 @@ name = "rusqlite"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsqlite3-sys 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2084,20 +2098,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2107,7 +2121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2117,7 +2131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2128,7 +2142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2213,7 +2227,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2237,7 +2251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "socket2"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2289,9 +2303,9 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2305,9 +2319,9 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2317,10 +2331,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.33"
+version = "0.15.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2330,9 +2344,9 @@ name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2646,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "tower"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#4d6d2c8572cc6012872743603f57a187ac229b5d"
+source = "git+https://github.com/tower-rs/tower#9b27863a6160e2146bcf1bc6548a0334e7ad1fb8"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-buffer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2684,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc?rev=b67569b5aace78595b2813b25ab7feacc28311b7#b67569b5aace78595b2813b25ab7feacc28311b7"
+source = "git+https://github.com/tower-rs/tower-grpc?rev=62be26fd6cd6757d1ea0a2edc48d93c0937b36d5#62be26fd6cd6757d1ea0a2edc48d93c0937b36d5"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2702,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc?rev=b67569b5aace78595b2813b25ab7feacc28311b7#b67569b5aace78595b2813b25ab7feacc28311b7"
+source = "git+https://github.com/tower-rs/tower-grpc?rev=62be26fd6cd6757d1ea0a2edc48d93c0937b36d5#62be26fd6cd6757d1ea0a2edc48d93c0937b36d5"
 dependencies = [
  "codegen 0.1.1 (git+https://github.com/carllerche/codegen)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2712,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "tower-h2"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2#a3c958a243ef3d837933b31bf186ba0e6b0e60c9"
+source = "git+https://github.com/tower-rs/tower-h2#0865040d699697bbaf1c3b77b3f256b72f98cdf4"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2729,21 +2743,23 @@ dependencies = [
 [[package]]
 name = "tower-http"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http#9a3b77d07fdbd355bfe9f89157886d39f2e13a05"
+source = "git+https://github.com/tower-rs/tower-http#044e0ed5ae8b2e9946233b7cc8fc24471b2d126a"
 dependencies = [
- "http-body 0.1.0 (git+https://github.com/tower-rs/tower-http)",
+ "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-http-util 0.1.0 (git+https://github.com/tower-rs/tower-http)",
 ]
 
 [[package]]
 name = "tower-http-util"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http#9a3b77d07fdbd355bfe9f89157886d39f2e13a05"
+source = "git+https://github.com/tower-rs/tower-http#044e0ed5ae8b2e9946233b7cc8fc24471b2d126a"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "http-body 0.1.0 (git+https://github.com/tower-rs/tower-http)",
+ "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http-connection 0.1.0 (git+https://github.com/hyperium/http-connection)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2781,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "tower-request-modifier"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http#9a3b77d07fdbd355bfe9f89157886d39f2e13a05"
+source = "git+https://github.com/tower-rs/tower-http#044e0ed5ae8b2e9946233b7cc8fc24471b2d126a"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2855,7 +2871,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2878,7 +2894,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3015,9 +3031,9 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3171,7 +3187,7 @@ dependencies = [
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
 "checksum bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "959c8e54c1ad412ffeeb95f05a9cade02d2d40a7b3c2f852d3353148f4beff35"
-"checksum bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd1fa8ad26490b0a5cfec99089952250301b6716cdeaa7c9ab229598fb82ab66"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -3205,7 +3221,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum cryptoxide 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a5bf34813e0d7d5516c5f4bc0782f246f2398927c8bc82191a6ac580de6305e"
-"checksum curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1f8a6fc0376eb52dc18af94915cc04dfdf8353746c0e8c550ae683a0815e5c1"
+"checksum curve25519-dalek 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "750226d75fc2f5a8daec6e7477624e258674023eb73d8d647f63b943ca182a4a"
 "checksum custom_error 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c189751d60563837f66c7ebf87f6a6e4c101e937d54521e88620e89c79b8a2ad"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
@@ -3249,7 +3265,8 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
-"checksum http-body 0.1.0 (git+https://github.com/tower-rs/tower-http)" = "<none>"
+"checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
+"checksum http-connection 0.1.0 (git+https://github.com/hyperium/http-connection)" = "<none>"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.28 (registry+https://github.com/rust-lang/crates.io-index)" = "e8e4606fed1c162e3a63d408c07584429f49a4f34c7176cb6cbee60e78f2372c"
@@ -3299,9 +3316,9 @@ dependencies = [
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
-"checksum openssl 0.10.21 (registry+https://github.com/rust-lang/crates.io-index)" = "615b325b964d8fb0533e7fad5867f63677bbc79a274c9cd7a19443e1a6fcdd9e"
+"checksum openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)" = "a51f452b82d622fc8dd973d7266e9055ac64af25b957d9ced3989142dc61cb6b"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-"checksum openssl-sys 0.9.45 (registry+https://github.com/rust-lang/crates.io-index)" = "ce906a1d521507a94645974fc9ab0fb70ceeb789f7240b85617ca3d8d2cd2f46"
+"checksum openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)" = "05636e06b4f8762d4b81d24a351f3966f38bd25ccbcfd235606c91fdb82cc60f"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
@@ -3316,7 +3333,7 @@ dependencies = [
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
 "checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
-"checksum proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)" = "64c827cea7a7ab30ce4593e5e04d7a11617ad6ece2fa230605a78b00ff965316"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
 "checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
 "checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
@@ -3360,8 +3377,8 @@ dependencies = [
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
-"checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
+"checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
+"checksum serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "101b495b109a3e3ca8c4cbe44cf62391527cdfb6ba15821c5ce80bcd5ea23f9f"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "38b08a9a90e5260fe01c6480ec7c811606df6d3a660415808c3c3fa8ed95b582"
@@ -3378,7 +3395,7 @@ dependencies = [
 "checksum slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 "checksum slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5951a808c40f419922ee014c15b6ae1cd34d963538b57d8a4778b9ca3fff1e0b"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
-"checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
+"checksum socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4e626972d3593207547f14bf5fc9efa4d0e7283deb73fef1dff313dae9ab8878"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strfmt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b278b244ef7aa5852b277f52dd0c6cac3a109919e1f6d699adde63251227a30f"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
@@ -3388,7 +3405,7 @@ dependencies = [
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01dca13cf6c3b179864ab3292bd794e757618d35a7766b7c46050c614ba00829"
-"checksum syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)" = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836"
+"checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
@@ -3420,8 +3437,8 @@ dependencies = [
 "checksum tower 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-buffer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c98a7784e6c8ba106bc98d44ed1dbb9c018a8e0322e5e894d365f9020967128"
 "checksum tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
-"checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=b67569b5aace78595b2813b25ab7feacc28311b7)" = "<none>"
-"checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=b67569b5aace78595b2813b25ab7feacc28311b7)" = "<none>"
+"checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=62be26fd6cd6757d1ea0a2edc48d93c0937b36d5)" = "<none>"
+"checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=62be26fd6cd6757d1ea0a2edc48d93c0937b36d5)" = "<none>"
 "checksum tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)" = "<none>"
 "checksum tower-http 0.1.0 (git+https://github.com/tower-rs/tower-http)" = "<none>"
 "checksum tower-http-util 0.1.0 (git+https://github.com/tower-rs/tower-http)" = "<none>"

--- a/doc/advanced/01_the_genesis_block.md
+++ b/doc/advanced/01_the_genesis_block.md
@@ -40,7 +40,7 @@ There are multiple _parts_ in the genesis file:
 | `epoch_stability_depth` | number | allowed size of a fork (in number of block) |
 | `consensus_leader_ids` | array | the list of the BFT leader at the beginning of the blockchain |
 | `max_number_of_transactions_per_block` | number | the maximum number of transactions allowed in a block |
-| `bootstrap_key_slots_percentage` | number | placeholder, do not use |
+| `bft_slots_ratio` | number | placeholder, do not use |
 | `allow_account_creation` | boolean | allow creating accounts without publishing certificate |
 | `linear_fee` | object | linear fee settings, set the fee for transaction and certificate publishing |
 

--- a/doc/advanced/01_the_genesis_block.md
+++ b/doc/advanced/01_the_genesis_block.md
@@ -22,13 +22,12 @@ For example your genesis file may look like:
 
 There are multiple _parts_ in the genesis file:
 
-* `blockchain_configuration`: this is the static setting of the blockchain
-  the data the cannot change, ever.
-* `initial_setting`: this is a list of settings that can be change later
-  utilising the update protocol.
+* `blockchain_configuration`: this is a list of configuration
+  parameters of the blockchain, some of which can be changed later
+  via the update protocol;
 * `initial_utxos`: the list of initial utxos (addresses and credited value);
 * `legacy_utxos`: the list of legacy cardano utxos (base58 encoded addresses
-  and credited values);
+  and credited values).
 
 ### `blockchain_configuration` options
 
@@ -40,11 +39,6 @@ There are multiple _parts_ in the genesis file:
 | `slot_duration` | number | the number of seconds between the creation of 2 blocks |
 | `epoch_stability_depth` | number | allowed size of a fork (in number of block) |
 | `consensus_leader_ids` | array | the list of the BFT leader at the beginning of the blockchain |
-
-### initial settings
-
-| option | format | description |
-|:-------|:-------|:------------|
 | `max_number_of_transactions_per_block` | number | the maximum number of transactions allowed in a block |
 | `bootstrap_key_slots_percentage` | number | placeholder, do not use |
 | `allow_account_creation` | boolean | allow creating accounts without publishing certificate |

--- a/doc/advanced/02_starting_bft_blockchain.md
+++ b/doc/advanced/02_starting_bft_blockchain.md
@@ -33,7 +33,6 @@ blockchain_configuration:
   consensus_leader_ids:
     - ed25519e_pk1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
     - ed25519e_pk13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
-initial_setting:
   allow_account_creation: true
   linear_fees:
     constant: 0

--- a/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
+++ b/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
@@ -45,7 +45,7 @@ blockchain_configuration:
 
 # The Initial settings defines the settings than may change during
 # the life time of the blockchain.
-initial_setting:
+blockchain_configuration:
 
   # This is hte max number of messages allowed in a given Block
   max_number_of_transactions_per_block: 255

--- a/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
+++ b/src/bin/jcli_app/block/genesis/DOCUMENTED_EXAMPLE.yaml
@@ -1,6 +1,4 @@
-# The Blockchain Configuration defines the different settings
-# of the blockchain that cannot be changed once the blockchain
-# is started.
+# The Blockchain Configuration defines the settings of the blockchain.
 blockchain_configuration:
 
   # The block0-date defines the date the blockchain starts
@@ -36,23 +34,13 @@ blockchain_configuration:
     - ed25519e_pk1hj8k4jyhsrva7ndynak25jagf3qcj4usnp54gnzvrejnwrufxpgqytzy6u
 
   # Genesis praos parameter D
-  consensus_genesis_praos_param_d: 0.220
+  bft_slots_ratio: 0.220
 
   # Genesis praos parameter F
   consensus_genesis_praos_param_f: 0.220
 
-
-
-# The Initial settings defines the settings than may change during
-# the life time of the blockchain.
-blockchain_configuration:
-
   # This is hte max number of messages allowed in a given Block
   max_number_of_transactions_per_block: 255
-
-  # This is the `d` parameter when running in BFT/genesis praos
-  # compatibility mode
-  bootstrap_key_slots_percentage: ~
 
   # Allow the creation of accounts from the output of a transaction
   #

--- a/src/bin/jcli_app/block/genesis/yaml.rs
+++ b/src/bin/jcli_app/block/genesis/yaml.rs
@@ -47,10 +47,9 @@ struct BlockchainConfiguration {
     epoch_stability_depth: Option<u32>,
     #[serde(default)]
     consensus_leader_ids: Vec<SerdeLeaderId>,
-    consensus_genesis_praos_param_d: Option<SerdeAsString<Milli>>,
     consensus_genesis_praos_param_f: Option<SerdeAsString<Milli>>,
     max_number_of_transactions_per_block: Option<u32>,
-    bootstrap_key_slots_percentage: Option<u8>,
+    bft_slots_ratio: Option<SerdeAsString<Milli>>,
     allow_account_creation: Option<bool>,
     linear_fee: Option<InitialLinearFee>,
 }
@@ -267,10 +266,9 @@ impl BlockchainConfiguration {
         let mut slot_duration = None;
         let mut epoch_stability_depth = None;
         let mut consensus_leader_ids = vec![];
-        let mut consensus_genesis_praos_param_d = None;
         let mut consensus_genesis_praos_param_f = None;
         let mut max_number_of_transactions_per_block = None;
-        let mut bootstrap_key_slots_percentage = None;
+        let mut bft_slots_ratio = None;
         let mut allow_account_creation = None;
         let mut linear_fee = None;
 
@@ -301,9 +299,6 @@ impl BlockchainConfiguration {
                 ConfigParam::RemoveBftLeader(_) => {
                     panic!("block 0 attempts to remove a BFT leader")
                 }
-                ConfigParam::ConsensusGenesisPraosParamD(param) => consensus_genesis_praos_param_d
-                    .replace(SerdeAsString(*param))
-                    .map(|_| "ConsensusGenesisPraosParamD"),
                 ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(param) => {
                     consensus_genesis_praos_param_f
                         .replace(SerdeAsString(*param))
@@ -314,9 +309,9 @@ impl BlockchainConfiguration {
                         .replace(*param)
                         .map(|_| "MaxNumberOfTransactionsPerBlock")
                 }
-                ConfigParam::BootstrapKeySlotsPercentage(param) => bootstrap_key_slots_percentage
-                    .replace(*param)
-                    .map(|_| "BootstrapKeySlotsPercentage"),
+                ConfigParam::BftSlotsRatio(param) => bft_slots_ratio
+                    .replace(SerdeAsString(*param))
+                    .map(|_| "BftSlotsRatio"),
                 ConfigParam::AllowAccountCreation(param) => allow_account_creation
                     .replace(*param)
                     .map(|_| "AllowAccountCreation"),
@@ -341,10 +336,9 @@ impl BlockchainConfiguration {
             slot_duration: slot_duration.expect(&format!("{} SlotDuration", PREFIX)),
             epoch_stability_depth,
             consensus_leader_ids,
-            consensus_genesis_praos_param_d,
             consensus_genesis_praos_param_f,
             max_number_of_transactions_per_block,
-            bootstrap_key_slots_percentage,
+            bft_slots_ratio,
             allow_account_creation,
             linear_fee,
         }
@@ -360,10 +354,9 @@ impl BlockchainConfiguration {
             slot_duration,
             epoch_stability_depth,
             consensus_leader_ids,
-            consensus_genesis_praos_param_d,
             consensus_genesis_praos_param_f,
             max_number_of_transactions_per_block,
-            bootstrap_key_slots_percentage,
+            bft_slots_ratio,
             allow_account_creation,
             linear_fee,
         } = self;
@@ -386,11 +379,6 @@ impl BlockchainConfiguration {
         for leader_id in consensus_leader_ids {
             initial_ents.push(ConfigParam::AddBftLeader(leader_id.0))
         }
-        if let Some(consensus_genesis_praos_param_d) = consensus_genesis_praos_param_d {
-            initial_ents.push(ConfigParam::ConsensusGenesisPraosParamD(
-                consensus_genesis_praos_param_d.0,
-            ))
-        }
         if let Some(consensus_genesis_praos_param_f) = consensus_genesis_praos_param_f {
             initial_ents.push(ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(
                 consensus_genesis_praos_param_f.0,
@@ -399,8 +387,8 @@ impl BlockchainConfiguration {
         if let Some(d) = max_number_of_transactions_per_block {
             initial_ents.push(ConfigParam::MaxNumberOfTransactionsPerBlock(d))
         }
-        if let Some(d) = bootstrap_key_slots_percentage {
-            initial_ents.push(ConfigParam::BootstrapKeySlotsPercentage(d))
+        if let Some(d) = bft_slots_ratio {
+            initial_ents.push(ConfigParam::BftSlotsRatio(d.0))
         }
         if let Some(d) = allow_account_creation {
             initial_ents.push(ConfigParam::AllowAccountCreation(d))
@@ -449,10 +437,9 @@ blockchain_configuration:
   consensus_leader_ids:
     - ed25519e_pk1hj8k4jyhsrva7ndynak25jagf3qcj4usnp54gnzvrejnwrufxpgqytzy6u
     - ed25519e_pk173x5f5xhg66x9yl4x50wnqg9mfwmmt4fma0styptcq4fuyvg3p7q9zxvy7
-  consensus_genesis_praos_param_d: "0.222"
   consensus_genesis_praos_param_f: "0.444"
   max_number_of_transactions_per_block: 255
-  bootstrap_key_slots_percentage: 4
+  bft_slots_ratio: "0.222"
   allow_account_creation: true
   linear_fee:
     coefficient: 1

--- a/src/blockcfg/mod.rs
+++ b/src/blockcfg/mod.rs
@@ -9,7 +9,7 @@ pub use chain_impl_mockchain::{
     config::{self, Block0Date, ConfigParam},
     leadership::{BftLeader, GenesisLeader, Leader, LeaderOutput, Leadership},
     ledger::{Ledger, LedgerParameters, LedgerStaticParameters},
-    message::{InitialEnts, Message, MessageId},
+    message::{ConfigParams, Message, MessageId},
     multiverse::Multiverse,
 };
 use std::time::{Duration, SystemTime};
@@ -28,7 +28,7 @@ custom_error! {pub Block0Malformed
 
 pub trait Block0DataSource {
     fn slot_duration(&self) -> Result<Duration, Block0Error>;
-    fn slots_per_epoch(&self) -> Result<Option<u64>, Block0Error>;
+    fn slots_per_epoch(&self) -> Result<Option<u32>, Block0Error>;
     fn start_time(&self) -> Result<SystemTime, Block0Error>;
 }
 
@@ -42,7 +42,7 @@ impl Block0DataSource for Block {
         Err(Block0Malformed::NoSlotDuration.into())
     }
 
-    fn slots_per_epoch(&self) -> Result<Option<u64>, Block0Error> {
+    fn slots_per_epoch(&self) -> Result<Option<u32>, Block0Error> {
         for config in initial(self)?.iter() {
             if let ConfigParam::SlotsPerEpoch(slots) = config {
                 return Ok(Some(*slots));
@@ -61,7 +61,7 @@ impl Block0DataSource for Block {
     }
 }
 
-fn initial(block: &Block) -> Result<&InitialEnts, Block0Malformed> {
+fn initial(block: &Block) -> Result<&ConfigParams, Block0Malformed> {
     for message in block.messages() {
         if let Message::Initial(init) = message {
             return Ok(init);

--- a/src/blockcfg/mod.rs
+++ b/src/blockcfg/mod.rs
@@ -24,11 +24,12 @@ custom_error! {pub Block0Malformed
     NoStartTime = "missing `block0-start' value in the block0",
     NoDiscrimination = "missing `discrimination' value in the block0",
     NoSlotDuration = "missing `slot_duration' value in the block0",
+    NoSlotsPerEpoch = "missing `slots_per_epoch' value in the block0",
 }
 
 pub trait Block0DataSource {
     fn slot_duration(&self) -> Result<Duration, Block0Error>;
-    fn slots_per_epoch(&self) -> Result<Option<u32>, Block0Error>;
+    fn slots_per_epoch(&self) -> Result<u32, Block0Error>;
     fn start_time(&self) -> Result<SystemTime, Block0Error>;
 }
 
@@ -42,13 +43,13 @@ impl Block0DataSource for Block {
         Err(Block0Malformed::NoSlotDuration.into())
     }
 
-    fn slots_per_epoch(&self) -> Result<Option<u32>, Block0Error> {
+    fn slots_per_epoch(&self) -> Result<u32, Block0Error> {
         for config in initial(self)?.iter() {
             if let ConfigParam::SlotsPerEpoch(slots) = config {
-                return Ok(Some(*slots));
+                return Ok(*slots);
             }
         }
-        Ok(None)
+        Err(Block0Malformed::NoSlotsPerEpoch.into())
     }
 
     fn start_time(&self) -> Result<SystemTime, Block0Error> {

--- a/src/clock/configuration.rs
+++ b/src/clock/configuration.rs
@@ -14,7 +14,7 @@ impl Epoch {
 #[derive(Clone)]
 pub struct ClockEpochConfiguration {
     pub slot_duration: Duration,
-    pub slots_per_epoch: u64,
+    pub slots_per_epoch: u32,
 }
 
 impl ClockEpochConfiguration {

--- a/src/start_up/mod.rs
+++ b/src/start_up/mod.rs
@@ -102,7 +102,7 @@ pub fn prepare_clock(block0: &Block) -> Result<Clock, Error> {
 
     let initial_epoch = ClockEpochConfiguration {
         slot_duration,
-        slots_per_epoch: slots_per_epoch.unwrap_or(100), // FIXME
+        slots_per_epoch,
     };
 
     info!(

--- a/src/start_up/mod.rs
+++ b/src/start_up/mod.rs
@@ -102,7 +102,7 @@ pub fn prepare_clock(block0: &Block) -> Result<Clock, Error> {
 
     let initial_epoch = ClockEpochConfiguration {
         slot_duration,
-        slots_per_epoch: slots_per_epoch.unwrap_or(10 * 10),
+        slots_per_epoch: slots_per_epoch.unwrap_or(100), // FIXME
     };
 
     info!(

--- a/tests/common/configuration/genesis_model.rs
+++ b/tests/common/configuration/genesis_model.rs
@@ -15,7 +15,7 @@ pub struct BlockchainConfig {
     pub slot_duration: i32,
     pub epoch_stability_depth: i32,
     pub consensus_leader_ids: Vec<String>,
-    pub consensus_genesis_praos_param_d: Option<String>,
+    pub bft_slots_ratio: Option<String>,
     pub consensus_genesis_praos_param_f: Option<String>,
     pub allow_account_creation: bool,
     pub linear_fees: LinearFees,
@@ -95,7 +95,7 @@ impl GenesisYaml {
                         "ed25519e_pk1xuqdxht6f0kkh0lf3ck3gfyvnpk33s09du92w6740mfmxl6hsfpsp8grmk",
                     ),
                 ],
-                consensus_genesis_praos_param_d: Some("0.222".to_owned()),
+                bft_slots_ratio: Some("0.222".to_owned()),
                 consensus_genesis_praos_param_f: Some("0.444".to_owned()),
                 allow_account_creation: true,
                 linear_fees: LinearFees {

--- a/tests/common/configuration/genesis_model.rs
+++ b/tests/common/configuration/genesis_model.rs
@@ -13,6 +13,7 @@ pub struct BlockchainConfig {
     pub discrimination: String,
     pub block0_consensus: String,
     pub slot_duration: i32,
+    pub slots_per_epoch: u32,
     pub epoch_stability_depth: i32,
     pub consensus_leader_ids: Vec<String>,
     pub bft_slots_ratio: Option<String>,
@@ -86,6 +87,7 @@ impl GenesisYaml {
                 discrimination: String::from("test"),
                 block0_consensus: String::from("bft"),
                 slot_duration: 15,
+                slots_per_epoch: 100,
                 epoch_stability_depth: 2600,
                 consensus_leader_ids: vec![
                     String::from(

--- a/tests/common/configuration/genesis_model.rs
+++ b/tests/common/configuration/genesis_model.rs
@@ -17,10 +17,6 @@ pub struct BlockchainConfig {
     pub consensus_leader_ids: Vec<String>,
     pub consensus_genesis_praos_param_d: Option<String>,
     pub consensus_genesis_praos_param_f: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct InitialSetting {
     pub allow_account_creation: bool,
     pub linear_fees: LinearFees,
 }
@@ -41,7 +37,6 @@ pub struct Fund {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GenesisYaml {
     pub blockchain_configuration: BlockchainConfig,
-    pub initial_setting: InitialSetting,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_funds: Option<Vec<Fund>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -102,8 +97,6 @@ impl GenesisYaml {
                 ],
                 consensus_genesis_praos_param_d: Some("0.222".to_owned()),
                 consensus_genesis_praos_param_f: Some("0.444".to_owned()),
-            },
-            initial_setting: InitialSetting {
                 allow_account_creation: true,
                 linear_fees: LinearFees {
                     constant: 0,

--- a/tests/jcli_rest_test.rs
+++ b/tests/jcli_rest_test.rs
@@ -95,7 +95,7 @@ pub fn test_correct_error_is_returned_for_incorrect_block_id() {
             &jormungandr_rest_address,
         ),
         "Status(400)",
-        "This assertion is incorrect on purpose to aviod failing build when running test,
+        "This assertion is incorrect on purpose to avoid failing build when running test,
         after #298 is fixed it need to be changed to correct one",
     );
 }
@@ -117,7 +117,7 @@ pub fn test_correct_error_is_returned_for_incorrect_block_id_in_next_block_id_re
             &jormungandr_rest_address,
         ),
         "Status(400)",
-        "This assertion is incorrect on purpose to aviod failing build when running test,
+        "This assertion is incorrect on purpose to avoid failing build when running test,
         after #298 is fixed it need to be changed to correct one",
     );
 }
@@ -156,7 +156,7 @@ pub fn test_correct_error_is_returned_for_incorrect_host_address() {
     process_assert::assert_process_failed_and_matches_message_with_desc(
         jcli_wrapper::jcli_commands::get_rest_block_tip_command(&incorrect_host),
         "thread 'main' panicked at",
-        "This assertion is incorrect on purpose to aviod failing build when running test,
+        "This assertion is incorrect on purpose to avoid failing build when running test,
         after #298 is fixed it need to be changed to correct one",
     );
 }
@@ -172,7 +172,7 @@ pub fn test_correct_error_is_returned_for_incorrect_path() {
     process_assert::assert_process_failed_and_matches_message_with_desc(
         jcli_wrapper::jcli_commands::get_rest_block_tip_command(&incorrect_host),
         "thread 'main' panicked at",
-        "This assertion is incorrect on purpose to aviod failing build when running test,
+        "This assertion is incorrect on purpose to avoid failing build when running test,
         after #298 is fixed it need to be changed to correct one",
     );
 }


### PR DESCRIPTION
This means block 0 no longer contains a (malformed) `UpdateProposal` message, only an `Initial` message containing configuration parameters.

This also means that `initial_setting` in the YAML genesis configuration file is gone - all settings are now part of `blockchain_configuration`. (Originally the former was supposed to be the immutable parameters, but it was questionable whether some of them are really immutable, e.g. slot duration, BFT leaders,  consensus version etc.)

(This PR depends on https://github.com/input-output-hk/rust-cardano/pull/669.)