### PR TITLE
Upgrade Slog to 2.5.1

### DIFF
--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0.38"
 serde_yaml = "0.8"
-slog = { version = "^2.4", features = [ "max_level_trace", "release_max_level_trace" ] }
+slog = { version = "^2.5.1", features = [ "max_level_trace", "release_max_level_trace" ] }
 slog-async = "2.3.0"
 slog-gelf = { version = "0.1.0", optional = true }
 slog-journald = { version = "2.0.0", optional = true }
@@ -36,6 +36,7 @@ cryptoxide = "0.1"
 futures    = "0.1"
 http = "0.1.16"
 hyper = "0.12"
+lazy_static = "1.3"
 mime = "^0.3.7"
 tokio      = "^0.1.16"
 structopt = "^0.2"
@@ -82,7 +83,6 @@ galvanic-test = "0.2.0"
 assert_cmd = "0.11"
 assert_fs = "0.11"
 mktemp = "0.4.0"
-lazy_static = "1.3"
 custom_error = "1.6"
 
 [features]

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -22,6 +22,8 @@ extern crate hex;
 extern crate http;
 extern crate hyper;
 extern crate jormungandr_lib;
+#[macro_use]
+extern crate lazy_static;
 extern crate native_tls;
 extern crate network_core;
 extern crate network_grpc;

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -105,7 +105,8 @@ impl CommandLine {
     }
 }
 
-fn log_level_parse(level: &str) -> Result<FilterLevel, &'static str> {
-    // Error message is ignored by Clap, because it generates message based on list of variants
-    level.parse().map_err(|_| "")
+fn log_level_parse(level: &str) -> Result<FilterLevel, String> {
+    level
+        .parse()
+        .map_err(|_| format!("Unknown log level value: '{}'", level))
 }

--- a/jormungandr/src/settings/mod.rs
+++ b/jormungandr/src/settings/mod.rs
@@ -5,43 +5,20 @@ pub mod start;
 pub use self::command_arguments::CommandLine;
 pub use self::start::Error;
 use crate::blockcfg::HeaderHash;
-use slog::FilterLevel;
 use std::path::PathBuf;
 
-const LOG_FILTER_LEVEL_POSSIBLE_VALUES: &[&'static str] =
-    &["off", "critical", "error", "warn", "info", "debug", "trace"];
-
-// TODO remove and switch to FilterLevel::as_str() when it's released
-fn filter_level_to_str(filter_level: FilterLevel) -> &'static str {
-    LOG_FILTER_LEVEL_POSSIBLE_VALUES[filter_level.as_usize()]
+lazy_static! {
+    pub static ref LOG_FILTER_LEVEL_POSSIBLE_VALUES: Vec<&'static str> = {
+        slog::LOG_LEVEL_NAMES
+            .iter()
+            .map(|name| name.to_ascii_lowercase())
+            .map(|name| &*Box::leak(name.into_boxed_str()))
+            .collect()
+    };
 }
 
 #[derive(Clone, Debug)]
 pub enum Block0Info {
     Path(PathBuf),
     Hash(HeaderHash),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn filter_level_to_str_tests() {
-        assert_filter_level_to_str(FilterLevel::Off);
-        assert_filter_level_to_str(FilterLevel::Critical);
-        assert_filter_level_to_str(FilterLevel::Error);
-        assert_filter_level_to_str(FilterLevel::Warning);
-        assert_filter_level_to_str(FilterLevel::Info);
-        assert_filter_level_to_str(FilterLevel::Debug);
-        assert_filter_level_to_str(FilterLevel::Trace);
-    }
-
-    fn assert_filter_level_to_str(level: FilterLevel) {
-        println!("Testing for level {:?}", level);
-        let string = filter_level_to_str(level);
-        let new_level = string.parse().expect("Failed to parse");
-        assert_eq!(level, new_level, "Invalid parse value");
-        println!("Testing for level {:?} succeeded!", level);
-    }
 }

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -208,24 +208,22 @@ impl<'de> Deserialize<'de> for InterestLevel {
 mod filter_level_opt_serde {
     use super::*;
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<FilterLevel>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<FilterLevel>, D::Error> {
         Option::<String>::deserialize(deserializer)?
             .map(|variant| {
                 variant.parse().map_err(|_| {
-                    D::Error::unknown_variant(&variant, LOG_FILTER_LEVEL_POSSIBLE_VALUES)
+                    D::Error::unknown_variant(&variant, &**LOG_FILTER_LEVEL_POSSIBLE_VALUES)
                 })
             })
             .transpose()
     }
 
-    pub fn serialize<S>(data: &Option<FilterLevel>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        data.map(crate::settings::filter_level_to_str)
-            .serialize(serializer)
+    pub fn serialize<S: Serializer>(
+        data: &Option<FilterLevel>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        data.map(|level| level.as_str()).serialize(serializer)
     }
 }


### PR DESCRIPTION
The goal is to clean up some ugliness around handling `slog::FilterLevel`