### PR TITLE
Introduce `--quiet` CLI option and `quietness` configuration option.

### DIFF
--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -67,10 +67,17 @@ pub struct StartArguments {
     raw(setting = "structopt::clap::AppSettings::ColoredHelp")
 )]
 pub struct CommandLine {
-    /// activate the verbosity, the more occurrences the more verbose.
+    /// Activate quiet mode.
+    /// The more occurrences, the quieter the output.
+    /// (-q, -qq, -qqq)
+    #[structopt(short = "q", long = "quiet", parse(from_occurrences))]
+    pub quietness: u8,
+
+    /// Activate verbose mode.
+    /// The more occurrences, the more verbose the output.
     /// (-v, -vv, -vvv)
     #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
-    pub verbose: u8,
+    pub verbosity: u8,
 
     /// Set format of the log emitted. Can be "json" or "plain".
     /// If not configured anywhere, defaults to "plain".

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 
 #[derive(Debug)]
 pub struct LogSettings {
-    pub verbosity: slog::Level,
+    pub level: slog::Level,
     pub format: LogFormat,
     pub output: LogOutput,
 }
@@ -86,7 +86,7 @@ impl FromStr for LogOutput {
 impl LogSettings {
     pub fn to_logger(&self) -> Result<Logger, Error> {
         let drain = self.output.to_logger(&self.format)?.fuse();
-        let drain = slog::LevelFilter::new(drain, self.verbosity).fuse();
+        let drain = slog::LevelFilter::new(drain, self.level).fuse();
         Ok(slog::Logger::root(drain, o!()))
     }
 }

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConfigLogSettings {
+    pub quietness: Option<u8>,
     pub verbosity: Option<u8>,
     pub format: Option<LogFormat>,
     pub output: Option<LogOutput>,


### PR DESCRIPTION
### CLI Option

The `--quiet` CLI option works in a similar way to the preexisting `--verbose` CLI option, but in reverse.

The more occurrences of `--quiet`, the quieter the output.

The `--quiet` and `--verbose` options are **mutually exclusive**.

### Configuration Option

The `quietness` configuration option works in a similar way to the preexisting `verbosity` configuration option, but in reverse.

The higher the level of `quietness`, the quieter the output.

The `quietness` and `verbosity` options are **mutually exclusive**.