### PR TITLE
make sure we use the latest stable available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ before_install:
   - rustup self update
 
 install:
+  - rustup udpate stable
   - sh ci/install.sh
   - source ~/.cargo/env || true
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 User guide documentation available [here](https://input-output-hk.github.io/jormungandr)
 
+## Master current build status
+
+| CI | Status | Description |
+|---:|:------:|:------------|
+| Travis CI | [![Build Status](https://travis-ci.org/input-output-hk/jormungandr.svg?branch=master)](https://travis-ci.org/input-output-hk/jormungandr) | Master and release |
+| CircleCI | [![CircleCI](https://circleci.com/gh/input-output-hk/jormungandr/tree/master.svg?style=svg)](https://circleci.com/gh/input-output-hk/jormungandr/tree/master) | Master and PRs |
+| Appveyor | [![Build status](https://ci.appveyor.com/api/projects/status/1y5583gqc4xn8x3j/branch/master?svg=true)](https://ci.appveyor.com/project/NicolasDP/jormungandr/branch/master) | Master, release and PRs |
+
 ## How to install from sources
 
 Currently the minimum supported version of the rust compiler is 1.35, however


### PR DESCRIPTION
it may be possible travis-ci image is not utilising the latest stable version (which is the one we officially support). In order to prevent cases where travis-ci image for rust does not contains the latest stable yet we can make sure to update it with `rustup`.

We don't need to handle cases for beta or nightly here as we only care about stable in travis ci