### PR TITLE
Don't let one client connection terminate task

### DIFF
--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -180,24 +180,26 @@ pub fn run(
         let conn_state = ConnectionState::new(state.clone(), &peer);
         let state = state.clone();
         info!(conn_state.logger(), "connecting to initial gossip peer");
-        client::connect(conn_state, conn_channels.clone())
-            .and_then(move |(client, mut comms)| {
-                // TODO
-                let node_id = client.remote_node_id();
-                let gossip = Gossip::from_nodes(iter::once(state.node.clone()));
-                match comms.try_send_gossip(gossip) {
-                    Ok(()) => state.peers.insert_peer(node_id, comms),
-                    Err(e) => {
-                        warn!(
-                            client.logger(),
-                            "gossiping to peer failed just after connection: {:?}", e
-                        );
-                        return Err(());
+        tokio::spawn(
+            client::connect(conn_state, conn_channels.clone())
+                .and_then(move |(client, mut comms)| {
+                    // TODO
+                    let node_id = client.remote_node_id();
+                    let gossip = Gossip::from_nodes(iter::once(state.node.clone()));
+                    match comms.try_send_gossip(gossip) {
+                        Ok(()) => state.peers.insert_peer(node_id, comms),
+                        Err(e) => {
+                            warn!(
+                                client.logger(),
+                                "gossiping to peer failed just after connection: {:?}", e
+                            );
+                            return Err(());
+                        }
                     }
-                }
-                Ok(client)
-            })
-            .and_then(|client| client)
+                    Ok(client)
+                })
+                .and_then(|client| client),
+        )
     });
 
     let handle_cmds = handle_network_input(input, global_state.clone(), channels.clone());


### PR DESCRIPTION
Spawn the client connection futures into separate tasks so that they don't cause the network thread to terminate when a client connection goes down.