### PR TITLE
add hex-crate to replace cardano::util::hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.1.0"
+
+[[package]]
 name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1217,7 @@ dependencies = [
  "galvanic-test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtmpl 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.1.0",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jormungandr-utils 0.2.0",
@@ -1273,6 +1278,7 @@ dependencies = [
  "galvanic-test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtmpl 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.1.0",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "hex",
   "jormungandr-utils",
   "jormungandr-lib",
   "jormungandr",

--- a/hex/Cargo.toml
+++ b/hex/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "hex"
+version = "0.1.0"
+authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>"]
+edition = "2018"
+
+[dependencies]

--- a/hex/src/lib.rs
+++ b/hex/src/lib.rs
@@ -1,0 +1,121 @@
+//! simple implementation of hexadecimal encoding and decoding
+//!
+//! # Example
+//!
+//! ```
+//! use hex::{Error, encode, decode};
+//!
+//! let example = b"some bytes";
+//!
+//! assert!(example.as_ref() == decode(&encode(example)).unwrap().as_slice());
+//! ```
+//!
+use std::{fmt, result};
+
+const ALPHABET: &'static [u8] = b"0123456789abcdef";
+
+/// hexadecimal encoding/decoding potential errors
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
+pub enum Error {
+    /// error when a given character is not part of the supported
+    /// hexadecimal alphabet. Contains the index of the faulty byte
+    UnknownSymbol(usize),
+}
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &Error::UnknownSymbol(idx) => write!(f, "Unknown symbol at byte index {}", idx),
+        }
+    }
+}
+impl ::std::error::Error for Error {}
+
+pub type Result<T> = result::Result<T, Error>;
+
+/// encode bytes into an hexadecimal string
+///
+///  # Example
+///
+/// ```
+/// use hex::{Error, encode};
+///
+/// let example = b"some bytes";
+///
+/// assert_eq!("736f6d65206279746573", encode(example));
+/// ```
+pub fn encode(input: &[u8]) -> String {
+    let mut v = Vec::with_capacity(input.len() * 2);
+    for &byte in input.iter() {
+        v.push(ALPHABET[(byte >> 4) as usize]);
+        v.push(ALPHABET[(byte & 0xf) as usize]);
+    }
+
+    unsafe { String::from_utf8_unchecked(v) }
+}
+
+/// decode the given hexadecimal string
+///
+///  # Example
+///
+/// ```
+/// use hex::{Error, decode};
+///
+/// let example = r"736f6d65206279746573";
+///
+/// assert!(decode(example).is_ok());
+/// ```
+pub fn decode(input: &str) -> Result<Vec<u8>> {
+    let mut b = Vec::with_capacity(input.len() / 2);
+    let mut modulus = 0;
+    let mut buf = 0;
+
+    for (idx, byte) in input.bytes().enumerate() {
+        buf <<= 4;
+
+        match byte {
+            b'A'...b'F' => buf |= byte - b'A' + 10,
+            b'a'...b'f' => buf |= byte - b'a' + 10,
+            b'0'...b'9' => buf |= byte - b'0',
+            b' ' | b'\r' | b'\n' | b'\t' => {
+                buf >>= 4;
+                continue;
+            }
+            _ => {
+                return Err(Error::UnknownSymbol(idx));
+            }
+        }
+
+        modulus += 1;
+        if modulus == 2 {
+            modulus = 0;
+            b.push(buf);
+        }
+    }
+
+    Ok(b)
+}
+
+#[cfg(test)]
+mod tests {
+    fn encode(input: &[u8], expected: &str) {
+        let encoded = super::encode(input);
+        assert_eq!(encoded, expected);
+    }
+    fn decode(expected: &[u8], input: &str) {
+        let decoded = super::decode(input).unwrap();
+        assert_eq!(decoded.as_slice(), expected);
+    }
+
+    #[test]
+    fn test_vector_1() {
+        encode(&[1, 2, 3, 4], "01020304");
+        decode(&[1, 2, 3, 4], "01020304");
+    }
+
+    #[test]
+    fn test_vector_2() {
+        encode(&[0xff, 0x0f, 0xff, 0xff], "ff0fffff");
+        decode(&[0xff, 0x0f, 0xff, 0xff], "ff0fffff");
+    }
+}

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -43,6 +43,7 @@ actix-net = "0.2.6"
 native-tls = "0.2.2"
 regex = "1.1.2"
 bech32 = "0.6"
+hex             = { path = "../hex" }
 chain-core      = { path = "../cardano-deps/chain-core" }
 chain-impl-mockchain = { path = "../cardano-deps/chain-impl-mockchain" }
 chain-storage   = { path = "../cardano-deps/chain-storage" }

--- a/jcli/src/jcli_app/debug/message.rs
+++ b/jcli/src/jcli_app/debug/message.rs
@@ -1,4 +1,4 @@
-use cardano::util::hex;
+use hex;
 use chain_core::property::Deserialize as _;
 use chain_impl_mockchain::message::Message as MockMessage;
 use jcli_app::debug::Error;

--- a/jcli/src/jcli_app/debug/message.rs
+++ b/jcli/src/jcli_app/debug/message.rs
@@ -1,6 +1,6 @@
-use hex;
 use chain_core::property::Deserialize as _;
 use chain_impl_mockchain::message::Message as MockMessage;
+use hex;
 use jcli_app::debug::Error;
 use jcli_app::utils::{error::CustomErrorFiller, io};
 use std::io::{BufRead, BufReader};

--- a/jcli/src/jcli_app/debug/mod.rs
+++ b/jcli/src/jcli_app/debug/mod.rs
@@ -1,6 +1,6 @@
 mod message;
 
-use cardano::util::hex;
+use hex;
 use jcli_app::utils::error::CustomErrorFiller;
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/jcli/src/jcli_app/key.rs
+++ b/jcli/src/jcli_app/key.rs
@@ -1,5 +1,5 @@
 use bech32::{u5, Bech32, FromBase32, ToBase32};
-use cardano::util::hex;
+use hex;
 use chain_crypto::{
     AsymmetricKey, AsymmetricPublicKey, Curve25519_2HashDH, Ed25519, Ed25519Bip32, Ed25519Extended,
     SumEd25519_12,
@@ -16,7 +16,7 @@ use structopt::{clap::arg_enum, StructOpt};
 custom_error! { pub Error
     Io { source: std::io::Error } = "I/O error",
     Bech32 { source: bech32::Error } = "invalid Bech32",
-    Hex { source: cardano::util::hex::Error } = "invalid Hexadecimal",
+    Hex { source: hex::Error } = "invalid Hexadecimal",
     SecretKey { source: chain_crypto::SecretKeyError } = "invalid secret key",
     Rand { source: rand::Error } = "error while using random source",
     InvalidSeed { seed_len: usize } = "invalid seed length, expected 32 bytes but received {seed_len}",
@@ -192,7 +192,7 @@ impl ToBytes {
         }?;
         let bytes = Vec::<u8>::from_base32(bech32.data())?;
         let mut output = self.output_file.open()?;
-        writeln!(output, "{}", cardano::util::hex::encode(&bytes))?;
+        writeln!(output, "{}", hex::encode(&bytes))?;
         Ok(())
     }
 }
@@ -215,7 +215,7 @@ impl FromBytes {
 }
 
 fn read_hex<P: AsRef<Path>>(path: Option<P>) -> Result<Vec<u8>, Error> {
-    cardano::util::hex::decode(read_line(path)?.trim()).map_err(Into::into)
+    hex::decode(read_line(path)?.trim()).map_err(Into::into)
 }
 
 fn read_bech32<P: AsRef<Path>>(path: Option<P>) -> Result<Bech32, Error> {

--- a/jcli/src/jcli_app/key.rs
+++ b/jcli/src/jcli_app/key.rs
@@ -1,9 +1,9 @@
 use bech32::{u5, Bech32, FromBase32, ToBase32};
-use hex;
 use chain_crypto::{
     AsymmetricKey, AsymmetricPublicKey, Curve25519_2HashDH, Ed25519, Ed25519Bip32, Ed25519Extended,
     SumEd25519_12,
 };
+use hex;
 use jcli_app::utils::io;
 use rand::{rngs::EntropyRng, SeedableRng};
 use rand_chacha::ChaChaRng;

--- a/jcli/src/jcli_app/rest/v0/block/next_id.rs
+++ b/jcli/src/jcli_app/rest/v0/block/next_id.rs
@@ -1,5 +1,5 @@
-use hex;
 use chain_crypto::Blake2b256;
+use hex;
 use jcli_app::utils::{DebugFlag, HostAddr, RestApiSender};
 use structopt::StructOpt;
 

--- a/jcli/src/jcli_app/rest/v0/block/next_id.rs
+++ b/jcli/src/jcli_app/rest/v0/block/next_id.rs
@@ -1,4 +1,4 @@
-use cardano::util::hex;
+use hex;
 use chain_crypto::Blake2b256;
 use jcli_app::utils::{DebugFlag, HostAddr, RestApiSender};
 use structopt::StructOpt;

--- a/jcli/src/jcli_app/rest/v0/block/subcommand.rs
+++ b/jcli/src/jcli_app/rest/v0/block/subcommand.rs
@@ -1,5 +1,5 @@
 use super::next_id::NextId;
-use cardano::util::hex;
+use hex;
 use jcli_app::utils::{DebugFlag, HostAddr, RestApiSender};
 use structopt::StructOpt;
 

--- a/jcli/src/jcli_app/rest/v0/message/mod.rs
+++ b/jcli/src/jcli_app/rest/v0/message/mod.rs
@@ -1,4 +1,4 @@
-use cardano::util::hex;
+use hex;
 use jcli_app::utils::{DebugFlag, HostAddr, OutputFormat, RestApiSender};
 use std::fs;
 use std::io::{stdin, BufRead};

--- a/jcli/src/jcli_app/transaction/mod.rs
+++ b/jcli/src/jcli_app/transaction/mod.rs
@@ -12,7 +12,7 @@ mod seal;
 mod staging;
 
 use self::staging::StagingKind;
-use cardano::util::hex;
+use hex;
 use chain_core::property::Serialize as _;
 use chain_impl_mockchain as chain;
 use jcli_app::utils::error::CustomErrorFiller;

--- a/jcli/src/jcli_app/transaction/mod.rs
+++ b/jcli/src/jcli_app/transaction/mod.rs
@@ -12,9 +12,9 @@ mod seal;
 mod staging;
 
 use self::staging::StagingKind;
-use hex;
 use chain_core::property::Serialize as _;
 use chain_impl_mockchain as chain;
+use hex;
 use jcli_app::utils::error::CustomErrorFiller;
 use jcli_app::utils::key_parser;
 use std::path::PathBuf;

--- a/jcli/src/jcli_app/utils/account_id.rs
+++ b/jcli/src/jcli_app/utils/account_id.rs
@@ -1,8 +1,8 @@
 use bech32::{Bech32, FromBase32};
-use hex;
 use chain_addr::{Address, Kind};
 use chain_crypto::{Ed25519, PublicKey};
 use chain_impl_mockchain::account;
+use hex;
 
 #[derive(Debug)]
 pub struct AccountId {

--- a/jcli/src/jcli_app/utils/account_id.rs
+++ b/jcli/src/jcli_app/utils/account_id.rs
@@ -1,5 +1,5 @@
 use bech32::{Bech32, FromBase32};
-use cardano::util::hex;
+use hex;
 use chain_addr::{Address, Kind};
 use chain_crypto::{Ed25519, PublicKey};
 use chain_impl_mockchain::account;

--- a/jcli/src/jcli_app/utils/rest_api.rs
+++ b/jcli/src/jcli_app/utils/rest_api.rs
@@ -1,4 +1,4 @@
-use cardano::util::hex;
+use hex;
 use jcli_app::utils::DebugFlag;
 use reqwest::{Error, RequestBuilder, Response};
 use std::{fmt, io::Write};

--- a/jcli/src/main.rs
+++ b/jcli/src/main.rs
@@ -5,6 +5,7 @@ extern crate chain_core;
 extern crate chain_crypto;
 extern crate chain_impl_mockchain;
 extern crate gtmpl;
+extern crate hex;
 extern crate jormungandr_utils;
 extern crate mime;
 extern crate num_traits;

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -44,6 +44,7 @@ actix-net = "0.2.6"
 native-tls = "0.2.2"
 regex = "1.1.2"
 bech32 = "0.6"
+hex             = { path = "../hex" }
 chain-core      = { path = "../cardano-deps/chain-core" }
 chain-impl-mockchain = { path = "../cardano-deps/chain-impl-mockchain" }
 chain-storage   = { path = "../cardano-deps/chain-storage" }

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -20,6 +20,7 @@ extern crate cryptoxide;
 #[macro_use(try_ready)]
 extern crate futures;
 extern crate generic_array;
+extern crate hex;
 extern crate http;
 extern crate hyper;
 extern crate jormungandr_lib;

--- a/jormungandr/src/rest/v0/utxo/utxo.rs
+++ b/jormungandr/src/rest/v0/utxo/utxo.rs
@@ -30,7 +30,7 @@ impl serde::ser::Serialize for TxId {
         S: serde::ser::Serializer,
     {
         if serializer.is_human_readable() {
-            let hex = cardano::util::hex::encode(self.0.as_ref());
+            let hex = hex::encode(self.0.as_ref());
             serializer.serialize_str(&hex)
         } else {
             serializer.serialize_bytes(self.0.as_ref())

--- a/testing/mjolnir/Cargo.toml
+++ b/testing/mjolnir/Cargo.toml
@@ -19,6 +19,7 @@ chain-addr = { path = "../../cardano-deps/chain-addr" }
 chain-core = { path = "../../cardano-deps/chain-core" }
 chain-crypto = { path = "../../cardano-deps/chain-crypto" }
 chain-impl-mockchain = { path = "../../cardano-deps/chain-impl-mockchain" }
+hex = { path = "../../hex" }
 serde = "^1.0.59"
 serde_derive = "^1.0.59"
 

--- a/testing/mjolnir/src/lib.rs
+++ b/testing/mjolnir/src/lib.rs
@@ -6,7 +6,7 @@ extern crate serde_derive;
 mod utils;
 
 use bech32::{Bech32, FromBase32};
-use cardano::util::hex;
+use hex;
 use cfg_if::cfg_if;
 use chain_addr as addr;
 use chain_core::{
@@ -67,7 +67,7 @@ impl PrivateKey {
 
     /// Read private key from hex representation.
     pub fn from_hex(input: &str) -> Result<PrivateKey, JsValue> {
-        use cardano::util::hex::decode;
+        use hex::decode;
         decode(input)
             .map_err(|e| JsValue::from_str(&format!("{:?}", e)))
             .and_then(|bytes| {
@@ -93,13 +93,13 @@ pub struct PublicKey(key::SpendingPublicKey);
 impl PublicKey {
     /// Show public key as hex string.
     pub fn to_hex(&self) -> String {
-        use cardano::util::hex::encode;
+        use hex::encode;
         encode(self.0.as_ref())
     }
 
     /// Read public key from hex string.
     pub fn from_hex(input: &str) -> Result<PublicKey, JsValue> {
-        use cardano::util::hex::decode;
+        use hex::decode;
         decode(input)
             .map_err(|e| JsValue::from_str(&format!("{:?}", e)))
             .and_then(|bytes| {


### PR DESCRIPTION
Mostly temporary to break the dependency quickly and without much rewrite, probably should be removed in favor of an existing crate at some point