### PR TITLE
Rename MessageBox::send to try_send

### DIFF
--- a/src/blockchain/process.rs
+++ b/src/blockchain/process.rs
@@ -59,7 +59,7 @@ pub fn handle_input(
                     );
                     debug!(logger, "Header: {:?}", header);
                     network_msg_box
-                        .send(NetworkMsg::Propagate(PropagateMsg::Block(header)))
+                        .try_send(NetworkMsg::Propagate(PropagateMsg::Block(header)))
                         .unwrap_or_else(|err| {
                             error!(logger, "cannot propagate block to network: {}", err)
                         });
@@ -96,7 +96,7 @@ pub fn handle_input(
                     debug!(logger, "Header: {:?}", header);
                     // Propagate the block to other nodes
                     network_msg_box
-                        .send(NetworkMsg::Propagate(PropagateMsg::Block(header)))
+                        .try_send(NetworkMsg::Propagate(PropagateMsg::Block(header)))
                         .unwrap_or_else(|err| {
                             error!(logger, "cannot propagate block to network: {}", err)
                         });
@@ -122,7 +122,7 @@ pub fn handle_input(
                 BlockHeaderTriage::ProcessBlockToState => {
                     info!(logger, "Block announcement is interesting, fetch block");
                     network_msg_box
-                        .send(NetworkMsg::GetBlocks(node_id, vec![header.id()]))
+                        .try_send(NetworkMsg::GetBlocks(node_id, vec![header.id()]))
                         .unwrap_or_else(|err| {
                             error!(logger, "cannot propagate block to network: {}", err)
                         });

--- a/src/leadership/process.rs
+++ b/src/leadership/process.rs
@@ -230,7 +230,7 @@ fn handle_epoch(
     .and_then(move |()| {
         info!(logger, "End of epoch" ; "epoch" => date.epoch);
         block_message
-            .send(BlockMsg::LeadershipExpectEndOfEpoch)
+            .try_send(BlockMsg::LeadershipExpectEndOfEpoch)
             .unwrap();
         future::ok(())
     })

--- a/src/leadership/task.rs
+++ b/src/leadership/task.rs
@@ -173,7 +173,7 @@ fn handle_leadership(
                 }
             };
 
-            block_message.send(BlockMsg::LeadershipBlock(block)).unwrap();
+            block_message.try_send(BlockMsg::LeadershipBlock(block)).unwrap();
 
             future::ok(())
         })

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -103,7 +103,7 @@ where
             BlockEvent::Announce(header) => {
                 self.channels
                     .block_box
-                    .send(BlockMsg::AnnouncedBlock(header, self.remote_node_id))
+                    .try_send(BlockMsg::AnnouncedBlock(header, self.remote_node_id))
                     .unwrap();
             }
             BlockEvent::Solicit(block_ids) => {
@@ -151,7 +151,7 @@ where
                 .and_then(move |blocks| {
                     blocks
                         .for_each(move |block| {
-                            block_box.send(BlockMsg::NetworkBlock(block)).unwrap();
+                            block_box.try_send(BlockMsg::NetworkBlock(block)).unwrap();
                             Ok(())
                         })
                         .map_err(move |e| {

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -150,7 +150,7 @@ impl BlockService for NodeService {
     fn on_uploaded_block(&mut self, block: Block) -> Self::OnUploadedBlockFuture {
         self.channels
             .block_box
-            .send(BlockMsg::NetworkBlock(block))
+            .try_send(BlockMsg::NetworkBlock(block))
             .unwrap();
         future::ok(())
     }

--- a/src/network/subscription.rs
+++ b/src/network/subscription.rs
@@ -20,7 +20,7 @@ where
         inbound
             .for_each(move |header| {
                 block_box
-                    .send(BlockMsg::AnnouncedBlock(header, node_id))
+                    .try_send(BlockMsg::AnnouncedBlock(header, node_id))
                     .unwrap();
                 Ok(())
             })

--- a/src/utils/async_msg.rs
+++ b/src/utils/async_msg.rs
@@ -26,12 +26,11 @@ impl<Msg> MessageBox<Msg> {
     /// A call to this function never blocks
     /// the current thread.
     ///
-    /// # Panics
+    /// # Errors
     ///
     /// If the channel is full or the receiving MessageQueue has been dropped,
-    /// the sending thread panics.
-    ///
-    pub fn send(&mut self, a: Msg) -> Result<(), TrySendError<Msg>> {
+    /// an error is returned in `Err`.
+    pub fn try_send(&mut self, a: Msg) -> Result<(), TrySendError<Msg>> {
         self.0.try_send(a)
     }
 }


### PR DESCRIPTION
Follow the convention with underlying sender and its error type,
denoting the method as fallible.

Fixed the method comment to describe the new behavior.