### PR TITLE
CircleCI: Streamline the workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,20 @@ jobs:
     working_directory: /mnt/crate
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
             - cargo-v3-{{ checksum "Cargo.toml" }}
             - cargo-v3-
-      - run: git submodule sync
-      - run: git submodule update --init
       - run: cargo fetch
       - save_cache:
           key: cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
           paths:
             - /usr/local/cargo/registry
             - /usr/local/cargo/git
+
   rustfmt:
     docker:
       - image: rust:latest
@@ -34,74 +35,27 @@ jobs:
       - run:
           name: Check rustfmt
           command: cargo fmt -- --check
-  build_debug:
-    docker:
-      - image: rust:latest
-    working_directory: /mnt/crate
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - restore_cache:
-          keys:
-            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
-      - run:
-          name: Print version information
-          command: rustc --version; cargo --version
-      - run:
-          name: Build
-          command: cargo build --frozen
-      - persist_to_workspace:
-          root: target
-          paths:
-            - debug/*
+
   test_debug:
     docker:
       - image: rust:latest
     working_directory: /mnt/crate
     steps:
       - checkout
-      - attach_workspace:
-          at: target
       - run: git submodule sync
       - run: git submodule update --init
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
+      - run:
+          name: Build
+          command: cargo build --tests --frozen --verbose
       - run:
           name: Test
           command: cargo test --frozen --verbose
-
-  build_release:
-    docker:
-      - image: rust:latest
-    working_directory: /mnt/crate
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - restore_cache:
-          keys:
-            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
-      - run:
-          name: Print version information
-          command: rustc --version; cargo --version
-      - run:
-          name: Build in release profile
-          command: cargo build --release --frozen
-      - persist_to_workspace:
-          root: target
-          paths:
-            - release/*
 
   test_release:
     docker:
@@ -109,45 +63,20 @@ jobs:
     working_directory: /mnt/crate
     steps:
       - checkout
-      - attach_workspace:
-          at: target
       - run: git submodule sync
       - run: git submodule update --init
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
+      - run:
+          name: Build
+          command: cargo build --tests --release --frozen --verbose
       - run:
           name: Test
           command: cargo test --release --frozen --verbose
-
-  build_nightly:
-    docker:
-      - image: rustlang/rust:nightly
-    working_directory: /mnt/crate
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - restore_cache:
-          keys:
-            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
-      - run:
-          name: Print version information
-          command: rustc --version; cargo --version
-      - run:
-          name: Build in debug profile
-          command: cargo build --frozen
-      - persist_to_workspace:
-          root: target
-          paths:
-            - debug/*
 
   test_nightly:
     docker:
@@ -155,18 +84,17 @@ jobs:
     working_directory: /mnt/crate
     steps:
       - checkout
-      - attach_workspace:
-          at: target
       - run: git submodule sync
       - run: git submodule update --init
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
+      - run:
+          name: Build
+          command: cargo build --tests --frozen --verbose
       - run:
           name: Test
           command: cargo test --frozen --verbose
@@ -177,24 +105,15 @@ workflows:
     jobs:
       - cargo_fetch
       - rustfmt
-      - build_debug:
-          requires:
-            - rustfmt
-            - cargo_fetch
-      - build_release:
-          requires:
-            - rustfmt
-            - cargo_fetch
       - test_debug:
           requires:
-            - build_debug
+            - rustfmt
+            - cargo_fetch
       - test_release:
-          requires:
-            - build_release
-      - build_nightly:
           requires:
             - rustfmt
             - cargo_fetch
       - test_nightly:
           requires:
-            - build_nightly
+            - rustfmt
+            - cargo_fetch


### PR DESCRIPTION
Remove the build jobs that don't currently do anything useful that needs to be done separately from test jobs.
Don't use the workspace, as build results no longer need to be handed off to other jobs (this may be resurrected when coverage is to be introduced).

Clean up `restore_cache` steps: only precise cache hits are used for the test jobs, as verified by the `--frozen` option given to cargo.