### PR TITLE
Update Leadership module to handle new blockchain API

### DIFF
--- a/jormungandr-lib/src/interfaces/leadership_log.rs
+++ b/jormungandr-lib/src/interfaces/leadership_log.rs
@@ -1,0 +1,103 @@
+use crate::{interfaces::BlockDate, time::SystemTime};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub struct EnclaveLeaderId(u32);
+
+/// log identifier in the leadership log. Can be used to update
+/// back some.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LeadershipLogId(EnclaveLeaderId, BlockDate);
+
+/// provides information regarding events in the leadership schedule
+///
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LeadershipLog {
+    created_at_time: SystemTime,
+    scheduled_at_time: SystemTime,
+    scheduled_at_date: BlockDate,
+    wake_at_time: Option<SystemTime>,
+    finished_at_time: Option<SystemTime>,
+    enclave_leader_id: EnclaveLeaderId,
+}
+
+impl EnclaveLeaderId {
+    pub fn new() -> Self {
+        EnclaveLeaderId(0)
+    }
+
+    pub fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+impl LeadershipLog {
+    pub fn new(
+        enclave_leader_id: EnclaveLeaderId,
+        scheduled_at_date: BlockDate,
+        scheduled_at_time: SystemTime,
+    ) -> Self {
+        LeadershipLog {
+            created_at_time: SystemTime::now(),
+            scheduled_at_time,
+            scheduled_at_date,
+            wake_at_time: None,
+            finished_at_time: None,
+            enclave_leader_id,
+        }
+    }
+
+    /// retrieve a unique identifier to this log
+    pub fn leadership_log_id(&self) -> LeadershipLogId {
+        LeadershipLogId(self.enclave_leader_id, self.scheduled_at_date)
+    }
+
+    pub fn created_at_time(&self) -> &SystemTime {
+        &self.created_at_time
+    }
+    pub fn scheduled_at_date(&self) -> &BlockDate {
+        &self.scheduled_at_date
+    }
+    pub fn scheduled_at_time(&self) -> &SystemTime {
+        &self.scheduled_at_time
+    }
+    pub fn wake_at_time(&self) -> &Option<SystemTime> {
+        &self.wake_at_time
+    }
+    pub fn finished_at_time(&self) -> &Option<SystemTime> {
+        &self.finished_at_time
+    }
+    pub fn enclave_leader_id(&self) -> &EnclaveLeaderId {
+        &self.enclave_leader_id
+    }
+
+    /// make a leadership event as triggered.
+    ///
+    /// This should be called when the leadership event has started.
+    ///
+    /// # panic
+    ///
+    /// on non-release build, this function will panic if the log was already
+    /// marked as awaken.
+    ///
+    pub fn mark_wake(&mut self) {
+        debug_assert!(self.wake_at_time.is_none());
+        self.wake_at_time = Some(SystemTime::now())
+    }
+
+    /// make a leadership event as finished.
+    ///
+    /// This should be called when the leadership event has finished its
+    /// scheduled action.
+    ///
+    /// # panic
+    ///
+    /// on non-release build, this function will panic if the log was already
+    /// marked as finished.
+    ///
+    pub fn mark_finished(&mut self) {
+        debug_assert!(self.finished_at_time.is_none());
+        self.finished_at_time = Some(SystemTime::now())
+    }
+}

--- a/jormungandr-lib/src/interfaces/leadership_log.rs
+++ b/jormungandr-lib/src/interfaces/leadership_log.rs
@@ -1,4 +1,5 @@
 use crate::{interfaces::BlockDate, time::SystemTime};
+use std::fmt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
@@ -99,5 +100,11 @@ impl LeadershipLog {
     pub fn mark_finished(&mut self) {
         debug_assert!(self.finished_at_time.is_none());
         self.finished_at_time = Some(SystemTime::now())
+    }
+}
+
+impl fmt::Display for EnclaveLeaderId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/jormungandr-lib/src/interfaces/leadership_log.rs
+++ b/jormungandr-lib/src/interfaces/leadership_log.rs
@@ -1,6 +1,6 @@
 use crate::{interfaces::BlockDate, time::SystemTime};
-use std::fmt;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 #[serde(transparent)]

--- a/jormungandr-lib/src/interfaces/mod.rs
+++ b/jormungandr-lib/src/interfaces/mod.rs
@@ -4,6 +4,7 @@ mod block0_configuration;
 mod blockdate;
 mod certificate;
 mod fragment_log;
+mod leadership_log;
 mod old_address;
 mod transaction_output;
 mod transaction_witness;
@@ -18,6 +19,7 @@ pub use self::certificate::{
     Certificate, CertificateFromBech32Error, CertificateFromStrError, CertificateToBech32Error,
 };
 pub use self::fragment_log::{FragmentLog, FragmentOrigin, FragmentStatus};
+pub use self::leadership_log::{EnclaveLeaderId, LeadershipLog, LeadershipLogId};
 pub use self::old_address::OldAddress;
 pub use self::transaction_output::TransactionOutput;
 pub use self::transaction_witness::TransactionWitness;

--- a/jormungandr/src/leadership/mod.rs
+++ b/jormungandr/src/leadership/mod.rs
@@ -92,6 +92,8 @@ mod process;
 mod schedule;
 mod task;
 
+pub mod protocols;
+
 pub use self::leaderships::*;
 
 pub use self::epoch_parameters::EpochParameters;

--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -4,13 +4,13 @@ use crate::{
     fragment::Pool,
     intercom::BlockMsg,
     leadership::{EpochParameters, Leadership, Task, TaskParameters},
-    secure::enclave::{Enclave},
+    secure::enclave::Enclave,
     stats_counter::StatsCounter,
     utils::{async_msg::MessageBox, task::TokioServiceInfo},
 };
-use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use chain_core::property::BlockDate as _;
 use chain_time::era::{EpochPosition, EpochSlotOffset};
+use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use slog::Logger;
 use std::sync::Arc;
 use tokio::{

--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -4,10 +4,11 @@ use crate::{
     fragment::Pool,
     intercom::BlockMsg,
     leadership::{EpochParameters, Leadership, Task, TaskParameters},
-    secure::enclave::{Enclave, LeaderId},
+    secure::enclave::{Enclave},
     stats_counter::StatsCounter,
     utils::{async_msg::MessageBox, task::TokioServiceInfo},
 };
+use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use chain_core::property::BlockDate as _;
 use chain_time::era::{EpochPosition, EpochSlotOffset};
 use slog::Logger;

--- a/jormungandr/src/leadership/protocols/enclave.rs
+++ b/jormungandr/src/leadership/protocols/enclave.rs
@@ -1,0 +1,69 @@
+use crate::{
+    blockcfg::{Block, BlockBuilder, Leadership},
+    secure::enclave::Enclave as SecureEnclave,
+};
+use std::sync::Arc;
+use tokio::{prelude::*, sync::lock::Lock};
+
+pub use crate::secure::enclave::{LeaderEvent, LeaderId as EnclaveLeaderId};
+
+error_chain! {}
+
+/// represent the client side of an enclave. From there we will query the
+/// actual enclave about schedules and signing blocks
+///
+#[derive(Clone)]
+pub struct Enclave {
+    /// TODO: we will need to remove this to instead query data to an
+    /// external service (running in the secure enclave). For now we
+    /// hold on the `SecureEnclave` . But it will need to be separated
+    /// when we have the necessary crypto done.
+    inner: Lock<SecureEnclave>,
+}
+
+impl Enclave {
+    /// create a new enclave structure. This will need to change in the future
+    /// with a parameter to contact the secure enclave instead of the dummy type.
+    pub fn new(secure_enclave: SecureEnclave) -> Self {
+        Enclave {
+            inner: Lock::new(secure_enclave),
+        }
+    }
+
+    /// ask the enclave to attempt computing some leadership schedule for the
+    /// given settings
+    ///
+    /// TODO: for now we are utilising the Leadership object fully but on the long
+    ///       run this might be limited to only the required data.
+    pub fn query_schedules(
+        &self,
+        leadership: Arc<Leadership>,
+        slot_start: u32,
+        nb_slots: u32,
+    ) -> impl Future<Item = Vec<LeaderEvent>, Error = Error> {
+        let mut inner = self.inner.clone();
+        future::poll_fn(move || Ok(inner.poll_lock()))
+            .map(move |guard| guard.leadership_evaluate(&leadership, slot_start, nb_slots))
+    }
+
+    /// ask the leader associated to the `LeaderEvent` to finalize the given
+    /// block by providing the proof.
+    ///
+    /// TODO: for now we are querying the whole with the block builder but on the long
+    ///       run we will only need the block signing data.
+    pub fn query_block_finalize(
+        &self,
+        block_builder: BlockBuilder,
+        event: LeaderEvent,
+    ) -> impl Future<Item = Block, Error = Error> {
+        let mut inner = self.inner.clone();
+
+        future::poll_fn(move || Ok(inner.poll_lock())).and_then(move |guard| {
+            if let Some(block) = guard.create_block(block_builder, event) {
+                future::ok(block)
+            } else {
+                future::err("Leader is not in the enclave to sign the block".into())
+            }
+        })
+    }
+}

--- a/jormungandr/src/leadership/protocols/enclave.rs
+++ b/jormungandr/src/leadership/protocols/enclave.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::sync::Arc;
 use tokio::{prelude::*, sync::lock::Lock};
 
-pub use crate::secure::enclave::{LeaderEvent};
+pub use crate::secure::enclave::LeaderEvent;
 
 error_chain! {}
 
@@ -33,7 +33,7 @@ impl Enclave {
     /// ask the enclave to attempt computing some leadership schedule for the
     /// given settings
     ///
-    /// TODO: for now we are utilising the Leadership object fully but on the long
+    /// TODO: for now we are utilizing the Leadership object fully but on the long
     ///       run this might be limited to only the required data.
     pub fn query_schedules(
         &self,

--- a/jormungandr/src/leadership/protocols/enclave.rs
+++ b/jormungandr/src/leadership/protocols/enclave.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::sync::Arc;
 use tokio::{prelude::*, sync::lock::Lock};
 
-pub use crate::secure::enclave::{LeaderEvent, LeaderId as EnclaveLeaderId};
+pub use crate::secure::enclave::{LeaderEvent};
 
 error_chain! {}
 

--- a/jormungandr/src/leadership/protocols/logs.rs
+++ b/jormungandr/src/leadership/protocols/logs.rs
@@ -1,0 +1,194 @@
+use jormungandr_lib::{interfaces::{LeadershipLog, LeadershipLogId}};
+use std::time::Duration;
+use tokio::{
+    prelude::*,
+    sync::lock::{Lock, LockGuard},
+    timer,
+};
+
+/// all leadership logs, allow for following up on the different entity
+/// of the blockchain
+#[derive(Clone)]
+pub struct Logs(Lock<internal::Logs>);
+
+/// leadership log handle. will allow to update the status of the log
+/// without having to hold the [`Logs`]
+///
+/// [`Logs`]: ./struct.Logs.html
+pub struct LeadershipLogHandle {
+    internal_id: LeadershipLogId,
+    logs: Logs,
+}
+
+impl LeadershipLogHandle {
+    /// make a leadership event as triggered.
+    ///
+    /// This should be called when the leadership event has started.
+    ///
+    /// # panic
+    ///
+    /// on non-release build, this function will panic if the log was already
+    /// marked as awaken.
+    ///
+    pub fn mark_wake(&mut self) -> impl Future<Item = (), Error = ()> {
+        self.logs.mark_wake(self.internal_id)
+    }
+
+    /// make a leadership event as finished.
+    ///
+    /// This should be called when the leadership event has finished its
+    /// scheduled action.
+    ///
+    /// # panic
+    ///
+    /// on non-release build, this function will panic if the log was already
+    /// marked as finished.
+    ///
+    pub fn mark_finished(&mut self) -> impl Future<Item = (), Error = ()> {
+        self.logs.mark_finished(self.internal_id)
+    }
+}
+
+impl Logs {
+    /// create a Leadership Logs. This will make sure we delete from time to time
+    /// some of the logs that are not necessary.
+    ///
+    /// the `ttl` can be any sensible value the user will see appropriate. The log will
+    /// live at least its scheduled time + `ttl`.
+    ///
+    /// On changes, the log's TTL will be reset to this `ttl`.
+    pub fn new(ttl: Duration) -> Self {
+        Logs(Lock::new(internal::Logs::new(ttl)))
+    }
+
+    pub fn insert(
+        &mut self,
+        log: LeadershipLog,
+    ) -> impl Future<Item = LeadershipLogHandle, Error = ()> {
+        let logs = self.clone();
+        self.inner_mut().and_then(move |mut guard| {
+            let id = guard.insert(log);
+
+            future::ok(LeadershipLogHandle {
+                internal_id: id,
+                logs: logs,
+            })
+        })
+    }
+
+    fn mark_wake(
+        &mut self,
+        leadership_log_id: LeadershipLogId,
+    ) -> impl Future<Item = (), Error = ()> {
+        self.inner_mut().and_then(move |mut guard| {
+            guard.mark_wake(&leadership_log_id.into());
+            future::ok(())
+        })
+    }
+
+    fn mark_finished(
+        &mut self,
+        leadership_log_id: LeadershipLogId,
+    ) -> impl Future<Item = (), Error = ()> {
+        self.inner_mut().and_then(move |mut guard| {
+            guard.mark_finished(&leadership_log_id.into());
+            future::ok(())
+        })
+    }
+
+    pub fn poll_purge(&mut self) -> impl Future<Item = (), Error = timer::Error> {
+        self.inner_mut()
+            .and_then(move |mut guard| future::poll_fn(move || guard.poll_purge()))
+    }
+
+    pub fn logs(&self) -> impl Future<Item = Vec<LeadershipLog>, Error = ()> {
+        self.inner()
+            .and_then(|guard| future::ok(guard.logs().cloned().collect()))
+    }
+
+    fn inner<E>(&self) -> impl Future<Item = LockGuard<internal::Logs>, Error = E> {
+        let mut lock = self.0.clone();
+        future::poll_fn(move || Ok(lock.poll_lock()))
+    }
+
+    fn inner_mut<E>(&mut self) -> impl Future<Item = LockGuard<internal::Logs>, Error = E> {
+        self.inner()
+    }
+}
+
+pub(super) mod internal {
+    use super::{LeadershipLog, LeadershipLogId};
+    use std::{
+        collections::HashMap,
+        time::{Duration, Instant},
+    };
+    use tokio::{
+        prelude::*,
+        timer::{self, delay_queue, DelayQueue},
+    };
+
+    pub struct Logs {
+        entries: HashMap<LeadershipLogId, (LeadershipLog, delay_queue::Key)>,
+        expirations: DelayQueue<LeadershipLogId>,
+        ttl: Duration,
+    }
+
+    impl Logs {
+        pub fn new(ttl: Duration) -> Self {
+            Logs {
+                entries: HashMap::new(),
+                expirations: DelayQueue::new(),
+                ttl,
+            }
+        }
+
+        pub fn insert(&mut self, log: LeadershipLog) -> LeadershipLogId {
+            let id = log.leadership_log_id();
+
+            let now = std::time::SystemTime::now();
+            let minimal_duration = if &now < log.scheduled_at_time().as_ref() {
+                log.scheduled_at_time().as_ref().duration_since(now).unwrap()
+            } else {
+                Duration::from_secs(0)
+            };
+            let ttl = minimal_duration.checked_add(self.ttl).unwrap_or(self.ttl);
+
+            let delay = self.expirations.insert(id.clone(), ttl);
+
+            self.entries.insert(id, (log, delay));
+            id
+        }
+
+        pub fn mark_wake(&mut self, leadership_log_id: &LeadershipLogId) {
+            if let Some((ref mut log, ref key)) = self.entries.get_mut(leadership_log_id) {
+                log.mark_wake();
+
+                self.expirations.reset_at(key, Instant::now() + self.ttl);
+            } else {
+                unimplemented!()
+            }
+        }
+
+        pub fn mark_finished(&mut self, leadership_log_id: &LeadershipLogId) {
+            if let Some((ref mut log, ref key)) = self.entries.get_mut(leadership_log_id) {
+                log.mark_finished();
+
+                self.expirations.reset_at(key, Instant::now() + self.ttl);
+            } else {
+                unimplemented!()
+            }
+        }
+
+        pub fn poll_purge(&mut self) -> Poll<(), timer::Error> {
+            while let Some(entry) = try_ready!(self.expirations.poll()) {
+                self.entries.remove(entry.get_ref());
+            }
+
+            Ok(Async::Ready(()))
+        }
+
+        pub fn logs<'a>(&'a self) -> impl Iterator<Item = &'a LeadershipLog> {
+            self.entries.values().map(|(v, _)| v)
+        }
+    }
+}

--- a/jormungandr/src/leadership/protocols/mod.rs
+++ b/jormungandr/src/leadership/protocols/mod.rs
@@ -63,4 +63,4 @@ mod schedule;
 
 pub use self::enclave::{Enclave, Error as EnclaveError, LeaderEvent};
 pub use self::logs::{LeadershipLogHandle, Logs};
-pub use self::schedule::{Event, Schedule};
+pub use self::schedule::{Schedule, Schedules};

--- a/jormungandr/src/leadership/protocols/mod.rs
+++ b/jormungandr/src/leadership/protocols/mod.rs
@@ -1,0 +1,64 @@
+//! new module to prepare for the new leadership scheduling of blocks
+//!
+//! here we need to take into consideration that won't have access to the
+//! cryptographic objects of the leader: they will be executed in a secure
+//! enclave.
+//!
+//! ## data structures
+//!
+//! We need to separate our components as following:
+//!
+//! 1. the enclave:
+//!     * upon receiving the necessary parameters, it will return a schedule
+//!       when it should be elected to create a block;
+//!     * upon receiving the necessary parameters, it will create the
+//!       proof to finalize the creation of a block;
+//! 2. the schedule:
+//!     * it holds the schedules for a given epoch
+//!     * we can query it to get a list of schedule for the REST API (useful to
+//!       have information when the node is expected to create blocks);
+//!     * optional but useful: have a way to update if a schedule has been
+//!       executed (and what time);
+//!     * optional: have a way for the blockchain task to update
+//!       the schedule to know if the scheduled block as been accepted in the
+//!       branch;
+//!
+//! The enclave is not yet implemented, but we will need to separate the crypto
+//! from the representation here.
+//!
+//! ## workflow
+//!
+//! The flow process will work as follow:
+//!
+//! 1. the leadership module will receive a new event to create prepare a leadership
+//!    schedule; It will only includes the `Leadership` object from chain_lib and the
+//!    `TimeFrame` active for the future blocks to come;
+//! 2. upon receiving these data, it will query the **enclave** to know the list of expected
+//!    scheduled leader elections; (this part may require heavy cryptographic computation,
+//!    we may want to split this part into incrementally long queries);
+//! 3. once the schedule is retrieved (even partially) we can start waiting for the appropriate
+//!    time to create a new block (to run block fragment selection) and ask the enclave to sign
+//!    the block;
+//! 4. once a block is ready we need to send it to the blockchain task to process it and update
+//!    the blockchain.
+//!
+//! ## how and when to trigger a new leadership event
+//!
+//! The blockchain module has the material to create the new leadership parameters
+//! for a given epoch (the `Leadership` object and the time frame). It needs to send
+//! the appropriate data when necessary.
+//!
+//! 2 ways to trigger a new leadership schedule from the blockchain module:
+//!
+//! 1. the blockchain detects an epoch transition,
+//! 2. the leadership sent an end of epoch signal to the blockchain;
+//!
+//! Now doing so we may trigger the same leader schedule twice. We will need to make sure
+//! we don't duplicate the work everywhere.
+//!
+
+mod enclave;
+mod schedule;
+
+pub use self::enclave::{Enclave, EnclaveLeaderId, Error as EnclaveError, LeaderEvent};
+pub use self::schedule::{Event, Schedule};

--- a/jormungandr/src/leadership/protocols/mod.rs
+++ b/jormungandr/src/leadership/protocols/mod.rs
@@ -64,3 +64,267 @@ mod schedule;
 pub use self::enclave::{Enclave, Error as EnclaveError, LeaderEvent};
 pub use self::logs::{LeadershipLogHandle, Logs};
 pub use self::schedule::{Schedule, Schedules};
+use crate::{
+    blockcfg::{BlockBuilder, BlockDate, HeaderContentEvalContext, LedgerParameters},
+    blockchain::protocols::Branch,
+    fragment,
+    intercom::BlockMsg,
+    leadership::Leadership,
+    utils::{async_msg::MessageBox, task::TokioServiceInfo},
+};
+use chain_time::{
+    era::{EpochPosition, EpochSlotOffset},
+    TimeFrame,
+};
+use std::sync::Arc;
+use tokio::{prelude::*, sync::mpsc};
+
+error_chain! {
+    errors {
+        ScheduleError {
+            description("error while polling for scheduled events"),
+        }
+        NewEpochToScheduleReceiverError {
+            description("cannot receive new epoch to schedule notification "),
+        }
+        FragmentSelectionFailed {
+            description("fragment selection failed")
+        }
+        Enclave {
+            description("error while querying the enclave")
+        }
+        CannotSendLeadershipBlock {
+            description("Cannot send the leadership's new created block")
+        }
+    }
+}
+
+pub struct NewEpochToSchedule {
+    pub new_schedule: Arc<Leadership>,
+    pub new_parameters: Arc<LedgerParameters>,
+    pub time_frame: TimeFrame,
+}
+
+pub struct LeadershipModule {
+    logs: Logs,
+    service_info: TokioServiceInfo,
+    enclave: Enclave,
+    fragment_pool: fragment::Pool,
+    tip: Branch,
+    block_message: MessageBox<BlockMsg>,
+}
+
+impl LeadershipModule {
+    fn handle_schedule(&self, schedule: Schedule) {
+        let logger = self.service_info.logger().new(o!("leader" => schedule.leader_event().id.to_string(), "date" => schedule.leader_event().date.to_string()));
+        let fragment_pool = self.fragment_pool.clone();
+        let tip = self.tip.clone();
+        let enclave = self.enclave.clone();
+        let leader_event: LeaderEvent = schedule.leader_event;
+        let date = leader_event.date.clone();
+        let ledger_parameters = schedule.epoch_ledger_parameters;
+        let sender = self.block_message.clone();
+        let log_awake = schedule.log.mark_wake();
+        let log_finish = schedule.log.mark_finished();
+
+        self.service_info.spawn(
+            log_awake
+                .map_err(|()| unreachable!())
+                .and_then(move |()| {
+                    info!(logger, "leader event starting");
+
+                    prepare_block(fragment_pool, date, tip, ledger_parameters)
+                })
+                .and_then(move |bb| {
+                    enclave
+                        .query_block_finalize(bb, leader_event)
+                        .map_err(|_| unimplemented!())
+                })
+                .and_then(|block| {
+                    sender
+                        .send(BlockMsg::LeadershipBlock(block))
+                        .map_err(|_send_error| ErrorKind::CannotSendLeadershipBlock.into())
+                })
+                .and_then(|_: MessageBox<BlockMsg>| log_finish.map_err(|()| unreachable!()))
+                .map_err(|_: Error| unimplemented!()),
+        );
+    }
+
+    fn handle_new_epoch_event(
+        self,
+        scheduler: Schedules,
+        new_epoch_event: NewEpochToSchedule,
+    ) -> impl Future<Item = (Self, Schedules), Error = Error> {
+        let leadership = new_epoch_event.new_schedule;
+        let epoch_parameters = new_epoch_event.new_parameters;
+        let era = leadership.era().clone();
+        let epoch = leadership.epoch();
+        let time_frame = new_epoch_event.time_frame;
+        let logs = self.logs.clone();
+
+        let slot_start = 0;
+        let nb_slots = era.slots_per_epoch();
+
+        let logger = self.service_info.logger().new(o!("epoch" => epoch));
+
+        debug!(logger, "handling new epoch event");
+
+        self.enclave
+            .query_schedules(leadership.clone(), slot_start, nb_slots)
+            .map_err(|e| Error::with_chain(e, ErrorKind::Enclave))
+            .and_then(move |schedules| {
+                stream::iter_ok::<_, Error>(schedules).fold(
+                    scheduler,
+                    move |scheduler, schedule| {
+                        let slot = era.from_era_to_slot(EpochPosition {
+                            epoch: chain_time::Epoch(schedule.date.epoch),
+                            slot: EpochSlotOffset(schedule.date.slot_id),
+                        });
+                        let slot_system_time = time_frame
+                            .slot_to_systemtime(slot)
+                            .expect("The slot should always be in the given time frame here");
+
+                        debug!(logger, "registering new leader event";
+                            "leader"     => schedule.id.to_string(),
+                            "block date" => schedule.date.to_string()
+                        );
+
+                        scheduler
+                            .schedule(
+                                logs.clone(),
+                                leadership.clone(),
+                                epoch_parameters.clone(),
+                                slot_system_time.into(),
+                                schedule,
+                            )
+                            .map_err(|()| Error::from("error while adding a new schedule"))
+                    },
+                )
+            })
+            .map(|scheduler| (self, scheduler))
+    }
+
+    pub fn start(
+        service_info: TokioServiceInfo,
+        logs: Logs,
+        enclave: Enclave,
+        fragment_pool: fragment::Pool,
+        tip_branch: Branch,
+        new_epoch_events: mpsc::Receiver<NewEpochToSchedule>,
+        block_message: MessageBox<BlockMsg>,
+    ) -> impl Future<Item = (), Error = Error> {
+        let scheduler_future = Schedules::new().into_future();
+        let new_epoch_future = new_epoch_events.into_future();
+
+        let leadership_module = LeadershipModule {
+            logs,
+            service_info,
+            enclave,
+            fragment_pool,
+            tip: tip_branch,
+            block_message,
+        };
+
+        future::loop_fn(
+            (leadership_module, scheduler_future, new_epoch_future),
+            |(leadership_module, scheduler_future, new_epoch_future)| {
+                scheduler_future
+                    .select2(new_epoch_future)
+                    .map_err(|either| match either {
+                        future::Either::A(((error, _scheduler), _new_epoch_events)) => {
+                            Error::with_chain(error, ErrorKind::ScheduleError)
+                        }
+                        future::Either::B(((error, _new_epoch_events), _scheduler)) => {
+                            Error::with_chain(error, ErrorKind::NewEpochToScheduleReceiverError)
+                        }
+                    })
+                    .and_then(move |either| {
+                        match either {
+                            future::Either::A(((schedule, schedules), new_epoch_future)) => {
+                                let schedule = schedule.expect(
+                                    "delay queue should always be NotReady if no more schedule",
+                                );
+                                let scheduler_future = schedules.into_future();
+
+                                leadership_module.handle_schedule(schedule.into_inner());
+
+                                future::Either::A(future::ok((
+                                    leadership_module,
+                                    scheduler_future,
+                                    new_epoch_future,
+                                )))
+                            }
+                            future::Either::B((
+                                (new_epoch_event, new_epoch_events),
+                                scheduler_future,
+                            )) => {
+                                let new_epoch_event =
+                                    new_epoch_event.expect("Expect the event to not close");
+
+                                // the stream didn't yield an element so we can retrieve the inner schedule here
+                                let schedules = scheduler_future.into_inner().unwrap();
+
+                                future::Either::B(
+                                    leadership_module
+                                        .handle_new_epoch_event(schedules, new_epoch_event)
+                                        .map(move |(leadership_module, schedules)| {
+                                            (
+                                                leadership_module,
+                                                schedules.into_future(),
+                                                new_epoch_events.into_future(),
+                                            )
+                                        }),
+                                )
+                            }
+                        }
+                    })
+                    // for now we continue the loop forever (until kill/crash)
+                    // we can at some point connect this to the `utils::task::Task`
+                    // input feature to `Loop::Break` on receiving a shutdown
+                    // instruction
+                    .map(future::Loop::Continue)
+            },
+        )
+    }
+}
+
+fn prepare_block(
+    mut fragment_pool: fragment::Pool,
+    date: BlockDate,
+    tip: Branch,
+    epoch_parameters: Arc<LedgerParameters>,
+) -> impl Future<Item = BlockBuilder, Error = Error> {
+    use crate::fragment::selection::{FragmentSelectionAlgorithm as _, OldestFirst};
+
+    let selection_algorithm = OldestFirst::new(250 /* TODO!! */);
+
+    tip.get_ref()
+        .map_err(|_: std::convert::Infallible| unreachable!())
+        .and_then(move |tip_reference| {
+            use chain_core::property::ChainLength as _;
+
+            let parent_id = tip_reference.hash().clone();
+            let chain_length = tip_reference.chain_length().next();
+            let ledger = tip_reference.ledger();
+
+            let metadata = HeaderContentEvalContext {
+                block_date: date,
+                chain_length,
+                nonce: None,
+            };
+
+            fragment_pool
+                .select(
+                    ledger.as_ref().clone(),
+                    metadata,
+                    epoch_parameters.as_ref().clone(),
+                    selection_algorithm,
+                )
+                .map(|selection_algorithm| selection_algorithm.finalize())
+                .map(move |mut bb| {
+                    bb.date(date).parent(parent_id).chain_length(chain_length);
+                    bb
+                })
+                .map_err(|()| ErrorKind::FragmentSelectionFailed.into())
+        })
+}

--- a/jormungandr/src/leadership/protocols/mod.rs
+++ b/jormungandr/src/leadership/protocols/mod.rs
@@ -58,7 +58,9 @@
 //!
 
 mod enclave;
+mod logs;
 mod schedule;
 
-pub use self::enclave::{Enclave, EnclaveLeaderId, Error as EnclaveError, LeaderEvent};
+pub use self::enclave::{Enclave, Error as EnclaveError, LeaderEvent};
+pub use self::logs::{LeadershipLogHandle, Logs};
 pub use self::schedule::{Event, Schedule};

--- a/jormungandr/src/leadership/protocols/schedule.rs
+++ b/jormungandr/src/leadership/protocols/schedule.rs
@@ -1,85 +1,43 @@
-use crate::leadership::protocols::{LeaderEvent};
-use jormungandr_lib::{interfaces::{BlockDate, EnclaveLeaderId}, time::SystemTime};
-use serde::Serialize;
-use tokio::timer::delay_queue::{self, DelayQueue};
+use crate::leadership::protocols::{LeadershipLogHandle, Logs, LeaderEvent};
+use jormungandr_lib::{time::SystemTime, interfaces::LeadershipLog};
+use tokio::{prelude::*, timer::delay_queue::{self, DelayQueue}, sync::lock::Lock};
 
-pub struct Event {
-    schedule: Schedule,
-
-    enclave_data: LeaderEvent,
-}
-
-#[derive(Clone, Serialize)]
 pub struct Schedule {
-    created_at_time: SystemTime,
-    scheduled_at_time: SystemTime,
-    scheduled_at_date: BlockDate,
-    wake_at_time: Option<SystemTime>,
-    finished_at_time: Option<SystemTime>,
-    enclave_leader_id: EnclaveLeaderId,
+    /// keep a hand on the log handle so we can update
+    /// the logs as we see fit
+    log: LeadershipLogHandle,
+
+    /// data for the enclave to work on
+    leader_event: LeaderEvent,
 }
 
 /// one of the main issue with the current build for the
 pub struct Schedules {
-    scheduled_events: DelayQueue<Event>,
+    scheduler: Lock<DelayQueue<Schedule>>,
 
-    schedules: Vec<Schedule>,
+    logs: Logs
 }
 
-impl Event {
-    /// schedule a new leader event at the given time
-    pub fn new(scheduled_at_time: SystemTime, enclave_data: LeaderEvent) -> Self {
-        Event {
-            schedule: Schedule::new(enclave_data.id, enclave_data.date.into(), scheduled_at_time),
-            enclave_data,
+impl Schedules {
+    pub fn new(logger: Logs) -> Self {
+        Schedules {
+            scheduler: Lock::new(DelayQueue::new()),
+            logs: logger,
         }
     }
 
-    /// mark the current schedule is starting to process. This will add some
-    /// metadata to the `Schedule` so we can later trace in the log what is
-    /// happening in the schedule (especially the diff between the scheduled_at_time
-    /// and wake_at_tome will give the time it actually took for schedule to start)
-    pub fn mark_wake(&mut self) {
-        self.schedule.mark_wake()
-    }
-
-    /// mark the current schedule has finished processing its task.
-    /// it will add some metadata to follow up with when the task
-    /// has finished. Allowing to extrapolate some information
-    /// such as how long the schedule ran for
-    pub fn mark_finished(&mut self) {
-        self.schedule.mark_finished()
-    }
-
-    /// retrieve the metadata for the enclave
-    pub fn leader_event(&self) -> &LeaderEvent {
-        &self.enclave_data
-    }
-}
-
-impl Schedule {
-    fn new(
-        enclave_leader_id: EnclaveLeaderId,
-        scheduled_at_date: BlockDate,
-        scheduled_at_time: SystemTime,
-    ) -> Self {
-        Schedule {
-            created_at_time: SystemTime::now(),
-            scheduled_at_time,
-            scheduled_at_date,
-            wake_at_time: None,
-            finished_at_time: None,
-            enclave_leader_id,
-        }
-    }
-
-    fn mark_wake(&mut self) {
-        debug_assert!(self.wake_at_time.is_none());
-        self.wake_at_time = Some(SystemTime::now())
-    }
-
-    fn mark_finished(&mut self) {
-        debug_assert!(self.finished_at_time.is_none());
-        self.finished_at_time = Some(SystemTime::now())
+    pub fn schedule(&mut self, scheduled_at_time: SystemTime, leader_event: LeaderEvent) -> impl Future<Item = (), Error = ()> {
+        let log = LeadershipLog::new(leader_event.id, leader_event.date.into(), scheduled_at_time);
+        let scheduler = self.scheduler.clone();
+        self.logs.insert(log)
+            .map(move |handle| {
+                Schedule {
+                    log: handle,
+                    leader_event,
+                }
+            })
+            .and_then(|schedule| {
+                scheduler.insert_at(schedule, std::time::Instant::now())
+            })
     }
 }

--- a/jormungandr/src/leadership/protocols/schedule.rs
+++ b/jormungandr/src/leadership/protocols/schedule.rs
@@ -1,0 +1,84 @@
+use crate::leadership::protocols::{EnclaveLeaderId, LeaderEvent};
+use jormungandr_lib::{interfaces::BlockDate, time::SystemTime};
+use serde::Serialize;
+use tokio::timer::delay_queue::{self, DelayQueue};
+
+pub struct Event {
+    schedule: Schedule,
+
+    enclave_data: LeaderEvent,
+}
+
+#[derive(Clone, Serialize)]
+pub struct Schedule {
+    created_at_time: SystemTime,
+    scheduled_at_time: SystemTime,
+    scheduled_at_date: BlockDate,
+    wake_at_time: Option<SystemTime>,
+    finished_at_time: Option<SystemTime>,
+    enclave_leader_id: EnclaveLeaderId,
+}
+
+pub struct Schedules {
+    scheduled_events: DelayQueue<Event>,
+
+    schedules: Vec<Schedule>,
+}
+
+impl Event {
+    /// schedule a new leader event at the given time
+    pub fn new(scheduled_at_time: SystemTime, enclave_data: LeaderEvent) -> Self {
+        Event {
+            schedule: Schedule::new(enclave_data.id, enclave_data.date.into(), scheduled_at_time),
+            enclave_data,
+        }
+    }
+
+    /// mark the current schedule is starting to process. This will add some
+    /// metadata to the `Schedule` so we can later trace in the log what is
+    /// happening in the schedule (especially the diff between the scheduled_at_time
+    /// and wake_at_tome will give the time it actually took for schedule to start)
+    pub fn mark_wake(&mut self) {
+        self.schedule.mark_wake()
+    }
+
+    /// mark the current schedule has finished processing its task.
+    /// it will add some metadata to follow up with when the task
+    /// has finished. Allowing to extrapolate some information
+    /// such as how long the schedule ran for
+    pub fn mark_finished(&mut self) {
+        self.schedule.mark_finished()
+    }
+
+    /// retrieve the metadata for the enclave
+    pub fn leader_event(&self) -> &LeaderEvent {
+        &self.enclave_data
+    }
+}
+
+impl Schedule {
+    fn new(
+        enclave_leader_id: EnclaveLeaderId,
+        scheduled_at_date: BlockDate,
+        scheduled_at_time: SystemTime,
+    ) -> Self {
+        Schedule {
+            created_at_time: SystemTime::now(),
+            scheduled_at_time,
+            scheduled_at_date,
+            wake_at_time: None,
+            finished_at_time: None,
+            enclave_leader_id,
+        }
+    }
+
+    fn mark_wake(&mut self) {
+        debug_assert!(self.wake_at_time.is_none());
+        self.wake_at_time = Some(SystemTime::now())
+    }
+
+    fn mark_finished(&mut self) {
+        debug_assert!(self.finished_at_time.is_none());
+        self.finished_at_time = Some(SystemTime::now())
+    }
+}

--- a/jormungandr/src/leadership/protocols/schedule.rs
+++ b/jormungandr/src/leadership/protocols/schedule.rs
@@ -1,5 +1,5 @@
-use crate::leadership::protocols::{EnclaveLeaderId, LeaderEvent};
-use jormungandr_lib::{interfaces::BlockDate, time::SystemTime};
+use crate::leadership::protocols::{LeaderEvent};
+use jormungandr_lib::{interfaces::{BlockDate, EnclaveLeaderId}, time::SystemTime};
 use serde::Serialize;
 use tokio::timer::delay_queue::{self, DelayQueue};
 
@@ -19,6 +19,7 @@ pub struct Schedule {
     enclave_leader_id: EnclaveLeaderId,
 }
 
+/// one of the main issue with the current build for the
 pub struct Schedules {
     scheduled_events: DelayQueue<Event>,
 

--- a/jormungandr/src/leadership/schedule.rs
+++ b/jormungandr/src/leadership/schedule.rs
@@ -2,8 +2,8 @@ use crate::{
     leadership::TaskParameters,
     secure::enclave::{Enclave, LeaderEvent},
 };
-use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use chain_time::era::{EpochPosition, EpochSlotOffset};
+use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use slog::Logger;
 use std::time::SystemTime;
 use tokio::{

--- a/jormungandr/src/leadership/schedule.rs
+++ b/jormungandr/src/leadership/schedule.rs
@@ -1,7 +1,8 @@
 use crate::{
     leadership::TaskParameters,
-    secure::enclave::{Enclave, LeaderEvent, LeaderId},
+    secure::enclave::{Enclave, LeaderEvent},
 };
+use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use chain_time::era::{EpochPosition, EpochSlotOffset};
 use slog::Logger;
 use std::time::SystemTime;

--- a/jormungandr/src/leadership/task.rs
+++ b/jormungandr/src/leadership/task.rs
@@ -6,13 +6,13 @@ use crate::{
     fragment::Pool,
     intercom::BlockMsg,
     leadership::{LeaderSchedule, Leadership},
-    secure::enclave::{Enclave},
+    secure::enclave::Enclave,
     stats_counter::StatsCounter,
     utils::async_msg::MessageBox,
 };
-use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use chain_core::property::ChainLength as _;
 use chain_time::timeframe::TimeFrame;
+use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use slog::Logger;
 use std::sync::Arc;
 use tokio::{prelude::*, sync::watch};

--- a/jormungandr/src/leadership/task.rs
+++ b/jormungandr/src/leadership/task.rs
@@ -6,10 +6,11 @@ use crate::{
     fragment::Pool,
     intercom::BlockMsg,
     leadership::{LeaderSchedule, Leadership},
-    secure::enclave::{Enclave, LeaderId},
+    secure::enclave::{Enclave},
     stats_counter::StatsCounter,
     utils::async_msg::MessageBox,
 };
+use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use chain_core::property::ChainLength as _;
 use chain_time::timeframe::TimeFrame;
 use slog::Logger;

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -14,7 +14,6 @@ use chain_impl_mockchain::value::{Value, ValueError};
 use chain_storage::store;
 
 use crate::intercom::TransactionMsg;
-use crate::secure::enclave::LeaderId;
 use crate::secure::NodeSecret;
 use bytes::{Bytes, IntoBuf};
 use futures::Future;
@@ -274,7 +273,7 @@ pub fn post_leaders(secret: Json<NodeSecret>, context: State<Context>) -> impl R
 
 pub fn delete_leaders(
     context: State<Context>,
-    leader_id: Path<LeaderId>,
+    leader_id: Path<EnclaveLeaderId>,
 ) -> Result<impl Responder, Error> {
     match context.enclave.remove_leader(*leader_id) {
         true => Ok(HttpResponse::Ok().finish()),

--- a/jormungandr/src/secure/enclave.rs
+++ b/jormungandr/src/secure/enclave.rs
@@ -1,7 +1,7 @@
 use crate::blockcfg::{BlockBuilder, BlockDate};
-use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use chain_impl_mockchain::block::Block;
 use chain_impl_mockchain::leadership::{Leader, LeaderOutput, Leadership};
+use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 

--- a/jormungandr/src/secure/enclave.rs
+++ b/jormungandr/src/secure/enclave.rs
@@ -37,7 +37,7 @@ impl Enclave {
     }
 
     pub fn from_vec(leaders: Vec<Leader>) -> Self {
-        let mut e = Self::new();
+        let e = Self::new();
         for leader in leaders {
             e.add_leader(leader);
         }

--- a/jormungandr/src/secure/enclave.rs
+++ b/jormungandr/src/secure/enclave.rs
@@ -1,18 +1,9 @@
 use crate::blockcfg::{BlockBuilder, BlockDate};
+use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use chain_impl_mockchain::block::Block;
 use chain_impl_mockchain::leadership::{Leader, LeaderOutput, Leadership};
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(transparent)]
-pub struct LeaderId(u32);
-
-impl LeaderId {
-    pub fn next(self) -> Self {
-        Self(self.0 + 1)
-    }
-}
 
 #[derive(Clone)]
 pub struct Enclave {
@@ -26,7 +17,7 @@ pub struct LeaderEvent {
 }
 
 fn get_maximum_id<A>(leaders: &BTreeMap<LeaderId, A>) -> LeaderId {
-    leaders.keys().last().copied().unwrap_or(LeaderId(0))
+    leaders.keys().last().copied().unwrap_or(LeaderId::new())
 }
 
 impl Enclave {


### PR DESCRIPTION
This is part of the work in #672 

Now this provides multiple changes that will be most welcome in the way the leadership schedule is organised:

1. all the schedule are now logged in just as for the fragment. So we can expose an API endpoint to monitor the leadership activities;
2. the separation with the number of leaders registered to the node and the node is more clear. The new `Enclave` interface in the leadership module emulates the future interfaces the secure enclave will provide;
3. we also have better control on the leadership's tokio spawned tasks. We no longer spawn competitive tasks