### PR TITLE
Fix incorrect PATH setting

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,8 +34,9 @@ RUN mkdir -p ${ENV_PREFIX} && \
         $HOME/.cargo/bin/jormungandr $HOME/.cargo/bin/jcli ${ENV_PREFIX}/bin && \
     rm -rf $HOME/.cargo $HOME/.rustup ${ENV_PREFIX}/src
 
-RUN export PATH=$ENV_PREFIX/bin:$PATH && \ 
-    mkdir -p ${ENV_PREFIX}/cfg && \
+ENV PATH=${ENV_PREFIX}/bin:${PATH}
+
+RUN mkdir -p ${ENV_PREFIX}/cfg && \
     mkdir -p ${ENV_PREFIX}/secret && \
     cd ${ENV_PREFIX}/bin && \
     sh ./bootstrap -p ${REST_PORT} -x -c ${ENV_PREFIX}/cfg -k ${ENV_PREFIX}/secret


### PR DESCRIPTION
`RUN export PATH=$ENV_PREFIX/bin:$PATH` will not add `$ENV_PREFIX/bin` to the final image and will lead to the following error:
`/app/bin/startup_script.sh: 1: /app/bin/startup_script.sh: jormungandr: not found`

Updated with correct environment replacement.