### PR TITLE
Fix genesis.yaml consensus version naming

### DIFF
--- a/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
@@ -40,7 +40,7 @@ pub fn test_genesis_stake_pool_with_account_faucet_starts_successfully() {
     );
 
     let mut config = startup::ConfigurationBuilder::new()
-        .with_block0_consensus("genesis_praos")
+        .with_block0_consensus("genesis")
         .with_bft_slots_ratio("0".to_owned())
         .with_consensus_genesis_praos_active_slot_coeff("0.1")
         .with_consensus_leaders_ids(vec![leader.public_key.clone()])

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
@@ -309,6 +309,7 @@ enum DiscriminationDef {
 #[serde(rename_all = "snake_case", remote = "ConsensusVersion")]
 enum ConsensusVersionDef {
     Bft,
+    #[serde(rename = "genesis")]
     GenesisPraos,
 }
 

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -33,7 +33,7 @@ FAUCET_AMOUNT=1000000000000
 FIXED_AMOUNT=1000000000000
 ADDRTYPE="--testing"
 
-CONSENSUS="genesis_praos"
+CONSENSUS="genesis"
 SECRET_PATH="."
 CONFIG_PATH="."
 ADD_STARTUP_SCRIPT=0
@@ -42,7 +42,7 @@ while getopts 'bc:ghk:p:s:xCod:e:' c
 do
     case $c in
         b) CONSENSUS="bft" ;;
-        g) CONSENSUS="genesis_praos" ;;
+        g) CONSENSUS="genesis" ;;
         p) REST_PORT="${OPTARG}" ;;
         k) SECRET_PATH="${OPTARG}" ;;
         c) CONFIG_PATH="${OPTARG}" ;;


### PR DESCRIPTION
Genesis.yaml parser was expecting consensus version "genesis_praos" instead of "genesis". This is in conflict with documentation and string parsing of chain-impl-mockchain enum.