### PR TITLE
Add error for logger init

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -252,7 +252,7 @@ pub struct InitializedNode {
 fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let command_line = CommandLine::load();
     let raw_settings = RawSettings::load(command_line)?;
-    let logger = raw_settings.to_logger();
+    let logger = raw_settings.to_logger()?;
 
     let init_logger = logger.new(o!(log::KEY_TASK => "init"));
     let settings = raw_settings.try_into_settings(&init_logger)?;

--- a/src/settings/logging.rs
+++ b/src/settings/logging.rs
@@ -33,7 +33,7 @@ impl FromStr for LogFormat {
 }
 
 impl LogSettings {
-    pub fn to_logger(&self) -> Logger {
+    pub fn to_logger(&self) -> Result<Logger, Error> {
         let drain = match self.format {
             LogFormat::Plain => {
                 let decorator = slog_term::TermDecorator::new().build();
@@ -46,6 +46,10 @@ impl LogSettings {
             }
         };
         let drain = slog::LevelFilter::new(drain, self.verbosity).fuse();
-        slog::Logger::root(drain, o!())
+        Ok(slog::Logger::root(drain, o!()))
     }
+}
+
+custom_error! {pub Error
+    ImpossibleError {} = @{{ unreachable!(); "" }} // Custom_error requires at least 1 variant
 }

--- a/src/settings/start/mod.rs
+++ b/src/settings/start/mod.rs
@@ -5,7 +5,7 @@ pub use self::config::Rest;
 use self::config::{Config, ConfigLogSettings};
 use self::network::Protocol;
 use crate::rest::Error as RestError;
-use crate::settings::logging::LogSettings;
+use crate::settings::logging::{self, LogSettings};
 use crate::settings::{command_arguments::*, Block0Info};
 use slog::Logger;
 
@@ -43,7 +43,7 @@ impl RawSettings {
         })
     }
 
-    pub fn to_logger(&self) -> Logger {
+    pub fn to_logger(&self) -> Result<Logger, logging::Error> {
         let level = if self.command_line.verbose == 0 {
             match self.config.logger {
                 Some(ConfigLogSettings {

--- a/src/start_up/error.rs
+++ b/src/start_up/error.rs
@@ -1,4 +1,7 @@
-use crate::{blockcfg, blockchain, network, secure, settings};
+use crate::{
+    blockcfg, blockchain, network, secure,
+    settings::{self, logging},
+};
 use chain_storage::error::Error as StorageError;
 use std::io;
 
@@ -8,7 +11,7 @@ custom_error! {pub ErrorKind
 }
 
 custom_error! {pub Error
-    LoggingInitializationError = "Unable to initialize the logger",
+    LoggingInitializationError { source: logging::Error } = "Unable to initialize the logger",
     ConfigurationError{source: settings::Error} = "Error in the overall configuration of the node",
     IO{source: io::Error, reason: ErrorKind} = "I/O Error with {reason}",
     ParseError{ source: io::Error, reason: ErrorKind} = "Parsing error on {reason}",
@@ -23,20 +26,14 @@ impl Error {
     #[inline]
     pub fn code(&self) -> i32 {
         match self {
-            Error::LoggingInitializationError => 1,
-            Error::ConfigurationError { source: _ } => 2,
-            Error::IO {
-                source: _,
-                reason: _,
-            } => 3,
-            Error::ParseError {
-                source: _,
-                reason: _,
-            } => 4,
-            Error::StorageError { source: _ } => 5,
-            Error::Blockchain { source: _ } => 6,
-            Error::Block0 { source: _ } => 7,
-            Error::NodeSecrets { source: _ } => 8,
+            Error::LoggingInitializationError { .. } => 1,
+            Error::ConfigurationError { .. } => 2,
+            Error::IO { .. } => 3,
+            Error::ParseError { .. } => 4,
+            Error::StorageError { .. } => 5,
+            Error::Blockchain { .. } => 6,
+            Error::Block0 { .. } => 7,
+            Error::NodeSecrets { .. } => 8,
             Error::FetchBlock0 { .. } => 9,
         }
     }


### PR DESCRIPTION
This is first step of #65. Some loggers will be able to fail on initialization and we want to be prepared