### PR TITLE
Jcli no panic

### DIFF
--- a/src/bin/jcli_app/certificate/get_stake_pool_id.rs
+++ b/src/bin/jcli_app/certificate/get_stake_pool_id.rs
@@ -1,16 +1,7 @@
 use chain_impl_mockchain::certificate::CertificateContent;
-use jcli_app::utils::io;
-use jormungandr_utils::certificate as cert_utils;
-use std::io::{Read, Write};
+use jcli_app::certificate::{self, Error};
 use std::path::PathBuf;
 use structopt::StructOpt;
-
-custom_error! {pub Error
-    Encoding { source: cert_utils::Error } = "Invalid certificate",
-    CryptoEncoding { source: chain_crypto::bech32::Error } = "Invalid private key",
-    Io { source: std::io::Error } = "I/O Error",
-    NotStakePoolRegistration = "Invalid certificate, expecting a stake pool registration",
-}
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
@@ -23,17 +14,10 @@ pub struct GetStakePoolId {
 
 impl GetStakePoolId {
     pub fn exec(self) -> Result<(), Error> {
-        let mut input = io::open_file_read(&self.input).unwrap();
-        let mut input_str = String::new();
-        input.read_to_string(&mut input_str)?;
-        let cert = cert_utils::deserialize_from_bech32(&input_str.trim())?;
-
+        let cert = certificate::read_cert(self.input)?;
         match cert.content {
-            CertificateContent::StakePoolRegistration(s) => {
-                let id = s.to_id();
-                let mut f = io::open_file_write(&self.output).unwrap();
-                writeln!(f, "{}", id)?;
-                Ok(())
+            CertificateContent::StakePoolRegistration(stake_pool_info) => {
+                certificate::write_output(self.output, stake_pool_info.to_id())
             }
             _ => Err(Error::NotStakePoolRegistration),
         }

--- a/src/bin/jcli_app/certificate/new_stake_delegation.rs
+++ b/src/bin/jcli_app/certificate/new_stake_delegation.rs
@@ -1,16 +1,11 @@
 use chain_crypto::{Ed25519Extended, PublicKey};
-use chain_impl_mockchain::certificate::{self, CertificateContent, StakeDelegation as Delegation};
-use jcli_app::utils::io;
+use chain_impl_mockchain::certificate::{
+    Certificate, CertificateContent, StakeDelegation as Delegation,
+};
+use jcli_app::certificate::{self, Error};
 use jcli_app::utils::key_parser::parse_pub_key;
-use jormungandr_utils::certificate as cert_utils;
-use std::io::Write;
 use std::path::PathBuf;
 use structopt::StructOpt;
-
-custom_error! {pub Error
-    Encoding { source: cert_utils::Error } = "Invalid certificate",
-    Io { source: std::io::Error } = "I/O error",
-}
 
 #[derive(StructOpt)]
 pub struct StakeDelegation {
@@ -31,15 +26,10 @@ impl StakeDelegation {
             stake_key_id: self.stake_id.into(),
             pool_id: self.pool_id.into(),
         };
-
-        let cert = certificate::Certificate {
+        let cert = Certificate {
             content: CertificateContent::StakeDelegation(content),
             signatures: vec![],
         };
-
-        let bech32 = cert_utils::serialize_to_bech32(&cert)?;
-        let mut file = io::open_file_write(&self.output).unwrap();
-        writeln!(file, "{}", bech32)?;
-        Ok(())
+        certificate::write_cert(self.output, cert)
     }
 }

--- a/src/bin/jcli_app/certificate/new_stake_key_registration.rs
+++ b/src/bin/jcli_app/certificate/new_stake_key_registration.rs
@@ -1,18 +1,11 @@
 use chain_crypto::{Ed25519Extended, PublicKey};
 use chain_impl_mockchain::certificate::{
-    self, CertificateContent, StakeKeyRegistration as Registration,
+    Certificate, CertificateContent, StakeKeyRegistration as Registration,
 };
-use jcli_app::utils::io;
+use jcli_app::certificate::{self, Error};
 use jcli_app::utils::key_parser::parse_pub_key;
-use jormungandr_utils::certificate as cert_utils;
-use std::io::Write;
 use std::path::PathBuf;
 use structopt::StructOpt;
-
-custom_error! {pub Error
-    Encoding { source: cert_utils::Error } = "Invalid certificate",
-    Io { source: std::io::Error } = "I/O error",
-}
 
 #[derive(StructOpt)]
 pub struct StakeKeyRegistration {
@@ -29,15 +22,10 @@ impl StakeKeyRegistration {
         let content = Registration {
             stake_key_id: self.key.into(),
         };
-
-        let cert = certificate::Certificate {
+        let cert = Certificate {
             content: CertificateContent::StakeKeyRegistration(content),
             signatures: vec![],
         };
-
-        let bech32 = cert_utils::serialize_to_bech32(&cert)?;
-        let mut file = io::open_file_write(&self.output).unwrap();
-        writeln!(file, "{}", bech32)?;
-        Ok(())
+        certificate::write_cert(self.output, cert)
     }
 }

--- a/src/bin/jcli_app/certificate/new_stake_pool_registration.rs
+++ b/src/bin/jcli_app/certificate/new_stake_pool_registration.rs
@@ -1,20 +1,13 @@
 use chain_crypto::{Curve25519_2HashDH, Ed25519Extended, PublicKey, SumEd25519_12};
 use chain_impl_mockchain::{
-    certificate::{self, CertificateContent},
+    certificate::{Certificate, CertificateContent},
     leadership::genesis::GenesisPraosLeader,
     stake::{StakeKeyId, StakePoolInfo},
 };
-use jcli_app::utils::io;
+use jcli_app::certificate::{self, Error};
 use jcli_app::utils::key_parser::parse_pub_key;
-use jormungandr_utils::certificate as cert_utils;
-use std::io::Write;
 use std::path::PathBuf;
 use structopt::StructOpt;
-
-custom_error! {pub Error
-    Encoding { source: cert_utils::Error } = "Invalid certificate",
-    Io { source: std::io::Error } = "I/O error",
-}
 
 #[derive(Debug, StructOpt)]
 pub struct StakePoolRegistration {
@@ -61,15 +54,10 @@ impl StakePoolRegistration {
                 vrf_public_key: self.vrf_key,
             },
         };
-
-        let cert = certificate::Certificate {
+        let cert = Certificate {
             content: CertificateContent::StakePoolRegistration(content),
             signatures: vec![],
         };
-
-        let bech32 = cert_utils::serialize_to_bech32(&cert)?;
-        let mut file = io::open_file_write(&self.output).unwrap();
-        writeln!(file, "{}", bech32)?;
-        Ok(())
+        certificate::write_cert(self.output, cert)
     }
 }

--- a/src/bin/jcli_app/certificate/sign.rs
+++ b/src/bin/jcli_app/certificate/sign.rs
@@ -1,19 +1,8 @@
-use chain_crypto::{bech32, Ed25519Extended, SecretKey};
+use chain_crypto::{bech32::Bech32, Ed25519Extended, SecretKey};
 use chain_impl_mockchain::certificate::CertificateContent;
-use jcli_app::utils::io;
-use jormungandr_utils::certificate as cert_utils;
-use std::{
-    fs,
-    io::{Read, Write},
-    path::PathBuf,
-};
+use jcli_app::certificate::{self, Error};
+use std::path::PathBuf;
 use structopt::StructOpt;
-
-custom_error! {pub Error
-    Encoding { source: cert_utils::Error } = "Invalid certificate",
-    CryptoEncoding { source: chain_crypto::bech32::Error } = "Invalid private key",
-    Io { source: std::io::Error } = "I/O Error",
-}
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
@@ -30,13 +19,10 @@ pub struct Sign {
 
 impl Sign {
     pub fn exec(self) -> Result<(), Error> {
-        let mut input = io::open_file_read(&self.input).unwrap();
-        let mut input_str = String::new();
-        input.read_to_string(&mut input_str)?;
-        let mut cert = cert_utils::deserialize_from_bech32(&input_str.trim())?;
-        let key_str = fs::read_to_string(self.signing_key)?;
-        let private_key =
-            <SecretKey<Ed25519Extended> as bech32::Bech32>::try_from_bech32_str(&key_str.trim())?;
+        let mut cert = certificate::read_cert(self.input)?;
+        let key_str = certificate::read_input(Some(self.signing_key))?;
+        let private_key = SecretKey::<Ed25519Extended>::try_from_bech32_str(key_str.trim())?;
+
         let signature = match &cert.content {
             CertificateContent::StakeKeyRegistration(s) => s.make_certificate(&private_key),
             CertificateContent::StakeKeyDeregistration(s) => s.make_certificate(&private_key),
@@ -45,9 +31,6 @@ impl Sign {
             CertificateContent::StakePoolRetirement(s) => s.make_certificate(&private_key),
         };
         cert.signatures.push(signature);
-        let bech32 = cert_utils::serialize_to_bech32(&cert)?;
-        let mut f = io::open_file_write(&self.output).unwrap();
-        writeln!(f, "{}", bech32)?;
-        Ok(())
+        certificate::write_cert(self.output, cert)
     }
 }

--- a/src/bin/jcli_app/debug/mod.rs
+++ b/src/bin/jcli_app/debug/mod.rs
@@ -1,5 +1,8 @@
 mod message;
 
+use cardano::util::hex;
+use jcli_app::utils::error::CustomErrorFiller;
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -9,8 +12,16 @@ pub enum Debug {
     Message(message::Message),
 }
 
+custom_error! {pub Error
+    Io { source: std::io::Error } = "I/O Error",
+    InputInvalid { source: std::io::Error, path: PathBuf }
+        = @{{ let _ = source; format_args!("invalid input file path '{}'", path.display()) }},
+    HexMalformed { source: hex::Error } = "hex encoding malformed",
+    MessageMalformed { source: std::io::Error, filler: CustomErrorFiller } = "message malformed",
+}
+
 impl Debug {
-    pub fn exec(self) {
+    pub fn exec(self) -> Result<(), Error> {
         match self {
             Debug::Message(message) => message.exec(),
         }

--- a/src/bin/jcli_app/key.rs
+++ b/src/bin/jcli_app/key.rs
@@ -7,75 +7,75 @@ use jcli_app::utils::io;
 use rand::{rngs::EntropyRng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::{
-    io::{Read, Write},
+    io::{BufRead, BufReader, Write},
     path::{Path, PathBuf},
 };
 use structopt::{clap::arg_enum, StructOpt};
 
-custom_error! {pub Error
+custom_error! { pub Error
     Io { source: std::io::Error } = "I/O error",
-    Bech32 { source: bech32::Error } = "Invalid Bech32",
-    Hex { source: cardano::util::hex::Error } = "Invalid Hexadecimal",
-    SecretKey { source: chain_crypto::SecretKeyError } = "Invalid secret key",
-    Rand { source: rand::Error } = "Error while using random source",
-    InvalidSeed { seed_len: usize } = "Invalid seed length, expected 32 bytes but received {seed_len}"
+    Bech32 { source: bech32::Error } = "invalid Bech32",
+    Hex { source: cardano::util::hex::Error } = "invalid Hexadecimal",
+    SecretKey { source: chain_crypto::SecretKeyError } = "invalid secret key",
+    Rand { source: rand::Error } = "error while using random source",
+    InvalidSeed { seed_len: usize } = "invalid seed length, expected 32 bytes but received {seed_len}",
+    InvalidInput { source: std::io::Error, path: PathBuf }
+        = @{{ let _ = source; format_args!("invalid input file path '{}'", path.display()) }},
+    InvalidOutput { source: std::io::Error, path: PathBuf }
+        = @{{ let _ = source; format_args!("invalid output file path '{}'", path.display()) }},
+    UnknownBech32PrivKeyHrp { hrp: String } = "unrecognized private key bech32 HRP: {hrp}",
 }
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "genesis", rename_all = "kebab-case")]
 pub enum Key {
     /// generate a private key
-    Generate(GenerateKeyArguments),
+    Generate(Generate),
     /// get the public key out of a given private key
-    ToPublic(ToPublicArguments),
+    ToPublic(ToPublic),
     /// retrive a private key from the given bytes
-    FromBytes(FromBytesArguments),
+    FromBytes(FromBytes),
     /// get the bytes out of a private key
-    ToBytes(ToBytesArguments),
+    ToBytes(ToBytes),
 }
 
 #[derive(StructOpt, Debug)]
-pub struct FromBytesArguments {
+pub struct FromBytes {
     /// Type of a private key
     ///
     /// value values are: ed25519, ed25510bip32, ed25519extended, curve25519_2hashdh or sumed25519_12
     #[structopt(long = "type")]
-    pub key_type: GenPrivKeyType,
+    key_type: GenPrivKeyType,
 
     /// retrieve the private key from the given bytes
     #[structopt(name = "INPUT_BYTES")]
-    pub input_bytes: Option<PathBuf>,
+    input_bytes: Option<PathBuf>,
 
-    /// output the private key in the given file or to stdout if no
-    /// value is provided.
-    #[structopt(name = "OUTPUT_FILE")]
-    pub output: Option<PathBuf>,
+    #[structopt(flatten)]
+    output_file: OutputFile,
 }
 
 #[derive(StructOpt, Debug)]
-pub struct ToBytesArguments {
-    /// output to write bytes of the private key
-    #[structopt(name = "OUTPUT_FILE")]
-    pub output: Option<PathBuf>,
+pub struct ToBytes {
+    #[structopt(flatten)]
+    output_file: OutputFile,
 
     /// path to the private key to serialize in bytes
     /// Or read from the standard input
     #[structopt(name = "INPUT_FILE")]
-    pub input_key: Option<PathBuf>,
+    input_key: Option<PathBuf>,
 }
 
 #[derive(StructOpt, Debug)]
-pub struct GenerateKeyArguments {
+pub struct Generate {
     /// Type of a private key
     ///
     /// value values are: ed25519, ed25510bip32, ed25519extended, curve25519_2hashdh or sumed25519_12
     #[structopt(long = "type")]
-    pub key_type: GenPrivKeyType,
+    key_type: GenPrivKeyType,
 
-    /// output the private key in the given file or to stdout if no
-    /// value is provided.
-    #[structopt(name = "OUTPUT_FILE")]
-    pub output: Option<PathBuf>,
+    #[structopt(flatten)]
+    output_file: OutputFile,
 
     /// optional seed to generate the key, for the same entropy the same key
     /// will be generated (32 bytes in hexadecimal). This seed will be fed to
@@ -87,22 +87,36 @@ pub struct GenerateKeyArguments {
         name = "SEED",
         parse(try_from_str = "hex::decode")
     )]
-    pub seed: Option<Vec<u8>>,
+    seed: Option<Vec<u8>>,
 }
 
 #[derive(StructOpt, Debug)]
-pub struct ToPublicArguments {
+pub struct ToPublic {
     /// the source private key to extract the public key from
     ///
     /// if no value passed, the private key will be read from the
     /// standard input
     #[structopt(long = "input")]
-    pub input_key: Option<PathBuf>,
+    input_key: Option<PathBuf>,
 
-    /// output the public key in the given file or to stdout if no
-    /// value is provided.
+    #[structopt(flatten)]
+    output_file: OutputFile,
+}
+
+#[derive(StructOpt, Debug)]
+struct OutputFile {
+    /// output the key to the given file or to stdout if not provided
     #[structopt(name = "OUTPUT_FILE")]
-    pub output: Option<PathBuf>,
+    output: Option<PathBuf>,
+}
+
+impl OutputFile {
+    fn open(&self) -> Result<impl Write, Error> {
+        io::open_file_write(&self.output).map_err(|source| Error::InvalidOutput {
+            source,
+            path: self.output.clone().unwrap_or_default(),
+        })
+    }
 }
 
 arg_enum! {
@@ -119,108 +133,113 @@ arg_enum! {
 impl Key {
     pub fn exec(self) -> Result<(), Error> {
         match self {
-            Key::Generate(args) => {
-                let priv_key_bech32 = match args.key_type {
-                    GenPrivKeyType::Ed25519 => gen_priv_key_bech32::<Ed25519>(args.seed)?,
-                    GenPrivKeyType::Ed25519Bip32 => gen_priv_key_bech32::<Ed25519Bip32>(args.seed)?,
-                    GenPrivKeyType::Ed25519Extended => {
-                        gen_priv_key_bech32::<Ed25519Extended>(args.seed)?
-                    }
-                    GenPrivKeyType::SumEd25519_12 => {
-                        gen_priv_key_bech32::<SumEd25519_12>(args.seed)?
-                    }
-                    GenPrivKeyType::Curve25519_2HashDH => {
-                        gen_priv_key_bech32::<Curve25519_2HashDH>(args.seed)?
-                    }
-                };
-                let mut file = io::open_file_write(&args.output).unwrap();
-                Ok(writeln!(file, "{}", priv_key_bech32)?)
-            }
-            Key::ToPublic(args) => {
-                let bech32 = read_bech32(args.input_key)?;
-
-                let pub_key_bech32 = match bech32.hrp() {
-                    Ed25519::SECRET_BECH32_HRP => gen_pub_key_bech32::<Ed25519>(bech32.data())?,
-                    Ed25519Bip32::SECRET_BECH32_HRP => {
-                        gen_pub_key_bech32::<Ed25519Bip32>(bech32.data())?
-                    }
-                    Ed25519Extended::SECRET_BECH32_HRP => {
-                        gen_pub_key_bech32::<Ed25519Extended>(bech32.data())?
-                    }
-                    SumEd25519_12::SECRET_BECH32_HRP => {
-                        gen_pub_key_bech32::<SumEd25519_12>(bech32.data())?
-                    }
-                    Curve25519_2HashDH::SECRET_BECH32_HRP => {
-                        gen_pub_key_bech32::<Curve25519_2HashDH>(bech32.data())?
-                    }
-                    other => panic!("Unrecognized private key bech32 HRP: {}", other),
-                };
-                let mut file = io::open_file_write(&args.output).unwrap();
-                Ok(writeln!(file, "{}", pub_key_bech32)?)
-            }
-            Key::ToBytes(args) => {
-                let bech32 = read_bech32(args.input_key)?;
-
-                match bech32.hrp() {
-                    Ed25519::PUBLIC_BECH32_HRP => {}
-                    Ed25519Bip32::PUBLIC_BECH32_HRP => {}
-                    Ed25519Extended::PUBLIC_BECH32_HRP => {}
-                    SumEd25519_12::PUBLIC_BECH32_HRP => {}
-                    Curve25519_2HashDH::PUBLIC_BECH32_HRP => {}
-                    Ed25519::SECRET_BECH32_HRP => {}
-                    Ed25519Bip32::SECRET_BECH32_HRP => {}
-                    Ed25519Extended::SECRET_BECH32_HRP => {}
-                    SumEd25519_12::SECRET_BECH32_HRP => {}
-                    Curve25519_2HashDH::SECRET_BECH32_HRP => {}
-                    other => panic!("Unrecognized private key bech32 HRP: {}", other),
-                }
-                use bech32::FromBase32;
-                let bytes: Vec<u8> = Vec::from_base32(bech32.data())?;
-                let mut file = io::open_file_write(&args.output).unwrap();
-                Ok(writeln!(file, "{}", cardano::util::hex::encode(&bytes))?)
-            }
-            Key::FromBytes(args) => {
-                let bytes = read_hex(args.input_bytes)?;
-
-                let priv_key_bech32 = match args.key_type {
-                    GenPrivKeyType::Ed25519 => get_priv_key_from_bytes::<Ed25519>(&bytes)?,
-                    GenPrivKeyType::Ed25519Bip32 => {
-                        get_priv_key_from_bytes::<Ed25519Bip32>(&bytes)?
-                    }
-                    GenPrivKeyType::Ed25519Extended => {
-                        get_priv_key_from_bytes::<Ed25519Extended>(&bytes)?
-                    }
-                    GenPrivKeyType::SumEd25519_12 => {
-                        get_priv_key_from_bytes::<SumEd25519_12>(&bytes)?
-                    }
-                    GenPrivKeyType::Curve25519_2HashDH => {
-                        get_priv_key_from_bytes::<Curve25519_2HashDH>(&bytes)?
-                    }
-                };
-                let mut file = io::open_file_write(&args.output).unwrap();
-                Ok(writeln!(file, "{}", priv_key_bech32)?)
-            }
+            Key::Generate(args) => args.exec(),
+            Key::ToPublic(args) => args.exec(),
+            Key::ToBytes(args) => args.exec(),
+            Key::FromBytes(args) => args.exec(),
         }
     }
 }
 
+impl Generate {
+    fn exec(self) -> Result<(), Error> {
+        let priv_key_bech32 = match self.key_type {
+            GenPrivKeyType::Ed25519 => gen_priv_key::<Ed25519>(self.seed)?,
+            GenPrivKeyType::Ed25519Bip32 => gen_priv_key::<Ed25519Bip32>(self.seed)?,
+            GenPrivKeyType::Ed25519Extended => gen_priv_key::<Ed25519Extended>(self.seed)?,
+            GenPrivKeyType::SumEd25519_12 => gen_priv_key::<SumEd25519_12>(self.seed)?,
+            GenPrivKeyType::Curve25519_2HashDH => gen_priv_key::<Curve25519_2HashDH>(self.seed)?,
+        };
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", priv_key_bech32)?;
+        Ok(())
+    }
+}
+
+impl ToPublic {
+    fn exec(self) -> Result<(), Error> {
+        let bech32 = read_bech32(self.input_key)?;
+        let data = bech32.data();
+        let pub_key_bech32 = match bech32.hrp() {
+            Ed25519::SECRET_BECH32_HRP => gen_pub_key::<Ed25519>(data),
+            Ed25519Bip32::SECRET_BECH32_HRP => gen_pub_key::<Ed25519Bip32>(data),
+            Ed25519Extended::SECRET_BECH32_HRP => gen_pub_key::<Ed25519Extended>(data),
+            SumEd25519_12::SECRET_BECH32_HRP => gen_pub_key::<SumEd25519_12>(data),
+            Curve25519_2HashDH::SECRET_BECH32_HRP => gen_pub_key::<Curve25519_2HashDH>(data),
+            other => Err(Error::UnknownBech32PrivKeyHrp {
+                hrp: other.to_string(),
+            }),
+        }?;
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", pub_key_bech32)?;
+        Ok(())
+    }
+}
+
+impl ToBytes {
+    fn exec(self) -> Result<(), Error> {
+        let bech32 = read_bech32(self.input_key)?;
+
+        match bech32.hrp() {
+            Ed25519::PUBLIC_BECH32_HRP
+            | Ed25519Bip32::PUBLIC_BECH32_HRP
+            | Ed25519Extended::PUBLIC_BECH32_HRP
+            | SumEd25519_12::PUBLIC_BECH32_HRP
+            | Curve25519_2HashDH::PUBLIC_BECH32_HRP
+            | Ed25519::SECRET_BECH32_HRP
+            | Ed25519Bip32::SECRET_BECH32_HRP
+            | Ed25519Extended::SECRET_BECH32_HRP
+            | SumEd25519_12::SECRET_BECH32_HRP
+            | Curve25519_2HashDH::SECRET_BECH32_HRP => Ok(()),
+            other => Err(Error::UnknownBech32PrivKeyHrp {
+                hrp: other.to_string(),
+            }),
+        }?;
+        let bytes = Vec::<u8>::from_base32(bech32.data())?;
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", cardano::util::hex::encode(&bytes))?;
+        Ok(())
+    }
+}
+
+impl FromBytes {
+    fn exec(self) -> Result<(), Error> {
+        let bytes = read_hex(self.input_bytes)?;
+
+        let priv_key_bech32 = match self.key_type {
+            GenPrivKeyType::Ed25519 => bytes_to_priv_key::<Ed25519>(&bytes)?,
+            GenPrivKeyType::Ed25519Bip32 => bytes_to_priv_key::<Ed25519Bip32>(&bytes)?,
+            GenPrivKeyType::Ed25519Extended => bytes_to_priv_key::<Ed25519Extended>(&bytes)?,
+            GenPrivKeyType::SumEd25519_12 => bytes_to_priv_key::<SumEd25519_12>(&bytes)?,
+            GenPrivKeyType::Curve25519_2HashDH => bytes_to_priv_key::<Curve25519_2HashDH>(&bytes)?,
+        };
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", priv_key_bech32)?;
+        Ok(())
+    }
+}
+
 fn read_hex<P: AsRef<Path>>(path: Option<P>) -> Result<Vec<u8>, Error> {
-    let mut input = io::open_file_read(&path).unwrap();
-    let mut input_str = String::new();
-    input.read_to_string(&mut input_str)?;
-    Ok(cardano::util::hex::decode(&input_str.trim_end())?)
+    cardano::util::hex::decode(read_line(path)?.trim()).map_err(Into::into)
 }
 
 fn read_bech32<P: AsRef<Path>>(path: Option<P>) -> Result<Bech32, Error> {
-    let mut input = io::open_file_read(&path).unwrap();
-    let mut input_str = String::new();
-    input.read_to_string(&mut input_str)?;
-
-    let bech32: Bech32 = input_str.trim_end().parse()?;
-    Ok(bech32)
+    read_line(path)?.trim().parse().map_err(Into::into)
 }
 
-fn gen_priv_key_bech32<K: AsymmetricKey>(seed: Option<Vec<u8>>) -> Result<Bech32, Error> {
+fn read_line<P: AsRef<Path>>(path: Option<P>) -> Result<String, Error> {
+    let input = io::open_file_read(&path).map_err(|source| Error::InvalidInput {
+        source,
+        path: path
+            .map(|path| path.as_ref().to_owned())
+            .unwrap_or_default(),
+    })?;
+    let mut line = String::new();
+    BufReader::new(input).read_line(&mut line)?;
+    Ok(line)
+}
+
+fn gen_priv_key<K: AsymmetricKey>(seed: Option<Vec<u8>>) -> Result<Bech32, Error> {
     let rng = if let Some(seed) = seed {
         if seed.len() != 32 {
             return Err(Error::InvalidSeed {
@@ -238,7 +257,7 @@ fn gen_priv_key_bech32<K: AsymmetricKey>(seed: Option<Vec<u8>>) -> Result<Bech32
     Ok(Bech32::new(hrp, secret.to_base32())?)
 }
 
-fn gen_pub_key_bech32<K: AsymmetricKey>(priv_key_bech32: &[u5]) -> Result<Bech32, Error> {
+fn gen_pub_key<K: AsymmetricKey>(priv_key_bech32: &[u5]) -> Result<Bech32, Error> {
     let priv_key_bytes = Vec::<u8>::from_base32(priv_key_bech32)?;
     let priv_key = K::secret_from_binary(&priv_key_bytes)?;
     let pub_key = K::compute_public(&priv_key);
@@ -246,7 +265,7 @@ fn gen_pub_key_bech32<K: AsymmetricKey>(priv_key_bech32: &[u5]) -> Result<Bech32
     Ok(Bech32::new(hrp, pub_key.to_base32())?)
 }
 
-fn get_priv_key_from_bytes<K: AsymmetricKey>(bytes: &[u8]) -> Result<String, Error> {
+fn bytes_to_priv_key<K: AsymmetricKey>(bytes: &[u8]) -> Result<String, Error> {
     use chain_crypto::bech32::Bech32 as _;
     let secret: chain_crypto::SecretKey<K> = chain_crypto::SecretKey::from_binary(bytes)?;
     Ok(secret.to_bech32_str())

--- a/src/bin/jcli_app/mod.rs
+++ b/src/bin/jcli_app/mod.rs
@@ -37,7 +37,7 @@ impl JCli {
     pub fn exec(self) -> Result<(), Box<Error>> {
         match self {
             JCli::Key(key) => key.exec()?,
-            JCli::Address(address) => address.exec(),
+            JCli::Address(address) => address.exec()?,
             JCli::Genesis(genesis) => genesis.exec(),
             JCli::Rest(rest) => rest.exec(),
             JCli::Transaction(transaction) => transaction.exec()?,

--- a/src/bin/jcli_app/mod.rs
+++ b/src/bin/jcli_app/mod.rs
@@ -41,7 +41,7 @@ impl JCli {
             JCli::Genesis(genesis) => genesis.exec(),
             JCli::Rest(rest) => rest.exec(),
             JCli::Transaction(transaction) => transaction.exec()?,
-            JCli::Debug(debug) => debug.exec(),
+            JCli::Debug(debug) => debug.exec()?,
             JCli::Certificate(certificate) => certificate.exec()?,
             JCli::AutoCompletion(auto_completion) => auto_completion.exec::<Self>(),
         };

--- a/src/bin/jcli_app/utils/error.rs
+++ b/src/bin/jcli_app/utils/error.rs
@@ -1,0 +1,14 @@
+/// Structure intended to block `From` generation in custom_error! macro
+/// Macro uses `source` field to automatically generate `std::error::Error::source` implementation.
+/// When this is the only field, it also generates `From` implementation for this source's type.
+/// It causes conflict when two error variants have the same source type.
+/// Addition of any field blocks generation of `From`, but doesn't affect `Error::source`.
+/// This structure can be added as such field to bypass described issue.
+#[derive(Debug)]
+pub struct CustomErrorFiller;
+
+impl ToString for CustomErrorFiller {
+    fn to_string(&self) -> String {
+        "custom error filler".to_string()
+    }
+}

--- a/src/bin/jcli_app/utils/mod.rs
+++ b/src/bin/jcli_app/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod error;
 mod host_addr;
 pub mod io;
 pub mod key_parser;

--- a/tests/jcli_key_tests.rs
+++ b/tests/jcli_key_tests.rs
@@ -75,7 +75,7 @@ pub fn test_key_with_too_long_seed_generation() {
 fn test_key_invalid_seed_length(seed: &str) -> () {
     process_assert::assert_process_failed_and_contains_message(
         jcli_wrapper::jcli_commands::get_key_generate_with_seed_command("Ed25519Extended", &seed),
-        "Invalid seed length, expected 32 bytes but received",
+        "invalid seed length, expected 32 bytes but received",
     );
 }
 


### PR DESCRIPTION
Remove panics from JCLI commands: address, key, certificate and debug.

This is part of https://github.com/input-output-hk/jormungandr/issues/298 effort to make JCLI error handling consistent and user friendly.