### PR TITLE
Update delegating_stake.md

### DIFF
--- a/doc/stake_pool/delegating_stake.md
+++ b/doc/stake_pool/delegating_stake.md
@@ -36,8 +36,6 @@ To `jcli transaction add-certificate` command can be used to add a certificate t
 
 For example:
 
-Note that in order to finalize a transaction, it should have both inputs and outputs.
-
 ```sh
 
 ...


### PR DESCRIPTION
remove 'Note that in order to finalize a transaction, it should have both inputs and outputs.' 

QA validated that this is not accurate.