### PR TITLE
Move genesis.yaml initial state to single list

### DIFF
--- a/doc/advanced/01_the_genesis_block.md
+++ b/doc/advanced/01_the_genesis_block.md
@@ -40,8 +40,10 @@ There are multiple _parts_ in the genesis file:
 | `consensus_leader_ids` | array | the list of the BFT leader at the beginning of the blockchain |
 | `max_number_of_transactions_per_block` | number | the maximum number of transactions allowed in a block |
 | `bft_slots_ratio` | number | placeholder, do not use |
-| `allow_account_creation` | boolean | allow creating accounts without publishing certificate |
-| `linear_fee` | object | linear fee settings, set the fee for transaction and certificate publishing |
+| `linear_fees` | object | linear fee settings, set the fee for transaction and certificate publishing |
+| `consensus_genesis_praos_active_slot_coeff` | number | genesis praos active slot coefficient.  Determines minimum stake required to try becoming slot leader, must be in range (0,1] |
+| `kes_update_speed` | number | the speed to update the KES Key in seconds |
+| `slots_per_epoch` | number | number of slots in each epoch |
 
 _for more information about the BFT leaders in the genesis file, see
 [Starting a BFT Blockchain](./02_starting_bft_blockchain.md)_
@@ -76,5 +78,7 @@ initial:
 
 | variant | format | description |
 |:-------|:-------|:------------|
-| `address` | string | can be a [single address](../jcli/address.md#address-for-utxo) or an [account address](../jcli/address.md#address-for-account) (if `allow_account_creation` is set to true) |
+| `address` | string | can be a [single address](../jcli/address.md#address-for-utxo) or an [account address](../jcli/address.md#address-for-account) |
 | `value` | number | assigned value |
+
+`legacy_fund` differs only in address format, which is legacy Cardano

--- a/doc/advanced/01_the_genesis_block.md
+++ b/doc/advanced/01_the_genesis_block.md
@@ -26,11 +26,9 @@ There are multiple _parts_ in the genesis file:
 * `blockchain_configuration`: this is a list of configuration
   parameters of the blockchain, some of which can be changed later
   via the update protocol;
-* `initial_utxos`: the list of initial utxos (addresses and credited value);
-* `legacy_utxos`: the list of legacy cardano utxos (base58 encoded addresses
-  and credited values).
+* `initial`: list of steps to create initial state of ledger
 
-### `blockchain_configuration` options
+## `blockchain_configuration` options
 
 | option | format | description |
 |:-------|:-------|:------------|
@@ -48,22 +46,35 @@ There are multiple _parts_ in the genesis file:
 _for more information about the BFT leaders in the genesis file, see
 [Starting a BFT Blockchain](./02_starting_bft_blockchain.md)_
 
-### The initial Funds
+## `initial` options
 
-This is a list of the initial token present in the blockchain. It can be:
+Each entry can be one of 3 variants:
 
-* classic UTxO: a [single address](../jcli/address.md#address-for-utxo) and a value
-* an account (if `allow_account_creation` is set to true): an
-  [account address](../jcli/address.md#address-for-account) and a value
-
-### The legacy Funds
-
-This is a list of legacy cardano addresses and associated credited value.
+| variant | format | description |
+|:-------|:-------|:------------|
+| `fund` | object | initial deposits present in the blockchain |
+| `cert` | string | initial certificate |
+| `legacy_fund` | object| same as `fund`, but with legacy Cardano address format |
 
 Example:
 
 ```yaml
-legacy_funds:
-  - address: Ae2tdPwUPEZCEhYAUVU7evPfQCJjyuwM6n81x6hSjU9TBMSy2YwZEVydssL
-    value: 2000
+initial:
+  - fund:
+      address: <address>
+      value: 10000
+  - cert: <certificate>
+  - legacy_fund:
+      address: <legacy address>
+      value: 123
+  - fund:
+      address: <another address>
+      value: 1001
 ```
+
+### `fund` and `legacy_fund` format
+
+| variant | format | description |
+|:-------|:-------|:------------|
+| `address` | string | can be a [single address](../jcli/address.md#address-for-utxo) or an [account address](../jcli/address.md#address-for-account) (if `allow_account_creation` is set to true) |
+| `value` | number | assigned value |

--- a/doc/advanced/02_starting_bft_blockchain.md
+++ b/doc/advanced/02_starting_bft_blockchain.md
@@ -30,18 +30,25 @@ blockchain_configuration:
   slots_per_epoch: 5
   slot_duration: 15
   epoch_stability_depth: 10
-  consensus_genesis_praos_active_slot_coeff: 0.22
   consensus_leader_ids:
     - ed25519e_pk1k3wjgdcdcn23k6dwr0cyh88ad7a4ayenyxaherfazwy363pyy8wqppn7j3
     - ed25519e_pk13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
-  allow_account_creation: true
+  bft_slots_ratio: 0.220
+  consensus_genesis_praos_active_slot_coeff: 0.22
+  max_number_of_transactions_per_block: 255
   linear_fees:
-    constant: 0
-    coefficient: 0
-    certificate: 0
-initial_funds:
-  - address: ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
-    value: 10000
+    constant: 2
+    coefficient: 1
+    certificate: 4
+  kes_update_speed: 43200
+initial:
+  - fund:
+      address: ta1svy0mwwm7mdwcuj308aapjw6ra4c3e6cygd0f333nvtjzxg8ahdvxlswdf0
+      value: 10000
+  - cert: cert1qgqqqqqqqqqqqqqqqqqqq0p5avfqqmgurpe7s9k7933q0wj420jl5xqvx8lywcu5jcr7fwqa9qmdn93q4nm7c4fsay3mzeqgq3c0slnut9kns08yn2qn80famup7nvgtfuyszqzqrd4lxlt5ylplfu76p8f6ks0ggprzatp2c8rn6ev3hn9dgr38tzful4h0udlwa0536vyrrug7af9ujmrr869afs0yw9gj5x7z24l8sps3zzcmv
+  - legacy_fund:
+      address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
+      value: 123
 ```
 
 In order to start your blockchain in BFT mode you need to be sure that:

--- a/jcli/src/jcli_app/block/DOCUMENTED_EXAMPLE.yaml
+++ b/jcli/src/jcli_app/block/DOCUMENTED_EXAMPLE.yaml
@@ -54,22 +54,19 @@ blockchain_configuration:
   # The speed to update the KES Key in seconds
   kes_update_speed: 43200 # 12hours
 
-# The initial state of the ledger. Each item is applied in order of this list
+# Initial state of the ledger. Each item is applied in order of this list
 initial:
-  # The initial deposits present in the blockchain.
-  #
-  # It can be UTxO addresses or account (if allow_account_creation is set).
+  # Initial deposits present in the blockchain
   - fund:
-      # this is the personal address of the developers, have a good heart and
-      # leave a good initial deposit for them
+      # UTxO addresses or account
       address: {initial_funds_address}
       value: 10000
 
-  # The initial certificate
+  # Initial certificate
   - cert: cert1qgqqqqqqqqqqqqqqqqqqq0p5avfqqmgurpe7s9k7933q0wj420jl5xqvx8lywcu5jcr7fwqa9qmdn93q4nm7c4fsay3mzeqgq3c0slnut9kns08yn2qn80famup7nvgtfuyszqzqrd4lxlt5ylplfu76p8f6ks0ggprzatp2c8rn6ev3hn9dgr38tzful4h0udlwa0536vyrrug7af9ujmrr869afs0yw9gj5x7z24l8sps3zzcmv
 
-  # the initial deposits present in the blockchain but utilizing the
-  # legacy Cardano address format
+  # Initial deposits present in the blockchain
   - legacy_fund:
+      # Legacy Cardano address
       address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
       value: 123

--- a/jcli/src/jcli_app/block/DOCUMENTED_EXAMPLE.yaml
+++ b/jcli/src/jcli_app/block/DOCUMENTED_EXAMPLE.yaml
@@ -54,21 +54,22 @@ blockchain_configuration:
   # The speed to update the KES Key in seconds
   kes_update_speed: 43200 # 12hours
 
-# The initial deposits present in the blockchain.
-#
-# It can be UTxO addresses or account (if allow_account_creation is set).
-initial_funds:
-  # this is the personal address of the developers, have a good heart and
-  # leave a good initial deposit for them
-  - address: {initial_funds_address}
-    value: 10000
+# The initial state of the ledger. Each item is applied in order of this list
+initial:
+  # The initial deposits present in the blockchain.
+  #
+  # It can be UTxO addresses or account (if allow_account_creation is set).
+  - fund:
+      # this is the personal address of the developers, have a good heart and
+      # leave a good initial deposit for them
+      address: {initial_funds_address}
+      value: 10000
 
-# The initial certificates.
-initial_certs:
-  - cert1qgqqqqqqqqqqqqqqqqqqq0p5avfqqmgurpe7s9k7933q0wj420jl5xqvx8lywcu5jcr7fwqa9qmdn93q4nm7c4fsay3mzeqgq3c0slnut9kns08yn2qn80famup7nvgtfuyszqzqrd4lxlt5ylplfu76p8f6ks0ggprzatp2c8rn6ev3hn9dgr38tzful4h0udlwa0536vyrrug7af9ujmrr869afs0yw9gj5x7z24l8sps3zzcmv
+  # The initial certificate
+  - cert: cert1qgqqqqqqqqqqqqqqqqqqq0p5avfqqmgurpe7s9k7933q0wj420jl5xqvx8lywcu5jcr7fwqa9qmdn93q4nm7c4fsay3mzeqgq3c0slnut9kns08yn2qn80famup7nvgtfuyszqzqrd4lxlt5ylplfu76p8f6ks0ggprzatp2c8rn6ev3hn9dgr38tzful4h0udlwa0536vyrrug7af9ujmrr869afs0yw9gj5x7z24l8sps3zzcmv
 
-# the initial deposits present in the blockchain but utilising the
-# legacy cardano address format
-legacy_funds:
-  - address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
-    value: 123
+  # the initial deposits present in the blockchain but utilizing the
+  # legacy Cardano address format
+  - legacy_fund:
+      address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
+      value: 123

--- a/jcli/src/jcli_app/block/yaml.rs
+++ b/jcli/src/jcli_app/block/yaml.rs
@@ -8,10 +8,10 @@ use chain_impl_mockchain::{
     certificate::Certificate,
     config::{Block0Date, ConfigParam},
     fee::LinearFee,
-    legacy::{self, OldAddress},
+    legacy::{OldAddress, UtxoDeclaration},
     message::{ConfigParams, Message},
     milli::Milli,
-    transaction,
+    transaction::{AuthenticatedTransaction, NoExtra, Output, Transaction},
     value::Value,
 };
 use jormungandr_utils::serde::{self, SerdeAsString, SerdeLeaderId};
@@ -31,11 +31,7 @@ pub struct Genesis {
     /// mechanism.
     blockchain_configuration: BlockchainConfiguration,
     #[serde(default)]
-    initial_funds: Vec<InitialUTxO>,
-    #[serde(default)]
-    initial_certs: Vec<InitialCertificate>,
-    #[serde(default)]
-    legacy_funds: Vec<LegacyUTxO>,
+    initial: Vec<Initial>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -66,6 +62,14 @@ struct InitialLinearFee {
     certificate: u64,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Initial {
+    Fund(InitialUTxO),
+    Cert(InitialCertificate),
+    LegacyFund(LegacyUTxO),
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 struct InitialCertificate(#[serde(with = "serde::certificate")] Certificate);
@@ -88,181 +92,36 @@ struct LegacyUTxO {
 type StaticStr = &'static str;
 
 custom_error! {pub Error
-    FirstBlock0MessageNotInit = "First message of block 0 is not initial",
-    InitUtxoHasInput = "Initial UTXO has input",
-    InitConfigParamMissing { name: StaticStr } = "Initial message misses parameter {name}",
-    InitConfigParamDuplicate { name: StaticStr } = "Initial message contains duplicate parameter {name}",
+    FirstBlock0MessageNotInit = "first message of block 0 is not initial",
+    Block0MessageUnexpected  = "non-first message of block 0 has unexpected type",
+    InitUtxoHasInput = "initial UTXO has input",
+    InitConfigParamMissing { name: StaticStr } = "initial message misses parameter {name}",
+    InitConfigParamDuplicate { name: StaticStr } = "initial message contains duplicate parameter {name}",
 }
 
 impl Genesis {
     pub fn from_block(block: &Block) -> Result<Self, Error> {
-        let mut messages = block.messages().peekable();
+        let mut messages = block.messages();
 
         let blockchain_configuration = match messages.next() {
-            Some(Message::Initial(initial)) => BlockchainConfiguration::from_ents(initial)?,
-            _ => return Err(Error::FirstBlock0MessageNotInit),
-        };
-        let initial_funds = get_initial_utxos(&mut messages)?;
-        let legacy_funds = get_legacy_utxos(&mut messages);
-        let initial_certs = get_initial_certs(&mut messages);
+            Some(Message::Initial(initial)) => BlockchainConfiguration::from_ents(initial),
+            _ => Err(Error::FirstBlock0MessageNotInit),
+        }?;
 
         Ok(Genesis {
             blockchain_configuration,
-            initial_funds,
-            legacy_funds,
-            initial_certs,
+            initial: try_initials_vec_from_messages(messages)?,
         })
     }
 
     pub fn to_block(&self) -> Block {
         let mut builder = BlockBuilder::new();
-
         builder.message(Message::Initial(
             self.blockchain_configuration.clone().to_ents(),
         ));
-
-        builder.messages(
-            self.to_initial_messages(
-                self.blockchain_configuration
-                    .max_number_of_transactions_per_block
-                    .unwrap_or(255) as usize,
-            ),
-        );
-        builder.messages(
-            self.to_legacy_messages(
-                self.blockchain_configuration
-                    .max_number_of_transactions_per_block
-                    .unwrap_or(255) as usize,
-            ),
-        );
-        builder.messages(self.to_certificate_messages());
+        builder.messages(self.initial.iter().map(Message::from));
         builder.make_genesis_block()
     }
-
-    fn to_initial_messages(&self, max_output_per_message: usize) -> Vec<Message> {
-        let mut messages = Vec::new();
-        let mut utxo_iter = self.initial_funds.iter();
-
-        while let Some(utxo) = utxo_iter.next() {
-            let mut outputs = Vec::with_capacity(max_output_per_message);
-            outputs.push(transaction::Output {
-                address: utxo.address.clone(),
-                value: utxo.value,
-            });
-
-            while let Some(utxo) = utxo_iter.next() {
-                outputs.push(transaction::Output {
-                    address: utxo.address.clone(),
-                    value: utxo.value,
-                });
-                if outputs.len() == max_output_per_message {
-                    break;
-                }
-            }
-
-            let transaction = transaction::AuthenticatedTransaction {
-                transaction: transaction::Transaction {
-                    inputs: Vec::new(),
-                    outputs: outputs,
-                    extra: transaction::NoExtra,
-                },
-                witnesses: Vec::new(),
-            };
-            messages.push(Message::Transaction(transaction));
-        }
-
-        messages
-    }
-
-    fn to_certificate_messages(&self) -> Vec<Message> {
-        self.initial_certs
-            .iter()
-            .map(|cert| transaction::AuthenticatedTransaction {
-                transaction: transaction::Transaction {
-                    inputs: vec![],
-                    outputs: vec![],
-                    extra: cert.0.clone(),
-                },
-                witnesses: vec![],
-            })
-            .map(Message::Certificate)
-            .collect()
-    }
-
-    fn to_legacy_messages(&self, max_output_per_message: usize) -> Vec<Message> {
-        let mut messages = Vec::new();
-        let mut utxo_iter = self.legacy_funds.iter();
-
-        while let Some(utxo) = utxo_iter.next() {
-            let mut outputs = Vec::with_capacity(max_output_per_message);
-            outputs.push((utxo.address.clone(), utxo.value));
-
-            while let Some(utxo) = utxo_iter.next() {
-                outputs.push((utxo.address.clone(), utxo.value));
-                if outputs.len() == max_output_per_message {
-                    break;
-                }
-            }
-
-            let declaration = legacy::UtxoDeclaration { addrs: outputs };
-
-            messages.push(Message::OldUtxoDeclaration(declaration));
-        }
-
-        messages
-    }
-}
-
-type PeekableMessages<'a> = std::iter::Peekable<<&'a Block as HasMessages<'a>>::Messages>;
-
-fn get_initial_utxos<'a>(messages: &mut PeekableMessages<'a>) -> Result<Vec<InitialUTxO>, Error> {
-    let mut vec = Vec::new();
-
-    while let Some(Message::Transaction(transaction)) = messages.peek() {
-        messages.next();
-        if !transaction.transaction.inputs.is_empty() {
-            return Err(Error::InitUtxoHasInput);
-        }
-
-        for output in transaction.transaction.outputs.iter() {
-            let initial_utxo = InitialUTxO {
-                address: output.address.clone(),
-                value: output.value,
-            };
-
-            vec.push(initial_utxo);
-        }
-    }
-
-    Ok(vec)
-}
-fn get_legacy_utxos<'a>(messages: &mut PeekableMessages<'a>) -> Vec<LegacyUTxO> {
-    let mut vec = Vec::new();
-
-    while let Some(Message::OldUtxoDeclaration(old_decls)) = messages.peek() {
-        messages.next();
-        for (address, value) in old_decls.addrs.iter() {
-            let legacy_utxo = LegacyUTxO {
-                address: address.clone(),
-                value: value.clone(),
-            };
-
-            vec.push(legacy_utxo);
-        }
-    }
-
-    vec
-}
-fn get_initial_certs<'a>(messages: &mut PeekableMessages<'a>) -> Vec<InitialCertificate> {
-    let mut vec = Vec::new();
-
-    while let Some(Message::Certificate(transaction)) = messages.peek() {
-        messages.next();
-        let cert = transaction.transaction.extra.clone();
-        vec.push(InitialCertificate(cert));
-    }
-
-    vec
 }
 
 impl BlockchainConfiguration {
@@ -408,6 +267,108 @@ fn param_missing_error(name: &'static str) -> Error {
     Error::InitConfigParamMissing { name }
 }
 
+fn try_initials_vec_from_messages<'a>(
+    mut messages: impl Iterator<Item = &'a Message>,
+) -> Result<Vec<Initial>, Error> {
+    let mut inits = Vec::new();
+    for message in messages {
+        match message {
+            Message::Transaction(tx) => try_extend_inits_with_tx(&mut inits, tx)?,
+            Message::Certificate(tx) => extend_inits_with_cert(&mut inits, tx),
+            Message::OldUtxoDeclaration(utxo) => extend_inits_with_legacy_utxo(&mut inits, utxo),
+            _ => return Err(Error::Block0MessageUnexpected),
+        }
+    }
+    Ok(inits)
+}
+
+fn try_extend_inits_with_tx(
+    initials: &mut Vec<Initial>,
+    tx: &AuthenticatedTransaction<Address, NoExtra>,
+) -> Result<(), Error> {
+    if !tx.transaction.inputs.is_empty() {
+        return Err(Error::InitUtxoHasInput);
+    }
+    let inits_iter = tx
+        .transaction
+        .outputs
+        .iter()
+        .map(|output| InitialUTxO {
+            address: output.address.clone(),
+            value: output.value,
+        })
+        .map(Initial::Fund);
+    initials.extend(inits_iter);
+    Ok(())
+}
+
+fn extend_inits_with_cert(
+    initials: &mut Vec<Initial>,
+    tx: &AuthenticatedTransaction<Address, Certificate>,
+) {
+    let cert = InitialCertificate(tx.transaction.extra.clone());
+    initials.push(Initial::Cert(cert))
+}
+
+fn extend_inits_with_legacy_utxo(initials: &mut Vec<Initial>, utxo_decl: &UtxoDeclaration) {
+    let inits_iter = utxo_decl
+        .addrs
+        .iter()
+        .map(|(address, value)| LegacyUTxO {
+            address: address.clone(),
+            value: value.clone(),
+        })
+        .map(Initial::LegacyFund);
+    initials.extend(inits_iter)
+}
+
+impl<'a> From<&'a Initial> for Message {
+    fn from(initial: &'a Initial) -> Message {
+        match initial {
+            Initial::Fund(utxo) => utxo.into(),
+            Initial::Cert(cert) => cert.into(),
+            Initial::LegacyFund(utxo) => utxo.into(),
+        }
+    }
+}
+
+impl<'a> From<&'a InitialUTxO> for Message {
+    fn from(utxo: &'a InitialUTxO) -> Message {
+        Message::Transaction(AuthenticatedTransaction {
+            transaction: Transaction {
+                inputs: vec![],
+                outputs: vec![Output {
+                    address: utxo.address.clone(),
+                    value: utxo.value,
+                }],
+                extra: NoExtra,
+            },
+            witnesses: vec![],
+        })
+    }
+}
+
+impl<'a> From<&'a InitialCertificate> for Message {
+    fn from(utxo: &'a InitialCertificate) -> Message {
+        Message::Certificate(AuthenticatedTransaction {
+            transaction: Transaction {
+                inputs: vec![],
+                outputs: vec![],
+                extra: utxo.0.clone(),
+            },
+            witnesses: vec![],
+        })
+    }
+}
+
+impl<'a> From<&'a LegacyUTxO> for Message {
+    fn from(utxo: &'a LegacyUTxO) -> Message {
+        Message::OldUtxoDeclaration(UtxoDeclaration {
+            addrs: vec![(utxo.address.clone(), utxo.value)],
+        })
+    }
+}
+
 pub fn documented_example(now: std::time::SystemTime) -> String {
     let secs = now
         .duration_since(std::time::SystemTime::UNIX_EPOCH)
@@ -472,16 +433,17 @@ blockchain_configuration:
     constant: 2
     certificate: 4
   kes_update_speed: 43200
-initial_funds:
-  - address: {}
-    value: 10000
-initial_certs:
-  - cert1qgqqqqqqqqqqqqqqqqqqq0p5avfqqmgurpe7s9k7933q0wj420jl5xqvx8lywcu5jcr7fwqa9qmdn93q4nm7c4fsay3mzeqgq3c0slnut9kns08yn2qn80famup7nvgtfuyszqzqrd4lxlt5ylplfu76p8f6ks0ggprzatp2c8rn6ev3hn9dgr38tzful4h0udlwa0536vyrrug7af9ujmrr869afs0yw9gj5x7z24l8sps3zzcmv
-legacy_funds:
-  - address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
-    value: 123
-  - address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
-    value: 456"#, leader_1_pk, leader_2_pk, initial_funds_address);
+initial:
+  - cert: cert1qgqqqqqqqqqqqqqqqqqqq0p5avfqqmgurpe7s9k7933q0wj420jl5xqvx8lywcu5jcr7fwqa9qmdn93q4nm7c4fsay3mzeqgq3c0slnut9kns08yn2qn80famup7nvgtfuyszqzqrd4lxlt5ylplfu76p8f6ks0ggprzatp2c8rn6ev3hn9dgr38tzful4h0udlwa0536vyrrug7af9ujmrr869afs0yw9gj5x7z24l8sps3zzcmv
+  - legacy_fund:
+      address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
+      value: 123
+  - fund:
+      address: {}
+      value: 10000
+  - legacy_fund:
+      address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
+      value: 456"#, leader_1_pk, leader_2_pk, initial_funds_address);
         let genesis: Genesis =
             serde_yaml::from_str(genesis_yaml.as_str()).expect("Failed to deserialize YAML");
 

--- a/jcli/src/jcli_app/block/yaml.rs
+++ b/jcli/src/jcli_app/block/yaml.rs
@@ -20,6 +20,7 @@ use rand_chacha::ChaChaRng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Genesis {
     /// the initial configuration of the blockchain
     ///
@@ -35,6 +36,7 @@ pub struct Genesis {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct BlockchainConfiguration {
     block0_date: u64,
     #[serde(with = "serde::as_string")]
@@ -56,6 +58,7 @@ struct BlockchainConfiguration {
 
 // FIXME: duplicates LinearFee, can we get rid of this?
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct InitialLinearFee {
     coefficient: u64,
     constant: u64,
@@ -63,7 +66,7 @@ struct InitialLinearFee {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 enum Initial {
     Fund(InitialUTxO),
     Cert(InitialCertificate),
@@ -71,10 +74,11 @@ enum Initial {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(transparent)]
+#[serde(transparent, deny_unknown_fields)]
 struct InitialCertificate(#[serde(with = "serde::certificate")] Certificate);
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct InitialUTxO {
     #[serde(with = "serde::address")]
     pub address: Address,
@@ -83,6 +87,7 @@ struct InitialUTxO {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct LegacyUTxO {
     pub address: OldAddress,
     #[serde(with = "serde::value")]

--- a/jormungandr-integration-tests/src/common/startup/configuration_builder.rs
+++ b/jormungandr-integration-tests/src/common/startup/configuration_builder.rs
@@ -1,5 +1,5 @@
 use crate::common::configuration::{
-    genesis_model::{Fund, GenesisYaml},
+    genesis_model::{Fund, GenesisYaml, Initial},
     jormungandr_config::JormungandrConfig,
     node_config_model::{Logger, NodeConfig, Peer},
     secret_model::SecretModel,
@@ -112,7 +112,8 @@ impl ConfigurationBuilder {
             .blockchain_configuration
             .consensus_genesis_praos_active_slot_coeff =
             self.consensus_genesis_praos_active_slot_coeff.clone();
-        genesis_model.initial_certs = self.certs.clone();
+        let certs = self.certs.iter().cloned().map(Initial::Cert);
+        genesis_model.initial.extend(certs);
         let path_to_output_block = super::build_genesis_block(&genesis_model);
 
         let mut config = JormungandrConfig::from(genesis_model, node_config);

--- a/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -1,5 +1,4 @@
-use crate::common::configuration::genesis_model::Fund;
-use crate::common::configuration::genesis_model::GenesisYaml;
+use crate::common::configuration::genesis_model::{Fund, GenesisYaml, Initial};
 use crate::common::configuration::jormungandr_config::JormungandrConfig;
 use crate::common::file_utils;
 use crate::common::jcli_wrapper;
@@ -34,7 +33,7 @@ pub fn test_genesis_with_empty_consenus_leaders_list_fails_to_build() {
 #[test]
 pub fn test_genesis_for_production_is_successfully_built() {
     let mut config = JormungandrConfig::new();
-    config.genesis_yaml.initial_funds = None;
+    config.genesis_yaml.initial.clear();
     config.genesis_yaml.blockchain_configuration.discrimination = Some("production".to_string());
     let input_yaml_file_path = GenesisYaml::serialize(&config.genesis_yaml);
     let path_to_output_block = file_utils::get_path_in_temp("block0.bin");
@@ -48,10 +47,10 @@ pub fn test_genesis_for_prod_with_initial_funds_for_testing_address_fail_to_buil
     let test_address = jcli_wrapper::assert_address_single(&public_key, Discrimination::Test);
 
     let mut config = JormungandrConfig::new();
-    config.genesis_yaml.initial_funds = Some(vec![Fund {
+    config.genesis_yaml.initial = vec![Initial::Fund(Fund {
         value: 100,
         address: test_address.clone(),
-    }]);
+    })];
     config.genesis_yaml.blockchain_configuration.discrimination = Some("production".to_string());
     jcli_wrapper::assert_genesis_encode_fails(&config.genesis_yaml, "Invalid discrimination");
 }
@@ -69,7 +68,7 @@ pub fn test_genesis_for_prod_with_wrong_discrimination_fail_to_build() {
 #[test]
 pub fn test_genesis_without_initial_funds_is_built_successfully() {
     let mut config = JormungandrConfig::new();
-    config.genesis_yaml.initial_funds = None;
+    config.genesis_yaml.initial.clear();
     let input_yaml_file_path = GenesisYaml::serialize(&config.genesis_yaml);
     let path_to_output_block = file_utils::get_path_in_temp("block0.bin");
     jcli_wrapper::assert_genesis_encode(&input_yaml_file_path, &path_to_output_block);

--- a/jormungandr-integration-tests/src/jcli/rest/utxo.rs
+++ b/jormungandr-integration-tests/src/jcli/rest/utxo.rs
@@ -25,7 +25,7 @@ pub fn test_correct_utxos_are_read_from_node() {
         jcli_wrapper::assert_address_single(&reciever_public_key, Discrimination::Test);
     println!("Reciever address generated: {}", &reciever_address);
 
-    let funds = vec![
+    let mut funds = vec![
         Fund {
             address: reciever_address.clone(),
             value: 100,
@@ -41,8 +41,10 @@ pub fn test_correct_utxos_are_read_from_node() {
         .build();
     let jormungandr_rest_address = config.get_node_address();
     let _jormungandr = startup::start_jormungandr_node(&mut config);
-    let content = jcli_wrapper::assert_rest_utxo_get(&jormungandr_rest_address);
+    let mut content = jcli_wrapper::assert_rest_utxo_get(&jormungandr_rest_address);
 
+    funds.sort_by_key(|fund| fund.address.clone());
+    content.sort_by_key(|utxo| utxo.out_addr.clone());
     assert_eq!(content.len(), funds.len());
     assert_eq!(funds[0].address, content[0].out_addr);
     assert_eq!(funds[0].value.to_string(), content[0].out_value.to_string());

--- a/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
@@ -47,10 +47,8 @@ pub fn test_jormungandr_passive_node_without_trusted_peers_fails_to_start() {
 
 #[test]
 pub fn test_jormungandr_without_initial_funds_starts_sucessfully() {
-    let mut config = startup::ConfigurationBuilder::new()
-        .with_funds(vec![])
-        .build();
-    config.genesis_yaml.legacy_funds = None;
+    let mut config = startup::ConfigurationBuilder::new().build();
+    config.genesis_yaml.initial.clear();
     let _jormungandr = startup::start_jormungandr_node(&mut config);
 }
 

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -197,12 +197,12 @@ blockchain_configuration:
   block0_consensus: ${CONSENSUS}
   bft_slots_ratio: 0
   kes_update_speed: 43200 # 12hours
-initial_certs:
-  - ${STAKE_POOL_CERT}
-  - ${STAKE_DELEGATION_CERT}
-initial_funds:
-  - address: ${FAUCET_ADDR}
-    value: ${FAUCET_AMOUNT}
+initial:
+  - fund:
+      address: ${FAUCET_ADDR}
+      value: ${FAUCET_AMOUNT}
+  - cert: ${STAKE_POOL_CERT}
+  - cert: ${STAKE_DELEGATION_CERT}
 EOF
 
 cat << EOF > ${SECRET_PATH}/pool-secret1.yaml
@@ -272,7 +272,7 @@ else
       sed -e "s/####FAUCET_SK####/${FAUCET_SK}/" \
           -e "s/####BLOCK0_HASH####/${BLOCK0_HASH}/" \
           -e "s;####REST_URL####;${REST_URL};" \
-          -e "s/####CLI####/${CLI}/" \
+          -e "s;####CLI####;${CLI};" \
           -e "s/####COLORS####/${COLORS}/" \
           -e "s/####FEE_CONSTANT####/${FEE_CONSTANT}/" \
           -e "s/####FEE_CERTIFICATE####/${FEE_CERTIFICATE}/" \


### PR DESCRIPTION
Fixes #403.

Also adds requirement that genesis.yaml can't have unknown fields. This will reject obsolete files instead of silently ignoring their content and generating invalid block.

Also updates docs for genesis.yaml, some fields were obsolete and some missing