### PR TITLE
Move JCLI's genesis into jormungandr-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -113,7 +113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -464,10 +464,10 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -835,7 +835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -851,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -984,7 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "h2"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1065,13 +1065,13 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.29"
+version = "0.12.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1099,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1142,7 +1142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "integer-encoding"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1228,6 +1228,7 @@ dependencies = [
  "hex 0.1.0",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jormungandr-lib 0.2.2",
  "jormungandr-utils 0.2.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1287,7 +1288,7 @@ dependencies = [
  "hex 0.1.0",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "jormungandr-lib 0.2.2",
  "jormungandr-utils 0.2.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1350,14 +1351,18 @@ version = "0.2.2"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cardano-legacy-address 0.1.1",
  "chain-addr 0.1.0",
+ "chain-core 0.1.0",
  "chain-crypto 0.1.0",
  "chain-impl-mockchain 0.1.0",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "custom_error 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-bip32 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1585,8 +1590,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1657,7 +1662,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-connection 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-core 0.1.0-dev",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1707,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1963,7 +1968,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2212,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2228,10 +2233,10 @@ dependencies = [
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2376,7 +2381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2507,7 +2512,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2614,7 +2619,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2630,7 +2635,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2640,7 +2645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.35"
+version = "0.15.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2655,7 +2660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2681,7 +2686,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2693,7 +2698,7 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2719,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2985,7 +2990,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3028,7 +3033,7 @@ dependencies = [
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-connection 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3272,7 +3277,7 @@ dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3447,7 +3452,7 @@ dependencies = [
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
-"checksum cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0e37fba0087d9f3f4e269827a55dc511abf3e440cc097a0c154ff4e6584f988"
+"checksum cid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6908948032561f2550467a477f659cdc358320a805237b9b5035c0350c441def"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -3493,7 +3498,7 @@ dependencies = [
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
-"checksum flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
+"checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
 "checksum float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "134a8fa843d80a51a5b77d36d42bc2def9edcb0262c914861d08129fd1926600"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -3511,7 +3516,7 @@ dependencies = [
 "checksum globwalk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89fa2e29859da05acd066bd45996f05c271b271d7ec4a781f909682328f65d25"
 "checksum gtmpl 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2dd34107b19afe784797100ad4ece4828c36fd9c20a835fd4844d404db972808"
 "checksum gtmpl_value 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1993b2a77fb10a996f4421a33deaa78dbac73a7914b9873088567e2556b6842"
-"checksum h2 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "1e42e3daed5a7e17b12a0c23b5b2fbff23a925a570938ebee4baca1a9a1a2240"
+"checksum h2 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "69b2a5a3092cbebbc951fe55408402e696ee2ed09019137d1800fc2c411265d2"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
@@ -3519,12 +3524,12 @@ dependencies = [
 "checksum http-connection 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f6080cea47f7371d4da9a46dd52787c598ce93886393e400bc178f9039bac27"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
-"checksum hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)" = "e2cd6adf83b3347d36e271f030621a8cf95fd1fd0760546b9fc5a24a0f1447c7"
+"checksum hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)" = "40e7692b2009a70b1e9b362284add4d8b75880fefddb4acaa5e67194e843f219"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum ignore 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8dc57fa12805f367736a38541ac1a9fc6a52812a0ca959b1d4d4b640a89eb002"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
-"checksum integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "26746cbc2e680af687e88d717f20ff90079bd10fc984ad57d277cd0e37309fa5"
+"checksum integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1aec89c15e2cfa0f0eae8ca60e03cb10b30d25ea2c0ad7d6be60a95e32729994"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "08f7eadeaf4b52700de180d147c4805f199854600b36faa963d91114827b2ffc"
 "checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
@@ -3621,7 +3626,7 @@ dependencies = [
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
 "checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
-"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "00eb63f212df0e358b427f0f40aa13aaea010b470be642ad422bcbca2feff2e4"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6381ddfe91dbb659b4b132168da15985bc84162378cf4fcdc4eb99c857d063e2"
@@ -3670,7 +3675,7 @@ dependencies = [
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01dca13cf6c3b179864ab3292bd794e757618d35a7766b7c46050c614ba00829"
-"checksum syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)" = "641e117d55514d6d918490e47102f7e08d096fdde360247e4a10f7a91a8478d3"
+"checksum syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)" = "8b4f551a91e2e3848aeef8751d0d4eec9489b6474c720fd4c55958d8d31a430c"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum syslog 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bbc9b0acde4f7c05fdc1cfb05239b8a53a66815dd86c67fee5aa9bfac5b4ed42"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
@@ -3678,7 +3683,7 @@ dependencies = [
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
-"checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
+"checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/doc/advanced/01_the_genesis_block.md
+++ b/doc/advanced/01_the_genesis_block.md
@@ -18,7 +18,7 @@ jcli genesis init
 For example your genesis file may look like:
 
 ```yaml
-{{#include ../../jcli/src/jcli_app/block/DOCUMENTED_EXAMPLE.yaml}}
+{{#include ../../jormungandr-lib/src/interfaces/block0_configuration/DOCUMENTED_EXAMPLE.yaml}}
 ```
 
 There are multiple _parts_ in the genesis file:

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -58,6 +58,7 @@ reqwest = "0.9.11"
 custom_error = "1.6"
 num-traits = "0.2"
 jormungandr-utils = { path = "../jormungandr-utils" }
+jormungandr-lib = { path = "../jormungandr-lib" }
 strfmt = "0.1"
 gtmpl = "0.5.6"
 mktemp = "0.4.0"

--- a/jcli/src/jcli_app/block/mod.rs
+++ b/jcli/src/jcli_app/block/mod.rs
@@ -9,7 +9,9 @@ use chain_impl_mockchain::{
     ledger::{self, Ledger},
 };
 use jcli_app::utils::{error::CustomErrorFiller, io};
-use jormungandr_lib::interfaces::{block0_configuration_documented_example, Block0Configuration, Block0ConfigurationError};
+use jormungandr_lib::interfaces::{
+    block0_configuration_documented_example, Block0Configuration, Block0ConfigurationError,
+};
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/jcli/src/main.rs
+++ b/jcli/src/main.rs
@@ -5,6 +5,7 @@ extern crate chain_crypto;
 extern crate chain_impl_mockchain;
 extern crate gtmpl;
 extern crate hex;
+extern crate jormungandr_lib;
 extern crate jormungandr_utils;
 extern crate mime;
 extern crate num_traits;

--- a/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -11,13 +11,6 @@ pub fn test_genesis_block_is_built_from_corect_yaml() {
 }
 
 #[test]
-pub fn test_genesis_without_block0_date_fails_to_build() {
-    let mut config = JormungandrConfig::new();
-    config.genesis_yaml.blockchain_configuration.block0_date = None;
-    jcli_wrapper::assert_genesis_encode_fails(&config.genesis_yaml, "missing field `block0_date`")
-}
-
-#[test]
 pub fn test_genesis_with_empty_consenus_leaders_list_fails_to_build() {
     let mut config = JormungandrConfig::new();
     config

--- a/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -54,7 +54,7 @@ pub fn test_genesis_for_prod_with_wrong_discrimination_fail_to_build() {
     config.genesis_yaml.blockchain_configuration.discrimination = Some("prod".to_string());
     jcli_wrapper::assert_genesis_encode_fails(
         &config.genesis_yaml,
-        " Invalid Address Discrimination",
+        "blockchain_configuration.discrimination: unknown variant `prod`, expected `test` or `production`",
     );
 }
 

--- a/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
@@ -40,7 +40,7 @@ pub fn test_genesis_stake_pool_with_account_faucet_starts_successfully() {
     );
 
     let mut config = startup::ConfigurationBuilder::new()
-        .with_block0_consensus("genesis")
+        .with_block0_consensus("genesis_praos")
         .with_bft_slots_ratio("0".to_owned())
         .with_consensus_genesis_praos_active_slot_coeff("0.1")
         .with_consensus_leaders_ids(vec![leader.public_key.clone()])

--- a/jormungandr-lib/Cargo.toml
+++ b/jormungandr-lib/Cargo.toml
@@ -10,8 +10,11 @@ serde = { version = "1.0", features = ["derive"] }
 custom_error = "1.6"
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 chain-addr      = { path = "../chain-deps/chain-addr" }
+chain-core      = { path = "../chain-deps/chain-core" }
 chain-crypto    = { path = "../chain-deps/chain-crypto" }
+cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }
 rand_core = "0.3"
+rand_chacha = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 humantime = "1.2"
 
@@ -19,5 +22,6 @@ humantime = "1.2"
 rand = "0.6"
 quickcheck = "0.8"
 chain-crypto    = { path = "../chain-deps/chain-crypto", features = [ "property-test-api" ] }
+ed25519-bip32 = "0.1"
 serde_yaml = "0.8"
 bincode = "1.1"

--- a/jormungandr-lib/src/interfaces/block0_configuration/DOCUMENTED_EXAMPLE.yaml
+++ b/jormungandr-lib/src/interfaces/block0_configuration/DOCUMENTED_EXAMPLE.yaml
@@ -3,14 +3,18 @@ blockchain_configuration:
 
   # The block0-date defines the date the blockchain starts
   # expected value in seconds since UNIX_EPOCH
-  block0_date: {now}
+  #
+  # By default the value will be the current date and time. Or you can
+  # add a specific time by entering the number of seconds since UNIX
+  # Epoch
+  block0_date: {default_block0_date}
 
   # This is the type of discrimination of the blockchain
   # of this blockchain is meant for production then
   # use 'production' instead.
   #
   # otherwise leave as this
-  discrimination: test
+  discrimination: {discrimination}
 
   # The initial consensus version:
   #
@@ -18,41 +22,49 @@ blockchain_configuration:
   # * Genesis Praos consensus: genesis
   block0_consensus: bft
 
-  # Number of slots in each epoch
-  slots_per_epoch: 5
+  # Number of slots in each epoch.
+  #
+  # default value is {default_slots_per_epoch}
+  slots_per_epoch: {default_slots_per_epoch}
 
   # The slot duration, in seconds, is the time between the creation
   # of 2 blocks
-  slot_duration: 15
+  #
+  # default value is {default_slot_duration}
+  slot_duration: {default_slot_duration}
 
-  # The number of blocks (*10) per epoch
-  epoch_stability_depth: 10
-
-  # A list of Ed25519 Extended PublicKey that represents the
+  # A list of Ed25519 PublicKey that represents the
   # BFT leaders encoded as bech32. The order in the list matters.
   consensus_leader_ids:
     - {leader_1}
     - {leader_2}
+
   # Genesis praos parameter D
-  bft_slots_ratio: 0.220
+  #
+  # default value: {default_bft_slots_ratio}
+  bft_slots_ratio: {default_bft_slots_ratio}
 
   # Genesis praos active slot coefficient
   # Determines minimum stake required to try becoming slot leader, must be in range (0,1]
-  consensus_genesis_praos_active_slot_coeff: 0.22
-
-  # This is the max number of messages allowed in a given Block
-  max_number_of_transactions_per_block: 255
+  #
+  # default value: {default_consensus_genesis_praos_active_slot_coeff}
+  consensus_genesis_praos_active_slot_coeff: {default_consensus_genesis_praos_active_slot_coeff}
 
   # The fee calculations settings
   #
-  # fee(num_bytes, has_certificate) = constant + num_bytes * coefficient + has_certificate * certificate
+  # total fees: constant + (num_inputs + num_outputs) * coefficient [+ certificate]
   linear_fees:
+    # this is the minimum value to pay for every transaction
     constant: 2
+    # the additional fee to pay for every inputs and outputs
     coefficient: 1
+    # the additional fee to pay if the transaction embeds a certificate
     certificate: 4
 
   # The speed to update the KES Key in seconds
-  kes_update_speed: 43200 # 12hours
+  #
+  # default value: {default_kes_update_speed}
+  kes_update_speed: {default_kes_update_speed}
 
 # Initial state of the ledger. Each item is applied in order of this list
 initial:
@@ -67,6 +79,6 @@ initial:
 
   # Initial deposits present in the blockchain
   # - legacy_fund:
-  #     # Legacy Cardano address
-  #     address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
-  #     value: 123
+      # Legacy Cardano address
+      # address: 48mDfYyQn21iyEPzCfkATEHTwZBcZJqXhRJezmswfvc6Ne89u1axXsiazmgd7SwT8VbafbVnCvyXhBSMhSkPiCezMkqHC4dmxRahRC86SknFu6JF6hwSg8
+      # value: 123

--- a/jormungandr-lib/src/interfaces/block0_configuration/active_slot_coefficient.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/active_slot_coefficient.rs
@@ -1,0 +1,250 @@
+use chain_impl_mockchain::{config::ConfigParam, milli::Milli};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{convert::TryFrom, fmt, str::FromStr as _};
+
+const DEFAULT_ACTIVE_SLOT_COEFFICIENT: u64 = 0_100;
+const MINIMUM_ACTIVE_SLOT_COEFFICIENT: u64 = 0_001;
+const MAXIMUM_ACTIVE_SLOT_COEFFICIENT: u64 = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ActiveSlotCoefficient(pub(crate) Milli);
+
+impl ActiveSlotCoefficient {
+    /// minimal value for the active slot coefficient
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::ActiveSlotCoefficient;
+    /// # use chain_impl_mockchain::milli::Milli;
+    ///
+    /// assert_eq!(ActiveSlotCoefficient::MINIMUM, ActiveSlotCoefficient::new(Milli::from_millis(0_001)).unwrap())
+    /// ```
+    pub const MINIMUM: Self =
+        ActiveSlotCoefficient(Milli::from_millis(MINIMUM_ACTIVE_SLOT_COEFFICIENT));
+
+    /// maximal value for the active slot coefficient
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::ActiveSlotCoefficient;
+    /// # use chain_impl_mockchain::milli::Milli;
+    ///
+    /// assert_eq!(ActiveSlotCoefficient::MAXIMUM, ActiveSlotCoefficient::new(Milli::from_millis(1_000)).unwrap())
+    /// ```
+    pub const MAXIMUM: Self =
+        ActiveSlotCoefficient(Milli::from_millis(MAXIMUM_ACTIVE_SLOT_COEFFICIENT));
+
+    pub fn new(milli: Milli) -> Option<Self> {
+        if milli.to_millis() < MINIMUM_ACTIVE_SLOT_COEFFICIENT
+            || MAXIMUM_ACTIVE_SLOT_COEFFICIENT < milli.to_millis()
+        {
+            None
+        } else {
+            Some(ActiveSlotCoefficient(milli))
+        }
+    }
+}
+
+custom_error! { pub TryFromActiveSlotCoefficientError
+    Incompatible = "Incompatible Config param, expected active slot coefficient",
+    Invalid { coefficient: Milli } = "invalid active slot coefficient {coefficient}",
+}
+
+impl TryFrom<ConfigParam> for ActiveSlotCoefficient {
+    type Error = TryFromActiveSlotCoefficientError;
+    fn try_from(config_param: ConfigParam) -> Result<Self, Self::Error> {
+        match config_param {
+            ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(coefficient) => {
+                ActiveSlotCoefficient::new(coefficient)
+                    .ok_or(TryFromActiveSlotCoefficientError::Invalid { coefficient })
+            }
+            _ => Err(TryFromActiveSlotCoefficientError::Incompatible),
+        }
+    }
+}
+
+impl From<ActiveSlotCoefficient> for ConfigParam {
+    fn from(active_slot_coefficient: ActiveSlotCoefficient) -> Self {
+        ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(active_slot_coefficient.0)
+    }
+}
+
+impl fmt::Display for ActiveSlotCoefficient {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Default for ActiveSlotCoefficient {
+    fn default() -> Self {
+        ActiveSlotCoefficient::new(Milli::from_millis(DEFAULT_ACTIVE_SLOT_COEFFICIENT))
+            .expect("Default should be a valid value at all time")
+    }
+}
+
+impl Serialize for ActiveSlotCoefficient {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.0 == Milli::ONE {
+            serializer.serialize_u64(1)
+        } else {
+            serializer.serialize_str(&self.0.to_string())
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ActiveSlotCoefficient {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{self, Visitor};
+        struct ActiveSlotCoefficientVisitor;
+        impl<'de> Visitor<'de> for ActiveSlotCoefficientVisitor {
+            type Value = ActiveSlotCoefficient;
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(
+                    formatter,
+                    "active slot coefficient within range of {} and {}",
+                    ActiveSlotCoefficient::MINIMUM,
+                    ActiveSlotCoefficient::MAXIMUM,
+                )
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if v == 1 {
+                    Ok(ActiveSlotCoefficient(Milli::ONE))
+                } else {
+                    Err(E::custom(format!(
+                        "value out of bound, can only accept within range of {} and {}",
+                        ActiveSlotCoefficient::MINIMUM,
+                        ActiveSlotCoefficient::MAXIMUM,
+                    )))
+                }
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_str(&format!("{:.3}", v))
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let milli = Milli::from_str(s).map_err(E::custom)?;
+                let milli = milli.to_millis();
+
+                if milli < MINIMUM_ACTIVE_SLOT_COEFFICIENT {
+                    Err(E::custom(format!(
+                        "cannot have active slot coefficient below {}",
+                        ActiveSlotCoefficient::MINIMUM,
+                    )))
+                } else if MAXIMUM_ACTIVE_SLOT_COEFFICIENT < milli {
+                    Err(E::custom(format!(
+                        "cannot have active slot coefficient above {}",
+                        ActiveSlotCoefficient::MAXIMUM,
+                    )))
+                } else {
+                    Ok(ActiveSlotCoefficient(Milli::from_millis(milli)))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(ActiveSlotCoefficientVisitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for ActiveSlotCoefficient {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            use rand::Rng as _;
+            let v = g.gen_range(
+                MINIMUM_ACTIVE_SLOT_COEFFICIENT,
+                MAXIMUM_ACTIVE_SLOT_COEFFICIENT,
+            );
+            ActiveSlotCoefficient(Milli::from_millis(v))
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_invalid_type() {
+        const EXAMPLE: &'static str = "---\ntrue";
+
+        let _: ActiveSlotCoefficient = serde_yaml::from_str(EXAMPLE).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_below_bounds() {
+        const VALUE: u64 = MINIMUM_ACTIVE_SLOT_COEFFICIENT - 1;
+        let example = format!("---\n{}", VALUE);
+
+        let _: ActiveSlotCoefficient = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_above_bounds() {
+        const VALUE: u64 = MAXIMUM_ACTIVE_SLOT_COEFFICIENT + 1;
+        let example = format!("---\n{}", VALUE);
+
+        let _: ActiveSlotCoefficient = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    fn deserialize_from_float() {
+        const VALUE: Milli = Milli::from_millis(500);
+        let example = format!("---\n{}", VALUE);
+
+        let decoded: ActiveSlotCoefficient = serde_yaml::from_str(&example).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    #[test]
+    fn deserialize_from_number() {
+        const VALUE: Milli = Milli::ONE;
+        let example = format!("---\n{}", 1);
+
+        let decoded: ActiveSlotCoefficient = serde_yaml::from_str(&example).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    #[test]
+    fn deserialize_from_str() {
+        const VALUE: Milli = Milli::from_millis(220);
+        const ACTIVE_SLOT_STR: &'static str = "---\n\"0.220\"";
+
+        let decoded: ActiveSlotCoefficient = serde_yaml::from_str(&ACTIVE_SLOT_STR).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    quickcheck! {
+        fn serde_encode_decode(active_slot_coefficient: ActiveSlotCoefficient) -> bool {
+            let s = serde_yaml::to_string(&active_slot_coefficient).unwrap();
+            let active_slot_coefficient_dec: ActiveSlotCoefficient = serde_yaml::from_str(&s).unwrap();
+
+            active_slot_coefficient == active_slot_coefficient_dec
+        }
+
+        fn convert_from_to_config_param(active_slot_coefficient: ActiveSlotCoefficient) -> bool {
+            let cp = ConfigParam::from(active_slot_coefficient);
+            let active_slot_coefficient_dec = ActiveSlotCoefficient::try_from(cp).unwrap();
+
+            active_slot_coefficient == active_slot_coefficient_dec
+        }
+    }
+}

--- a/jormungandr-lib/src/interfaces/block0_configuration/bft_slots_ratio.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/bft_slots_ratio.rs
@@ -114,6 +114,8 @@ impl<'de> Deserialize<'de> for BFTSlotsRatio {
             {
                 if v == 1 {
                     Ok(BFTSlotsRatio(Milli::ONE))
+                } else if v == 0 {
+                    Ok(BFTSlotsRatio(Milli::ZERO))
                 } else {
                     Err(E::custom(format!(
                         "value out of bound, can only accept within range of {} and {}",
@@ -210,7 +212,17 @@ mod test {
     }
 
     #[test]
-    fn deserialize_from_number() {
+    fn deserialize_from_number_0() {
+        const VALUE: Milli = Milli::ZERO;
+        let example = format!("---\n{}", 0);
+
+        let decoded: BFTSlotsRatio = serde_yaml::from_str(&example).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    #[test]
+    fn deserialize_from_number_1() {
         const VALUE: Milli = Milli::ONE;
         let example = format!("---\n{}", 1);
 

--- a/jormungandr-lib/src/interfaces/block0_configuration/bft_slots_ratio.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/bft_slots_ratio.rs
@@ -1,0 +1,247 @@
+use chain_impl_mockchain::{config::ConfigParam, milli::Milli};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{convert::TryFrom, fmt, str::FromStr as _};
+
+const DEFAULT_BFT_SLOTS_RATIO: u64 = 0_220;
+const MINIMUM_BFT_SLOTS_RATIO: u64 = 0_000;
+const MAXIMUM_BFT_SLOTS_RATIO: u64 = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BFTSlotsRatio(pub(crate) Milli);
+
+impl BFTSlotsRatio {
+    /// minimal value for the BFT slot ratio
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::BFTSlotsRatio;
+    /// # use chain_impl_mockchain::milli::Milli;
+    ///
+    /// assert_eq!(BFTSlotsRatio::MINIMUM, BFTSlotsRatio::new(Milli::ZERO).unwrap())
+    /// ```
+    pub const MINIMUM: Self = BFTSlotsRatio(Milli::from_millis(MINIMUM_BFT_SLOTS_RATIO));
+
+    /// maximal value for the bft slot ratio
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::BFTSlotsRatio;
+    /// # use chain_impl_mockchain::milli::Milli;
+    ///
+    /// assert_eq!(BFTSlotsRatio::MAXIMUM, BFTSlotsRatio::new(Milli::ONE).unwrap())
+    /// ```
+    pub const MAXIMUM: Self = BFTSlotsRatio(Milli::from_millis(MAXIMUM_BFT_SLOTS_RATIO));
+
+    pub fn new(milli: Milli) -> Option<Self> {
+        if milli.to_millis() < MINIMUM_BFT_SLOTS_RATIO
+            || MAXIMUM_BFT_SLOTS_RATIO < milli.to_millis()
+        {
+            None
+        } else {
+            Some(BFTSlotsRatio(milli))
+        }
+    }
+}
+
+custom_error! { pub TryFromBFTSlotsRatioError
+    Incompatible = "Incompatible Config param, expected BFT slots ratio",
+    Invalid { ratio: Milli } = "invalid BFT slots ratio {ratio}",
+}
+
+impl TryFrom<ConfigParam> for BFTSlotsRatio {
+    type Error = TryFromBFTSlotsRatioError;
+    fn try_from(config_param: ConfigParam) -> Result<Self, Self::Error> {
+        match config_param {
+            ConfigParam::BftSlotsRatio(ratio) => {
+                BFTSlotsRatio::new(ratio).ok_or(TryFromBFTSlotsRatioError::Invalid { ratio })
+            }
+            _ => Err(TryFromBFTSlotsRatioError::Incompatible),
+        }
+    }
+}
+
+impl From<BFTSlotsRatio> for ConfigParam {
+    fn from(bft_slots_ratio: BFTSlotsRatio) -> Self {
+        ConfigParam::BftSlotsRatio(bft_slots_ratio.0)
+    }
+}
+
+impl fmt::Display for BFTSlotsRatio {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Default for BFTSlotsRatio {
+    fn default() -> Self {
+        BFTSlotsRatio::new(Milli::from_millis(DEFAULT_BFT_SLOTS_RATIO))
+            .expect("Default should be a valid value at all time")
+    }
+}
+
+impl Serialize for BFTSlotsRatio {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.0 == Milli::ONE {
+            serializer.serialize_u64(1)
+        } else {
+            serializer.serialize_str(&self.0.to_string())
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BFTSlotsRatio {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{self, Visitor};
+        struct BFTSlotsRatioVisitor;
+        impl<'de> Visitor<'de> for BFTSlotsRatioVisitor {
+            type Value = BFTSlotsRatio;
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(
+                    formatter,
+                    "BFT slots ratio within range of {} and {}",
+                    BFTSlotsRatio::MINIMUM,
+                    BFTSlotsRatio::MAXIMUM,
+                )
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if v == 1 {
+                    Ok(BFTSlotsRatio(Milli::ONE))
+                } else {
+                    Err(E::custom(format!(
+                        "value out of bound, can only accept within range of {} and {}",
+                        BFTSlotsRatio::MINIMUM,
+                        BFTSlotsRatio::MAXIMUM,
+                    )))
+                }
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_str(&format!("{:.3}", v))
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let milli = Milli::from_str(s).map_err(E::custom)?;
+                let milli = milli.to_millis();
+
+                if milli < MINIMUM_BFT_SLOTS_RATIO {
+                    Err(E::custom(format!(
+                        "cannot have BFT slots ratio below {}",
+                        BFTSlotsRatio::MINIMUM,
+                    )))
+                } else if MAXIMUM_BFT_SLOTS_RATIO < milli {
+                    Err(E::custom(format!(
+                        "cannot have BFT slots ratio above {}",
+                        BFTSlotsRatio::MAXIMUM,
+                    )))
+                } else {
+                    Ok(BFTSlotsRatio(Milli::from_millis(milli)))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(BFTSlotsRatioVisitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for BFTSlotsRatio {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            use rand::Rng as _;
+            let v = g.gen_range(MINIMUM_BFT_SLOTS_RATIO, MAXIMUM_BFT_SLOTS_RATIO);
+            BFTSlotsRatio(Milli::from_millis(v))
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_invalid_type() {
+        const EXAMPLE: &'static str = "---\ntrue";
+
+        let _: BFTSlotsRatio = serde_yaml::from_str(EXAMPLE).unwrap();
+    }
+
+    /// this test is ignored for as long as MINIMUM_BFT_SLOTS_RATIO is set
+    /// to Milli::ZERO
+    #[test]
+    #[should_panic]
+    #[ignore]
+    fn deserialize_from_below_bounds() {
+        const VALUE: u64 = MINIMUM_BFT_SLOTS_RATIO;
+        let example = format!("---\n{}", VALUE);
+
+        let _: BFTSlotsRatio = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_above_bounds() {
+        const VALUE: u64 = MAXIMUM_BFT_SLOTS_RATIO + 1;
+        let example = format!("---\n{}", VALUE);
+
+        let _: BFTSlotsRatio = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    fn deserialize_from_float() {
+        const VALUE: Milli = Milli::from_millis(500);
+        let example = format!("---\n{}", VALUE);
+
+        let decoded: BFTSlotsRatio = serde_yaml::from_str(&example).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    #[test]
+    fn deserialize_from_number() {
+        const VALUE: Milli = Milli::ONE;
+        let example = format!("---\n{}", 1);
+
+        let decoded: BFTSlotsRatio = serde_yaml::from_str(&example).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    #[test]
+    fn deserialize_from_str() {
+        const VALUE: Milli = Milli::from_millis(220);
+        const ACTIVE_SLOT_STR: &'static str = "---\n\"0.220\"";
+
+        let decoded: BFTSlotsRatio = serde_yaml::from_str(&ACTIVE_SLOT_STR).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    quickcheck! {
+        fn serde_encode_decode(active_slot_coefficient: BFTSlotsRatio) -> bool {
+            let s = serde_yaml::to_string(&active_slot_coefficient).unwrap();
+            let active_slot_coefficient_dec: BFTSlotsRatio = serde_yaml::from_str(&s).unwrap();
+
+            active_slot_coefficient == active_slot_coefficient_dec
+        }
+
+        fn convert_from_to_config_param(bft_slots_ratio: BFTSlotsRatio) -> bool {
+            let cp = ConfigParam::from(bft_slots_ratio);
+            let bft_slots_ratio_dec = BFTSlotsRatio::try_from(cp).unwrap();
+
+            bft_slots_ratio == bft_slots_ratio_dec
+        }
+    }
+}

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
@@ -1,0 +1,366 @@
+use crate::{
+    interfaces::{
+        ActiveSlotCoefficient, BFTSlotsRatio, ConsensusLeaderId, KESUpdateSpeed,
+        NumberOfSlotsPerEpoch, SlotDuration,
+    },
+    time::SecondsSinceUnixEpoch,
+};
+use chain_addr::Discrimination;
+use chain_impl_mockchain::{
+    block::ConsensusVersion,
+    config::{Block0Date, ConfigParam},
+    fee::LinearFee,
+    message::config::ConfigParams,
+};
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+/// Initial blockchain configuration for block0
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BlockchainConfiguration {
+    /// the number of seconds since UNIX Epoch
+    ///
+    /// any value between 0 (1/1/1970) and 1099511627775 (20/08/4147) is valid
+    #[serde(default)]
+    block0_date: SecondsSinceUnixEpoch,
+
+    /// the address discrimination (test or production)
+    #[serde(with = "DiscriminationDef")]
+    discrimination: Discrimination,
+
+    /// the type of consensus to utilise from the starting point of the
+    /// blockchain. `bft` or `genesis`
+    #[serde(with = "ConsensusVersionDef")]
+    block0_consensus: ConsensusVersion,
+
+    /// the list of consensus leaders
+    ///
+    /// depending of `block0_consensus` value:
+    ///
+    /// * `bft`: will be the list of BFT leaders, they will write blocks
+    ///    in a round robin fashion, filling every blocks deterministically.
+    /// * `genesis`: will be the list of leaders that will take over creating
+    ///   blocks from the stake pool. Useful for during transition from BFT
+    ///   to genesis.
+    ///
+    /// If the `consensus_version` is `bft`. This value cannot be left empty.
+    #[serde(default)]
+    consensus_leader_ids: Vec<ConsensusLeaderId>,
+
+    /// the linear fee settings.
+    ///
+    /// * constant is the minimal fee to pay for any kind of transaction
+    /// * coefficient will be added for every inputs and outputs
+    /// * certificate will be added if a certificate is embedded
+    ///
+    /// `constant + coefficient * (num_inputs + num_outputs) [+ certificate]`
+    ///
+    #[serde(with = "LinearFeeDef")]
+    linear_fees: LinearFee,
+
+    /// number of slots in one given epoch. The default value is `720`.
+    ///
+    #[serde(default)]
+    slots_per_epoch: NumberOfSlotsPerEpoch,
+
+    /// the number of seconds between the creation of 2 slots. The default
+    /// is `5` seconds.
+    #[serde(default)]
+    slot_duration: SlotDuration,
+
+    /// number of seconds between 2 required KES Key updates.
+    ///
+    /// KES means, Key Evolving Signature. It is the scheme used in
+    /// genesis to sign blocks and guarantee that one block signer
+    /// cannot reuse a key that was valid at a given state when
+    /// to create a fork.
+    #[serde(default)]
+    kes_update_speed: KESUpdateSpeed,
+
+    /// the active slot coefficient to determine the minimal stake
+    /// in order to participate to the consensus.
+    ///
+    /// default value is 0.1
+    #[serde(default)]
+    consensus_genesis_praos_active_slot_coeff: ActiveSlotCoefficient,
+
+    /// allow BFT and Genesis Praos to live together by allocating some
+    /// slots to the `consensus_leader_ids` (the BFT Leaders).
+    ///
+    /// default value is 0.22.
+    #[serde(default)]
+    bft_slots_ratio: BFTSlotsRatio,
+
+    /// TODO: need some love
+    /// this value is left for compatibility only but should be removed or
+    /// replaced by something more meaningful: max block size (in bytes)
+    #[serde(default)]
+    max_number_of_transactions_per_block: Option<u32>,
+
+    /// TODO: need some love
+    /// this value is left for compatibility only be should be removed
+    /// or replaced by something more meaningful or merged with
+    /// `slots_per_epoch`.
+    #[serde(default)]
+    epoch_stability_depth: Option<u32>,
+}
+
+impl From<BlockchainConfiguration> for ConfigParams {
+    fn from(blockchain_configuration: BlockchainConfiguration) -> Self {
+        blockchain_configuration.into_config_params()
+    }
+}
+
+type StaticStr = &'static str;
+
+custom_error! {pub FromConfigParamsError
+    InitConfigParamMissing { name: StaticStr } = "initial message misses parameter {name}",
+    InitConfigParamDuplicate { name: StaticStr } = "initial message contains duplicate parameter {name}",
+    NumberOfSlotsPerEpoch { source: super::number_of_slots_per_epoch::TryFromNumberOfSlotsPerEpochError } = "Invalid number of slots per epoch",
+    SlotDuration { source: super::slots_duration::TryFromSlotDurationError } = "Invalid slot duration value",
+    ConsensusLeaderId { source: super::leader_id::TryFromConsensusLeaderIdError } = "Invalid consensus leader id",
+    ActiveSlotCoefficient { source: super::active_slot_coefficient::TryFromActiveSlotCoefficientError } = "Invalid active slot coefficient value",
+    BFTSlotsRatio { source: super::bft_slots_ratio::TryFromBFTSlotsRatioError } = "Invalid BFT Slot ratio",
+    KESUpdateSpeed { source: super::kes_update_speed::TryFromKESUpdateSpeedError } = "Invalid KES Update speed value",
+}
+
+impl TryFrom<ConfigParams> for BlockchainConfiguration {
+    type Error = FromConfigParamsError;
+    fn try_from(params: ConfigParams) -> Result<Self, Self::Error> {
+        Self::from_config_params(params)
+    }
+}
+
+impl BlockchainConfiguration {
+    pub fn new(
+        discrimination: Discrimination,
+        block0_consensus: ConsensusVersion,
+        linear_fees: LinearFee,
+    ) -> Self {
+        BlockchainConfiguration {
+            block0_date: SecondsSinceUnixEpoch::default(),
+            discrimination,
+            block0_consensus,
+            linear_fees,
+            consensus_leader_ids: Vec::default(),
+            slots_per_epoch: NumberOfSlotsPerEpoch::default(),
+            slot_duration: SlotDuration::default(),
+            kes_update_speed: KESUpdateSpeed::default(),
+            consensus_genesis_praos_active_slot_coeff: ActiveSlotCoefficient::default(),
+            bft_slots_ratio: BFTSlotsRatio::default(),
+            max_number_of_transactions_per_block: None,
+            epoch_stability_depth: None,
+        }
+    }
+
+    fn from_config_params(params: ConfigParams) -> Result<Self, FromConfigParamsError> {
+        fn param_missing_error(name: &'static str) -> FromConfigParamsError {
+            FromConfigParamsError::InitConfigParamMissing { name }
+        }
+
+        let mut block0_date = None;
+        let mut discrimination = None;
+        let mut block0_consensus = None;
+        let mut slots_per_epoch = None;
+        let mut slot_duration = None;
+        let mut epoch_stability_depth = None;
+        let mut consensus_leader_ids = vec![];
+        let mut consensus_genesis_praos_active_slot_coeff = None;
+        let mut max_number_of_transactions_per_block = None;
+        let mut bft_slots_ratio = None;
+        let mut linear_fees = None;
+        let mut kes_update_speed = None;
+
+        for param in params.iter().cloned() {
+            match param {
+                ConfigParam::Block0Date(param) => block0_date
+                    .replace(SecondsSinceUnixEpoch::from(SecondsSinceUnixEpoch(param.0)))
+                    .map(|_| "block0_date"),
+                ConfigParam::ConsensusVersion(param) => {
+                    block0_consensus.replace(param).map(|_| "block0_consensus")
+                }
+                ConfigParam::Discrimination(param) => {
+                    discrimination.replace(param).map(|_| "discrimination")
+                }
+                cp @ ConfigParam::SlotsPerEpoch(_) => slots_per_epoch
+                    .replace(NumberOfSlotsPerEpoch::try_from(cp)?)
+                    .map(|_| "slots_per_epoch"),
+                cp @ ConfigParam::SlotDuration(_) => slot_duration
+                    .replace(SlotDuration::try_from(cp)?)
+                    .map(|_| "slot_duration"),
+                cp @ ConfigParam::AddBftLeader(_) => {
+                    consensus_leader_ids.push(ConsensusLeaderId::try_from(cp)?);
+                    None
+                }
+                cp @ ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(_) => {
+                    consensus_genesis_praos_active_slot_coeff
+                        .replace(ActiveSlotCoefficient::try_from(cp)?)
+                        .map(|_| "consensus_genesis_praos_active_slot_coeff")
+                }
+                cp @ ConfigParam::BftSlotsRatio(_) => bft_slots_ratio
+                    .replace(BFTSlotsRatio::try_from(cp)?)
+                    .map(|_| "bft_slots_ratio"),
+                ConfigParam::LinearFee(param) => linear_fees.replace(param).map(|_| "linear_fees"),
+                cp @ ConfigParam::KESUpdateSpeed(_) => kes_update_speed
+                    .replace(KESUpdateSpeed::try_from(cp)?)
+                    .map(|_| "kes_update_speed"),
+
+                ConfigParam::RemoveBftLeader(_) => {
+                    panic!("block 0 attempts to remove a BFT leader")
+                }
+                ConfigParam::ProposalExpiration(_param) => unimplemented!(),
+                ConfigParam::MaxNumberOfTransactionsPerBlock(param) => {
+                    max_number_of_transactions_per_block
+                        .replace(param)
+                        .map(|_| "max_number_of_transactions_per_block")
+                }
+                ConfigParam::EpochStabilityDepth(param) => epoch_stability_depth
+                    .replace(param)
+                    .map(|_| "epoch_stability_depth"),
+            }
+            .map(|name| Err(FromConfigParamsError::InitConfigParamDuplicate { name }))
+            .unwrap_or(Ok(()))?;
+        }
+
+        Ok(BlockchainConfiguration {
+            block0_date: block0_date.ok_or(param_missing_error("block0_date"))?,
+            discrimination: discrimination.ok_or(param_missing_error("discrimination"))?,
+            block0_consensus: block0_consensus.ok_or(param_missing_error("block0_consensus"))?,
+            slots_per_epoch: slots_per_epoch.ok_or(param_missing_error("slots_per_epoch"))?,
+            slot_duration: slot_duration.ok_or(param_missing_error("slot_duration"))?,
+            consensus_genesis_praos_active_slot_coeff: consensus_genesis_praos_active_slot_coeff
+                .ok_or(param_missing_error(
+                    "consensus_genesis_praos_active_slot_coeff",
+                ))?,
+            bft_slots_ratio: bft_slots_ratio.ok_or(param_missing_error("bft_slots_ratio"))?,
+            linear_fees: linear_fees.ok_or(param_missing_error("linear_fees"))?,
+            kes_update_speed: kes_update_speed.ok_or(param_missing_error("kes_update_speed"))?,
+            epoch_stability_depth,
+            consensus_leader_ids,
+            max_number_of_transactions_per_block,
+        })
+    }
+
+    fn into_config_params(self) -> ConfigParams {
+        let BlockchainConfiguration {
+            block0_date,
+            discrimination,
+            block0_consensus,
+            linear_fees,
+            consensus_leader_ids,
+            slots_per_epoch,
+            slot_duration,
+            kes_update_speed,
+            consensus_genesis_praos_active_slot_coeff,
+            bft_slots_ratio,
+            max_number_of_transactions_per_block,
+            epoch_stability_depth,
+        } = self;
+
+        let mut params = ConfigParams::new();
+
+        params.push(ConfigParam::Block0Date(Block0Date(block0_date.0)));
+        params.push(ConfigParam::Discrimination(discrimination));
+        params.push(ConfigParam::ConsensusVersion(block0_consensus));
+        params.push(ConfigParam::LinearFee(linear_fees));
+        params.push(ConfigParam::from(slots_per_epoch));
+        params.push(ConfigParam::from(slot_duration));
+        params.push(ConfigParam::from(kes_update_speed));
+        params.push(ConfigParam::from(consensus_genesis_praos_active_slot_coeff));
+        params.push(ConfigParam::from(bft_slots_ratio));
+
+        if let Some(max_number_of_transactions_per_block) = max_number_of_transactions_per_block {
+            params.push(ConfigParam::MaxNumberOfTransactionsPerBlock(
+                max_number_of_transactions_per_block,
+            ));
+        }
+
+        if let Some(epoch_stability_depth) = epoch_stability_depth {
+            params.push(ConfigParam::EpochStabilityDepth(epoch_stability_depth));
+        }
+
+        consensus_leader_ids
+            .into_iter()
+            .map(ConfigParam::from)
+            .fold(params, |mut params, cp| {
+                params.push(cp);
+                params
+            })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case", remote = "LinearFee")]
+struct LinearFeeDef {
+    constant: u64,
+    coefficient: u64,
+    certificate: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", remote = "Discrimination")]
+enum DiscriminationDef {
+    Test,
+    Production,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", remote = "ConsensusVersion")]
+enum ConsensusVersionDef {
+    Bft,
+    GenesisPraos,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for BlockchainConfiguration {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            BlockchainConfiguration {
+                block0_date: SecondsSinceUnixEpoch::arbitrary(g),
+                discrimination: if bool::arbitrary(g) {
+                    Discrimination::Production
+                } else {
+                    Discrimination::Test
+                },
+                block0_consensus: if bool::arbitrary(g) {
+                    ConsensusVersion::Bft
+                } else {
+                    ConsensusVersion::GenesisPraos
+                },
+                linear_fees: LinearFee::new(
+                    u64::arbitrary(g),
+                    u64::arbitrary(g),
+                    u64::arbitrary(g),
+                ),
+                consensus_leader_ids: Arbitrary::arbitrary(g),
+                slots_per_epoch: NumberOfSlotsPerEpoch::arbitrary(g),
+                slot_duration: SlotDuration::arbitrary(g),
+                kes_update_speed: KESUpdateSpeed::arbitrary(g),
+                consensus_genesis_praos_active_slot_coeff: ActiveSlotCoefficient::arbitrary(g),
+                bft_slots_ratio: BFTSlotsRatio::arbitrary(g),
+                max_number_of_transactions_per_block: Arbitrary::arbitrary(g),
+                epoch_stability_depth: Arbitrary::arbitrary(g),
+            }
+        }
+    }
+
+    quickcheck! {
+        fn serde_encode_decode(blockchain_configuration: BlockchainConfiguration) -> bool {
+            let s = serde_yaml::to_string(&blockchain_configuration).unwrap();
+            let blockchain_configuration_dec: BlockchainConfiguration = serde_yaml::from_str(&s).unwrap();
+
+            blockchain_configuration == blockchain_configuration_dec
+        }
+
+        fn convert_from_to_config_param(blockchain_configuration: BlockchainConfiguration) -> bool {
+            let cps = ConfigParams::from(blockchain_configuration.clone());
+            let blockchain_configuration_dec = BlockchainConfiguration::try_from(cps).unwrap();
+
+            blockchain_configuration == blockchain_configuration_dec
+        }
+    }
+}

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
@@ -1,0 +1,275 @@
+use crate::interfaces::{Address, OldAddress, Value};
+use chain_impl_mockchain::{
+    certificate,
+    legacy::UtxoDeclaration,
+    message::Message,
+    transaction::{AuthenticatedTransaction, NoExtra, Output, Transaction},
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum Initial {
+    Fund(InitialUTxO),
+    Cert(Certificate),
+    LegacyFund(LegacyUTxO),
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InitialUTxO {
+    pub address: Address,
+    pub value: Value,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegacyUTxO {
+    pub address: OldAddress,
+    pub value: Value,
+}
+
+#[derive(Clone, Debug)]
+pub struct Certificate(certificate::Certificate);
+
+/* ------------------- Serde ----------------------------------------------- */
+
+impl Serialize for Certificate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use bech32::{Bech32, ToBase32 as _};
+        use chain_core::property::Serialize as _;
+        use serde::ser::Error as _;
+
+        let bytes = self.0.serialize_as_vec().map_err(S::Error::custom)?;
+        let bech32 =
+            Bech32::new("cert".to_string(), bytes.to_base32()).map_err(S::Error::custom)?;
+
+        format!("{}", bech32).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Certificate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use bech32::{Bech32, FromBase32 as _};
+        use chain_core::mempack::{ReadBuf, Readable as _};
+        use serde::de::Error as _;
+
+        let bech32_str = String::deserialize(deserializer)?;
+        let bech32: Bech32 = bech32_str.parse().map_err(D::Error::custom)?;
+        if bech32.hrp() != "cert" {
+            return Err(D::Error::custom(format!(
+                "Expecting certificate in bech32, with HRP 'cert'"
+            )));
+        }
+        let bytes: Vec<u8> = Vec::from_base32(bech32.data()).map_err(D::Error::custom)?;
+        let mut buf = ReadBuf::from(&bytes);
+        certificate::Certificate::read(&mut buf)
+            .map_err(D::Error::custom)
+            .map(Certificate)
+    }
+}
+
+custom_error! {pub Error
+    FirstBlock0MessageNotInit = "first message of block 0 is not initial",
+    Block0MessageUnexpected  = "non-first message of block 0 has unexpected type",
+    InitUtxoHasInput = "initial UTXO has input",
+}
+
+
+pub fn try_initials_vec_from_messages<'a>(
+    messages: impl Iterator<Item = &'a Message>,
+) -> Result<Vec<Initial>, Error> {
+    let mut inits = Vec::new();
+    for message in messages {
+        match message {
+            Message::Transaction(tx) => try_extend_inits_with_tx(&mut inits, tx)?,
+            Message::Certificate(tx) => extend_inits_with_cert(&mut inits, tx),
+            Message::OldUtxoDeclaration(utxo) => extend_inits_with_legacy_utxo(&mut inits, utxo),
+            _ => return Err(Error::Block0MessageUnexpected),
+        }
+    }
+    Ok(inits)
+}
+
+fn try_extend_inits_with_tx(
+    initials: &mut Vec<Initial>,
+    tx: &AuthenticatedTransaction<chain_addr::Address, NoExtra>,
+) -> Result<(), Error> {
+    if !tx.transaction.inputs.is_empty() {
+        return Err(Error::InitUtxoHasInput);
+    }
+    let inits_iter = tx
+        .transaction
+        .outputs
+        .iter()
+        .map(|output| InitialUTxO {
+            address: output.address.clone().into(),
+            value: output.value.into(),
+        })
+        .map(Initial::Fund);
+    initials.extend(inits_iter);
+    Ok(())
+}
+
+fn extend_inits_with_cert(
+    initials: &mut Vec<Initial>,
+    tx: &AuthenticatedTransaction<chain_addr::Address, certificate::Certificate>,
+) {
+    let cert = Certificate(tx.transaction.extra.clone());
+    initials.push(Initial::Cert(cert))
+}
+
+fn extend_inits_with_legacy_utxo(initials: &mut Vec<Initial>, utxo_decl: &UtxoDeclaration) {
+    let inits_iter = utxo_decl
+        .addrs
+        .iter()
+        .map(|(address, value)| LegacyUTxO {
+            address: address.clone().into(),
+            value: value.clone().into(),
+        })
+        .map(Initial::LegacyFund);
+    initials.extend(inits_iter)
+}
+
+impl<'a> From<&'a Initial> for Message {
+    fn from(initial: &'a Initial) -> Message {
+        match initial {
+            Initial::Fund(utxo) => utxo.into(),
+            Initial::Cert(cert) => cert.into(),
+            Initial::LegacyFund(utxo) => utxo.into(),
+        }
+    }
+}
+
+impl<'a> From<&'a InitialUTxO> for Message {
+    fn from(utxo: &'a InitialUTxO) -> Message {
+        Message::Transaction(AuthenticatedTransaction {
+            transaction: Transaction {
+                inputs: vec![],
+                outputs: vec![Output {
+                    address: utxo.address.clone().into(),
+                    value: utxo.value.into(),
+                }],
+                extra: NoExtra,
+            },
+            witnesses: vec![],
+        })
+    }
+}
+
+impl<'a> From<&'a Certificate> for Message {
+    fn from(utxo: &'a Certificate) -> Message {
+        Message::Certificate(AuthenticatedTransaction {
+            transaction: Transaction {
+                inputs: vec![],
+                outputs: vec![],
+                extra: utxo.0.clone(),
+            },
+            witnesses: vec![],
+        })
+    }
+}
+
+impl<'a> From<&'a LegacyUTxO> for Message {
+    fn from(utxo: &'a LegacyUTxO) -> Message {
+        Message::OldUtxoDeclaration(UtxoDeclaration {
+            addrs: vec![(utxo.address.clone().into(), utxo.value.into())],
+        })
+    }
+}
+
+/*
+
+pub fn documented_example(now: std::time::SystemTime) -> String {
+    let secs = now
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let sk: SecretKey<Ed25519Extended> = SecretKey::generate(&mut ChaChaRng::from_seed([0; 32]));
+    let pk: PublicKey<Ed25519> = sk.to_public();
+    let leader_1: KeyPair<Ed25519> = KeyPair::generate(&mut ChaChaRng::from_seed([1; 32]));
+    let leader_2: KeyPair<Ed25519> = KeyPair::generate(&mut ChaChaRng::from_seed([2; 32]));
+
+    let initial_funds_address = Address(Discrimination::Test, Kind::Single(pk));
+    let initial_funds_address = AddressReadable::from_address(&initial_funds_address).to_string();
+    let leader_1_pk = leader_1.public_key().to_bech32_str();
+    let leader_2_pk = leader_2.public_key().to_bech32_str();
+    format!(
+        include_str!("DOCUMENTED_EXAMPLE.yaml"),
+        now = secs,
+        leader_1 = leader_1_pk,
+        leader_2 = leader_2_pk,
+        initial_funds_address = initial_funds_address
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_yaml;
+
+    #[test]
+    fn conversion_to_and_from_message_preserves_data() {
+        let sk: SecretKey<Ed25519Extended> =
+            SecretKey::generate(&mut ChaChaRng::from_seed([0; 32]));
+        let pk: PublicKey<Ed25519> = sk.to_public();
+
+        let leader_1: KeyPair<Ed25519> = KeyPair::generate(&mut ChaChaRng::from_seed([1; 32]));
+        let leader_2: KeyPair<Ed25519> = KeyPair::generate(&mut ChaChaRng::from_seed([2; 32]));
+
+        let initial_funds_address = Address(Discrimination::Test, Kind::Single(pk));
+        let initial_funds_address =
+            AddressReadable::from_address(&initial_funds_address).to_string();
+
+        let leader_1_pk = leader_1.public_key().to_bech32_str();
+        let leader_2_pk = leader_2.public_key().to_bech32_str();
+
+        let genesis_yaml = format!(r#"
+---
+blockchain_configuration:
+  block0_date: 123456789
+  discrimination: test
+  block0_consensus: bft
+  slots_per_epoch: 5
+  slot_duration: 15
+  epoch_stability_depth: 10
+  consensus_leader_ids:
+    - {}
+    - {}
+  consensus_genesis_praos_active_slot_coeff: "0.444"
+  max_number_of_transactions_per_block: 255
+  bft_slots_ratio: "0.222"
+  linear_fees:
+    coefficient: 1
+    constant: 2
+    certificate: 4
+  kes_update_speed: 43200
+initial:
+  - cert: cert1qgqqqqqqqqqqqqqqqqqqq0p5avfqqmgurpe7s9k7933q0wj420jl5xqvx8lywcu5jcr7fwqa9qmdn93q4nm7c4fsay3mzeqgq3c0slnut9kns08yn2qn80famup7nvgtfuyszqzqrd4lxlt5ylplfu76p8f6ks0ggprzatp2c8rn6ev3hn9dgr38tzful4h0udlwa0536vyrrug7af9ujmrr869afs0yw9gj5x7z24l8sps3zzcmv
+  - fund:
+      address: {}
+      value: 10000"#, leader_1_pk, leader_2_pk, initial_funds_address);
+        let genesis: Genesis =
+            serde_yaml::from_str(genesis_yaml.as_str()).expect("Failed to deserialize YAML");
+
+        let block = genesis.to_block();
+        let new_genesis = Genesis::from_block(&block).expect("Failed to build genesis");
+
+        let new_genesis_yaml =
+            serde_yaml::to_string(&new_genesis).expect("Failed to serialize YAML");
+        assert_eq!(
+            genesis_yaml.trim(),
+            new_genesis_yaml,
+            "\nGenesis YAML has changed after conversions:\n{}\n",
+            new_genesis_yaml
+        );
+    }
+}
+
+*/

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
@@ -81,7 +81,6 @@ custom_error! {pub Error
     InitUtxoHasInput = "initial UTXO has input",
 }
 
-
 pub fn try_initials_vec_from_messages<'a>(
     messages: impl Iterator<Item = &'a Message>,
 ) -> Result<Vec<Initial>, Error> {

--- a/jormungandr-lib/src/interfaces/block0_configuration/kes_update_speed.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/kes_update_speed.rs
@@ -51,8 +51,9 @@ impl TryFrom<ConfigParam> for KESUpdateSpeed {
     type Error = TryFromKESUpdateSpeedError;
     fn try_from(config_param: ConfigParam) -> Result<Self, Self::Error> {
         match config_param {
-            ConfigParam::KESUpdateSpeed(speed) => KESUpdateSpeed::new(speed)
-                .ok_or(TryFromKESUpdateSpeedError::Invalid { speed }),
+            ConfigParam::KESUpdateSpeed(speed) => {
+                KESUpdateSpeed::new(speed).ok_or(TryFromKESUpdateSpeedError::Invalid { speed })
+            }
             _ => Err(TryFromKESUpdateSpeedError::Incompatible),
         }
     }

--- a/jormungandr-lib/src/interfaces/block0_configuration/kes_update_speed.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/kes_update_speed.rs
@@ -1,0 +1,214 @@
+use crate::time::Duration;
+use chain_impl_mockchain::config::ConfigParam;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::{convert::TryFrom, fmt, str::FromStr as _};
+
+const DEFAULT_KES_SPEED_UPDATE: u32 = 12 * 3600;
+const MINIMUM_KES_SPEED_UPDATE_IN_SECONDS: u32 = 60;
+const MAXIMUM_KES_SPEED_UPDATE_IN_SECONDS: u32 = 365 * 24 * 3600;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct KESUpdateSpeed(pub(crate) u32);
+
+impl KESUpdateSpeed {
+    /// minimal value for the KES Update Speed
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::KESUpdateSpeed;
+    ///
+    /// assert_eq!(KESUpdateSpeed::MINIMUM, KESUpdateSpeed::new(60).unwrap())
+    /// ```
+    pub const MINIMUM: Self = KESUpdateSpeed(MINIMUM_KES_SPEED_UPDATE_IN_SECONDS);
+
+    /// maximum value for the KES Update Speed
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::KESUpdateSpeed;
+    ///
+    /// assert_eq!(KESUpdateSpeed::MAXIMUM, KESUpdateSpeed::new(365 * 24 * 3600).unwrap())
+    /// ```
+    pub const MAXIMUM: Self = KESUpdateSpeed(MAXIMUM_KES_SPEED_UPDATE_IN_SECONDS);
+
+    /// create a new KESUpdateSpeed value
+    ///
+    /// returns `None` if the value is not within the boundaries of
+    /// `KESUpdateSpeed::MINIMUM` and `KESUpdateSpeed::MAXIMUM`.
+    pub fn new(v: u32) -> Option<Self> {
+        if v < MINIMUM_KES_SPEED_UPDATE_IN_SECONDS || MAXIMUM_KES_SPEED_UPDATE_IN_SECONDS < v {
+            None
+        } else {
+            Some(KESUpdateSpeed(v))
+        }
+    }
+}
+
+custom_error! { pub TryFromKESUpdateSpeedError
+    Incompatible = "Incompatible Config param, expected KES Update Speed",
+    Invalid { speed: u32 } = "Invalid KES Update speed {speed}",
+}
+
+impl TryFrom<ConfigParam> for KESUpdateSpeed {
+    type Error = TryFromKESUpdateSpeedError;
+    fn try_from(config_param: ConfigParam) -> Result<Self, Self::Error> {
+        match config_param {
+            ConfigParam::KESUpdateSpeed(speed) => KESUpdateSpeed::new(speed)
+                .ok_or(TryFromKESUpdateSpeedError::Invalid { speed }),
+            _ => Err(TryFromKESUpdateSpeedError::Incompatible),
+        }
+    }
+}
+
+impl From<KESUpdateSpeed> for ConfigParam {
+    fn from(kes_update_speed: KESUpdateSpeed) -> Self {
+        ConfigParam::KESUpdateSpeed(kes_update_speed.0)
+    }
+}
+
+impl fmt::Display for KESUpdateSpeed {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Duration::new(self.0 as u64, 0).fmt(f)
+    }
+}
+
+impl Default for KESUpdateSpeed {
+    fn default() -> Self {
+        KESUpdateSpeed::new(DEFAULT_KES_SPEED_UPDATE)
+            .expect("Default should be a valid value at all time")
+    }
+}
+
+impl<'de> Deserialize<'de> for KESUpdateSpeed {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{self, Visitor};
+        struct KESUpdateSpeedVisitor;
+        impl<'de> Visitor<'de> for KESUpdateSpeedVisitor {
+            type Value = KESUpdateSpeed;
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(
+                    formatter,
+                    "Number of seconds between 2 KES update (valid values are between {} ({}) and {} ({}))",
+                    MINIMUM_KES_SPEED_UPDATE_IN_SECONDS, KESUpdateSpeed::MINIMUM,
+                    MAXIMUM_KES_SPEED_UPDATE_IN_SECONDS, KESUpdateSpeed::MAXIMUM,
+                )
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if v < (MINIMUM_KES_SPEED_UPDATE_IN_SECONDS as u64) {
+                    Err(E::custom(format!(
+                        "cannot have less than {} ({}) between two KES Update",
+                        MINIMUM_KES_SPEED_UPDATE_IN_SECONDS,
+                        KESUpdateSpeed::MINIMUM
+                    )))
+                } else if v > (MAXIMUM_KES_SPEED_UPDATE_IN_SECONDS as u64) {
+                    Err(E::custom(format!(
+                        "cannot have more than {} ({}) between two KES Update",
+                        MAXIMUM_KES_SPEED_UPDATE_IN_SECONDS,
+                        KESUpdateSpeed::MAXIMUM
+                    )))
+                } else {
+                    Ok(KESUpdateSpeed(v as u32))
+                }
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let duration = Duration::from_str(s).map_err(E::custom)?;
+
+                if duration.as_ref().subsec_nanos() != 0 {
+                    return Err(E::custom("cannot sub-seconds in the KES update speed"));
+                }
+
+                let seconds = duration.as_ref().as_secs();
+                self.visit_u64(seconds)
+            }
+        }
+        deserializer.deserialize_any(KESUpdateSpeedVisitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for KESUpdateSpeed {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            use rand::Rng as _;
+            let v = g.gen_range(
+                MINIMUM_KES_SPEED_UPDATE_IN_SECONDS,
+                MAXIMUM_KES_SPEED_UPDATE_IN_SECONDS,
+            );
+            KESUpdateSpeed(v)
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_invalid_type() {
+        const EXAMPLE: &'static str = "---\ntrue";
+
+        let _: KESUpdateSpeed = serde_yaml::from_str(EXAMPLE).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_below_bounds() {
+        const VALUE: u32 = MINIMUM_KES_SPEED_UPDATE_IN_SECONDS - 1;
+        let example = format!("---\n{}", VALUE);
+
+        let _: KESUpdateSpeed = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_above_bounds() {
+        const VALUE: u32 = MAXIMUM_KES_SPEED_UPDATE_IN_SECONDS + 1;
+        let example = format!("---\n{}", VALUE);
+
+        let _: KESUpdateSpeed = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    fn deserialize_from_number() {
+        const VALUE: u32 = 92827;
+        let example = format!("---\n{}", VALUE);
+
+        let decoded: KESUpdateSpeed = serde_yaml::from_str(&example).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    #[test]
+    fn deserialize_from_duration_str() {
+        const VALUE: u32 = 2 * 24 * 3600 + 6 * 3600 + 15 * 60 + 34;
+        const DURATION_STR: &'static str = "---\n2days 6h 15m 34s";
+
+        let decoded: KESUpdateSpeed = serde_yaml::from_str(&DURATION_STR).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    quickcheck! {
+        fn serde_encode_decode(kes_update_speed: KESUpdateSpeed) -> bool {
+            let s = serde_yaml::to_string(&kes_update_speed).unwrap();
+            let kes_update_speed_dec: KESUpdateSpeed = serde_yaml::from_str(&s).unwrap();
+
+            kes_update_speed == kes_update_speed_dec
+        }
+
+        fn convert_from_to_config_param(kes_update_speed: KESUpdateSpeed) -> bool {
+            let cp = ConfigParam::from(kes_update_speed);
+            let kes_update_speed_dec = KESUpdateSpeed::try_from(cp).unwrap();
+
+            kes_update_speed == kes_update_speed_dec
+        }
+    }
+}

--- a/jormungandr-lib/src/interfaces/block0_configuration/leader_id.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/leader_id.rs
@@ -1,0 +1,108 @@
+use chain_crypto::{bech32::Bech32 as _, Ed25519, PublicKey};
+use chain_impl_mockchain::{config::ConfigParam, leadership::bft::LeaderId};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{convert::TryFrom, fmt};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConsensusLeaderId(pub LeaderId);
+
+custom_error! { pub TryFromConsensusLeaderIdError
+    Incompatible = "Incompatible Config param, expected Add BFT Leader",
+}
+
+impl TryFrom<ConfigParam> for ConsensusLeaderId {
+    type Error = TryFromConsensusLeaderIdError;
+    fn try_from(config_param: ConfigParam) -> Result<Self, Self::Error> {
+        match config_param {
+            ConfigParam::AddBftLeader(leader_id) => Ok(ConsensusLeaderId(leader_id)),
+            _ => Err(TryFromConsensusLeaderIdError::Incompatible),
+        }
+    }
+}
+
+impl From<ConsensusLeaderId> for ConfigParam {
+    fn from(consensus_leader_id: ConsensusLeaderId) -> Self {
+        ConfigParam::AddBftLeader(consensus_leader_id.0)
+    }
+}
+
+impl Serialize for ConsensusLeaderId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.as_public_key().to_bech32_str().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ConsensusLeaderId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{self, Visitor};
+        struct ConsensusLeaderIdVisitor;
+        impl<'de> Visitor<'de> for ConsensusLeaderIdVisitor {
+            type Value = ConsensusLeaderId;
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                use chain_crypto::AsymmetricPublicKey as _;
+                write!(
+                    formatter,
+                    "bech32 encoding of the leader id's public key ({})",
+                    Ed25519::PUBLIC_BECH32_HRP
+                )
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                PublicKey::try_from_bech32_str(s)
+                    .map(|pk| ConsensusLeaderId(pk.into()))
+                    .map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(ConsensusLeaderIdVisitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for ConsensusLeaderId {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            use crate::crypto::key::KeyPair;
+
+            let kp: KeyPair<Ed25519> = KeyPair::arbitrary(g);
+            let public_key = kp.identifier().into_public_key();
+            ConsensusLeaderId(LeaderId::from(public_key))
+        }
+    }
+
+    #[test]
+    fn deserialize_from_str() {
+        const STR: &'static str =
+            "---\n\"ed25519_pk1evu9kfx9tztez708nac569hcp0xwkvekxpwc7m8ztxu44tmq4gws3yayej\"";
+
+        let _: ConsensusLeaderId = serde_yaml::from_str(&STR).unwrap();
+    }
+
+    quickcheck! {
+        fn serde_encode_decode(consensus_leader_id: ConsensusLeaderId) -> bool {
+            let s = serde_yaml::to_string(&consensus_leader_id).unwrap();
+            let consensus_leader_id_dec: ConsensusLeaderId = serde_yaml::from_str(&s).unwrap();
+
+            consensus_leader_id == consensus_leader_id_dec
+        }
+
+        fn convert_from_to_config_param(consensus_leader_id: ConsensusLeaderId) -> bool {
+            let cp = ConfigParam::from(consensus_leader_id.clone());
+            let consensus_leader_id_dec = ConsensusLeaderId::try_from(cp).unwrap();
+
+            consensus_leader_id == consensus_leader_id_dec
+        }
+    }
+}

--- a/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
@@ -1,0 +1,111 @@
+mod active_slot_coefficient;
+mod bft_slots_ratio;
+mod initial_config;
+mod initial_fragment;
+mod kes_update_speed;
+mod leader_id;
+mod number_of_slots_per_epoch;
+mod slots_duration;
+
+pub use self::active_slot_coefficient::ActiveSlotCoefficient;
+pub use self::bft_slots_ratio::BFTSlotsRatio;
+pub use self::initial_config::BlockchainConfiguration;
+pub use self::initial_fragment::{Certificate, Initial, InitialUTxO, LegacyUTxO};
+pub use self::kes_update_speed::KESUpdateSpeed;
+pub use self::leader_id::ConsensusLeaderId;
+pub use self::number_of_slots_per_epoch::NumberOfSlotsPerEpoch;
+pub use self::slots_duration::SlotDuration;
+use chain_core::property::HasMessages as _;
+use chain_impl_mockchain::{
+    block::{Block, BlockBuilder},
+    message::Message,
+};
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom as _;
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Block0Configuration {
+    /// the initial configuration of the blockchain
+    ///
+    /// * the start date of the block 0;
+    /// * the discrimination;
+    /// * ...
+    ///
+    /// All that is static and does not need to have any update
+    /// mechanism.
+    pub blockchain_configuration: BlockchainConfiguration,
+
+    /// the initial fragments of the blockchain:
+    ///
+    /// * initial funds
+    /// * initial certificates (delegation, stake pool...)
+    #[serde(default)]
+    pub initial: Vec<Initial>,
+}
+
+custom_error! {pub Block0ConfigurationError
+    FirstBlock0MessageNotInit = "Invalid block, expecting the first block fragment to be an special Init fragment",
+    BlockchainConfiguration { source: initial_config::FromConfigParamsError } = "blockchain configuration is invalid",
+    InitialFragments { source: initial_fragment::Error } = "Invalid fragments"
+}
+
+impl Block0Configuration {
+    pub fn from_block(block: &Block) -> Result<Self, Block0ConfigurationError> {
+        let mut messages = block.messages();
+
+        let blockchain_configuration = match messages.next() {
+            Some(Message::Initial(initial)) => BlockchainConfiguration::try_from(initial.clone())?,
+            _ => return Err(Block0ConfigurationError::FirstBlock0MessageNotInit),
+        };
+
+        Ok(Block0Configuration {
+            blockchain_configuration,
+            initial: initial_fragment::try_initials_vec_from_messages(messages)?,
+        })
+    }
+
+    pub fn to_block(&self) -> Block {
+        let mut builder = BlockBuilder::new();
+        builder.message(Message::Initial(
+            self.blockchain_configuration.clone().into(),
+        ));
+        builder.messages(self.initial.iter().map(Message::from));
+        builder.make_genesis_block()
+    }
+}
+
+pub fn block0_configuration_documented_example() -> String {
+    use chain_crypto::{bech32::Bech32 as _, Ed25519, KeyPair, PublicKey, SecretKey};
+    use rand_chacha::ChaChaRng;
+    use rand_core::SeedableRng as _;
+
+    let mut rng = ChaChaRng::from_seed([0; 32]);
+
+    const DISCRIMINATION: chain_addr::Discrimination = chain_addr::Discrimination::Test;
+
+    let sk: SecretKey<Ed25519> = SecretKey::generate(&mut rng);
+    let pk: PublicKey<Ed25519> = sk.to_public();
+    let leader_1: KeyPair<Ed25519> = KeyPair::generate(&mut rng);
+    let leader_2: KeyPair<Ed25519> = KeyPair::generate(&mut rng);
+
+    let initial_funds_address = chain_addr::Address(DISCRIMINATION, chain_addr::Kind::Single(pk));
+    let initial_funds_address = crate::interfaces::Address::from(initial_funds_address);
+    let leader_1_pk = leader_1.public_key().to_bech32_str();
+    let leader_2_pk = leader_2.public_key().to_bech32_str();
+
+    format!(
+        include_str!("DOCUMENTED_EXAMPLE.yaml"),
+        discrimination = DISCRIMINATION,
+        default_block0_date = crate::time::SecondsSinceUnixEpoch::default(),
+        default_slots_per_epoch = NumberOfSlotsPerEpoch::default(),
+        default_slot_duration = SlotDuration::default(),
+        default_bft_slots_ratio = BFTSlotsRatio::default(),
+        default_consensus_genesis_praos_active_slot_coeff = ActiveSlotCoefficient::default(),
+        default_kes_update_speed = KESUpdateSpeed::default(),
+        leader_1 = leader_1_pk,
+        leader_2 = leader_2_pk,
+        initial_funds_address = initial_funds_address
+    )
+}
+

--- a/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
@@ -108,4 +108,3 @@ pub fn block0_configuration_documented_example() -> String {
         initial_funds_address = initial_funds_address
     )
 }
-

--- a/jormungandr-lib/src/interfaces/block0_configuration/number_of_slots_per_epoch.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/number_of_slots_per_epoch.rs
@@ -1,0 +1,187 @@
+use chain_impl_mockchain::config::ConfigParam;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::{convert::TryFrom, fmt};
+
+const DEFAULT_NUMBER_OF_SLOTS_PER_EPOCH: u32 = 720;
+const MINIMUM_NUMBER_OF_SLOTS_PER_EPOCH: u32 = 1;
+const MAXIMUM_NUMBER_OF_SLOTS_PER_EPOCH: u32 = 1_000_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct NumberOfSlotsPerEpoch(pub(crate) u32);
+
+impl NumberOfSlotsPerEpoch {
+    /// minimal value for the number of slots per epoch
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::NumberOfSlotsPerEpoch;
+    ///
+    /// assert_eq!(NumberOfSlotsPerEpoch::MINIMUM, NumberOfSlotsPerEpoch::new(1).unwrap())
+    /// ```
+    pub const MINIMUM: Self = NumberOfSlotsPerEpoch(MINIMUM_NUMBER_OF_SLOTS_PER_EPOCH);
+
+    /// maximal value for the number of slots per epoch
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::NumberOfSlotsPerEpoch;
+    ///
+    /// assert_eq!(NumberOfSlotsPerEpoch::MAXIMUM, NumberOfSlotsPerEpoch::new(1_000_000).unwrap())
+    /// ```
+    pub const MAXIMUM: Self = NumberOfSlotsPerEpoch(MAXIMUM_NUMBER_OF_SLOTS_PER_EPOCH);
+
+    /// create a new `NumberOfSlotsPerEpoch` value
+    ///
+    /// returns `None` if the value is not within the boundaries of
+    /// `NumberOfSlotsPerEpoch::MINIMUM` and `NumberOfSlotsPerEpoch::MAXIMUM`.
+    pub fn new(v: u32) -> Option<Self> {
+        if v < MINIMUM_NUMBER_OF_SLOTS_PER_EPOCH || MAXIMUM_NUMBER_OF_SLOTS_PER_EPOCH < v {
+            None
+        } else {
+            Some(NumberOfSlotsPerEpoch(v))
+        }
+    }
+}
+
+custom_error! { pub TryFromNumberOfSlotsPerEpochError
+    Incompatible = "Incompatible Config param, expected number of slots per epoch",
+    Invalid { slots: u32 } = "invalid number of slots per epoch {slots}"
+}
+
+impl TryFrom<ConfigParam> for NumberOfSlotsPerEpoch {
+    type Error = TryFromNumberOfSlotsPerEpochError;
+    fn try_from(config_param: ConfigParam) -> Result<Self, Self::Error> {
+        match config_param {
+            ConfigParam::SlotsPerEpoch(slots) => NumberOfSlotsPerEpoch::new(slots)
+                .ok_or(TryFromNumberOfSlotsPerEpochError::Invalid { slots }),
+            _ => Err(TryFromNumberOfSlotsPerEpochError::Incompatible),
+        }
+    }
+}
+
+impl From<NumberOfSlotsPerEpoch> for ConfigParam {
+    fn from(number_of_slots_per_epoch: NumberOfSlotsPerEpoch) -> Self {
+        ConfigParam::SlotsPerEpoch(number_of_slots_per_epoch.0)
+    }
+}
+
+impl fmt::Display for NumberOfSlotsPerEpoch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Default for NumberOfSlotsPerEpoch {
+    fn default() -> Self {
+        NumberOfSlotsPerEpoch::new(DEFAULT_NUMBER_OF_SLOTS_PER_EPOCH)
+            .expect("Default should be a valid value at all time")
+    }
+}
+
+impl<'de> Deserialize<'de> for NumberOfSlotsPerEpoch {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{self, Visitor};
+        struct NumberOfSlotsPerEpochVisitor;
+        impl<'de> Visitor<'de> for NumberOfSlotsPerEpochVisitor {
+            type Value = NumberOfSlotsPerEpoch;
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(
+                    formatter,
+                    "Number of slots per epoch (between {} and {})",
+                    NumberOfSlotsPerEpoch::MINIMUM,
+                    NumberOfSlotsPerEpoch::MAXIMUM,
+                )
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if v < (MINIMUM_NUMBER_OF_SLOTS_PER_EPOCH as u64) {
+                    Err(E::custom(format!(
+                        "cannot have less than {} slots in an epoch",
+                        NumberOfSlotsPerEpoch::MINIMUM,
+                    )))
+                } else if v > (MAXIMUM_NUMBER_OF_SLOTS_PER_EPOCH as u64) {
+                    Err(E::custom(format!(
+                        "cannot have more than {} slots in an epoch",
+                        NumberOfSlotsPerEpoch::MAXIMUM,
+                    )))
+                } else {
+                    Ok(NumberOfSlotsPerEpoch(v as u32))
+                }
+            }
+        }
+        deserializer.deserialize_u64(NumberOfSlotsPerEpochVisitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for NumberOfSlotsPerEpoch {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            use rand::Rng as _;
+            let v = g.gen_range(
+                MINIMUM_NUMBER_OF_SLOTS_PER_EPOCH,
+                MAXIMUM_NUMBER_OF_SLOTS_PER_EPOCH,
+            );
+            NumberOfSlotsPerEpoch(v)
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_invalid_type() {
+        const EXAMPLE: &'static str = "---\n\"928\"";
+
+        let _: NumberOfSlotsPerEpoch = serde_yaml::from_str(EXAMPLE).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_below_bounds() {
+        const VALUE: u32 = MINIMUM_NUMBER_OF_SLOTS_PER_EPOCH - 1;
+        let example = format!("---\n{}", VALUE);
+
+        let _: NumberOfSlotsPerEpoch = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_above_bounds() {
+        const VALUE: u64 = (MAXIMUM_NUMBER_OF_SLOTS_PER_EPOCH as u64) + 1;
+        let example = format!("---\n{}", VALUE);
+
+        let _: NumberOfSlotsPerEpoch = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    fn deserialize_from_number() {
+        const VALUE: u32 = 40;
+        let example = format!("---\n{}", VALUE);
+
+        let decoded: NumberOfSlotsPerEpoch = serde_yaml::from_str(&example).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    quickcheck! {
+        fn serde_encode_decode(number_of_slots_per_epoch: NumberOfSlotsPerEpoch) -> bool {
+            let s = serde_yaml::to_string(&number_of_slots_per_epoch).unwrap();
+            let number_of_slots_per_epoch_dec: NumberOfSlotsPerEpoch = serde_yaml::from_str(&s).unwrap();
+
+            number_of_slots_per_epoch == number_of_slots_per_epoch_dec
+        }
+
+        fn convert_from_to_config_param(number_of_slots_per_epoch: NumberOfSlotsPerEpoch) -> bool {
+            let cp = ConfigParam::from(number_of_slots_per_epoch);
+            let number_of_slots_per_epoch_dec = NumberOfSlotsPerEpoch::try_from(cp).unwrap();
+
+            number_of_slots_per_epoch == number_of_slots_per_epoch_dec
+        }
+    }
+}

--- a/jormungandr-lib/src/interfaces/block0_configuration/slots_duration.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/slots_duration.rs
@@ -1,0 +1,211 @@
+use crate::time::Duration;
+use chain_impl_mockchain::config::ConfigParam;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::{convert::TryFrom, fmt, str::FromStr as _};
+
+const DEFAULT_SLOT_DURATION: u8 = 5;
+const MINIMUM_SLOT_DURATION: u8 = 1;
+const MAXIMUM_SLOT_DURATION: u8 = u8::max_value();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct SlotDuration(pub(crate) u8);
+
+impl SlotDuration {
+    /// minimal value for the slot duration
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::SlotDuration;
+    ///
+    /// assert_eq!(SlotDuration::MINIMUM, SlotDuration::new(1).unwrap())
+    /// ```
+    pub const MINIMUM: Self = SlotDuration(MINIMUM_SLOT_DURATION);
+    /// maximum value for the slot duration
+    ///
+    /// ```
+    /// # use jormungandr_lib::interfaces::SlotDuration;
+    ///
+    /// assert_eq!(SlotDuration::MAXIMUM, SlotDuration::new(255).unwrap())
+    /// ```
+    pub const MAXIMUM: Self = SlotDuration(MAXIMUM_SLOT_DURATION);
+
+    /// create a new SlotDuration value
+    ///
+    /// returns `None` if the value is not within the boundaries of
+    /// `SlotDuration::MINIMUM` and `SlotDuration::MAXIMUM`.
+    pub fn new(v: u8) -> Option<Self> {
+        if v < MINIMUM_SLOT_DURATION || MAXIMUM_SLOT_DURATION < v {
+            None
+        } else {
+            Some(SlotDuration(v))
+        }
+    }
+}
+
+custom_error! { pub TryFromSlotDurationError
+    Incompatible = "Incompatible Config param, expected slot duration",
+    Invalid { duration: u8 } = "Invalid slot duration {duration}"
+}
+
+impl TryFrom<ConfigParam> for SlotDuration {
+    type Error = TryFromSlotDurationError;
+    fn try_from(config_param: ConfigParam) -> Result<Self, Self::Error> {
+        match config_param {
+            ConfigParam::SlotDuration(duration) => {
+                SlotDuration::new(duration).ok_or(TryFromSlotDurationError::Invalid { duration })
+            }
+            _ => Err(TryFromSlotDurationError::Incompatible),
+        }
+    }
+}
+
+impl From<SlotDuration> for ConfigParam {
+    fn from(slots_duration: SlotDuration) -> Self {
+        ConfigParam::SlotDuration(slots_duration.0)
+    }
+}
+
+impl fmt::Display for SlotDuration {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Duration::new(self.0 as u64, 0).fmt(f)
+    }
+}
+
+impl Default for SlotDuration {
+    fn default() -> Self {
+        SlotDuration::new(DEFAULT_SLOT_DURATION)
+            .expect("Default should be a valid value at all time")
+    }
+}
+
+impl<'de> Deserialize<'de> for SlotDuration {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{self, Visitor};
+        struct SlotDurationVisitor;
+        impl<'de> Visitor<'de> for SlotDurationVisitor {
+            type Value = SlotDuration;
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(
+                    formatter,
+                    "Number of seconds between the creation of 2 blocks (between {} ({}) and {} ({}))",
+                    MINIMUM_SLOT_DURATION, SlotDuration::MINIMUM,
+                    MAXIMUM_SLOT_DURATION, SlotDuration::MAXIMUM,
+                )
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if v < (MINIMUM_SLOT_DURATION as u64) {
+                    Err(E::custom(format!(
+                        "cannot have less than {} ({}) between 2 slots",
+                        MINIMUM_SLOT_DURATION,
+                        SlotDuration::MINIMUM
+                    )))
+                } else if v > (MAXIMUM_SLOT_DURATION as u64) {
+                    Err(E::custom(format!(
+                        "cannot have more than {} ({}) between 2 slots",
+                        MAXIMUM_SLOT_DURATION,
+                        SlotDuration::MAXIMUM
+                    )))
+                } else {
+                    Ok(SlotDuration(v as u8))
+                }
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let duration = Duration::from_str(s).map_err(E::custom)?;
+
+                if duration.as_ref().subsec_nanos() != 0 {
+                    return Err(E::custom("sub-seconds not supported in slot duration"));
+                }
+
+                let seconds = duration.as_ref().as_secs();
+                self.visit_u64(seconds)
+            }
+        }
+        deserializer.deserialize_any(SlotDurationVisitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for SlotDuration {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            use rand::Rng as _;
+            let v = g.gen_range(MINIMUM_SLOT_DURATION, MAXIMUM_SLOT_DURATION);
+            SlotDuration(v)
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_invalid_type() {
+        const EXAMPLE: &'static str = "---\ntrue";
+
+        let _: SlotDuration = serde_yaml::from_str(EXAMPLE).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_below_bounds() {
+        const VALUE: u8 = MINIMUM_SLOT_DURATION - 1;
+        let example = format!("---\n{}", VALUE);
+
+        let _: SlotDuration = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn deserialize_from_above_bounds() {
+        const VALUE: u64 = (MAXIMUM_SLOT_DURATION as u64) + 1;
+        let example = format!("---\n{}", VALUE);
+
+        let _: SlotDuration = serde_yaml::from_str(&example).unwrap();
+    }
+
+    #[test]
+    fn deserialize_from_number() {
+        const VALUE: u8 = 15;
+        let example = format!("---\n{}", VALUE);
+
+        let decoded: SlotDuration = serde_yaml::from_str(&example).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    #[test]
+    fn deserialize_from_duration_str() {
+        const VALUE: u8 = 15;
+        const DURATION_STR: &'static str = "---\n15s";
+
+        let decoded: SlotDuration = serde_yaml::from_str(&DURATION_STR).unwrap();
+
+        assert_eq!(decoded.0, VALUE)
+    }
+
+    quickcheck! {
+        fn serde_encode_decode(slot_duration: SlotDuration) -> bool {
+            let s = serde_yaml::to_string(&slot_duration).unwrap();
+            let slot_duration_dec: SlotDuration = serde_yaml::from_str(&s).unwrap();
+
+            slot_duration == slot_duration_dec
+        }
+
+        fn convert_from_to_config_param(slot_duration: SlotDuration) -> bool {
+            let cp = ConfigParam::from(slot_duration);
+            let slot_duration_dec = SlotDuration::try_from(cp).unwrap();
+
+            slot_duration == slot_duration_dec
+        }
+    }
+}

--- a/jormungandr-lib/src/interfaces/mod.rs
+++ b/jormungandr-lib/src/interfaces/mod.rs
@@ -1,13 +1,17 @@
 mod account_state;
 mod address;
+mod block0_configuration;
 mod blockdate;
 mod fragment_log;
+mod old_address;
 mod utxo_info;
 mod value;
 
 pub use self::account_state::AccountState;
 pub use self::address::Address;
+pub use self::block0_configuration::*;
 pub use self::blockdate::BlockDate;
 pub use self::fragment_log::{FragmentLog, FragmentOrigin, FragmentStatus};
+pub use self::old_address::OldAddress;
 pub use self::utxo_info::UTxOInfo;
 pub use self::value::Value;

--- a/jormungandr-lib/src/interfaces/old_address.rs
+++ b/jormungandr-lib/src/interfaces/old_address.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt, str::FromStr};
+
+/// OldAddress with the appropriate implementation for Serde API and
+/// Display/FromStr interfaces.
+///
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OldAddress(cardano_legacy_address::Addr);
+
+/* ---------------- Display ------------------------------------------------ */
+
+impl fmt::Display for OldAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for OldAddress {
+    type Err = cardano_legacy_address::ParseExtendedAddrError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(OldAddress)
+    }
+}
+
+/* ---------------- AsRef -------------------------------------------------- */
+
+impl AsRef<cardano_legacy_address::Addr> for OldAddress {
+    fn as_ref(&self) -> &cardano_legacy_address::Addr {
+        &self.0
+    }
+}
+/* ---------------- Conversion --------------------------------------------- */
+
+impl From<cardano_legacy_address::Addr> for OldAddress {
+    fn from(v: cardano_legacy_address::Addr) -> Self {
+        OldAddress(v)
+    }
+}
+
+impl From<OldAddress> for cardano_legacy_address::Addr {
+    fn from(v: OldAddress) -> Self {
+        v.0
+    }
+}
+
+/* ------------------- Serde ----------------------------------------------- */
+
+impl Serialize for OldAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for OldAddress {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        cardano_legacy_address::Addr::from_str(&s)
+            .map_err(|e| serde::de::Error::custom(e))
+            .map(OldAddress)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen, TestResult};
+
+    impl Arbitrary for OldAddress {
+        fn arbitrary<G>(g: &mut G) -> Self
+        where
+            G: Gen,
+        {
+            use ed25519_bip32::XPub;
+
+            let mut bytes: [u8; 64] = [0; 64];
+            for byte in bytes.iter_mut() {
+                *byte = u8::arbitrary(g);
+            }
+            let xpub = XPub::from_bytes(bytes);
+
+            let address =
+                cardano_legacy_address::ExtendedAddr::new_simple(&xpub, Arbitrary::arbitrary(g));
+            OldAddress(address.to_address())
+        }
+    }
+
+    quickcheck! {
+        fn address_display_parse(address: OldAddress) -> TestResult {
+            let s = address.to_string();
+            let address_dec: OldAddress = s.parse().unwrap();
+
+            TestResult::from_bool(address == address_dec)
+        }
+
+        fn address_serde_human_readable_encode_decode(address: OldAddress) -> TestResult {
+            let s = serde_yaml::to_string(&address).unwrap();
+            let address_dec: OldAddress = serde_yaml::from_str(&s).unwrap();
+
+            TestResult::from_bool(address == address_dec)
+        }
+    }
+}

--- a/jormungandr-lib/src/time.rs
+++ b/jormungandr-lib/src/time.rs
@@ -95,6 +95,10 @@ impl SecondsSinceUnixEpoch {
     ///
     /// This value will take you up to the year 4147.
     pub const MAX: Self = SecondsSinceUnixEpoch(0x000_000F_FFFF_FFFF);
+
+    pub fn now() -> Self {
+        SystemTime::now().into()
+    }
 }
 
 impl SystemTime {
@@ -123,6 +127,14 @@ impl Duration {
     #[inline]
     pub fn new(secs: u64, nanos: u32) -> Self {
         Duration(time::Duration::new(secs, nanos))
+    }
+}
+
+/* --------------------- Default ------------------------------------------- */
+
+impl Default for SecondsSinceUnixEpoch {
+    fn default() -> SecondsSinceUnixEpoch {
+        SecondsSinceUnixEpoch::now()
     }
 }
 

--- a/jormungandr/src/rest/v0/block/next_id.rs
+++ b/jormungandr/src/rest/v0/block/next_id.rs
@@ -1,4 +1,7 @@
 use super::parse_block_hash;
+
+use chain_storage::store;
+
 use actix_web::error::{Error as ActixError, ErrorBadRequest, ErrorInternalServerError};
 use actix_web::{Path, Query, State};
 use blockchain::BlockchainR;
@@ -16,8 +19,7 @@ pub fn handle_request(
     // FIXME: don't hog the blockchain lock.
     let blockchain = blockchain.lock_read();
     let storage = blockchain.storage.read().unwrap();
-    storage
-        .iterate_range(&block_id, &blockchain.get_tip().unwrap())
+    store::iterate_range(&*storage, &block_id, &blockchain.get_tip().unwrap())
         .map_err(|e| ErrorBadRequest(e))?
         .take(query_params.get_count())
         .try_fold(Bytes::new(), |mut bytes, res| {

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -30,7 +30,7 @@ SLOT_DURATION=10
 FAUCET_AMOUNT=1000000000
 ADDRTYPE="--testing"
 
-CONSENSUS="genesis"
+CONSENSUS="genesis_praos"
 SECRET_PATH="."
 CONFIG_PATH="."
 ADD_STARTUP_SCRIPT=0
@@ -39,7 +39,7 @@ while getopts 'bc:ghk:p:s:xCod' c
 do
     case $c in
         b) CONSENSUS="bft" ;;
-        g) CONSENSUS="genesis" ;;
+        g) CONSENSUS="genesis_praos" ;;
         p) REST_PORT="${OPTARG}" ;;
         k) SECRET_PATH="${OPTARG}" ;;
         c) CONFIG_PATH="${OPTARG}" ;;


### PR DESCRIPTION
This is a big chunk as it does not only move it but also enhance the quality of the error reporting, the quality of the parsing. Some values are not possible to be set in different format for certain cases.

for example, we accept slot_duration to be a u64 or a duration (`15s`). Same thing for the KES update speed value.

the error reporting is slightly better in some cases. also most of the encoding/decoding checks is done via library property test (no need to torture `jcli genesis encode|decode` for this now).

part of #434 
