### PR TITLE
jcli: 'remove allow_account_creation' from 'jcli genesis init'

### DIFF
--- a/jcli/src/jcli_app/block/DOCUMENTED_EXAMPLE.yaml
+++ b/jcli/src/jcli_app/block/DOCUMENTED_EXAMPLE.yaml
@@ -43,18 +43,10 @@ blockchain_configuration:
   # This is the max number of messages allowed in a given Block
   max_number_of_transactions_per_block: 255
 
-  # Allow the creation of accounts from the output of a transaction
-  #
-  # if set to false, account based wallet will not be created without
-  # publishing a stake certificate.
-  # if set to true, simply adding the account in the output of a transaction
-  # will allow the account to exist in the blockchain.
-  allow_account_creation: true
-
   # The fee calculations settings
   #
   # fee(num_bytes, has_certificate) = constant + num_bytes * coefficient + has_certificate * certificate
-  linear_fee:
+  linear_fees:
     constant: 2
     coefficient: 1
     certificate: 4

--- a/jcli/src/jcli_app/block/yaml.rs
+++ b/jcli/src/jcli_app/block/yaml.rs
@@ -467,7 +467,7 @@ blockchain_configuration:
   consensus_genesis_praos_active_slot_coeff: "0.444"
   max_number_of_transactions_per_block: 255
   bft_slots_ratio: "0.222"
-  linear_fee:
+  linear_fees:
     coefficient: 1
     constant: 2
     certificate: 4


### PR DESCRIPTION
Remove **allow_account_creation** from `jcli genesis init`
Fix #471 