### PR TITLE
Pulling missing chain blocks from the network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -43,7 +43,7 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -72,7 +72,7 @@ dependencies = [
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -86,7 +86,7 @@ dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -94,7 +94,7 @@ dependencies = [
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -123,7 +123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -782,7 +782,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -953,11 +953,11 @@ name = "globset"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bstr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1077,20 +1077,20 @@ dependencies = [
  "h2 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1127,7 +1127,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1176,7 +1176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1243,7 +1243,7 @@ dependencies = [
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1257,7 +1257,7 @@ dependencies = [
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strfmt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1302,7 +1302,7 @@ dependencies = [
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1315,7 +1315,7 @@ dependencies = [
  "slog-syslog 0.12.0 (git+https://github.com/slog-rs/syslog?rev=336da50ed86058bfa87d9b497f5921fb7f95ea42)",
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1336,7 +1336,7 @@ dependencies = [
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1807,7 +1807,7 @@ dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1891,7 +1891,7 @@ dependencies = [
  "float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1972,7 +1972,7 @@ dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.54"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2203,7 +2203,7 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2214,15 +2214,15 @@ dependencies = [
  "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2268,10 +2268,10 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2597,7 +2597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2724,7 +2724,7 @@ dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2756,7 +2756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2783,7 +2783,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2806,15 +2806,14 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2845,12 +2844,12 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-executor"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2864,7 +2863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2890,7 +2889,7 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2905,7 +2904,7 @@ dependencies = [
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2935,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-threadpool"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2946,7 +2945,7 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2957,7 +2956,7 @@ dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2968,14 +2967,6 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-trace-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3063,7 +3054,7 @@ dependencies = [
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-http-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3134,7 +3125,7 @@ dependencies = [
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3157,7 +3148,7 @@ dependencies = [
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3180,7 +3171,7 @@ dependencies = [
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-proto 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3446,7 +3437,7 @@ dependencies = [
 "checksum actix-web 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b0ac60f86c65a50b140139f499f4f7c6e49e4b5d88fbfba08e4e3975991f7bf4"
 "checksum actix_derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4300e9431455322ae393d43a2ba1ef96b8080573c0fc23b196219efedfb6ba69"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
-"checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
+"checksum aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b7aa1ccb7d7ea3f437cf025a2ab1c47cc6c1bc9fc84918ff449def12f5e282"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
@@ -3549,7 +3540,7 @@ dependencies = [
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum http-connection 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f6080cea47f7371d4da9a46dd52787c598ce93886393e400bc178f9039bac27"
-"checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
+"checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)" = "6481fff8269772d4463253ca83c788104a7305cb3fb9136bc651a6211e46e03f"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
@@ -3652,10 +3643,10 @@ dependencies = [
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
+"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
-"checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
+"checksum regex 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1325e8a57b7da4cbcb38b3957112f729990bad0a18420e7e250ef6b1d9a15763"
 "checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "00eb63f212df0e358b427f0f40aa13aaea010b470be642ad422bcbca2feff2e4"
@@ -3720,21 +3711,20 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-"checksum tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2ffcf4bcfc641413fa0f1427bf8f91dfc78f56a6559cbf50e04837ae442a87"
+"checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
-"checksum tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "83ea44c6c0773cc034771693711c35c677b4b5a4b21b9e7071704c54de7d555e"
+"checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
 "checksum tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"
 "checksum tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2162248ff317e2bc713b261f242b69dbb838b85248ed20bb21df56d60ea4cae7"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
-"checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
+"checksum tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "90ca01319dea1e376a001e8dc192d42ebde6dd532532a5bad988ac37db365b19"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 "checksum tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
-"checksum tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9c8a256d6956f7cb5e2bdfe8b1e8022f1a09206c6c2b1ba00f3b746b260c613"
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "839c195fd6e4e87442e7a631ea62632799695a3f897949192325a4e509ff4328"

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -312,6 +312,7 @@ custom_error! {pub RejectionReason
     Consensus { error: leadership::Error } = "{error}",
 }
 
+#[derive(Debug)]
 pub enum BlockHeaderTriage {
     /// mark that a block is of no interest for this blockchain
     NotOfInterest { reason: RejectionReason },

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -158,7 +158,7 @@ pub fn handle_input(
                         });
                 },
             );
-            reply.send(res).unwrap_or_default();
+            reply.reply(res);
         }
     };
 

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -149,6 +149,10 @@ pub fn handle_input(
             }
         }
         BlockMsg::ChainHeaders(headers, reply) => {
+            // FIXME: there is currently no sequencing between block
+            // requests/solicitations sent out to different peers.
+            // If a batch of blocks arrives out of order, it will be
+            // dropped by the BlockMsg::NetworkBlock processing above.
             let res = process_chain_headers_into_block_request(blockchain, headers, &logger).map(
                 |block_ids| {
                     network_msg_box

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -309,8 +309,10 @@ pub enum BlockMsg {
     /// A untrusted block Header has been received from the network task
     AnnouncedBlock(Header, NodeId),
     /// Headers for missing chain blocks have been received from the network
-    /// in response to a PullHeaders request.
-    ChainHeaders(Vec<Header>, oneshot::Sender<Result<(), Error>>),
+    /// in response to a PullHeaders request. The reply handle must be used to
+    /// continue streaming by sending Ok, or to cancel the incoming stream
+    /// with an error.
+    ChainHeaders(Vec<Header>, ReplyHandle<()>),
 }
 
 /// Propagation requests for the network task.

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -86,6 +86,12 @@ impl From<chain_storage::error::Error> for Error {
     }
 }
 
+impl From<Error> for core_error::Error {
+    fn from(err: Error) -> Self {
+        core_error::Error::new(err.code(), err)
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Display::fmt(&self.cause, f)

--- a/jormungandr/src/network/block_pull.rs
+++ b/jormungandr/src/network/block_pull.rs
@@ -1,0 +1,109 @@
+use crate::blockcfg::Header;
+use crate::intercom::{self, BlockMsg, ReplyFuture};
+use crate::utils::async_msg::MessageBox;
+use network_core::error as core_error;
+
+use futures::prelude::*;
+use futures::stream::Chunks;
+use futures::sync::mpsc;
+use slog::Logger;
+
+// Size of chunks to split processing of chain pull streams.
+// Apart from sizing data chunks for intercom messages, it also
+// determines how many blocks will be requested per each GetBlocks request
+// distributed between different peers.
+//
+// This may need to be made into a configuration parameter.
+const CHUNK_SIZE: usize = 32;
+
+/// State machine for pulling blocks from the network after processing
+/// the stream of block headers composing the chain.
+pub struct BlockPull<In>
+where
+    In: Stream<Item = Header, Error = core_error::Error>,
+{
+    in_chunks: Chunks<In>,
+    block_box: MessageBox<BlockMsg>,
+    chain_reply: Option<ReplyFuture<(), core_error::Error>>,
+    state: State,
+    logger: Logger,
+}
+
+enum State {
+    ReadNext,
+    SendingChunk(Option<BlockMsg>),
+    WaitReply,
+}
+
+impl<In> BlockPull<In>
+where
+    In: Stream<Item = Header, Error = core_error::Error>,
+{
+    pub fn new(stream: In, block_box: MessageBox<BlockMsg>, logger: Logger) -> Self {
+        BlockPull {
+            in_chunks: stream.chunks(CHUNK_SIZE),
+            block_box,
+            chain_reply: None,
+            state: State::ReadNext,
+            logger,
+        }
+    }
+}
+
+impl<In> Future for BlockPull<In>
+where
+    In: Stream<Item = Header, Error = core_error::Error>,
+{
+    type Item = ();
+    type Error = core_error::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        use self::State::*;
+
+        loop {
+            let new_state = match self.state {
+                ReadNext => {
+                    let chunk = match try_ready!(self.in_chunks.poll()) {
+                        None => return Ok(Async::Ready(())),
+                        Some(chunk) => chunk,
+                    };
+                    let (reply, reply_future) = intercom::unary_reply(self.logger.clone());
+                    debug_assert!(self.chain_reply.is_none());
+                    self.chain_reply = Some(reply_future);
+                    SendingChunk(Some(BlockMsg::ChainHeaders(chunk, reply)))
+                }
+                SendingChunk(ref mut msg) => match self.block_box.start_send(msg.take().unwrap()) {
+                    Ok(AsyncSink::NotReady(rejected_msg)) => {
+                        *msg = Some(rejected_msg);
+                        try_ready!(self
+                            .block_box
+                            .poll_complete()
+                            .map_err(convert_intercom_send_error));
+                        SendingChunk(msg.take())
+                    }
+                    Ok(AsyncSink::Ready) => WaitReply,
+                    Err(e) => return Err(convert_intercom_send_error(e)),
+                },
+                WaitReply => {
+                    self.block_box
+                        .poll_complete()
+                        .map_err(convert_intercom_send_error)?;
+                    let future = self
+                        .chain_reply
+                        .as_mut()
+                        .expect("the reply future should be initialized");
+                    try_ready!(future.poll());
+                    ReadNext
+                }
+            };
+            self.state = new_state;
+        }
+    }
+}
+
+fn convert_intercom_send_error<T>(_: mpsc::SendError<T>) -> core_error::Error {
+    core_error::Error::new(
+        core_error::Code::Canceled,
+        "the node stopped processing incoming headers",
+    )
+}

--- a/jormungandr/src/network/chain_pull.rs
+++ b/jormungandr/src/network/chain_pull.rs
@@ -18,7 +18,7 @@ const CHUNK_SIZE: usize = 32;
 
 /// State machine for pulling blocks from the network after processing
 /// the stream of block headers composing the chain.
-pub struct BlockPull<In>
+pub struct ChainPull<In>
 where
     In: Stream<Item = Header, Error = core_error::Error>,
 {
@@ -35,12 +35,12 @@ enum State {
     WaitReply,
 }
 
-impl<In> BlockPull<In>
+impl<In> ChainPull<In>
 where
     In: Stream<Item = Header, Error = core_error::Error>,
 {
     pub fn new(stream: In, block_box: MessageBox<BlockMsg>, logger: Logger) -> Self {
-        BlockPull {
+        ChainPull {
             in_chunks: stream.chunks(CHUNK_SIZE),
             block_box,
             chain_reply: None,
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<In> Future for BlockPull<In>
+impl<In> Future for ChainPull<In>
 where
     In: Stream<Item = Header, Error = core_error::Error>,
 {

--- a/jormungandr/src/network/client.rs
+++ b/jormungandr/src/network/client.rs
@@ -1,5 +1,5 @@
 use super::{
-    block_pull::BlockPull,
+    chain_pull::ChainPull,
     grpc,
     p2p::comm::{PeerComms, Subscription},
     p2p::topology,
@@ -200,7 +200,7 @@ where
                 })
                 .and_then(move |headers| {
                     let err_logger = and_then_logger.clone();
-                    BlockPull::new(headers, block_box, and_then_logger).map_err(move |e| {
+                    ChainPull::new(headers, block_box, and_then_logger).map_err(move |e| {
                         warn!(err_logger, "header pull failed: {:?}", e);
                     })
                 }),

--- a/jormungandr/src/network/client.rs
+++ b/jormungandr/src/network/client.rs
@@ -1,7 +1,7 @@
 use super::{
     block_pull::BlockPull,
     grpc,
-    p2p::comm::{ClientCommand, PeerComms, Subscription},
+    p2p::comm::{PeerComms, Subscription},
     p2p::topology,
     subscription, Channels, ConnectionState,
 };
@@ -10,27 +10,24 @@ use crate::{
     intercom::{self, BlockMsg, ClientMsg},
 };
 use futures::prelude::*;
-use futures::sync::mpsc;
-use network_core::{
-    client::{self as core_client, block::BlockService, gossip::GossipService, p2p::P2pService},
-    gossip::Node,
-    subscription::BlockEvent,
-};
+use network_core::client as core_client;
+use network_core::client::block::BlockService;
+use network_core::client::gossip::GossipService;
+use network_core::client::p2p::P2pService;
+use network_core::gossip::Node;
+use network_core::subscription::{BlockEvent, ChainPullRequest};
 use slog::Logger;
-
-// Length of the channel buffering commands for client connections to the peers.
-const COMMAND_BUFFER_LEN: usize = 32;
 
 pub struct Client<S>
 where
     S: BlockService,
 {
     service: S,
-    commands: mpsc::Receiver<ClientCommand>,
     channels: Channels,
     remote_node_id: topology::NodeId,
     block_events: S::BlockSubscription,
     block_solicitations: Subscription<Vec<HeaderHash>>,
+    chain_pulls: Subscription<ChainPullRequest<HeaderHash>>,
     logger: Logger,
 }
 
@@ -58,8 +55,7 @@ where
         state: ConnectionState,
         channels: Channels,
     ) -> impl Future<Item = (Self, PeerComms), Error = ()> {
-        let (commands_tx, commands_rx) = mpsc::channel(COMMAND_BUFFER_LEN);
-        let mut peer_comms = PeerComms::client(commands_tx);
+        let mut peer_comms = PeerComms::new();
         let err_logger = state.logger().clone();
         service
             .ready()
@@ -101,18 +97,19 @@ where
                     // managed with just the global state.
                     subscription::process_gossip(gossip_sub, state.global, client_logger.clone());
 
-                    // Plug the block solicitations to be handled
+                    // Plug the block solicitations and header pulls to be handled
                     // via client requests.
                     let block_solicitations = peer_comms.subscribe_to_block_solicitations();
+                    let chain_pulls = peer_comms.subscribe_to_chain_pulls();
 
                     // Resolve with the client instance and communication handles.
                     let client = Client {
                         service,
-                        commands: commands_rx,
                         channels,
                         remote_node_id: node_id,
                         block_events,
                         block_solicitations,
+                        chain_pulls,
                         logger: client_logger,
                     };
                     Ok((client, peer_comms))
@@ -157,14 +154,14 @@ where
                         }),
                 );
             }
-            BlockEvent::Missing { from, to } => {
+            BlockEvent::Missing(req) => {
                 let (reply_handle, stream) = intercom::stream_reply::<
                     Header,
                     network_core::error::Error,
                 >(self.logger.clone());
                 self.channels.client_box.send_to(ClientMsg::GetHeadersRange(
-                    from,
-                    to,
+                    req.from,
+                    req.to,
                     reply_handle,
                 ));
                 let node_id = self.remote_node_id;
@@ -191,30 +188,23 @@ where
     S::PullHeadersFuture: Send + 'static,
     S::PullHeadersStream: Send + 'static,
 {
-    fn process_command(&mut self, command: ClientCommand) {
-        match command {
-            ClientCommand::PullHeaders { from, to } => {
-                let block_box = self.channels.block_box.clone();
-                let err_logger = self.logger.clone();
-                let and_then_logger = self.logger.clone();
-                tokio::spawn(
-                    self.service
-                        .pull_headers(&from, &to)
-                        .map_err(move |e| {
-                            warn!(
-                                err_logger,
-                                "solicitation request PullHeaders failed: {:?}", e
-                            );
-                        })
-                        .and_then(move |headers| {
-                            let err_logger = and_then_logger.clone();
-                            BlockPull::new(headers, block_box, and_then_logger).map_err(move |e| {
-                                warn!(err_logger, "header pull failed: {:?}", e);
-                            })
-                        }),
-                );
-            }
-        }
+    fn pull_headers(&mut self, req: ChainPullRequest<HeaderHash>) {
+        let block_box = self.channels.block_box.clone();
+        let err_logger = self.logger.clone();
+        let and_then_logger = self.logger.clone();
+        tokio::spawn(
+            self.service
+                .pull_headers(&req.from, &req.to)
+                .map_err(move |e| {
+                    warn!(err_logger, "PullHeaders request failed: {:?}", e);
+                })
+                .and_then(move |headers| {
+                    let err_logger = and_then_logger.clone();
+                    BlockPull::new(headers, block_box, and_then_logger).map_err(move |e| {
+                        warn!(err_logger, "header pull failed: {:?}", e);
+                    })
+                }),
+        );
     }
 }
 
@@ -280,20 +270,9 @@ where
                     self.process_block_event(event);
                 }
             }
-            match self.commands.poll().unwrap() {
-                Async::NotReady => {}
-                Async::Ready(None) => {
-                    debug!(self.logger, "client command stream closed");
-                    return Ok(().into());
-                }
-                Async::Ready(Some(command)) => {
-                    streams_ready = true;
-                    self.process_command(command);
-                }
-            }
-            // Block solicitations are special: they are handled with
-            // client requests on the client side, but on the server side,
-            // they are fed into the block event stream.
+            // Block solicitations and chain pulls are special:
+            // they are handled with client requests on the client side,
+            // but on the server side, they are fed into the block event stream.
             match self.block_solicitations.poll().unwrap() {
                 Async::NotReady => {}
                 Async::Ready(None) => {
@@ -303,6 +282,17 @@ where
                 Async::Ready(Some(block_ids)) => {
                     streams_ready = true;
                     self.solicit_blocks(&block_ids);
+                }
+            }
+            match self.chain_pulls.poll().unwrap() {
+                Async::NotReady => {}
+                Async::Ready(None) => {
+                    debug!(self.logger, "outbound header pull stream closed");
+                    return Ok(().into());
+                }
+                Async::Ready(Some(req)) => {
+                    streams_ready = true;
+                    self.pull_headers(req);
                 }
             }
             if !streams_ready {

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -5,7 +5,7 @@
 //! transactions...);
 //!
 
-mod block_pull;
+mod chain_pull;
 mod client;
 mod grpc;
 pub mod p2p;

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -5,6 +5,7 @@
 //! transactions...);
 //!
 
+mod block_pull;
 mod client;
 mod grpc;
 pub mod p2p;

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -12,7 +12,7 @@ mod service;
 mod subscription;
 
 use self::p2p::{
-    comm::{PeerComms, PeerMap},
+    comm::{PeerComms, Peers},
     topology::{self, P2pTopology},
 };
 use crate::blockcfg::{Block, HeaderHash};
@@ -59,7 +59,7 @@ pub struct GlobalState {
     pub config: Configuration,
     pub topology: P2pTopology,
     pub node: topology::Node,
-    pub peers: PeerMap,
+    pub peers: Peers,
     pub logger: Logger,
 }
 
@@ -94,7 +94,7 @@ impl GlobalState {
             config,
             topology,
             node,
-            peers: PeerMap::new(logger.clone()),
+            peers: Peers::new(logger.clone()),
             logger,
         }
     }
@@ -210,8 +210,12 @@ fn handle_network_input(
             handle_propagation_msg(msg, state.clone(), channels.clone());
             Ok(())
         }
-        NetworkMsg::GetBlocks(node_id, block_ids) => {
-            state.peers.solicit_blocks(node_id, block_ids);
+        NetworkMsg::GetBlocks(block_ids) => {
+            state.peers.fetch_blocks(block_ids);
+            Ok(())
+        }
+        NetworkMsg::GetNextBlock(node_id, block_id) => {
+            state.peers.solicit_blocks(node_id, vec![block_id]);
             Ok(())
         }
         NetworkMsg::PullHeaders { node_id, from, to } => {

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -331,6 +331,11 @@ impl Peers {
         }
     }
 
+    pub fn bump_peer_for_block_fetch(&self, node_id: topology::NodeId) {
+        let mut map = self.mutex.lock().unwrap();
+        map.bump_peer_for_block_fetch(node_id);
+    }
+
     pub fn fetch_blocks(&self, hashes: Vec<HeaderHash>) {
         let mut map = self.mutex.lock().unwrap();
         if let Some((node_id, comms)) = map.next_peer_for_block_fetch() {

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -45,8 +45,8 @@ impl PeerMap {
         let (node_ptr, last_needs_updating) = match self.map.entry(id) {
             Occupied(mut entry) => (entry.get_mut().as_mut().as_ptr(), false),
             Vacant(entry) => {
-                let mut node = Box::pin(Node::new(id, PeerComms::server()));
-                let mut node = entry.insert(node);
+                let node = Box::pin(Node::new(id, PeerComms::new()));
+                let node = entry.insert(node);
                 (node.as_mut().as_ptr(), true)
             }
         };
@@ -65,7 +65,7 @@ impl PeerMap {
         let mut node = Box::pin(Node::new(id, comms));
         let (node_ptr, last_needs_updating) = match self.map.entry(id) {
             Occupied(mut entry) => {
-                let (mut prev, next) = unsafe { entry.get_mut().unlink() };
+                let (prev, next) = unsafe { entry.get_mut().unlink() };
                 if next.is_none() {
                     // The old entry was the last,
                     // the cursor does not need updating.

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -1,0 +1,249 @@
+use super::PeerComms;
+use crate::network::p2p::topology::NodeId;
+
+use std::collections::{hash_map, HashMap};
+use std::pin::Pin;
+use std::ptr::NonNull;
+
+pub struct PeerMap {
+    map: HashMap<NodeId, Pin<Box<Node>>>,
+    block_cursor: BlockFetchCursor,
+}
+
+unsafe impl Send for PeerMap {}
+
+impl PeerMap {
+    pub fn new() -> Self {
+        PeerMap {
+            map: HashMap::new(),
+            block_cursor: BlockFetchCursor::Empty,
+        }
+    }
+
+    pub fn entry<'a>(&'a mut self, id: NodeId) -> Option<Entry<'a>> {
+        use std::collections::hash_map::Entry::*;
+
+        match self.map.entry(id) {
+            Vacant(_) => None,
+            Occupied(entry) => Some(Entry {
+                inner: entry,
+                block_cursor: &mut self.block_cursor,
+            }),
+        }
+    }
+
+    pub fn peer_comms(&mut self, id: NodeId) -> Option<&mut PeerComms> {
+        match self.map.get_mut(&id) {
+            None => None,
+            Some(pin) => Some(&mut pin.comms),
+        }
+    }
+
+    pub fn ensure_peer_comms(&mut self, id: NodeId) -> &mut PeerComms {
+        use std::collections::hash_map::Entry::*;
+
+        let (node_ptr, last_needs_updating) = match self.map.entry(id) {
+            Occupied(mut entry) => (entry.get_mut().as_mut().as_ptr(), false),
+            Vacant(entry) => {
+                let mut node = Box::pin(Node::new(id, PeerComms::server()));
+                let mut node = entry.insert(node);
+                (node.as_mut().as_ptr(), true)
+            }
+        };
+        // TODO: update to edition 2018 so we can use NLLs
+        if last_needs_updating {
+            unsafe {
+                self.push_last(id, node_ptr);
+            }
+        }
+        unsafe { &mut (*node_ptr.as_ptr()).comms }
+    }
+
+    pub fn insert_peer(&mut self, id: NodeId, comms: PeerComms) {
+        use std::collections::hash_map::Entry::*;
+
+        let mut node = Box::pin(Node::new(id, comms));
+        let (node_ptr, last_needs_updating) = match self.map.entry(id) {
+            Occupied(mut entry) => {
+                let (mut prev, next) = unsafe { entry.get_mut().unlink() };
+                if next.is_none() {
+                    // The old entry was the last,
+                    // the cursor does not need updating.
+                    // Just link with the previous node here.
+                    node.prev = prev;
+                    if let Some(mut prev) = prev {
+                        unsafe {
+                            prev.as_mut().next = Some(node.as_mut().as_ptr());
+                        }
+                    }
+                }
+                entry.insert(node);
+                (entry.into_mut().as_mut().as_ptr(), next.is_some())
+            }
+            Vacant(entry) => (entry.insert(node).as_mut().as_ptr(), true),
+        };
+        if last_needs_updating {
+            unsafe {
+                self.push_last(id, node_ptr);
+            }
+        }
+    }
+
+    pub fn next_peer_for_block_fetch(&mut self) -> Option<(NodeId, &mut PeerComms)> {
+        match self.block_cursor.next() {
+            None => None,
+            Some(id) => {
+                let node = self.map.get_mut(&id).unwrap();
+                let prev_id = match node.prev {
+                    None => None,
+                    Some(prev_ptr) => unsafe { Some(prev_ptr.as_ref().id) },
+                };
+                self.block_cursor.set_next(prev_id);
+                Some((id, &mut node.comms))
+            }
+        }
+    }
+
+    unsafe fn push_last(&mut self, id: NodeId, mut node_ptr: NonNull<Node>) {
+        if let Some(last_id) = self.block_cursor.last() {
+            let last = self.map.get_mut(&last_id).unwrap();
+            last.next = Some(node_ptr);
+            let node = node_ptr.as_mut();
+            node.prev = Some(NonNull::new_unchecked(last.as_mut().get_mut()));
+            node.next = None;
+        }
+        self.block_cursor.set_last(id);
+    }
+}
+
+// State for round-robin block fetching cursor.
+enum BlockFetchCursor {
+    // Placeholder when no entries exist in the map.
+    Empty,
+    Ids {
+        // The ID of the last node in the order.
+        last: NodeId,
+        // Cursor for the next node to fetch blocks from.
+        // If None, start from last.
+        next_back: Option<NodeId>,
+    },
+}
+
+impl BlockFetchCursor {
+    fn is_last(&self, id: NodeId) -> bool {
+        match self {
+            BlockFetchCursor::Empty => false,
+            BlockFetchCursor::Ids { last, .. } => *last == id,
+        }
+    }
+
+    fn last(&self) -> Option<NodeId> {
+        match self {
+            BlockFetchCursor::Empty => None,
+            BlockFetchCursor::Ids { last, .. } => Some(*last),
+        }
+    }
+
+    fn next(&self) -> Option<NodeId> {
+        match self {
+            BlockFetchCursor::Empty => None,
+            BlockFetchCursor::Ids { last, next_back } => next_back.or(Some(*last)),
+        }
+    }
+
+    fn set_last(&mut self, last: NodeId) {
+        *self = match self {
+            BlockFetchCursor::Empty => BlockFetchCursor::Ids {
+                last,
+                next_back: None,
+            },
+            BlockFetchCursor::Ids { ref next_back, .. } => BlockFetchCursor::Ids {
+                last,
+                next_back: *next_back,
+            },
+        }
+    }
+
+    fn set_next(&mut self, next: Option<NodeId>) {
+        match self {
+            BlockFetchCursor::Empty => unreachable!("node key set in empty peer collection"),
+            BlockFetchCursor::Ids { next_back, .. } => {
+                *next_back = next;
+            }
+        }
+    }
+}
+
+// Map node, pinned and linked through in linear order of recent use.
+struct Node {
+    // The node ID, duplicated in the value structure
+    // to access when navigating "sideways" in the order.
+    id: NodeId,
+    // The structurally unpinned peer communications entry.
+    comms: PeerComms,
+    // Pointer to the previous node.
+    prev: Option<NonNull<Node>>,
+    // Pointer to the next node.
+    next: Option<NonNull<Node>>,
+}
+
+unsafe impl Send for Node {}
+
+impl Node {
+    fn new(id: NodeId, comms: PeerComms) -> Self {
+        Node {
+            id,
+            comms,
+            prev: None,
+            next: None,
+        }
+    }
+
+    fn as_ptr(self: Pin<&mut Node>) -> NonNull<Node> {
+        unsafe { NonNull::new_unchecked(self.get_mut()) }
+    }
+
+    // Require a mutable borrow on self because this modifies
+    // adjacent nodes.
+    unsafe fn unlink(&mut self) -> (Option<NonNull<Node>>, Option<NonNull<Node>>) {
+        if let Some(mut prev) = self.prev {
+            prev.as_mut().next = self.next;
+        }
+        if let Some(mut next) = self.next {
+            next.as_mut().prev = self.prev;
+        }
+        (self.prev, self.next)
+    }
+}
+
+pub struct Entry<'a> {
+    inner: hash_map::OccupiedEntry<'a, NodeId, Pin<Box<Node>>>,
+    block_cursor: &'a mut BlockFetchCursor,
+}
+
+impl<'a> Entry<'a> {
+    pub fn comms(&mut self) -> &mut PeerComms {
+        &mut self.inner.get_mut().comms
+    }
+
+    pub fn remove(mut self) {
+        let id = *self.inner.key();
+        let (prev, _) = unsafe { self.inner.get_mut().unlink() };
+        if self.block_cursor.next() == Some(id) {
+            let next = match prev {
+                Some(prev) => unsafe { Some(prev.as_ref().id) },
+                None => None,
+            };
+            self.block_cursor.set_next(next);
+        }
+        if self.block_cursor.is_last(id) {
+            match prev {
+                Some(prev) => self.block_cursor.set_last(unsafe { prev.as_ref().id }),
+                None => {
+                    *self.block_cursor = BlockFetchCursor::Empty;
+                }
+            }
+        }
+        self.inner.remove();
+    }
+}

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -60,12 +60,6 @@ impl Node for NodeService {
     }
 }
 
-impl From<intercom::Error> for core_error::Error {
-    fn from(err: intercom::Error) -> Self {
-        core_error::Error::new(err.code(), err)
-    }
-}
-
 impl P2pService for NodeService {
     type NodeId = topology::NodeId;
 

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -1,5 +1,5 @@
 use super::{
-    block_pull::BlockPull,
+    chain_pull::ChainPull,
     p2p::comm::{BlockEventSubscription, Subscription},
     p2p::topology,
     subscription, Channels, GlobalStateR,
@@ -145,7 +145,7 @@ impl BlockService for NodeService {
     where
         In: Stream<Item = Self::Header, Error = core_error::Error> + Send + 'static,
     {
-        Box::new(BlockPull::new(
+        Box::new(ChainPull::new(
             headers,
             self.channels.block_box.clone(),
             self.logger.clone(),

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -171,6 +171,7 @@ impl BlockService for NodeService {
         subscription::process_block_announcements(
             inbound,
             subscriber,
+            self.global_state.clone(),
             self.channels.block_box.clone(),
             self.logger().clone(),
         );

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -1,14 +1,11 @@
 use super::{
-    p2p::{
-        comm::{BlockEventSubscription, Subscription},
-        topology,
-    },
+    block_pull::BlockPull,
+    p2p::comm::{BlockEventSubscription, Subscription},
+    p2p::topology,
     subscription, Channels, GlobalStateR,
 };
 use crate::blockcfg::{Block, BlockDate, Header, HeaderHash, Message, MessageId};
-use crate::intercom::{
-    self, stream_reply, unary_reply, BlockMsg, ClientMsg, ReplyFuture, ReplyStream,
-};
+use crate::intercom::{stream_reply, unary_reply, BlockMsg, ClientMsg, ReplyFuture, ReplyStream};
 use futures::future::{self, FutureResult};
 use futures::prelude::*;
 use network_core::{
@@ -148,8 +145,8 @@ impl BlockService for NodeService {
     where
         In: Stream<Item = Self::Header, Error = core_error::Error> + Send + 'static,
     {
-        unimplemented!();
-        future::ok(())
+        //BlockPull::new(headers, self.channels.block_box.clone(), self.logger.clone())
+        unimplemented!()
     }
 
     fn on_uploaded_block(&mut self, block: Block) -> Self::OnUploadedBlockFuture {

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -136,10 +136,14 @@ impl BlockService for NodeService {
 
     fn pull_headers(
         &mut self,
-        _from: &[Self::BlockId],
-        _to: &Self::BlockId,
+        from: &[Self::BlockId],
+        to: &Self::BlockId,
     ) -> Self::PullHeadersFuture {
-        unimplemented!()
+        let (handle, stream) = stream_reply(self.logger().clone());
+        self.channels
+            .client_box
+            .send_to(ClientMsg::GetHeadersRange(from.into(), *to, handle));
+        future::ok(stream)
     }
 
     fn pull_headers_to_tip(&mut self, _from: &[Self::BlockId]) -> Self::PullHeadersFuture {

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -80,7 +80,7 @@ impl BlockService for NodeService {
     type PullHeadersFuture = FutureResult<Self::PullHeadersStream, core_error::Error>;
     type GetHeadersStream = ReplyStream<Header, core_error::Error>;
     type GetHeadersFuture = FutureResult<Self::GetHeadersStream, core_error::Error>;
-    type PushHeadersFuture = FutureResult<(), core_error::Error>;
+    type PushHeadersFuture = Box<dyn Future<Item = (), Error = core_error::Error> + Send>;
     type OnUploadedBlockFuture = FutureResult<(), core_error::Error>;
     type BlockSubscription = BlockEventSubscription;
     type BlockSubscriptionFuture = FutureResult<Self::BlockSubscription, core_error::Error>;
@@ -145,8 +145,11 @@ impl BlockService for NodeService {
     where
         In: Stream<Item = Self::Header, Error = core_error::Error> + Send + 'static,
     {
-        //BlockPull::new(headers, self.channels.block_box.clone(), self.logger.clone())
-        unimplemented!()
+        Box::new(BlockPull::new(
+            headers,
+            self.channels.block_box.clone(),
+            self.logger.clone(),
+        ))
     }
 
     fn on_uploaded_block(&mut self, block: Block) -> Self::OnUploadedBlockFuture {

--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -10,6 +10,7 @@ use slog::Logger;
 pub fn process_block_announcements<S>(
     inbound: S,
     node_id: NodeId,
+    global_state: GlobalStateR,
     mut block_box: MessageBox<BlockMsg>,
     logger: Logger,
 ) -> tokio::executor::Spawn
@@ -19,6 +20,7 @@ where
     tokio::spawn(
         inbound
             .for_each(move |header| {
+                global_state.peers.bump_peer_for_block_fetch(node_id);
                 block_box
                     .try_send(BlockMsg::AnnouncedBlock(header, node_id))
                     .unwrap();

--- a/jormungandr/src/utils/async_msg.rs
+++ b/jormungandr/src/utils/async_msg.rs
@@ -2,7 +2,7 @@
 //! asynchronous reading.
 
 use futures::prelude::*;
-use futures::sync::mpsc::{self, Receiver, Sender, TrySendError};
+use futures::sync::mpsc::{self, Receiver, SendError, Sender, TrySendError};
 
 /// The output end of an in-memory FIFO channel.
 pub struct MessageBox<Msg>(Sender<Msg>);
@@ -32,6 +32,23 @@ impl<Msg> MessageBox<Msg> {
     /// an error is returned in `Err`.
     pub fn try_send(&mut self, a: Msg) -> Result<(), TrySendError<Msg>> {
         self.0.try_send(a)
+    }
+}
+
+impl<Msg> Sink for MessageBox<Msg> {
+    type SinkItem = Msg;
+    type SinkError = SendError<Msg>;
+
+    fn start_send(&mut self, msg: Msg) -> StartSend<Msg, SendError<Msg>> {
+        self.0.start_send(msg)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), SendError<Msg>> {
+        self.0.poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), SendError<Msg>> {
+        self.0.close()
     }
 }
 


### PR DESCRIPTION
Continuation of #554.

Adds a strategy of bumping the peer that has announced a block to the last in the linear order of peer entries. When blocks are fetched, the peers are to be picked from last to first.