### PR TITLE
make the display of the scheduling less verbose

### DIFF
--- a/src/leadership/schedule.rs
+++ b/src/leadership/schedule.rs
@@ -93,7 +93,7 @@ impl LeaderSchedule {
             match enclave.leadership_evaluate1(leadership, leader_id, slot_idx) {
                 None => debug!(logger, "not a leader at this time"),
                 Some(leader_output) => {
-                    info!(logger, "scheduling a block leader");
+                    debug!(logger, "scheduling a block leader");
                     self.events.insert(
                         ScheduledEvent {
                             expected_time: slot_system_time.clone(),


### PR DESCRIPTION
this is not really an _info_ it is more a debug. We plan to provide
the schedule as a service in input-output-hk/jormungandr#423