### PR TITLE
MessageBox::send: Don't panic if try_send fails

### DIFF
--- a/src/blockchain/process.rs
+++ b/src/blockchain/process.rs
@@ -58,7 +58,11 @@ pub fn handle_input(
                         "date" => header.date().to_string()
                     );
                     debug!(logger, "Header: {:?}", header);
-                    network_msg_box.send(NetworkMsg::Propagate(PropagateMsg::Block(header)));
+                    network_msg_box
+                        .send(NetworkMsg::Propagate(PropagateMsg::Block(header)))
+                        .unwrap_or_else(|err| {
+                            error!(logger, "cannot propagate block to network: {}", err)
+                        });
                 }
             }
         }
@@ -91,7 +95,11 @@ pub fn handle_input(
                     );
                     debug!(logger, "Header: {:?}", header);
                     // Propagate the block to other nodes
-                    network_msg_box.send(NetworkMsg::Propagate(PropagateMsg::Block(header)));
+                    network_msg_box
+                        .send(NetworkMsg::Propagate(PropagateMsg::Block(header)))
+                        .unwrap_or_else(|err| {
+                            error!(logger, "cannot propagate block to network: {}", err)
+                        });
                 }
             }
         }
@@ -113,7 +121,11 @@ pub fn handle_input(
                 }
                 BlockHeaderTriage::ProcessBlockToState => {
                     info!(logger, "Block announcement is interesting, fetch block");
-                    network_msg_box.send(NetworkMsg::GetBlocks(node_id, vec![header.id()]));
+                    network_msg_box
+                        .send(NetworkMsg::GetBlocks(node_id, vec![header.id()]))
+                        .unwrap_or_else(|err| {
+                            error!(logger, "cannot propagate block to network: {}", err)
+                        });
                 }
             }
         }

--- a/src/leadership/process.rs
+++ b/src/leadership/process.rs
@@ -229,7 +229,9 @@ fn handle_epoch(
     .map_err(|error| EndOfEpochReminderError::DelayFailed { source: error })
     .and_then(move |()| {
         info!(logger, "End of epoch" ; "epoch" => date.epoch);
-        block_message.send(BlockMsg::LeadershipExpectEndOfEpoch);
+        block_message
+            .send(BlockMsg::LeadershipExpectEndOfEpoch)
+            .unwrap();
         future::ok(())
     })
 }

--- a/src/leadership/task.rs
+++ b/src/leadership/task.rs
@@ -173,7 +173,7 @@ fn handle_leadership(
                 }
             };
 
-            block_message.send(BlockMsg::LeadershipBlock(block));
+            block_message.send(BlockMsg::LeadershipBlock(block)).unwrap();
 
             future::ok(())
         })

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -103,7 +103,8 @@ where
             BlockEvent::Announce(header) => {
                 self.channels
                     .block_box
-                    .send(BlockMsg::AnnouncedBlock(header, self.remote_node_id));
+                    .send(BlockMsg::AnnouncedBlock(header, self.remote_node_id))
+                    .unwrap();
             }
             BlockEvent::Solicit(block_ids) => {
                 let (reply_handle, stream) = intercom::stream_reply::<
@@ -150,7 +151,7 @@ where
                 .and_then(move |blocks| {
                     blocks
                         .for_each(move |block| {
-                            block_box.send(BlockMsg::NetworkBlock(block));
+                            block_box.send(BlockMsg::NetworkBlock(block)).unwrap();
                             Ok(())
                         })
                         .map_err(move |e| {

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -148,7 +148,10 @@ impl BlockService for NodeService {
     }
 
     fn on_uploaded_block(&mut self, block: Block) -> Self::OnUploadedBlockFuture {
-        self.channels.block_box.send(BlockMsg::NetworkBlock(block));
+        self.channels
+            .block_box
+            .send(BlockMsg::NetworkBlock(block))
+            .unwrap();
         future::ok(())
     }
 

--- a/src/network/subscription.rs
+++ b/src/network/subscription.rs
@@ -19,7 +19,9 @@ where
     tokio::spawn(
         inbound
             .for_each(move |header| {
-                block_box.send(BlockMsg::AnnouncedBlock(header, node_id));
+                block_box
+                    .send(BlockMsg::AnnouncedBlock(header, node_id))
+                    .unwrap();
                 Ok(())
             })
             .map_err(move |err| {

--- a/src/utils/async_msg.rs
+++ b/src/utils/async_msg.rs
@@ -2,7 +2,7 @@
 //! asynchronous reading.
 
 use futures::prelude::*;
-use futures::sync::mpsc::{self, Receiver, Sender};
+use futures::sync::mpsc::{self, Receiver, Sender, TrySendError};
 
 /// The output end of an in-memory FIFO channel.
 pub struct MessageBox<Msg>(Sender<Msg>);
@@ -31,8 +31,8 @@ impl<Msg> MessageBox<Msg> {
     /// If the channel is full or the receiving MessageQueue has been dropped,
     /// the sending thread panics.
     ///
-    pub fn send(&mut self, a: Msg) {
-        self.0.try_send(a).unwrap()
+    pub fn send(&mut self, a: Msg) -> Result<(), TrySendError<Msg>> {
+        self.0.try_send(a)
     }
 }
 


### PR DESCRIPTION
Previously, if `handle_input()` couldn't send a message, it would panic, causing the block task to exit. This would in turn cause the leadership tasks to panic. Now it logs a message like:
```
May 27 16:26:49.020 ERRO cannot propagate block to network: send failed because receiver is gone, task: block
```