### PR TITLE
CircleCI: Streamline the workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,15 +54,15 @@ jobs:
           command: rustc --version; cargo --version
       - run:
           name: Build binaries
-          command: cargo build -p jormungandr -p jcli --frozen --verbose
+          command: cargo build -p jormungandr -p jcli --offline --verbose
       - run:
           name: Build tests
-          command: cargo build --tests --frozen --verbose
+          command: cargo build --tests --offline --verbose
       - run:
           name: Test
           environment:
             RUST_BACKTRACE: 1
-          command: cargo test --frozen --verbose
+          command: cargo test --offline --verbose
 
   test_release:
     docker:
@@ -80,13 +80,13 @@ jobs:
           command: rustc --version; cargo --version
       - run:
           name: Build binaries
-          command: cargo build -p jormungandr -p jcli --release --frozen --verbose
+          command: cargo build -p jormungandr -p jcli --release --offline --verbose
       - run:
           name: Build tests
-          command: cargo build --tests --release --frozen --verbose
+          command: cargo build --tests --release --offline --verbose
       - run:
           name: Test
-          command: cargo test --release --frozen --verbose
+          command: cargo test --release --offline --verbose
 
   test_nightly:
     docker:
@@ -106,15 +106,15 @@ jobs:
           command: rustc --version; cargo --version
       - run:
           name: Build binaries
-          command: cargo build -p jormungandr -p jcli --frozen --verbose
+          command: cargo build -p jormungandr -p jcli --offline --verbose
       - run:
           name: Build tests
-          command: cargo build --tests --frozen --verbose
+          command: cargo build --tests --offline --verbose
       - run:
           name: Test
           environment:
             RUST_BACKTRACE: 1
-          command: cargo test --frozen --verbose
+          command: cargo test --offline --verbose
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,20 @@ jobs:
     working_directory: /mnt/crate
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
             - cargo-v3-{{ checksum "Cargo.toml" }}
             - cargo-v3-
-      - run: git submodule sync
-      - run: git submodule update --init
       - run: cargo fetch
       - save_cache:
           key: cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
           paths:
             - /usr/local/cargo/registry
             - /usr/local/cargo/git
+
   rustfmt:
     docker:
       - image: rust:latest
@@ -34,6 +35,7 @@ jobs:
       - run:
           name: Check rustfmt
           command: cargo fmt -- --check
+
   build_debug:
     docker:
       - image: rust:latest
@@ -45,36 +47,36 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Build
-          command: cargo build --frozen
+          command: cargo build -p jormungandr -p jcli --frozen
       - persist_to_workspace:
           root: target
           paths:
-            - debug/*
+            - debug
+
   test_debug:
     docker:
       - image: rust:latest
     working_directory: /mnt/crate
     steps:
       - checkout
-      - attach_workspace:
-          at: target
       - run: git submodule sync
       - run: git submodule update --init
+      - attach_workspace:
+          at: target
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
+      - run:
+          name: Build tests
+          command: cargo build --tests --frozen --verbose
       - run:
           name: Test
           command: cargo test --frozen --verbose
@@ -90,18 +92,16 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
-          name: Build in release profile
-          command: cargo build --release --frozen
+          name: Build
+          command: cargo build -p jormungandr -p jcli --release --frozen
       - persist_to_workspace:
           root: target
           paths:
-            - release/*
+            - release
 
   test_release:
     docker:
@@ -109,18 +109,19 @@ jobs:
     working_directory: /mnt/crate
     steps:
       - checkout
-      - attach_workspace:
-          at: target
       - run: git submodule sync
       - run: git submodule update --init
+      - attach_workspace:
+          at: target
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
+      - run:
+          name: Build tests
+          command: cargo build --tests --release --frozen --verbose
       - run:
           name: Test
           command: cargo test --release --frozen --verbose
@@ -136,18 +137,16 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
-          name: Build in debug profile
-          command: cargo build --frozen
+          name: Build
+          command: cargo build -p jormungandr -p jcli --frozen
       - persist_to_workspace:
           root: target
           paths:
-            - debug/*
+            - debug
 
   test_nightly:
     docker:
@@ -162,11 +161,12 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
+      - run:
+          name: Build tests
+          command: cargo build --tests --frozen --verbose
       - run:
           name: Test
           command: cargo test --frozen --verbose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ jobs:
   test_debug:
     docker:
       - image: rust:latest
+    environment:
+      CARGO_INCREMENTAL: 0
     working_directory: /mnt/crate
     steps:
       - checkout
@@ -87,6 +89,8 @@ jobs:
   test_nightly:
     docker:
       - image: rustlang/rust:nightly
+    environment:
+      CARGO_INCREMENTAL: 0
     working_directory: /mnt/crate
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,28 +36,6 @@ jobs:
           name: Check rustfmt
           command: cargo fmt -- --check
 
-  build_debug:
-    docker:
-      - image: rust:latest
-    working_directory: /mnt/crate
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - restore_cache:
-          keys:
-            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Print version information
-          command: rustc --version; cargo --version
-      - run:
-          name: Build
-          command: cargo build -p jormungandr -p jcli --frozen
-      - persist_to_workspace:
-          root: target
-          paths:
-            - debug
-
   test_debug:
     docker:
       - image: rust:latest
@@ -66,42 +44,21 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - attach_workspace:
-          at: target
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Print version information
           command: rustc --version; cargo --version
+      - run:
+          name: Build binaries
+          command: cargo build -p jormungandr -p jcli --frozen --verbose
       - run:
           name: Build tests
           command: cargo build --tests --frozen --verbose
       - run:
           name: Test
           command: cargo test --frozen --verbose
-
-  build_release:
-    docker:
-      - image: rust:latest
-    working_directory: /mnt/crate
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - restore_cache:
-          keys:
-            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Print version information
-          command: rustc --version; cargo --version
-      - run:
-          name: Build
-          command: cargo build -p jormungandr -p jcli --release --frozen
-      - persist_to_workspace:
-          root: target
-          paths:
-            - release
 
   test_release:
     docker:
@@ -111,14 +68,15 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - attach_workspace:
-          at: target
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Print version information
           command: rustc --version; cargo --version
+      - run:
+          name: Build binaries
+          command: cargo build -p jormungandr -p jcli --release --frozen --verbose
       - run:
           name: Build tests
           command: cargo build --tests --release --frozen --verbose
@@ -126,36 +84,12 @@ jobs:
           name: Test
           command: cargo test --release --frozen --verbose
 
-  build_nightly:
-    docker:
-      - image: rustlang/rust:nightly
-    working_directory: /mnt/crate
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - restore_cache:
-          keys:
-            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Print version information
-          command: rustc --version; cargo --version
-      - run:
-          name: Build
-          command: cargo build -p jormungandr -p jcli --frozen
-      - persist_to_workspace:
-          root: target
-          paths:
-            - debug
-
   test_nightly:
     docker:
       - image: rustlang/rust:nightly
     working_directory: /mnt/crate
     steps:
       - checkout
-      - attach_workspace:
-          at: target
       - run: git submodule sync
       - run: git submodule update --init
       - restore_cache:
@@ -164,6 +98,9 @@ jobs:
       - run:
           name: Print version information
           command: rustc --version; cargo --version
+      - run:
+          name: Build binaries
+          command: cargo build -p jormungandr -p jcli --frozen --verbose
       - run:
           name: Build tests
           command: cargo build --tests --frozen --verbose
@@ -177,24 +114,15 @@ workflows:
     jobs:
       - cargo_fetch
       - rustfmt
-      - build_debug:
-          requires:
-            - rustfmt
-            - cargo_fetch
-      - build_release:
-          requires:
-            - rustfmt
-            - cargo_fetch
       - test_debug:
           requires:
-            - build_debug
+            - rustfmt
+            - cargo_fetch
       - test_release:
-          requires:
-            - build_release
-      - build_nightly:
           requires:
             - rustfmt
             - cargo_fetch
       - test_nightly:
           requires:
-            - build_nightly
+            - rustfmt
+            - cargo_fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,8 @@ jobs:
           command: cargo build --tests --frozen --verbose
       - run:
           name: Test
+          environment:
+            RUST_BACKTRACE: 1
           command: cargo test --frozen --verbose
 
   test_release:
@@ -110,6 +112,8 @@ jobs:
           command: cargo build --tests --frozen --verbose
       - run:
           name: Test
+          environment:
+            RUST_BACKTRACE: 1
           command: cargo test --frozen --verbose
 
 workflows:


### PR DESCRIPTION
Eliminate separate build jobs as these only add workspace persistence overhead with no artefacts usable outside of the tests.
In the test jobs, build the tests in a separate step to reduce non-test output in the test step.

Clean up `restore_cache` steps: only precise cache hits are used for build and test jobs, as verified by the `--frozen` option given to cargo.