### PR TITLE
Fix localhost for BSD & OSX

### DIFF
--- a/jormungandr-integration-tests/src/jcli/rest/host.rs
+++ b/jormungandr-integration-tests/src/jcli/rest/host.rs
@@ -14,7 +14,7 @@ pub fn test_correct_error_is_returned_for_incorrect_host_syntax() {
 
 #[test]
 pub fn test_correct_error_is_returned_for_incorrect_host_address() {
-    let incorrect_host = "http://127.0.0.100:8443/api";
+    let incorrect_host = "http://127.0.0.1:8443/api";
 
     process_assert::assert_process_failed_and_matches_message(
         jcli_wrapper::jcli_commands::get_rest_block_tip_command(&incorrect_host),


### PR DESCRIPTION
127.0.0.100 is not bound on some system, use the usual localhost