### PR TITLE
improve jcli account-id parsing 

### DIFF
--- a/jcli/src/jcli_app/rest/v0/account/mod.rs
+++ b/jcli/src/jcli_app/rest/v0/account/mod.rs
@@ -1,4 +1,4 @@
-use jcli_app::utils::{DebugFlag, HostAddr, OutputFormat, RestApiSender};
+use jcli_app::utils::{AccountId, DebugFlag, HostAddr, OutputFormat, RestApiSender};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -12,8 +12,9 @@ pub enum Account {
         debug: DebugFlag,
         #[structopt(flatten)]
         output_format: OutputFormat,
-        /// ID of an account, bech32-encoded
-        account_id: String,
+        /// An Account ID either in the form of an address of kind account, or an account public key
+        #[structopt(parse(try_from_str = "AccountId::try_from_str"))]
+        account_id: AccountId,
     },
 }
 
@@ -26,7 +27,7 @@ impl Account {
             account_id,
         } = self;
         let url = addr
-            .with_segments(&["v0", "account", &account_id])
+            .with_segments(&["v0", "account", &account_id.to_url_arg()])
             .unwrap()
             .into_url();
         let builder = reqwest::Client::new().get(url);

--- a/jcli/src/jcli_app/utils/account_id.rs
+++ b/jcli/src/jcli_app/utils/account_id.rs
@@ -1,10 +1,10 @@
-use bech32::{Bech32, FromBase32, ToBase32};
-//use chain_crypto::bech32::Bech32;
+use bech32::{Bech32, FromBase32};
 use cardano::util::hex;
-use chain_addr::{Address, Kind, KindType};
-use chain_crypto::{AsymmetricPublicKey, Ed25519, PublicKey};
+use chain_addr::{Address, Kind};
+use chain_crypto::{Ed25519, PublicKey};
 use chain_impl_mockchain::account;
 
+#[derive(Debug)]
 pub struct AccountId {
     arg: String,
     account: account::Identifier,

--- a/jcli/src/jcli_app/utils/account_id.rs
+++ b/jcli/src/jcli_app/utils/account_id.rs
@@ -1,9 +1,9 @@
 use bech32::{Bech32, FromBase32, ToBase32};
 //use chain_crypto::bech32::Bech32;
-use chain_crypto::{AsymmetricPublicKey, PublicKey, Ed25519};
-use chain_impl_mockchain::account;
-use chain_addr::{Address, Kind, KindType};
 use cardano::util::hex;
+use chain_addr::{Address, Kind, KindType};
+use chain_crypto::{AsymmetricPublicKey, Ed25519, PublicKey};
+use chain_impl_mockchain::account;
 
 pub struct AccountId {
     arg: String,
@@ -15,7 +15,6 @@ fn id_from_pub(pk: PublicKey<Ed25519>) -> account::Identifier {
 }
 
 impl AccountId {
-
     // accept either an address with the account kind
     // or a ed25519 publickey
     pub fn try_from_str(src: &str) -> Result<Self, Error> {
@@ -24,20 +23,29 @@ impl AccountId {
             let dat = Vec::from_base32(b.data()).unwrap();
             if let Ok(addr) = Address::from_bytes(&dat) {
                 match addr.kind() {
-                    Kind::Account(pk) => {
-                        Ok(Self { arg: src.to_string(), account: id_from_pub(pk.clone()) })
-                    }, 
-                    _ => {
-                        Err(Error::AddressNotAccount { addr: src.to_string(), kind: format!("{:?}", addr.kind()) })
-                    }
+                    Kind::Account(pk) => Ok(Self {
+                        arg: src.to_string(),
+                        account: id_from_pub(pk.clone()),
+                    }),
+                    _ => Err(Error::AddressNotAccount {
+                        addr: src.to_string(),
+                        kind: format!("{:?}", addr.kind()),
+                    }),
                 }
             } else if let Ok(pk) = PublicKey::from_binary(&dat) {
-                Ok(Self { arg: src.to_string(), account: id_from_pub(pk) })
+                Ok(Self {
+                    arg: src.to_string(),
+                    account: id_from_pub(pk),
+                })
             } else {
-                Err(Error::NotRecognized { addr: src.to_string() })
+                Err(Error::NotRecognized {
+                    addr: src.to_string(),
+                })
             }
         } else {
-            Err(Error::NotRecognized { addr: src.to_string() })
+            Err(Error::NotRecognized {
+                addr: src.to_string(),
+            })
         }
     }
 
@@ -46,7 +54,6 @@ impl AccountId {
         hex::encode(self.account.as_ref().as_ref())
     }
 }
-
 
 custom_error! { pub Error
     NotRecognized { addr: String } = "account parameter '{addr}' isn't a valid address or publickey",

--- a/jcli/src/jcli_app/utils/account_id.rs
+++ b/jcli/src/jcli_app/utils/account_id.rs
@@ -1,0 +1,54 @@
+use bech32::{Bech32, FromBase32, ToBase32};
+//use chain_crypto::bech32::Bech32;
+use chain_crypto::{AsymmetricPublicKey, PublicKey, Ed25519};
+use chain_impl_mockchain::account;
+use chain_addr::{Address, Kind, KindType};
+use cardano::util::hex;
+
+pub struct AccountId {
+    arg: String,
+    account: account::Identifier,
+}
+
+fn id_from_pub(pk: PublicKey<Ed25519>) -> account::Identifier {
+    account::Identifier::from(pk)
+}
+
+impl AccountId {
+
+    // accept either an address with the account kind
+    // or a ed25519 publickey
+    pub fn try_from_str(src: &str) -> Result<Self, Error> {
+        use std::str::FromStr;
+        if let Ok(b) = Bech32::from_str(src) {
+            let dat = Vec::from_base32(b.data()).unwrap();
+            if let Ok(addr) = Address::from_bytes(&dat) {
+                match addr.kind() {
+                    Kind::Account(pk) => {
+                        Ok(Self { arg: src.to_string(), account: id_from_pub(pk.clone()) })
+                    }, 
+                    _ => {
+                        Err(Error::AddressNotAccount { addr: src.to_string(), kind: format!("{:?}", addr.kind()) })
+                    }
+                }
+            } else if let Ok(pk) = PublicKey::from_binary(&dat) {
+                Ok(Self { arg: src.to_string(), account: id_from_pub(pk) })
+            } else {
+                Err(Error::NotRecognized { addr: src.to_string() })
+            }
+        } else {
+            Err(Error::NotRecognized { addr: src.to_string() })
+        }
+    }
+
+    // account id is encoded in hexadecimal in url argument
+    pub fn to_url_arg(&self) -> String {
+        hex::encode(self.account.as_ref().as_ref())
+    }
+}
+
+
+custom_error! { pub Error
+    NotRecognized { addr: String } = "account parameter '{addr}' isn't a valid address or publickey",
+    AddressNotAccount { addr: String, kind: String } = "account parameter '{addr}' isn't an account address, found: '{kind}'",
+}

--- a/jcli/src/jcli_app/utils/mod.rs
+++ b/jcli/src/jcli_app/utils/mod.rs
@@ -1,3 +1,4 @@
+mod account_id;
 mod debug_flag;
 mod host_addr;
 mod rest_api;
@@ -7,6 +8,7 @@ pub mod io;
 pub mod key_parser;
 pub mod output_format;
 
+pub use self::account_id::AccountId;
 pub use self::debug_flag::DebugFlag;
 pub use self::host_addr::HostAddr;
 pub use self::output_format::OutputFormat;


### PR DESCRIPTION
allows now either a public key or an address in bech32 form.

fix #422