### PR TITLE
Proposal to replace ENTRYPOINT with CMD in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ LABEL description="Jormungandr latest"
 
 ARG PREFIX=/app
 ARG REST_PORT=8448
+ARG GRPC_PORT=8299
 
 ENV ENV_PREFIX=${PREFIX}
 
@@ -45,6 +46,6 @@ RUN mkdir -p ${ENV_PREFIX}/cfg && \
 EXPOSE ${REST_PORT}
 
 # expose gRPC port
-EXPOSE 8299 
+EXPOSE ${GRPC_PORT} 
 
 CMD [ "sh", "startup_script.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,15 +35,17 @@ RUN mkdir -p ${ENV_PREFIX} && \
     rm -rf $HOME/.cargo $HOME/.rustup ${ENV_PREFIX}/src
 
 ENV PATH=${ENV_PREFIX}/bin:${PATH}
+WORKDIR ${ENV_PREFIX}/bin
 
 RUN mkdir -p ${ENV_PREFIX}/cfg && \
     mkdir -p ${ENV_PREFIX}/secret && \
-    cd ${ENV_PREFIX}/bin && \
     sh ./bootstrap -p ${REST_PORT} -x -c ${ENV_PREFIX}/cfg -k ${ENV_PREFIX}/secret && \
-    chmod u+x ${ENV_PREFIX}/bin/startup_script.sh
+    chmod +x ./startup_script.sh
 
+# expose rest API port
 EXPOSE ${REST_PORT}
 
-WORKDIR ${ENV_PREFIX}/bin
+# expose gRPC port
+EXPOSE 8299 
 
 CMD [ "/bin/bash", "-c", "startup_script.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,7 @@ WORKDIR ${ENV_PREFIX}/bin
 
 RUN mkdir -p ${ENV_PREFIX}/cfg && \
     mkdir -p ${ENV_PREFIX}/secret && \
-    sh ./bootstrap -p ${REST_PORT} -x -c ${ENV_PREFIX}/cfg -k ${ENV_PREFIX}/secret && \
-    chmod +x ./startup_script.sh
+    sh ./bootstrap -p ${REST_PORT} -x -c ${ENV_PREFIX}/cfg -k ${ENV_PREFIX}/secret
 
 # expose rest API port
 EXPOSE ${REST_PORT}
@@ -48,4 +47,4 @@ EXPOSE ${REST_PORT}
 # expose gRPC port
 EXPOSE 8299 
 
-CMD [ "/bin/bash", "-c", "startup_script.sh" ]
+CMD [ "sh", "startup_script.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,6 @@ LABEL description="Jormungandr latest"
 
 ARG PREFIX=/app
 ARG REST_PORT=8448
-ARG GRPC_PORT=8299
 
 ENV ENV_PREFIX=${PREFIX}
 
@@ -42,10 +41,6 @@ RUN mkdir -p ${ENV_PREFIX}/cfg && \
     mkdir -p ${ENV_PREFIX}/secret && \
     sh ./bootstrap -p ${REST_PORT} -x -c ${ENV_PREFIX}/cfg -k ${ENV_PREFIX}/secret
 
-# expose rest API port
 EXPOSE ${REST_PORT}
-
-# expose gRPC port
-EXPOSE ${GRPC_PORT} 
 
 CMD [ "sh", "startup_script.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,11 @@ ENV PATH=${ENV_PREFIX}/bin:${PATH}
 RUN mkdir -p ${ENV_PREFIX}/cfg && \
     mkdir -p ${ENV_PREFIX}/secret && \
     cd ${ENV_PREFIX}/bin && \
-    sh ./bootstrap -p ${REST_PORT} -x -c ${ENV_PREFIX}/cfg -k ${ENV_PREFIX}/secret
+    sh ./bootstrap -p ${REST_PORT} -x -c ${ENV_PREFIX}/cfg -k ${ENV_PREFIX}/secret && \
+    chmod u+x ${ENV_PREFIX}/bin/startup_script.sh
 
 EXPOSE ${REST_PORT}
 
-ENTRYPOINT sh ${ENV_PREFIX}/bin/startup_script.sh
+WORKDIR ${ENV_PREFIX}/bin
+
+CMD [ "/bin/bash", "-c", "startup_script.sh" ]


### PR DESCRIPTION
This change will allow easier overriding, so we could do things like the following:

1. Start the node in the background
```bash
docker run -d --name j9r wang2bo2/j9r
```
2. Run scripts or jcli in separate containers:
```bash
docker run -t --rm --network=container:j9r wang2bo2/j9r create-account-and-delegate.sh
```
```bash
docker run -t --rm --network=container:j9r wang2bo2/j9r faucet-send-money.sh <account_addr> 10000000
```
```bash
docker run -t --rm --network=container:j9r wang2bo2/j9r jcli rest v0 account get <account_addr> -h "http://127.0.0.1:8448/api"
```

I have also made `${ENV_PREFIX}/bin` the `WORKDIR` because the scripts are referencing each other with `./`.