### PR TITLE
Documentation: update delegating_stake.md

### DIFF
--- a/doc/stake_pool/delegating_stake.md
+++ b/doc/stake_pool/delegating_stake.md
@@ -8,9 +8,9 @@ delegate its associated stake.
 
 You will need your:
 
-* account public key: a bech32 string of a public key
-* the Stake Pool ID: an hexadecimal string identifying the stake pool you want
-  to delegate your stake to.
+* account public key: a bech32 string of a public key.
+* the Stake Pool ID: an hexadecimal string identifying the stake pool to which you want
+  to delegate your stake.
 
 ```
 $ jcli certificate new stake-delegation STAKE_POOL_ID ACCOUNT_PUBLIC_KEY > stake_delegation.cert
@@ -19,7 +19,7 @@ $ jcli certificate new stake-delegation STAKE_POOL_ID ACCOUNT_PUBLIC_KEY > stake
 ## how to sign your delegation certificate
 
 We need to make sure that the owner of the account is authorizing this
-delegation to happens, and for that we need a cryptographic signature.
+delegation to happen, and for that we need a cryptographic signature.
 
 We will need the account secret key to create a signature
 
@@ -32,7 +32,7 @@ The output can now be added in the `transaction` and submitted to a node.
 
 ## submitting to a node
 
-To `jcli transaction add-certificate` command can be used to add a certificate to a transaction in _finalized_ state.
+The to `jcli transaction add-certificate` command can be used to add a certificate to a transaction in _finalized_ state.
 
 For example:
 
@@ -40,9 +40,9 @@ For example:
 
 ...
 
-jcli transaction finalize CHANGE_ADDRESS --fee-constant 5 --fee-coefficient 2 --fee-certificate 2 --staging tx
-
 jcli transaction add-certificate $(cat stake_delegation.cert) --staging tx
+
+jcli transaction finalize CHANGE_ADDRESS --fee-constant 5 --fee-coefficient 2 --fee-certificate 2 --staging tx
 
 ...
 


### PR DESCRIPTION
The delegation certificate should be added into the transaction before finalizing the transaction. So, the order of the example lines has been inverted.