### PR TITLE
Added block processing for new blockchain

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -388,11 +388,7 @@ impl Blockchain {
         }
     }
 
-    /// TODO: document this function
-    ///
-    /// apply the block on the blockchain from a post checked header
-    ///
-    pub fn apply_block(
+    fn apply_block(
         &mut self,
         post_checked_header: PostCheckedHeader,
         block: &Block,
@@ -427,6 +423,23 @@ impl Blockchain {
                 )
                 .map_err(|_: Infallible| unreachable!())
         })
+    }
+
+    /// Apply the block on the blockchain from a post checked header
+    /// and add it to the storage.
+    pub fn apply_and_store_block(
+        &mut self,
+        post_checked_header: PostCheckedHeader,
+        block: Block,
+    ) -> impl Future<Item = Ref, Error = Error> {
+        let mut storage = self.storage.clone();
+        self.apply_block(post_checked_header, &block)
+            .and_then(move |block_ref| {
+                storage
+                    .put_block(block)
+                    .map_err(|e| e.into())
+                    .and_then(move |()| Ok(block_ref))
+            })
     }
 
     /// Apply the given block0 in the blockchain (updating the RefCache and the other objects)

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -395,7 +395,7 @@ impl Blockchain {
     pub fn apply_block(
         &mut self,
         post_checked_header: PostCheckedHeader,
-        block: Block,
+        block: &Block,
     ) -> impl Future<Item = Ref, Error = Error> {
         let header = post_checked_header.header;
         let block_id = header.hash();
@@ -650,7 +650,7 @@ impl Blockchain {
                                         }
                                     })
                                     .and_then(move |post_checked_header: PostCheckedHeader| {
-                                        self6.apply_block(post_checked_header, block)
+                                        self6.apply_block(post_checked_header, &block)
                                     })
                                     .and_then(move |new_ref| {
                                         branch

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -664,4 +664,15 @@ impl Blockchain {
                     })
             })
     }
+
+    pub fn get_checkpoints(
+        &self,
+        branch: Branch,
+    ) -> impl Future<Item = Vec<HeaderHash>, Error = Error> {
+        let storage = self.storage.clone();
+        branch
+            .get_ref()
+            .map_err(|_| unreachable!())
+            .and_then(move |tip| storage.get_checkpoints(*tip.hash()).map_err(|e| e.into()))
+    }
 }

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -71,7 +71,7 @@ pub fn process_leadership_block(
                 ))
             }
         })
-        .and_then(move |post_checked| end_blockchain.apply_block(post_checked, &block))
+        .and_then(move |post_checked| end_blockchain.apply_and_store_block(post_checked, block))
 }
 
 pub fn process_block_announcement(
@@ -145,7 +145,9 @@ pub fn process_network_block(
             PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
                 let post_check_and_apply = blockchain
                     .post_check_header(header, parent_ref)
-                    .and_then(move |post_checked| end_blockchain.apply_block(post_checked, &block))
+                    .and_then(move |post_checked| {
+                        end_blockchain.apply_and_store_block(post_checked, block)
+                    })
                     .map(move |_| {
                         // TODO: advance branch?
                         debug!(logger, "block successfully applied");

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -1,7 +1,9 @@
+use super::{Blockchain, Branch, Error, ErrorKind, PreCheckedHeader, Ref};
 use crate::{
-    blockchain::{Blockchain, Branch, PreCheckedHeader},
+    blockcfg::{Block, Header, HeaderHash},
     intercom::{BlockMsg, NetworkMsg},
     leadership::NewEpochToSchedule,
+    network::p2p::topology::NodeId,
     stats_counter::StatsCounter,
     utils::{
         async_msg::MessageBox,
@@ -9,7 +11,12 @@ use crate::{
     },
 };
 use chain_core::property::HasHeader as _;
+
+use futures::future::Either;
+use slog::Logger;
 use tokio::{prelude::*, sync::mpsc::Sender};
+
+use std::convert::identity;
 
 pub fn handle_input(
     info: &TokioServiceInfo,
@@ -53,4 +60,141 @@ pub fn handle_input(
     };
 
     Ok(())
+}
+
+pub fn process_leadership_block(
+    mut blockchain: Blockchain,
+    block: Block,
+    parent: Ref,
+    logger: Logger,
+) -> impl Future<Item = Ref, Error = Error> {
+    let header = block.header();
+    // This is a trusted block from the leadership task,
+    // so we can skip pre-validation.
+    blockchain
+        .post_check_header(header, parent)
+        .and_then(move |post_checked| blockchain.apply_block(post_checked, block))
+}
+
+pub fn process_block_announcement(
+    mut blockchain: Blockchain,
+    branch: Branch,
+    header: Header,
+    node_id: NodeId,
+    mut network_msg_box: MessageBox<NetworkMsg>,
+    logger: Logger,
+) -> impl Future<Item = (), Error = Error> {
+    blockchain
+        .pre_check_header(header)
+        .and_then(move |pre_checked| match pre_checked {
+            PreCheckedHeader::AlreadyPresent { .. } => {
+                debug!(logger, "block is already present");
+                Either::A(future::ok(()))
+            }
+            PreCheckedHeader::MissingParent { header, .. } => {
+                debug!(logger, "block is missing a locally stored parent");
+                let to = header.hash();
+                Either::B(blockchain.get_checkpoints(branch).map(move |from| {
+                    network_msg_box
+                        .try_send(NetworkMsg::PullHeaders { node_id, from, to })
+                        .unwrap_or_else(move |err| {
+                            error!(
+                                logger,
+                                "cannot send PullHeaders request to network: {}", err
+                            )
+                        });
+                }))
+            }
+            PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
+                debug!(
+                    logger,
+                    "Announced block has a locally stored parent, fetch it"
+                );
+                network_msg_box
+                    .try_send(NetworkMsg::GetNextBlock(node_id, header.hash()))
+                    .unwrap_or_else(move |err| {
+                        error!(
+                            logger,
+                            "cannot send GetNextBlock request to network: {}", err
+                        )
+                    });
+                Either::A(future::ok(()))
+            }
+        })
+}
+
+pub fn process_network_block(
+    mut blockchain: Blockchain,
+    block: Block,
+    mut network_msg_box: MessageBox<NetworkMsg>,
+    logger: Logger,
+) -> impl Future<Item = (), Error = Error> {
+    let mut end_blockchain = blockchain.clone();
+    let header = block.header();
+    blockchain
+        .pre_check_header(header)
+        .and_then(move |pre_checked| match pre_checked {
+            PreCheckedHeader::AlreadyPresent { .. } => {
+                debug!(logger, "block is already present");
+                Either::A(future::ok(()))
+            }
+            PreCheckedHeader::MissingParent { header, .. } => {
+                debug!(logger, "block is missing a locally stored parent");
+                Either::A(future::err(
+                    ErrorKind::MissingParentBlockFromStorage(header).into(),
+                ))
+            }
+            PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
+                let post_check_and_apply = blockchain
+                    .post_check_header(header, parent_ref)
+                    .and_then(move |post_checked| end_blockchain.apply_block(post_checked, block))
+                    .map(move |_| {
+                        // TODO: advance branch?
+                        debug!(logger, "block successfully applied");
+                    });
+                Either::B(post_check_and_apply)
+            }
+        })
+}
+
+pub fn process_chain_headers_into_block_request<S>(
+    mut blockchain: Blockchain,
+    headers: S,
+    logger: Logger,
+) -> impl Future<Item = Vec<HeaderHash>, Error = Error>
+where
+    S: Stream<Item = Header>,
+{
+    headers
+        .map_err(|e| {
+            // TODO: map the incoming stream error to the result error
+            unimplemented!()
+        })
+        .and_then(move |header| {
+            blockchain
+                .pre_check_header(header)
+                .and_then(move |pre_checked| match pre_checked {
+                    PreCheckedHeader::AlreadyPresent { .. } => {
+                        // The block is already present. This may happen
+                        // if the peer has started from an earlier checkpoint
+                        // than our tip, so ignore this and proceed.
+                        Ok(None)
+                    }
+                    PreCheckedHeader::MissingParent { header, .. } => {
+                        // TODO: this fails on the first header after the
+                        // immediate descendant of the local tip. Need branch storage
+                        // that would store the whole header chain without blocks,
+                        // so that the chain can be pre-validated first and blocks
+                        // fetched afterwards in arbitrary order.
+                        Err(ErrorKind::MissingParentBlockFromStorage(header).into())
+                    }
+                    PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
+                        // TODO: limit the headers to the single epoch
+                        // before pausing to retrieve blocks.
+                        Ok(Some(header.hash()))
+                    }
+                })
+        })
+        .filter_map(identity)
+        .collect()
 }

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -71,7 +71,7 @@ pub fn process_leadership_block(
                 ))
             }
         })
-        .and_then(move |post_checked| end_blockchain.apply_block(post_checked, block))
+        .and_then(move |post_checked| end_blockchain.apply_block(post_checked, &block))
 }
 
 pub fn process_block_announcement(
@@ -145,7 +145,7 @@ pub fn process_network_block(
             PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
                 let post_check_and_apply = blockchain
                     .post_check_header(header, parent_ref)
-                    .and_then(move |post_checked| end_blockchain.apply_block(post_checked, block))
+                    .and_then(move |post_checked| end_blockchain.apply_block(post_checked, &block))
                     .map(move |_| {
                         // TODO: advance branch?
                         debug!(logger, "block successfully applied");

--- a/jormungandr/src/client.rs
+++ b/jormungandr/src/client.rs
@@ -162,7 +162,7 @@ fn handle_pull_blocks_to_tip(
         None => {
             return Err(Error::not_found(
                 "none of the starting points are found in the blockchain",
-            ))
+            ));
         }
     };
 

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -134,7 +134,7 @@ fn handle_block(
         })
         .and_then(move |post_checked| {
             end_blockchain
-                .apply_block(post_checked, block)
+                .apply_block(post_checked, &block)
                 .map_err(Error::ApplyBlockFailed)
         })
 }

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -135,7 +135,7 @@ fn handle_block(
         })
         .and_then(move |post_checked| {
             end_blockchain
-                .apply_block(post_checked, &block)
+                .apply_and_store_block(post_checked, block)
                 .map_err(Error::ApplyBlockFailed)
         })
 }

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -76,6 +76,7 @@ pub fn bootstrap_from_peer(
         .join(branch.get_ref().map_err(|_| unreachable!()))
         .and_then(|(mut client, tip)| {
             let tip_hash = *tip.hash();
+            debug!(logger, "pulling blocks starting from {}", tip_hash);
             client
                 .pull_blocks_to_tip(&[tip_hash])
                 .map_err(Error::PullRequestFailed)


### PR DESCRIPTION
Added functions to process blocks created by leadership and received from the network, and block announcements from the network, with the new blockchain API.

Added `Storage::get_checkpoints` which is now a stub.

Fix bootstrap and other problems by adding leadership and network blocks to the store.