### PR TITLE
Changing function declaration to POSIX-syntax

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -265,7 +265,7 @@ if [ ! -f "$SCRIPTPATH/faucet-send-money.shtempl" ] || [ ! -f "$SCRIPTPATH/fauce
     echo "warning: cannot find faucet-send-money or faucet-send-certificate template: skipping !"
 else
 
-    function process_file {
+    process_file() {
       FROM=${1}
       TO=${2}
 
@@ -285,4 +285,3 @@ else
     process_file "$SCRIPTPATH/faucet-send-certificate.shtempl" faucet-send-certificate.sh
     exit 0
 fi
-

--- a/scripts/faucet-send-certificate.shtempl
+++ b/scripts/faucet-send-certificate.shtempl
@@ -28,7 +28,7 @@ else
     WHITE=""
 fi
 
-function usage {
+usage() {
     echo "usage: $0 <CERTIFICATE PATH>"
 }
 


### PR DESCRIPTION
When installing on a new Ubuntu 18.04 server
I got the error message:

`function not found`

The solution is:

> The function keyword is a bashism, a bash extension. POSIX syntax does not use function and mandates the use of parenthesis.
https://stackoverflow.com/a/12469057

So this pull request improves this.