### PR TITLE
[Tests] Set rust backtrace in e2e tests

### DIFF
--- a/jormungandr-integration-tests/build.rs
+++ b/jormungandr-integration-tests/build.rs
@@ -1,9 +1,9 @@
 use std::env;
-use std::fs::rename;
 
 fn main() {
     let jor_cli_name = option_env!("JOR_CLI_NAME").unwrap_or("jcli");
     let jormungandr_name = option_env!("JORMUNGANDR_NAME").unwrap_or("jormungandr");
     println!("cargo:rustc-env=JOR_CLI_NAME={}", jor_cli_name);
     println!("cargo:rustc-env=JORMUNGANDR_NAME={}", jormungandr_name);
+    println!("cargo:rustc-env=RUST_BACKTRACE={}", "full");
 }


### PR DESCRIPTION
Set `RUST_BACKTRACE=full`  system variable during e2e to help debugging issues during test run