### PR TITLE
Jcli json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gtmpl"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gtmpl_value 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gtmpl_value"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "h2"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1166,14 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1189,6 +1213,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "galvanic-test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gtmpl 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jormungandr-utils 0.1.0",
@@ -3360,6 +3385,8 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum globset 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4feaabe24a0a658fd9cf4a9acf6ed284f045c77df0f49020ba3245cfb7b454"
 "checksum globwalk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89fa2e29859da05acd066bd45996f05c271b271d7ec4a781f909682328f65d25"
+"checksum gtmpl 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2dd34107b19afe784797100ad4ece4828c36fd9c20a835fd4844d404db972808"
+"checksum gtmpl_value 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1993b2a77fb10a996f4421a33deaa78dbac73a7914b9873088567e2556b6842"
 "checksum h2 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "2b53def7bb0253af7718036fe9338c15defd209136819464384f3a553e07481b"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
@@ -3377,6 +3404,7 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "08f7eadeaf4b52700de180d147c4805f199854600b36faa963d91114827b2ffc"
 "checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
+"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ custom_error = "1.6"
 num-traits = "0.2"
 jormungandr-utils = { path = "./utils" }
 strfmt = "0.1"
+gtmpl = "0.5.6"
 mktemp = "0.4.0"
 
 [dependencies.actix-web]

--- a/doc/jcli/rest.md
+++ b/doc/jcli/rest.md
@@ -10,6 +10,9 @@ Many CLI commands have common arguments:
 `https://` prefix. E.g. `-h http://127.0.0.1`, `--host https://node.com:8443/cardano/api`
 - `--debug` - Print additional debug information to stderr.
 The output format is intentionally undocumented and unstable
+- `--output-format <format>` - Format of output data. Possible values: json, yaml, default yaml.
+Any other value is treated as a custom format using values from output data structure.
+Syntax is Go text template: https://golang.org/pkg/text/template/.
 
 ## Node stats
 
@@ -23,6 +26,7 @@ The options are
 
 - -h <node_addr> - see [conventions](#conventions)
 - --debug - see [conventions](#conventions)
+- --output-format <format> - see [conventions](#conventions)
 
 
 YAML printed on success
@@ -46,6 +50,7 @@ The options are
 
 - -h <node_addr> - see [conventions](#conventions)
 - --debug - see [conventions](#conventions)
+- --output-format <format> - see [conventions](#conventions)
 
 
 YAML printed on success
@@ -86,6 +91,7 @@ The options are
 
 - -h <node_addr> - see [conventions](#conventions)
 - --debug - see [conventions](#conventions)
+- --output-format <format> - see [conventions](#conventions)
 
 YAML printed on success
 
@@ -183,6 +189,7 @@ jcli rest v0 account get <account-id> <options>
 The options are
 - -h <node_addr> - see [conventions](#conventions)
 - --debug - see [conventions](#conventions)
+- --output-format <format> - see [conventions](#conventions)
 
 YAML printed on success
 

--- a/src/bin/jcli.rs
+++ b/src/bin/jcli.rs
@@ -4,6 +4,7 @@ extern crate chain_addr;
 extern crate chain_core;
 extern crate chain_crypto;
 extern crate chain_impl_mockchain;
+extern crate gtmpl;
 extern crate jormungandr_utils;
 extern crate mime;
 extern crate num_traits;

--- a/src/bin/jcli_app/rest/v0/utxo/mod.rs
+++ b/src/bin/jcli_app/rest/v0/utxo/mod.rs
@@ -1,4 +1,4 @@
-use jcli_app::utils::{DebugFlag, HostAddr, RestApiSender};
+use jcli_app::utils::{DebugFlag, HostAddr, OutputFormat, RestApiSender};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -10,20 +10,24 @@ pub enum Utxo {
         addr: HostAddr,
         #[structopt(flatten)]
         debug: DebugFlag,
+        #[structopt(flatten)]
+        output_format: OutputFormat,
     },
 }
 
 impl Utxo {
     pub fn exec(self) {
-        let (addr, debug) = match self {
-            Utxo::Get { addr, debug } => (addr, debug),
-        };
+        let Utxo::Get {
+            addr,
+            debug,
+            output_format,
+        } = self;
         let url = addr.with_segments(&["v0", "utxo"]).unwrap().into_url();
         let builder = reqwest::Client::new().get(url);
         let response = RestApiSender::new(builder, &debug).send().unwrap();
         response.response().error_for_status_ref().unwrap();
-        let utxos: serde_json::Value = response.body().json().unwrap();
-        let utxos_yaml = serde_yaml::to_string(&utxos).unwrap();
-        println!("{}", utxos_yaml);
+        let status = response.body().json_value().unwrap();
+        let formatted = output_format.format_json(status).unwrap();
+        println!("{}", formatted);
     }
 }

--- a/src/bin/jcli_app/utils/mod.rs
+++ b/src/bin/jcli_app/utils/mod.rs
@@ -1,10 +1,13 @@
 mod debug_flag;
-pub mod error;
 mod host_addr;
+mod rest_api;
+
+pub mod error;
 pub mod io;
 pub mod key_parser;
-mod rest_api;
+pub mod output_format;
 
 pub use self::debug_flag::DebugFlag;
 pub use self::host_addr::HostAddr;
+pub use self::output_format::OutputFormat;
 pub use self::rest_api::{RestApiResponse, RestApiResponseBody, RestApiSender};

--- a/src/bin/jcli_app/utils/output_format.rs
+++ b/src/bin/jcli_app/utils/output_format.rs
@@ -1,0 +1,90 @@
+use gtmpl::Value as GtmplValue;
+use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
+use std::fmt::{self, Display, Formatter};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+pub struct OutputFormat {
+    /// Format of output data. Possible values: json, yaml.
+    /// Any other value is treated as a custom format using values from output data structure.
+    /// Syntax is Go text template: https://golang.org/pkg/text/template/.
+    #[structopt(long = "output-format", default_value = "yaml", parse(from_str))]
+    format: FormatVariant,
+}
+
+enum FormatVariant {
+    Yaml,
+    Json,
+    Custom(String),
+}
+
+impl<'a> From<&'a str> for FormatVariant {
+    fn from(format: &'a str) -> Self {
+        match format.trim().to_ascii_lowercase().as_str() {
+            "yaml" => FormatVariant::Yaml,
+            "json" => FormatVariant::Json,
+            _ => FormatVariant::Custom(format.to_string()),
+        }
+    }
+}
+
+custom_error! { pub Error
+    YamlFormattingFailed { source: serde_yaml::Error } = "failed to format output as YAML",
+    JsonFormattingFailed { source: serde_json::Error } = "failed to format output as JSON",
+    CustomFormattingFailed { source: GtmplError } = "failed to format output as custom format",
+}
+
+#[derive(Debug)]
+pub struct GtmplError(String);
+
+impl Display for GtmplError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for GtmplError {}
+
+impl OutputFormat {
+    pub fn format_json(&self, data: JsonValue) -> Result<String, Error> {
+        Ok(match self.format {
+            FormatVariant::Yaml => serde_yaml::to_string(&data)?,
+            FormatVariant::Json => serde_json::to_string_pretty(&data)?,
+            FormatVariant::Custom(ref format) => {
+                let gtmpl_value = json_value_to_gtmpl(data);
+                gtmpl::template(format.as_str(), gtmpl_value).map_err(GtmplError)?
+            }
+        })
+    }
+}
+
+fn json_value_to_gtmpl(value: JsonValue) -> GtmplValue {
+    match value {
+        JsonValue::Null => GtmplValue::Nil,
+        JsonValue::Bool(boolean) => boolean.into(),
+        JsonValue::Number(number) => json_number_to_gtmpl(number),
+        JsonValue::String(string) => string.into(),
+        JsonValue::Array(array) => json_array_to_gtmpl(array),
+        JsonValue::Object(object) => json_object_to_gtmpl(object),
+    }
+}
+
+fn json_number_to_gtmpl(number: JsonNumber) -> GtmplValue {
+    None.or_else(|| number.as_u64().map(Into::into))
+        .or_else(|| number.as_i64().map(Into::into))
+        .or_else(|| number.as_f64().map(Into::into))
+        .unwrap()
+}
+
+fn json_array_to_gtmpl(array: Vec<JsonValue>) -> GtmplValue {
+    let values = array.into_iter().map(json_value_to_gtmpl).collect();
+    GtmplValue::Array(values)
+}
+
+fn json_object_to_gtmpl(object: JsonMap<String, JsonValue>) -> GtmplValue {
+    let values = object
+        .into_iter()
+        .map(|(key, value)| (key, json_value_to_gtmpl(value)))
+        .collect();
+    GtmplValue::Object(values)
+}

--- a/src/bin/jcli_app/utils/rest_api.rs
+++ b/src/bin/jcli_app/utils/rest_api.rs
@@ -113,6 +113,10 @@ impl RestApiResponseBody {
         }
     }
 
+    pub fn json_value(&self) -> Result<serde_json::Value, serde_json::Error> {
+        self.json()
+    }
+
     pub fn is_empty(&self) -> bool {
         match self {
             RestApiResponseBody::Text(text) => text.is_empty(),


### PR DESCRIPTION
Add output formatting in JCLI REST commands. This fixes https://github.com/input-output-hk/jormungandr/issues/395.

This PR proposes small change in existing output format in UTxO getter and in logs getter. This is caused by a bug, design issue or lacking docs in TinyTemplate: https://github.com/bheisler/TinyTemplate/issues/3.