### PR TITLE
Update introduction.md

### DIFF
--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -2,15 +2,15 @@
 
 Welcome to the Jormungandr User Guide.
 
-Jormungandr is an implementation of a full node, written in rust, with the
-initial aim to support Ouroboros type of consensus protocol.
+Jormungandr is a node implementation, written in rust, with the
+initial aim to support the Ouroboros type of consensus protocol.
 
-A full node is a participant of a blockchain network, continuously making,
-sending, receiving and validating blocks. Each full node is responsible
+A node is a participant of a blockchain network, continuously making,
+sending, receiving, and validating blocks. Each node is responsible
 to make sure that all the rules of the protocol are followed.
 
 ## Mythology
 
-Jörmungandr refers to _Midgard Serpent_ in the Norse mythology. It is a hint to
-_Ouroboros_, the Ancient Egypt serpent, which is eating its own tail and the
+Jörmungandr refers to the _Midgard Serpent_ in Norse mythology. It is a hint to
+_Ouroboros_, the Ancient Egyptian serpent, who eat its own tail, as well as the
 [IOHK paper](https://eprint.iacr.org/2016/889.pdf) on proof of stake.


### PR DESCRIPTION
minor language edits and removed 'full' from the node description, as per Bruno's suggestion.