### PR TITLE
Block solicitation from network peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "curve25519-dalek 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-bip32 0.1.0",
+ "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -687,6 +688,18 @@ name = "ed25519-bip32"
 version = "0.1.0"
 dependencies = [
  "cryptoxide 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3229,6 +3242,7 @@ dependencies = [
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
+"checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
 "checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -335,7 +335,7 @@ pub fn handle_block(
     block: Block,
     is_tip_candidate: bool,
 ) -> Result<HandledBlock, HandleBlockError> {
-    match header_triage(blockchain, block.header(), is_tip_candidate)? {
+    match header_triage(blockchain, &block.header(), is_tip_candidate)? {
         BlockHeaderTriage::NotOfInterest { reason } => Ok(HandledBlock::Rejected { reason }),
         BlockHeaderTriage::MissingParentOrBranch { to } => {
             // the block is not directly connected to any block
@@ -413,7 +413,7 @@ fn process_block(
 
 pub fn header_triage(
     blockchain: &Blockchain,
-    header: Header,
+    header: &Header,
     is_tip_candidate: bool,
 ) -> Result<BlockHeaderTriage, HandleBlockError> {
     let block_id = header.id();
@@ -429,7 +429,7 @@ pub fn header_triage(
     let (block_tip, _) = blockchain.get_block_tip()?;
 
     if let Some(leadership) = blockchain.get_leadership_or_build(block_date.epoch, &parent_id) {
-        match leadership.verify(&header) {
+        match leadership.verify(header) {
             Verification::Success => {}
             Verification::Failure(err) => {
                 return Ok(BlockHeaderTriage::NotOfInterest {

--- a/src/blockchain/process.rs
+++ b/src/blockchain/process.rs
@@ -63,6 +63,40 @@ pub fn handle_input(
                 }
             }
         }
+        BlockMsg::NetworkBlock(block) => {
+            let mut blockchain = blockchain.lock_write();
+            match chain::handle_block(&mut blockchain, block, true).unwrap() {
+                HandledBlock::Rejected { reason } => {
+                    // TODO: drop the network peer that has sent
+                    // an invalid block.
+                    slog_warn!(logger, "rejecting block from the network: {:?}", reason);
+                }
+                HandledBlock::MissingBranchToBlock { to } => {
+                    // This is abnormal because we have received a block
+                    // that is not connected to preceding blocks, which
+                    // should not happen as we solicit blocks in descending
+                    // order.
+                    //
+                    // TODO: drop the network peer that has sent
+                    // the wrong block.
+                    slog_warn!(
+                        logger,
+                        "disconnected block received, missing intermediate blocks to {}",
+                        to
+                    );
+                }
+                HandledBlock::Acquired { header } => {
+                    slog_info!(logger,
+                        "block added successfully to Node's blockchain";
+                        "id" => header.id().to_string(),
+                        "date" => format!("{}.{}", header.date().epoch, header.date().slot_id)
+                    );
+                    slog_debug!(logger, "Header: {:?}", header);
+                    // Propagate the block to other nodes
+                    network_msg_box.send(NetworkMsg::Propagate(PropagateMsg::Block(header)));
+                }
+            }
+        }
         BlockMsg::AnnouncedBlock(header, node_id) => {
             let blockchain = blockchain.lock_read();
             match chain::header_triage(&blockchain, &header, false).unwrap() {

--- a/src/blockchain/process.rs
+++ b/src/blockchain/process.rs
@@ -82,7 +82,7 @@ pub fn handle_input(
                 }
                 BlockHeaderTriage::ProcessBlockToState => {
                     slog_info!(logger, "Block announcement is interesting, fetch block");
-                    network_msg_box.send(NetworkMsg::GetBlocks(node_id, vec![header]));
+                    network_msg_box.send(NetworkMsg::GetBlocks(node_id, vec![header.id()]));
                 }
             }
         }

--- a/src/intercom.rs
+++ b/src/intercom.rs
@@ -304,7 +304,7 @@ pub enum PropagateMsg {
 #[derive(Clone, Debug)]
 pub enum NetworkMsg {
     Propagate(PropagateMsg),
-    GetBlocks(NodeId, Vec<Header>),
+    GetBlocks(NodeId, Vec<HeaderHash>),
 }
 
 #[cfg(test)]

--- a/src/intercom.rs
+++ b/src/intercom.rs
@@ -1,4 +1,5 @@
 use crate::blockcfg::{Block, Header, HeaderHash, Message, MessageId};
+use crate::network::p2p_topology::NodeId;
 
 use network_core::error as core_error;
 
@@ -267,13 +268,14 @@ impl Debug for ClientMsg {
 }
 
 /// General Block Message for the block task
+#[derive(Debug)]
 pub enum BlockMsg {
     /// A trusted Block has been received from the leadership task
     LeadershipBlock(Block),
     /// Leadership process expect a new end of epoch
     LeadershipExpectEndOfEpoch,
     /// A untrusted block Header has been received from the network task
-    AnnouncedBlock(Header),
+    AnnouncedBlock(Header, NodeId),
 }
 
 impl Debug for BlockMsg {
@@ -282,16 +284,27 @@ impl Debug for BlockMsg {
         match self {
             LeadershipBlock(block) => f.debug_tuple("LeadershipBlock").field(block).finish(),
             LeadershipExpectEndOfEpoch => f.debug_tuple("LeadershipExpectEndOfEpoch").finish(),
-            AnnouncedBlock(header) => f.debug_tuple("AnnouncedBlock").field(header).finish(),
+            AnnouncedBlock(header, node_id) => f
+                .debug_tuple("AnnouncedBlock")
+                .field(header)
+                .field(node_id)
+                .finish(),
         }
     }
 }
 
-/// Message to propagate to the connected peers.
+/// Propagation requests for the network task.
 #[derive(Clone, Debug)]
-pub enum NetworkPropagateMsg {
+pub enum PropagateMsg {
     Block(Header),
     Message(Message),
+}
+
+/// Messages to the network task.
+#[derive(Clone, Debug)]
+pub enum NetworkMsg {
+    Propagate(PropagateMsg),
+    GetBlocks(NodeId, Vec<Header>),
 }
 
 #[cfg(test)]

--- a/src/intercom.rs
+++ b/src/intercom.rs
@@ -274,23 +274,10 @@ pub enum BlockMsg {
     LeadershipBlock(Block),
     /// Leadership process expect a new end of epoch
     LeadershipExpectEndOfEpoch,
+    /// An untrusted Block has been received from the network task
+    NetworkBlock(Block),
     /// A untrusted block Header has been received from the network task
     AnnouncedBlock(Header, NodeId),
-}
-
-impl Debug for BlockMsg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use BlockMsg::*;
-        match self {
-            LeadershipBlock(block) => f.debug_tuple("LeadershipBlock").field(block).finish(),
-            LeadershipExpectEndOfEpoch => f.debug_tuple("LeadershipExpectEndOfEpoch").finish(),
-            AnnouncedBlock(header, node_id) => f
-                .debug_tuple("AnnouncedBlock")
-                .field(header)
-                .field(node_id)
-                .finish(),
-        }
-    }
 }
 
 /// Propagation requests for the network task.

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
     let tpool = Arc::new(RwLock::new(tpool_data));
 
     // initialize the network propagation channel
-    let (network_msgbox, network_queue) = async_msg::channel(NETWORK_TASK_QUEUE_LEN);
+    let (mut network_msgbox, network_queue) = async_msg::channel(NETWORK_TASK_QUEUE_LEN);
     let new_epoch_notifier = bootstrapped_node.new_epoch_notifier;
 
     let stats_counter = StatsCounter::default();
@@ -126,7 +126,13 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         let blockchain = bootstrapped_node.blockchain.clone();
         let stats_counter = stats_counter.clone();
         services.spawn_future_with_inputs("block", move |info, input| {
-            blockchain::handle_input(info, &blockchain, &stats_counter, &network_msgbox, input);
+            blockchain::handle_input(
+                info,
+                &blockchain,
+                &stats_counter,
+                &mut network_msgbox,
+                input,
+            );
             futures::future::ok(())
         })
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,6 @@ use chain_impl_mockchain::message::{Message, MessageId};
 use crate::{
     blockcfg::Leader,
     blockchain::BlockchainR,
-    intercom::BlockMsg,
     rest::v0::node::stats::StatsCounter,
     settings::start::Settings,
     transaction::TPool,

--- a/src/network/grpc/client.rs
+++ b/src/network/grpc/client.rs
@@ -52,6 +52,8 @@ fn subscribe(
     let mut prop_handles = propagate::PeerHandles::new();
     let block_sub = client.block_subscription(prop_handles.blocks.subscribe());
     let gossip_sub = client.gossip_subscription(prop_handles.gossip.subscribe());
+    // TODO: decide if this is the way to make block requests
+    prop_handles.client = Some(client);
     block_sub
         .join(gossip_sub)
         .map_err(move |err| {

--- a/src/network/grpc/client.rs
+++ b/src/network/grpc/client.rs
@@ -66,7 +66,7 @@ fn subscribe(
                 );
                 return Err(());
             }
-            subscription::process_blocks(block_sub, block_box);
+            subscription::process_blocks(node_id, block_sub, block_box);
             subscription::process_gossip(gossip_sub, global_state);
             Ok((node_id, prop_handles))
         })

--- a/src/network/grpc/client.rs
+++ b/src/network/grpc/client.rs
@@ -22,15 +22,14 @@ use http::uri;
 use tokio::{executor::DefaultExecutor, net::TcpStream, runtime};
 use tower_service::Service as _;
 
-use std::{net::SocketAddr, slice};
+use std::slice;
 
 pub fn connect(
-    addr: SocketAddr,
     state: ConnectionState,
     channels: Channels,
 ) -> impl Future<Item = (p2p::NodeId, propagate::PeerHandles), Error = ()> {
     info!("connecting to subscription peer {}", state.connection);
-    info!("address: {}", addr);
+    let addr = state.connection;
     let peer = grpc_peer::TcpPeer::new(addr);
     let origin = origin_authority(addr);
 

--- a/src/network/grpc/client.rs
+++ b/src/network/grpc/client.rs
@@ -11,6 +11,7 @@ use crate::{
 use network_core::{
     client::{block::BlockService, gossip::GossipService},
     gossip::Node,
+    subscription::BlockEvent,
 };
 use network_grpc::{
     client::{Connect, Connection},
@@ -50,12 +51,16 @@ fn subscribe(
 ) -> impl Future<Item = (p2p::NodeId, propagate::PeerHandles), Error = ()> {
     let block_box = channels.block_box;
     let mut prop_handles = propagate::PeerHandles::new();
-    let block_sub = client.block_subscription(prop_handles.blocks.subscribe());
-    let gossip_sub = client.gossip_subscription(prop_handles.gossip.subscribe());
+    let block_sub_outbound = prop_handles.blocks.subscribe().map(|event| match event {
+        BlockEvent::Announce(header) => header,
+        BlockEvent::Solicit(_) => panic!("client connection used to solicit blocks"),
+    });
+    let block_req = client.block_subscription(block_sub_outbound);
+    let gossip_req = client.gossip_subscription(prop_handles.gossip.subscribe());
     // TODO: decide if this is the way to make block requests
     prop_handles.client = Some(client);
-    block_sub
-        .join(gossip_sub)
+    block_req
+        .join(gossip_req)
         .map_err(move |err| {
             error!("Subscription request failed: {:?}", err);
         })
@@ -67,7 +72,15 @@ fn subscribe(
                 );
                 return Err(());
             }
-            subscription::process_blocks(node_id, block_sub, block_box);
+            let block_sub = block_sub.map(|event| match event {
+                BlockEvent::Announce(header) => header,
+                BlockEvent::Solicit(_) => {
+                    // TODO: fetch blocks from client request task
+                    // and upload them
+                    unimplemented!()
+                }
+            });
+            subscription::process_block_announcements(node_id, block_sub, block_box);
             subscription::process_gossip(gossip_sub, global_state);
             Ok((node_id, prop_handles))
         })

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -197,10 +197,20 @@ fn handle_network_input(
         NetworkMsg::Propagate(msg) => {
             future::Either::A(handle_propagation_msg(msg, state.clone(), channels.clone()))
         }
-        NetworkMsg::GetBlocks(node_id, headers) => future::Either::B({
-            unimplemented!();
-            future::ok(())
-        }),
+        NetworkMsg::GetBlocks(node_id, block_ids) => future::Either::B(
+            state
+                .propagation_peers
+                .solicit_blocks(node_id, &block_ids)
+                .map(|blocks| {
+                    // TODO: feed blocks to the blockchain task
+                    unimplemented!();
+                    ()
+                })
+                .or_else(move |e| {
+                    warn!("failed to fetch blocks from peer {}: {:?}", node_id, e);
+                    future::ok::<(), ()>(())
+                }),
+        ),
     })
 }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -15,7 +15,7 @@ mod subscription;
 
 use crate::blockcfg::{Block, HeaderHash};
 use crate::blockchain::BlockchainR;
-use crate::intercom::{BlockMsg, ClientMsg, NetworkPropagateMsg, TransactionMsg};
+use crate::intercom::{BlockMsg, ClientMsg, NetworkMsg, PropagateMsg, TransactionMsg};
 use crate::settings::start::network::{Configuration, Listen, Peer, Protocol};
 use crate::utils::{
     async_msg::{MessageBox, MessageQueue},
@@ -31,7 +31,7 @@ use network_core::{
 };
 
 use futures::prelude::*;
-use futures::stream;
+use futures::{future, stream};
 use tokio::timer::Interval;
 
 use std::{error::Error, iter, net::SocketAddr, sync::Arc, time::Duration};
@@ -122,11 +122,7 @@ impl ConnectionState {
     }
 }
 
-pub fn run(
-    config: Configuration,
-    propagate_input: MessageQueue<NetworkPropagateMsg>,
-    channels: Channels,
-) {
+pub fn run(config: Configuration, input: MessageQueue<NetworkMsg>, channels: Channels) {
     // TODO: the node needs to be saved/loaded
     //
     // * the ID needs to be consistent between restart;
@@ -179,7 +175,7 @@ pub fn run(
         )
     });
 
-    let propagate = handle_propagation(propagate_input, global_state.clone(), channels.clone());
+    let handle_cmds = handle_network_input(input, global_state.clone(), channels.clone());
 
     // TODO: get gossip propagation interval from configuration
     let gossip = Interval::new_interval(Duration::from_secs(10))
@@ -191,50 +187,65 @@ pub fn run(
             Ok(())
         });
 
-    tokio::run(listener.join4(connections, propagate, gossip).map(|_| ()));
+    tokio::run(listener.join4(connections, handle_cmds, gossip).map(|_| ()));
 }
 
-fn handle_propagation(
-    input: MessageQueue<NetworkPropagateMsg>,
+fn handle_network_input(
+    input: MessageQueue<NetworkMsg>,
     state: GlobalStateR,
     channels: Channels,
 ) -> impl Future<Item = (), Error = ()> {
-    input.for_each(move |msg| {
-        debug!("to propagate: {:?}", &msg);
-        let channels = channels.clone();
-        let state = state.clone();
-        let nodes = state.topology.view().collect::<Vec<_>>();
-        debug!(
-            "will propagate to: {:?}",
-            nodes.iter().map(|node| node.id()).collect::<Vec<_>>()
-        );
-        let res = match msg {
-            NetworkPropagateMsg::Block(ref header) => state
-                .propagation_peers
-                .propagate_block(nodes, header.clone()),
-            NetworkPropagateMsg::Message(ref message) => state
-                .propagation_peers
-                .propagate_message(nodes, message.clone()),
-        };
-        // If any nodes selected for propagation are not in the
-        // active subscriptions map, connect to them and deliver
-        // the item.
-        res.map_err(|unreached_nodes| {
-            for node in unreached_nodes {
-                let msg = msg.clone();
-                connect_and_propagate_with(node, state.clone(), channels.clone(), |handles| {
-                    match msg {
-                        NetworkPropagateMsg::Block(header) => {
-                            handles.try_send_block(header).map_err(|e| e.kind())
-                        }
-                        NetworkPropagateMsg::Message(message) => {
-                            handles.try_send_message(message).map_err(|e| e.kind())
-                        }
-                    }
-                });
-            }
-        })
+    input.for_each(move |msg| match msg {
+        NetworkMsg::Propagate(msg) => {
+            future::Either::A(handle_propagation_msg(msg, state.clone(), channels.clone()))
+        }
+        NetworkMsg::GetBlocks(node_id, headers) => future::Either::B({
+            unimplemented!();
+            future::ok(())
+        }),
     })
+}
+
+fn handle_propagation_msg(
+    msg: PropagateMsg,
+    state: GlobalStateR,
+    channels: Channels,
+) -> impl Future<Item = (), Error = ()> {
+    debug!("to propagate: {:?}", &msg);
+    let nodes = state.topology.view().collect::<Vec<_>>();
+    debug!(
+        "will propagate to: {:?}",
+        nodes.iter().map(|node| node.id()).collect::<Vec<_>>()
+    );
+    let res = match msg {
+        PropagateMsg::Block(ref header) => state
+            .propagation_peers
+            .propagate_block(nodes, header.clone()),
+        PropagateMsg::Message(ref message) => state
+            .propagation_peers
+            .propagate_message(nodes, message.clone()),
+    };
+    // If any nodes selected for propagation are not in the
+    // active subscriptions map, connect to them and deliver
+    // the item.
+    future::result(res.map_err(|unreached_nodes| {
+        for node in unreached_nodes {
+            let msg = msg.clone();
+            connect_and_propagate_with(
+                node,
+                state.clone(),
+                channels.clone(),
+                |handles| match msg {
+                    PropagateMsg::Block(header) => {
+                        handles.try_send_block(header).map_err(|e| e.kind())
+                    }
+                    PropagateMsg::Message(message) => {
+                        handles.try_send_message(message).map_err(|e| e.kind())
+                    }
+                },
+            );
+        }
+    }))
 }
 
 fn send_gossip(state: GlobalStateR, channels: Channels) {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -197,20 +197,23 @@ fn handle_network_input(
         NetworkMsg::Propagate(msg) => {
             future::Either::A(handle_propagation_msg(msg, state.clone(), channels.clone()))
         }
-        NetworkMsg::GetBlocks(node_id, block_ids) => future::Either::B(
-            state
-                .propagation_peers
-                .solicit_blocks(node_id, &block_ids)
-                .map(|blocks| {
-                    // TODO: feed blocks to the blockchain task
-                    unimplemented!();
-                    ()
-                })
-                .or_else(move |e| {
-                    warn!("failed to fetch blocks from peer {}: {:?}", node_id, e);
-                    future::ok::<(), ()>(())
-                }),
-        ),
+        NetworkMsg::GetBlocks(node_id, block_ids) => {
+            let mut channels = channels.clone();
+            future::Either::B(
+                state
+                    .propagation_peers
+                    .solicit_blocks(node_id, &block_ids)
+                    .map(move |blocks| {
+                        for block in blocks {
+                            channels.block_box.send(BlockMsg::NetworkBlock(block));
+                        }
+                    })
+                    .or_else(move |e| {
+                        warn!("failed to fetch blocks from peer {}: {:?}", node_id, e);
+                        future::ok::<(), ()>(())
+                    }),
+            )
+        }
     })
 }
 

--- a/src/network/propagate.rs
+++ b/src/network/propagate.rs
@@ -1,13 +1,15 @@
-use super::p2p_topology as p2p;
+use super::{p2p_topology as p2p, BlockConfig};
 use crate::blockcfg::{Header, Message};
 
 use network_core::{
     error::Error,
     gossip::{Gossip, Node},
 };
+use network_grpc::client::Connection;
 
 use futures::prelude::*;
 use futures::sync::mpsc;
+use tokio::{executor::DefaultExecutor, net::TcpStream};
 
 use std::{
     collections::{hash_map, HashMap},
@@ -128,6 +130,10 @@ pub struct PeerHandles {
     pub blocks: PropagationHandle<Header>,
     pub messages: PropagationHandle<Message>,
     pub gossip: PropagationHandle<Gossip<p2p::Node>>,
+
+    // TODO: decide if we want this or send requests via
+    // the bidirectional stream
+    pub(super) client: Option<Connection<BlockConfig, TcpStream, DefaultExecutor>>,
 }
 
 impl PeerHandles {

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -142,7 +142,7 @@ impl BlockService for NodeService {
     where
         In: Stream<Item = Self::Header, Error = core_error::Error> + Send + 'static,
     {
-        subscription::process_blocks(inbound, self.channels.block_box.clone());
+        subscription::process_blocks(subscriber, inbound, self.channels.block_box.clone());
 
         let subscription = self
             .global_state

--- a/src/network/subscription.rs
+++ b/src/network/subscription.rs
@@ -1,18 +1,25 @@
-use super::{p2p_topology::Node, GlobalStateR};
+use super::{
+    p2p_topology::{Node, NodeId},
+    GlobalStateR,
+};
 use crate::{blockcfg::Header, intercom::BlockMsg, utils::async_msg::MessageBox};
 
 use network_core::{error as core_error, gossip::Gossip};
 
 use futures::prelude::*;
 
-pub fn process_blocks<S>(inbound: S, mut block_box: MessageBox<BlockMsg>) -> tokio::executor::Spawn
+pub fn process_blocks<S>(
+    node_id: NodeId,
+    inbound: S,
+    mut block_box: MessageBox<BlockMsg>,
+) -> tokio::executor::Spawn
 where
     S: Stream<Item = Header, Error = core_error::Error> + Send + 'static,
 {
     tokio::spawn(
         inbound
             .for_each(move |header| {
-                block_box.send(BlockMsg::AnnouncedBlock(header));
+                block_box.send(BlockMsg::AnnouncedBlock(header, node_id));
                 Ok(())
             })
             .map_err(|err| {

--- a/src/network/subscription.rs
+++ b/src/network/subscription.rs
@@ -8,7 +8,7 @@ use network_core::{error as core_error, gossip::Gossip};
 
 use futures::prelude::*;
 
-pub fn process_blocks<S>(
+pub fn process_block_announcements<S>(
     node_id: NodeId,
     inbound: S,
     mut block_box: MessageBox<BlockMsg>,

--- a/utils/src/serde.rs
+++ b/utils/src/serde.rs
@@ -130,12 +130,12 @@ pub mod witness {
 pub mod crypto {
     use super::*;
     use ::bech32::{Bech32 as Bech32Data, FromBase32 as _};
-    use chain_crypto::{AsymmetricKey, Blake2b256, PublicKey, SecretKey, SecretKeySizeStatic};
+    use chain_crypto::{AsymmetricKey, Blake2b256, PublicKey, SecretKey};
 
     pub fn deserialize_secret<'de, D, A>(deserializer: D) -> Result<SecretKey<A>, D::Error>
     where
         D: Deserializer<'de>,
-        A: SecretKeySizeStatic,
+        A: AsymmetricKey,
     {
         let secret_key_visitor = SecretKeyVisitor::new();
         if deserializer.is_human_readable() {
@@ -244,7 +244,7 @@ pub mod crypto {
 
     impl<'de, A> Visitor<'de> for SecretKeyVisitor<A>
     where
-        A: SecretKeySizeStatic,
+        A: AsymmetricKey,
     {
         type Value = SecretKey<A>;
 
@@ -282,10 +282,7 @@ pub mod crypto {
         {
             use chain_crypto::SecretKeyError;
             match Self::Value::from_binary(v) {
-                Err(SecretKeyError::SizeInvalid) => Err(E::custom(format!(
-                    "Invalid size (expected: {}bytes)",
-                    A::SECRET_KEY_SIZE
-                ))),
+                Err(SecretKeyError::SizeInvalid) => Err(E::custom("Invalid size")),
                 Err(SecretKeyError::StructureInvalid) => Err(E::custom("Invalid structure")),
                 Ok(key) => Ok(key),
             }

--- a/utils/src/serde.rs
+++ b/utils/src/serde.rs
@@ -6,7 +6,7 @@ use chain_crypto::{bech32::Bech32, Ed25519Extended, PublicKey};
 use chain_impl_mockchain::leadership::bft::LeaderId;
 use serde::{
     de::{Deserializer, Error as DeserializerError, Visitor},
-    ser::{Error as _, Serializer},
+    ser::Serializer,
     Deserialize, Serialize,
 };
 use std::fmt::{self, Display};
@@ -130,12 +130,12 @@ pub mod witness {
 pub mod crypto {
     use super::*;
     use ::bech32::{Bech32 as Bech32Data, FromBase32 as _};
-    use chain_crypto::{AsymmetricKey, Blake2b256, PublicKey, SecretKey};
+    use chain_crypto::{AsymmetricKey, Blake2b256, PublicKey, SecretKey, SecretKeySizeStatic};
 
     pub fn deserialize_secret<'de, D, A>(deserializer: D) -> Result<SecretKey<A>, D::Error>
     where
         D: Deserializer<'de>,
-        A: AsymmetricKey,
+        A: SecretKeySizeStatic,
     {
         let secret_key_visitor = SecretKeyVisitor::new();
         if deserializer.is_human_readable() {
@@ -244,7 +244,7 @@ pub mod crypto {
 
     impl<'de, A> Visitor<'de> for SecretKeyVisitor<A>
     where
-        A: AsymmetricKey,
+        A: SecretKeySizeStatic,
     {
         type Value = SecretKey<A>;
 


### PR DESCRIPTION
When the blockchain task decides that it needs the block announced by a network peer, have the network task retrieve it from the peer.