### PR TITLE
Improve GELF logging backend configuration

### DIFF
--- a/doc/quickstart/02_passive_node.md
+++ b/doc/quickstart/02_passive_node.md
@@ -46,40 +46,43 @@ peer_2_peer:
     blocks: normal
 ```
 
-Fields description:
+Description of the fields:
 
-- *storage*: (optional) path to the storage. If omitted, the
+- `storage`: (optional) Path to the storage. If omitted, the
   blockchain is stored in memory only.
-- *logger*: (optional) logger configuration,
-    - *verbosity*: 0 - warning, 1 - info, 2 -debug, 3 and above - trace
-    - *format*: log output format - plain or json.
-    - *output*: log output destination. Possible values are:
-      - `stderr`: the standard error stream
+- `logger`: (optional) Logging configuration:
+    - `verbosity`: 0 - warning, 1 - info, 2 - debug, 3 and above - trace
+    - `format`: Log output format, `plain` or `json`.
+    - `output`: Log output destination. Possible values are:
+      - `stderr`: standard error
       - `syslog`: syslog (only available on Unix systems)
       - `journald`: journald service (only available on Linux with systemd,
-        if jormungandr is built with the `systemd` feature)
-      - *gelf*: fields for GELF (Graylog) network logging protocol
+        (if jormungandr is built with the `systemd` feature)
+      - `gelf`: Configuration fields for GELF (Graylog) network logging protocol
         (if jormungandr is built with the `gelf` feature):
-        - *backend*: hostname:port of a graylog server.
-        - *log_id*: unique identifier of the log source of the logs.
-- *rest*: (optional) configuration of the rest endpoint.
-    - *listen*: listen address
-    - *pkcs12*: certificate file (optional)
-    - *prefix*: (optional) api prefix
-- *peer_2_peer*: the P2P network settings
-    - *trusted_peers*: (optional) the list of nodes to connect to in order to
-      bootstrap the p2p topology (and bootstrap our local blockchain);
-    - *public_id*: (optional) the public identifier send to the other nodes in the
-      p2p network. If not set it will be randomly generated.
-    - *public_address*: the address to listen from and accept connection
-      from. This is the public address that will be distributed to other peers
-      of the network that may find interest into participating to the blockchain
-      dissemination with the node;
-    - *topics_of_interests*: the different topics we are interested to hear about:
-      - *messages*: notify other peers this node is interested about Transactions
-        typical setting for a non mining node: `"low"`. For a stakepool: `"high"`;
-      - *blocks*: notify other peers this node is interested about new Blocs.
-        typical settings for a non mining node: `"normal"`. For a stakepool: `"high"`;
+        - `backend`: _hostname_:_port_ of a GELF server
+        - `log_id`: identifier of the source of the log, for the `host` field
+                    in the messages.
+- `rest`: (optional) Configuration of the REST endpoint.
+    - `listen`: _address_:_port_ to listen for requests
+    - `pkcs12`: (optional) Certificate file
+    - `prefix`: (optional) API prefix
+- `peer_2_peer`: P2P network settings
+    - `trusted_peers`: (optional) the list of nodes to connect to in order to
+      bootstrap the P2P topology (and bootstrap our local blockchain);
+    - `public_id`: (optional) the public identifier sent to the other nodes
+      in the P2P network. If not set it will be randomly generated.
+    - `public_address`: [multiaddr][multiaddr] string specifying address of the
+      P2P service. This is the public address that will be distributed to other
+      peers of the network that may find interest in participating to the
+      blockchain dissemination with the node.
+    - `topics_of_interests`: The dissemination topics this node is interested to hear about:
+      - `messages`: Transactions and other ledger entries.
+        Typical setting for a non-mining node: `low`. For a stakepool: `high`;
+      - `blocks`: Notifications about new blocks.
+        Typical setting for a non-mining node: `normal`. For a stakepool: `high`;
+
+[multiaddr]: https://github.com/multiformats/multiaddr
 
 # Starting the node
 

--- a/doc/quickstart/02_passive_node.md
+++ b/doc/quickstart/02_passive_node.md
@@ -53,9 +53,15 @@ Fields description:
 - *logger*: (optional) logger configuration,
     - *verbosity*: 0 - warning, 1 - info, 2 -debug, 3 and above - trace
     - *format*: log output format - plain or json.
-    - *output*: log output - stderr, gelf (graylog) syslog (unix only) or journald (linux with systemd only, must be enabled during compilation)
-    - *backend*: for gelf output: hostname:port of a graylog server.
-    - *logs_id*: for gelf output: unique id that identify the node as source of the logs.
+    - *output*: log output destination. Possible values are:
+      - `stderr`: the standard error stream
+      - `syslog`: syslog (only available on Unix systems)
+      - `journald`: journald service (only available on Linux with systemd,
+        if jormungandr is built with the `systemd` feature)
+      - *gelf*: fields for GELF (Graylog) network logging protocol
+        (if jormungandr is built with the `gelf` feature):
+        - *backend*: hostname:port of a graylog server.
+        - *log_id*: unique identifier of the log source of the logs.
 - *rest*: (optional) configuration of the rest endpoint.
     - *listen*: listen address
     - *pkcs12*: certificate file (optional)

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -77,7 +77,7 @@ pub struct CommandLine {
     #[structopt(long = "log-format", parse(try_from_str))]
     pub log_format: Option<LogFormat>,
 
-    /// Set format of the log emitted. Can be "stderr", "gelf", "syslog" (unix only) or "journald"
+    /// Set format of the log emitted. Can be "stderr", syslog" (unix only) or "journald"
     /// (linux with systemd only, must be enabled during compilation).
     /// If not configured anywhere, defaults to "stderr".
     #[structopt(long = "log-output", parse(try_from_str))]

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -121,6 +121,4 @@ impl LogFormat {
 
 custom_error! {pub Error
     SyslogAccessFailed { source: io::Error } = "syslog access failed",
-    MissingGelfBackend = "Please specify a backend (host:port of graylog server) for the GELF logger output",
-    MissingGelfSource = "Please specify a logs_id for your logs when using GELF logger output",
 }

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -15,8 +15,6 @@ pub struct LogSettings {
     pub verbosity: slog::Level,
     pub format: LogFormat,
     pub output: LogOutput,
-    pub backend: Option<String>,
-    pub logs_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -32,12 +30,15 @@ pub enum LogFormat {
 /// Output of the logger.
 pub enum LogOutput {
     Stderr,
-    #[cfg(feature = "gelf")]
-    Gelf,
     #[cfg(unix)]
     Syslog,
     #[cfg(feature = "systemd")]
     Journald,
+    #[cfg(feature = "gelf")]
+    Gelf {
+        backend: String,
+        log_id: String,
+    },
 }
 
 impl FromStr for LogFormat {
@@ -56,10 +57,8 @@ impl FromStr for LogOutput {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match &*s.trim().to_lowercase() {
+        match s.trim().to_lowercase().as_str() {
             "stderr" => Ok(LogOutput::Stderr),
-            #[cfg(feature = "gelf")]
-            "gelf" => Ok(LogOutput::Gelf),
             #[cfg(unix)]
             "syslog" => Ok(LogOutput::Syslog),
             #[cfg(feature = "systemd")]
@@ -71,45 +70,32 @@ impl FromStr for LogOutput {
 
 impl LogSettings {
     pub fn to_logger(&self) -> Result<Logger, Error> {
-        let drain = self
-            .output
-            .to_logger(&self.format, &self.backend, &self.logs_id)?
-            .fuse();
+        let drain = self.output.to_logger(&self.format)?.fuse();
         let drain = slog::LevelFilter::new(drain, self.verbosity).fuse();
         Ok(slog::Logger::root(drain, o!()))
     }
 }
 
 impl LogOutput {
-    fn to_logger(
-        &self,
-        format: &LogFormat,
-        backend: &Option<String>,
-        logs_id: &Option<String>,
-    ) -> Result<Async, Error> {
+    fn to_logger(&self, format: &LogFormat) -> Result<Async, Error> {
         match self {
             LogOutput::Stderr => Ok(format.decorate_stderr()),
-            #[cfg(feature = "gelf")]
-            LogOutput::Gelf => match backend {
-                Some(graylog_host_port) => {
-                    match logs_id {
-                        Some(graylog_source) => {
-                            let gelf_drain = LogFormat::Plain
-                                .decorate(Gelf::new(graylog_source, graylog_host_port).unwrap());
-                            // We also log to stderr otherwise users see no logs.
-                            // TODO: remove when multiple output is properly supported.
-                            let stderr_drain = format.decorate_stderr();
-                            Ok(slog::Duplicate(gelf_drain, stderr_drain).async())
-                        }
-                        _ => Err(Error::MissingGelfSource),
-                    }
-                }
-                _ => Err(Error::MissingGelfBackend),
-            },
             #[cfg(unix)]
             LogOutput::Syslog => Ok(format.decorate(slog_syslog::unix_3164(Facility::LOG_USER)?)),
             #[cfg(feature = "systemd")]
             LogOutput::Journald => Ok(format.decorate(JournaldDrain)),
+            #[cfg(feature = "gelf")]
+            LogOutput::Gelf {
+                backend: graylog_host_port,
+                log_id: graylog_source,
+            } => {
+                let gelf_drain = LogFormat::Plain
+                    .decorate(Gelf::new(graylog_source, graylog_host_port).unwrap());
+                // We also log to stderr otherwise users see no logs.
+                // TODO: remove when multiple output is properly supported.
+                let stderr_drain = format.decorate_stderr();
+                Ok(slog::Duplicate(gelf_drain, stderr_drain).async())
+            }
         }
     }
 }

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -24,8 +24,6 @@ pub struct ConfigLogSettings {
     pub verbosity: Option<u8>,
     pub format: Option<LogFormat>,
     pub output: Option<LogOutput>,
-    pub backend: Option<String>,
-    pub logs_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -44,14 +44,10 @@ impl RawSettings {
     }
 
     pub fn to_logger(&self) -> Result<Logger, logging::Error> {
-        let backend = self.config.logger.as_ref().and_then(|l| l.backend.clone());
-        let logs_id = self.config.logger.as_ref().and_then(|l| l.logs_id.clone());
         LogSettings {
             verbosity: self.logger_verbosity(),
             format: self.logger_format(),
             output: self.logger_output(),
-            backend,
-            logs_id,
         }
         .to_logger()
     }


### PR DESCRIPTION
Move config fields that make sense only for GELF under `gelf`, which must now be a property map used as the value of `logger.output`.
Removed `gelf` as an acceptable parameter for command line option `--log-output`, which did not work anyway due to lack of the required settings.
Improved documentation for config YAML overall.