### PR TITLE
Finalize the loop for the new leadership code/event

### DIFF
--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -1,6 +1,6 @@
 use super::{Blockchain, Branch, Error, ErrorKind, PreCheckedHeader, Ref};
 use crate::{
-    blockcfg::{Block, Header, HeaderHash},
+    blockcfg::{Block, Epoch, Header, HeaderHash},
     intercom::{self, BlockMsg, NetworkMsg, PropagateMsg},
     leadership::NewEpochToSchedule,
     network::p2p::topology::NodeId,

--- a/jormungandr/src/blockchain/reference.rs
+++ b/jormungandr/src/blockchain/reference.rs
@@ -29,6 +29,12 @@ pub struct Ref {
     /// keep the Block header in memory, this will avoid retrieving
     /// the data from the storage if needs be
     header: Header,
+
+    /// holder to the previous epoch state or more precisely the previous epoch's
+    /// last `Ref`. Every time there is a transition this value will be filled with
+    /// the parent `Ref`. Otherwise it will be copied from `Ref` to `Ref`.
+    ///
+    previous_epoch_state: Option<Arc<Ref>>,
 }
 
 impl Ref {
@@ -40,6 +46,7 @@ impl Ref {
         epoch_leadership_schedule: Arc<Leadership>,
         epoch_ledger_parameters: Arc<LedgerParameters>,
         header: Header,
+        previous_epoch_state: Option<Arc<Ref>>,
     ) -> Self {
         debug_assert!(
             (*ledger_pointer) == header.hash(),
@@ -53,6 +60,7 @@ impl Ref {
             epoch_leadership_schedule,
             epoch_ledger_parameters,
             header,
+            previous_epoch_state,
         }
     }
 
@@ -100,5 +108,9 @@ impl Ref {
 
     pub fn epoch_ledger_parameters(&self) -> &Arc<LedgerParameters> {
         &self.epoch_ledger_parameters
+    }
+
+    pub fn last_ref_previous_epoch(&self) -> Option<&Arc<Ref>> {
+        self.previous_epoch_state.as_ref()
     }
 }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -259,7 +259,7 @@ fn handle_network_input(
 }
 
 fn handle_propagation_msg(msg: PropagateMsg, state: GlobalStateR, channels: Channels) {
-    debug!(state.logger(), "to propagate: {:?}", &msg);
+    trace!(state.logger(), "to propagate: {:?}", &msg);
     let nodes = state.topology.view().collect::<Vec<_>>();
     debug!(
         state.logger(),


### PR DESCRIPTION
part of #672 

These changes make sure that we actually utilise the right leadership state when we use genesis/praos for the schedule as well as fixing the last regression on the self node since the changes in the blockchain representation.