### PR TITLE
add link to the Node REST Api documentation

### DIFF
--- a/doc/quickstart/03_rest_api.md
+++ b/doc/quickstart/03_rest_api.md
@@ -28,3 +28,6 @@ The result may be:
 > THE REST API IS STILL UNDER DEVELOPMENT
 
 Please note that the end points and the results may change in the future.
+
+To see the whole Node API documentation,
+[click here](https://editor.swagger.io/?url=https://raw.githubusercontent.com/input-output-hk/jormungandr/master/doc/openapi.yaml)


### PR DESCRIPTION
Even though the REST API is still unstable the link to the human readable API will allow everyone to start building on it and improving the doc.