### PR TITLE
it seems that debug_assertions feature was not doing what I expected

### DIFF
--- a/jormungandr/src/blockchain/protocols/reference.rs
+++ b/jormungandr/src/blockchain/protocols/reference.rs
@@ -41,11 +41,8 @@ impl Ref {
         epoch_ledger_parameters: Arc<LedgerParameters>,
         header: Header,
     ) -> Self {
-        #[cfg(debug_assertions)]
-        use std::ops::Deref as _;
-
         debug_assert!(
-            ledger_pointer.deref() == &header.hash(),
+            (*ledger_pointer) == header.hash(),
             "expect the GCRoot to be for the same `Header`"
         );
 


### PR DESCRIPTION
instead of accessing the reference from the gcroot, take the value out
instead. This will run a bit more slowly but will at least provide the
right behavior

This fixes the compilation in `--release` mode.