### PR TITLE
allow setting the address prefix manually when creating the address

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,0 @@
-use std::env;
-use std::fs::rename;
-
-fn main() {
-    let jor_cli_name = option_env!("JOR_CLI_NAME").unwrap_or("jcli");
-    println!("cargo:rustc-env=JOR_CLI_NAME={}", jor_cli_name);
-}

--- a/doc/jcli/address.md
+++ b/doc/jcli/address.md
@@ -69,3 +69,17 @@ $ jcli address \
     account ed25519_pk1c4yq3hflulynn8fef0hdq92579n3c49qxljasrl9dnuvcksk84gs9sqvc2
 ca1qhz5szxa8lnujwva8997a5q42nckw8z55qm7tkq0u4k03nz6zc74ze780qe
 ```
+
+### changing the address prefix
+
+You can decide to change the address prefix, allowing you to provide more
+enriched data to the user. However, this prefix is not forwarded to the node,
+it is only for UI/UX.
+
+```
+$ jcli address \
+    account \
+    --prefix=address_ \
+    ed25519_pk1yx6q8rsndawfx8hjzwntfs2h2c37v5g6edv67hmcxvrmxfjdz9wqeejchg
+address_1q5smgquwzdh4eyc77gf6ddxp2atz8ej3rt94nt6l0qes0vexf5g4cw68kdx
+```

--- a/jcli/build.rs
+++ b/jcli/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    let production_prefix = option_env!("ADDRESS_PREFIX").unwrap_or("ca");
-    println!("cargo:rustc-env=ADDRESS_PREFIX={}", production_prefix);
-}

--- a/jcli/src/jcli_app/address.rs
+++ b/jcli/src/jcli_app/address.rs
@@ -4,8 +4,6 @@ use chain_crypto::{AsymmetricPublicKey, Ed25519, PublicKey};
 use jcli_app::utils::key_parser::parse_pub_key;
 use structopt::StructOpt;
 
-pub const ADDRESS_PREFIX: &'static str = env!("ADDRESS_PREFIX");
-
 #[derive(StructOpt)]
 #[structopt(name = "address", rename_all = "kebab-case")]
 pub enum Address {
@@ -29,6 +27,19 @@ pub struct InfoArgs {
 }
 
 #[derive(StructOpt)]
+pub struct DiscriminationData {
+    /// set the discrimination type to testing (default is production)
+    #[structopt(long = "testing")]
+    testing: bool,
+
+    /// set the prefix to use to describe the address. This is only available
+    /// on the human readable representation of the address and will not be
+    /// used or checked by the node.
+    #[structopt(long = "prefix", default_value = "ca")]
+    prefix: String,
+}
+
+#[derive(StructOpt)]
 pub struct SingleArgs {
     /// A public key in bech32 encoding with the key type prefix
     #[structopt(name = "PUBLIC_KEY", parse(try_from_str = "parse_pub_key"))]
@@ -38,9 +49,8 @@ pub struct SingleArgs {
     #[structopt(name = "DELEGATION_KEY", parse(try_from_str = "parse_pub_key"))]
     delegation: Option<PublicKey<Ed25519>>,
 
-    /// set the discrimination type to testing (default is production)
-    #[structopt(long = "testing")]
-    testing: bool,
+    #[structopt(flatten)]
+    discrimination_data: DiscriminationData,
 }
 
 #[derive(StructOpt)]
@@ -49,9 +59,8 @@ pub struct AccountArgs {
     #[structopt(name = "PUBLIC_KEY", parse(try_from_str = "parse_pub_key"))]
     key: PublicKey<Ed25519>,
 
-    /// set the discrimination type to testing (default is production)
-    #[structopt(long = "testing")]
-    testing: bool,
+    #[structopt(flatten)]
+    discrimination_data: DiscriminationData,
 }
 
 custom_error! {pub Error
@@ -64,12 +73,25 @@ impl Address {
             Address::Info(info_args) => address_info(&info_args.address)?,
             Address::Single(single_args) => {
                 if let Some(delegation) = single_args.delegation {
-                    mk_delegation(single_args.key, single_args.testing, delegation)
+                    mk_delegation(
+                        &single_args.discrimination_data.prefix,
+                        single_args.key,
+                        single_args.discrimination_data.testing,
+                        delegation,
+                    )
                 } else {
-                    mk_single(single_args.key, single_args.testing)
+                    mk_single(
+                        &single_args.discrimination_data.prefix,
+                        single_args.key,
+                        single_args.discrimination_data.testing,
+                    )
                 }
             }
-            Address::Account(account_args) => mk_account(account_args.key, account_args.testing),
+            Address::Account(account_args) => mk_account(
+                &account_args.discrimination_data.prefix,
+                account_args.key,
+                account_args.discrimination_data.testing,
+            ),
         }
         Ok(())
     }
@@ -98,16 +120,16 @@ fn address_info(address: &AddressReadable) -> Result<(), Error> {
     Ok(())
 }
 
-fn mk_single(s: PublicKey<Ed25519>, testing: bool) {
-    mk_address_1(s, testing, Kind::Single)
+fn mk_single(prefix: &str, s: PublicKey<Ed25519>, testing: bool) {
+    mk_address_1(prefix, s, testing, Kind::Single)
 }
 
-fn mk_delegation(s: PublicKey<Ed25519>, testing: bool, d: PublicKey<Ed25519>) {
-    mk_address_2(s, d, testing, Kind::Group)
+fn mk_delegation(prefix: &str, s: PublicKey<Ed25519>, testing: bool, d: PublicKey<Ed25519>) {
+    mk_address_2(prefix, s, d, testing, Kind::Group)
 }
 
-fn mk_account(s: PublicKey<Ed25519>, testing: bool) {
-    mk_address_1(s, testing, Kind::Account)
+fn mk_account(prefix: &str, s: PublicKey<Ed25519>, testing: bool) {
+    mk_address_1(prefix, s, testing, Kind::Account)
 }
 
 fn mk_discrimination(testing: bool) -> Discrimination {
@@ -118,25 +140,25 @@ fn mk_discrimination(testing: bool) -> Discrimination {
     }
 }
 
-fn mk_address(discrimination: Discrimination, kind: Kind) {
+fn mk_address(prefix: &str, discrimination: Discrimination, kind: Kind) {
     let address = chain_addr::Address(discrimination, kind);
     println!(
         "{}",
-        AddressReadable::from_address(ADDRESS_PREFIX, &address).to_string()
+        AddressReadable::from_address(prefix, &address).to_string()
     );
 }
 
-fn mk_address_1<A, F>(s: PublicKey<A>, testing: bool, f: F)
+fn mk_address_1<A, F>(prefix: &str, s: PublicKey<A>, testing: bool, f: F)
 where
     F: FnOnce(PublicKey<A>) -> Kind,
     A: AsymmetricPublicKey,
 {
     let discrimination = mk_discrimination(testing);
     let kind = f(s);
-    mk_address(discrimination, kind);
+    mk_address(prefix, discrimination, kind);
 }
 
-fn mk_address_2<A1, A2, F>(s: PublicKey<A1>, d: PublicKey<A2>, testing: bool, f: F)
+fn mk_address_2<A1, A2, F>(prefix: &str, s: PublicKey<A1>, d: PublicKey<A2>, testing: bool, f: F)
 where
     F: FnOnce(PublicKey<A1>, PublicKey<A2>) -> Kind,
     A1: AsymmetricPublicKey,
@@ -144,5 +166,5 @@ where
 {
     let discrimination = mk_discrimination(testing);
     let kind = f(s, d);
-    mk_address(discrimination, kind);
+    mk_address(prefix, discrimination, kind);
 }

--- a/jcli/src/jcli_app/transaction/info.rs
+++ b/jcli/src/jcli_app/transaction/info.rs
@@ -1,7 +1,6 @@
 use chain_addr::{Address, AddressReadable};
 use chain_impl_mockchain::transaction::{Balance, Input, InputEnum, InputType, Output};
 use jcli_app::{
-    address::ADDRESS_PREFIX,
     transaction::{common, staging::Staging, Error},
     utils::io,
 };
@@ -62,6 +61,10 @@ pub struct Info {
     /// available variables: address and value.
     #[structopt(alias = "output", default_value = " + {address} {value}\n")]
     pub format_output: String,
+
+    /// set the address prefix to use when displaying the addresses
+    #[structopt(long = "prefix", default_value = "ca")]
+    address_prefix: String,
 }
 
 impl Info {
@@ -118,7 +121,7 @@ impl Info {
 
         vars.insert(
             "address".to_owned(),
-            AddressReadable::from_address(ADDRESS_PREFIX, &output.address).to_string(),
+            AddressReadable::from_address(&self.address_prefix, &output.address).to_string(),
         );
         vars.insert("value".to_owned(), output.value.0.to_string());
         self.write_info(writer, &self.format_output, vars)

--- a/jormungandr-lib/build.rs
+++ b/jormungandr-lib/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    let production_prefix = option_env!("ADDRESS_PREFIX").unwrap_or("ca");
-    println!("cargo:rustc-env=ADDRESS_PREFIX={}", production_prefix);
-}


### PR DESCRIPTION
this change allows to set any arbitrary address prefix. It can be used to set specific prefix to provide more enriched visual data for the users.