### PR TITLE
Allow starting the node with multiple leaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ If you are not a leader node, then you can start the jormundandr with:
 
 ```
 jormungandr --genesis-block block-0.bin \
-  --config example.config \
-  --without-leadership
+  --config example.config
 ```
 
 # documentations

--- a/doc/advanced/02_starting_bft_blockchain.md
+++ b/doc/advanced/02_starting_bft_blockchain.md
@@ -80,3 +80,6 @@ $ jormungandr --genesis-block block-0.bin \
     --config example.config \
     --secret node_secret.yaml
 ```
+
+It's possible to use the flag `--secret` multiple times to run a node
+with multiple leaders.

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,18 +154,19 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         });
     }
 
-    let leader_secrets: Vec<Leader> = bootstrapped_node
+    let leader_secrets: Result<Vec<Leader>, start_up::Error> = bootstrapped_node
         .settings
         .leadership
         .iter()
         .map(|secret_path| {
-            let secret = secure::NodeSecret::load_from_file(secret_path.as_path()).unwrap();
-            Leader {
+            let secret = secure::NodeSecret::load_from_file(secret_path.as_path())?;
+            Ok(Leader {
                 bft_leader: secret.bft(),
                 genesis_leader: secret.genesis(),
-            }
+            })
         })
         .collect();
+    let leader_secrets = leader_secrets?;
 
     if !leader_secrets.is_empty() {
         let tpool = tpool.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,20 +154,23 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         });
     }
 
-    let leader_secret = if let Some(secret_path) = bootstrapped_node.settings.leadership {
-        Some(secure::NodeSecret::load_from_file(secret_path.as_path())?)
-    } else {
-        None
-    };
+    let leader_secrets: Vec<Leader> = bootstrapped_node
+        .settings
+        .leadership
+        .iter()
+        .map(|secret_path| {
+            let secret = secure::NodeSecret::load_from_file(secret_path.as_path()).unwrap();
+            Leader {
+                bft_leader: secret.bft(),
+                genesis_leader: secret.genesis(),
+            }
+        })
+        .collect();
 
-    if let Some(secret) = leader_secret {
+    if !leader_secrets.is_empty() {
         let tpool = tpool.clone();
         let block_task = block_task.clone();
         let blockchain = bootstrapped_node.blockchain.clone();
-        let pk = Leader {
-            bft_leader: secret.bft(),
-            genesis_leader: secret.genesis(),
-        };
 
         services.spawn_future("leadership", logger, move |info| {
             let process = self::leadership::Process::new(
@@ -177,7 +180,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 block_task,
             );
 
-            process.start(vec![pk], new_epoch_notifier)
+            process.start(leader_secrets, new_epoch_notifier)
         });
     }
 

--- a/src/settings/command_arguments.rs
+++ b/src/settings/command_arguments.rs
@@ -34,10 +34,6 @@ pub struct StartArguments {
     #[structopt(long = "grpc-connect", parse(try_from_str))]
     pub grpc_connect: Vec<SocketAddr>,
 
-    /// Work without the leadership task.
-    #[structopt(long = "without-leadership")]
-    pub without_leadership: bool,
-
     /// Path to the blockchain pool storage directory
     #[structopt(long = "storage", parse(from_os_str))]
     pub storage: Option<PathBuf>,
@@ -46,9 +42,10 @@ pub struct StartArguments {
     #[structopt(long = "config", parse(from_os_str))]
     pub node_config: PathBuf,
 
-    /// Set the secret node config (in YAML format)
+    /// Set the secret node config (in YAML format). Can be given
+    /// multiple times.
     #[structopt(long = "secret", parse(from_os_str))]
-    pub secret: Option<PathBuf>,
+    pub secret: Vec<PathBuf>,
 
     /// Path to the genesis block (the block0) of the blockchain
     #[structopt(long = "genesis-block", parse(try_from_str))]

--- a/src/settings/start/config.rs
+++ b/src/settings/start/config.rs
@@ -10,7 +10,7 @@ use std::{collections::BTreeMap, fmt, net::SocketAddr, path::PathBuf};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
-    pub secret_file: Option<PathBuf>,
+    pub secret_files: Option<Vec<PathBuf>>,
     pub legacy_peers: Option<Vec<SocketAddr>>,
     pub grpc_peers: Option<Vec<SocketAddr>>,
     pub storage: Option<PathBuf>,


### PR DESCRIPTION
This allows the `--secret` flag to be specified multiple times in order to start a node with multiple BFT leaders, which is primarily useful for testing.