### PR TITLE
Fixed git submodule init missing instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to utilise the most recent stable version of the rust compiler.
 1. [install rustup](https://www.rust-lang.org/tools/install)
 2. run `rustup install stable`
 3. run `rustup default stable`
-4. make sure you have cloned the submodule too: `git submodule init; git submodule update`
+4. make sure you have cloned the submodule too: `git submodule update --init --recursive`
 5. install: `cargo install`
 
 Note:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to utilise the most recent stable version of the rust compiler.
 1. [install rustup](https://www.rust-lang.org/tools/install)
 2. run `rustup install stable`
 3. run `rustup default stable`
-4. make sure you have cloned the submodule too: `git submodule update`
+4. make sure you have cloned the submodule too: `git submodule init; git submodule update`
 5. install: `cargo install`
 
 Note:


### PR DESCRIPTION
Current README instructions omit the following instruction:
```
$ git submodule init
```

This PR adds this command to the README.