### PR TITLE
move the address prefix to -lib and jcli

### DIFF
--- a/jcli/build.rs
+++ b/jcli/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let production_prefix = option_env!("ADDRESS_PREFIX").unwrap_or("ca");
+    println!("cargo:rustc-env=ADDRESS_PREFIX={}", production_prefix);
+}

--- a/jcli/src/jcli_app/address.rs
+++ b/jcli/src/jcli_app/address.rs
@@ -4,6 +4,8 @@ use chain_crypto::{AsymmetricPublicKey, Ed25519, PublicKey};
 use jcli_app::utils::key_parser::parse_pub_key;
 use structopt::StructOpt;
 
+pub const ADDRESS_PREFIX: &'static str = env!("ADDRESS_PREFIX");
+
 #[derive(StructOpt)]
 #[structopt(name = "address", rename_all = "kebab-case")]
 pub enum Address {
@@ -118,7 +120,10 @@ fn mk_discrimination(testing: bool) -> Discrimination {
 
 fn mk_address(discrimination: Discrimination, kind: Kind) {
     let address = chain_addr::Address(discrimination, kind);
-    println!("{}", AddressReadable::from_address(&address).to_string());
+    println!(
+        "{}",
+        AddressReadable::from_address(ADDRESS_PREFIX, &address).to_string()
+    );
 }
 
 fn mk_address_1<A, F>(s: PublicKey<A>, testing: bool, f: F)

--- a/jcli/src/jcli_app/transaction/info.rs
+++ b/jcli/src/jcli_app/transaction/info.rs
@@ -1,6 +1,7 @@
 use chain_addr::{Address, AddressReadable};
 use chain_impl_mockchain::transaction::{Balance, Input, InputEnum, InputType, Output};
 use jcli_app::{
+    address::ADDRESS_PREFIX,
     transaction::{common, staging::Staging, Error},
     utils::io,
 };
@@ -117,7 +118,7 @@ impl Info {
 
         vars.insert(
             "address".to_owned(),
-            AddressReadable::from_address(&output.address).to_string(),
+            AddressReadable::from_address(ADDRESS_PREFIX, &output.address).to_string(),
         );
         vars.insert("value".to_owned(), output.value.0.to_string());
         self.write_info(writer, &self.format_output, vars)

--- a/jormungandr-integration-tests/src/common/configuration/genesis_model.rs
+++ b/jormungandr-integration-tests/src/common/configuration/genesis_model.rs
@@ -83,14 +83,14 @@ impl GenesisYaml {
         let pk1: PublicKey<Ed25519> = sk1.to_public();
         let initial_funds_address1 = Address(Discrimination::Test, Kind::Single(pk1));
         let initial_funds_address1 =
-            AddressReadable::from_address(&initial_funds_address1).to_string();
+            AddressReadable::from_address("ca", &initial_funds_address1).to_string();
 
         let sk2: SecretKey<Ed25519Extended> =
             SecretKey::generate(&mut ChaChaRng::from_seed([2; 32]));
         let pk2: PublicKey<Ed25519> = sk2.to_public();
         let initial_funds_address2 = Address(Discrimination::Test, Kind::Single(pk2));
         let initial_funds_address2 =
-            AddressReadable::from_address(&initial_funds_address2).to_string();
+            AddressReadable::from_address("ca", &initial_funds_address2).to_string();
 
         let initial_funds = vec![
             Fund {

--- a/jormungandr-lib/build.rs
+++ b/jormungandr-lib/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let production_prefix = option_env!("ADDRESS_PREFIX").unwrap_or("ca");
+    println!("cargo:rustc-env=ADDRESS_PREFIX={}", production_prefix);
+}

--- a/jormungandr-lib/src/crypto/account.rs
+++ b/jormungandr-lib/src/crypto/account.rs
@@ -27,7 +27,7 @@
 //!
 //! println!(
 //!   "Please, send money to my account: {}",
-//!   AddressReadable::from_address(&address)
+//!   AddressReadable::from_address("ca", &address)
 //! );
 //! ```
 //!

--- a/jormungandr-lib/src/interfaces/address.rs
+++ b/jormungandr-lib/src/interfaces/address.rs
@@ -7,11 +7,13 @@ use std::{fmt, str::FromStr};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Address(chain_addr::Address);
 
+pub const ADDRESS_PREFIX: &'static str = env!("ADDRESS_PREFIX");
+
 /* ---------------- Display ------------------------------------------------ */
 
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        chain_addr::AddressReadable::from_address(&self.0).fmt(f)
+        chain_addr::AddressReadable::from_address(ADDRESS_PREFIX, &self.0).fmt(f)
     }
 }
 
@@ -52,7 +54,7 @@ impl Serialize for Address {
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            let address = chain_addr::AddressReadable::from_address(&self.0);
+            let address = chain_addr::AddressReadable::from_address(ADDRESS_PREFIX, &self.0);
             serializer.serialize_str(address.as_string())
         } else {
             let bytes = self.0.to_bytes();
@@ -68,7 +70,7 @@ impl<'de> Deserialize<'de> for Address {
     {
         if deserializer.is_human_readable() {
             let s: String = String::deserialize(deserializer)?;
-            chain_addr::AddressReadable::from_str(&s)
+            chain_addr::AddressReadable::from_string_anyprefix(&s)
                 .map_err(|e| serde::de::Error::custom(e))
                 .map(|a| Address(a.to_address()))
         } else {


### PR DESCRIPTION
move chain-addr build.rs to -lib and jcli for now, temporary until full removal
now deserialize doesn't care about the address prefix anymore