### PR TITLE
Extend logs with app version, epoch and slot_id

### DIFF
--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -167,7 +167,7 @@ impl EndOfEpochReminder {
     ) -> Self {
         EndOfEpochReminder {
             epoch_receiver,
-            logger: slog::Logger::root(logger, o!(::log::KEY_SUB_TASK => "End Of Epoch Reminder")),
+            logger: logger.new(o!(::log::KEY_SUB_TASK => "End Of Epoch Reminder")),
             block_message_box,
         }
     }

--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -186,7 +186,9 @@ impl EndOfEpochReminder {
             // filter_map so we don't have to do the pattern match on `Option::Nothing`.
             .filter_map(|task_parameters| task_parameters)
             .for_each(move |task_parameters| {
-                handle_epoch(block_message.clone(), handle_logger.clone(), task_parameters)
+                let epoch = task_parameters.leadership.epoch();
+                let logger = handle_logger.new(o!("epoch" => epoch));
+                handle_epoch(block_message.clone(), logger, task_parameters)
             })
             .map_err(move |error| {
                 crit!(crit_logger, "critical error in the Leader task" ; "reason" => error.to_string())

--- a/jormungandr/src/leadership/schedule.rs
+++ b/jormungandr/src/leadership/schedule.rs
@@ -45,16 +45,13 @@ impl LeaderSchedule {
             events: DelayQueue::with_capacity(number_of_slots_per_epoch as usize),
         };
 
-        let logger = Logger::root(
-            logger,
-            o!(
-                "epoch" => leadership.epoch(),
-            ),
-        );
+        let logger = logger.new(o!(
+            "epoch" => leadership.epoch(),
+        ));
 
         for slot_idx in 0..number_of_slots_per_epoch {
             schedule.schedule(
-                Logger::root(logger.clone(), o!("epoch_slot" => slot_idx)),
+                logger.new(o!("epoch_slot" => slot_idx)),
                 now,
                 leader_id,
                 enclave,

--- a/jormungandr/src/leadership/task.rs
+++ b/jormungandr/src/leadership/task.rs
@@ -48,13 +48,10 @@ impl Task {
         block_message: MessageBox<BlockMsg>,
         stats_counter: StatsCounter,
     ) -> Self {
-        let logger = Logger::root(
-            logger,
-            o!(
-                ::log::KEY_SUB_TASK => "Leader Task",
-                // TODO: add some general context information here (leader alias?)
-            ),
-        );
+        let logger = logger.new(o!(
+            ::log::KEY_SUB_TASK => "Leader Task",
+            // TODO: add some general context information here (leader alias?)
+        ));
 
         Task {
             leadership_params: HandleLeadershipParams {

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -13,6 +13,7 @@ extern crate chain_impl_mockchain;
 extern crate chain_storage;
 extern crate chain_storage_sqlite;
 extern crate chain_time;
+#[macro_use(crate_name, crate_version)]
 extern crate clap;
 extern crate cryptoxide;
 #[macro_use(try_ready)]
@@ -311,6 +312,12 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let logger = raw_settings.to_logger()?;
 
     let init_logger = logger.new(o!(log::KEY_TASK => "init"));
+    info!(
+        init_logger,
+        "Starting {} {}",
+        crate_name!(),
+        crate_version!()
+    );
     let settings = raw_settings.try_into_settings(&init_logger)?;
     let storage = start_up::prepare_storage(&settings, &init_logger)?;
 


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/jormungandr/issues/645 and https://github.com/input-output-hk/jormungandr/issues/606.

Also replaces creation of child logger from `Logger::root` to `Logger::new`, because it has no performance penalty: https://github.com/slog-rs/slog/issues/210