### PR TITLE
Add explorer mode startup config

### DIFF
--- a/jormungandr/src/explorer.rs
+++ b/jormungandr/src/explorer.rs
@@ -1,0 +1,86 @@
+use super::blockchain::Blockchain;
+use crate::blockcfg::Block;
+use crate::blockcfg::ChainLength;
+use crate::intercom::ExplorerMsg;
+use crate::utils::task::{Input, ThreadServiceInfo};
+use chain_impl_mockchain::multiverse::{GCRoot, Multiverse};
+use futures::Future;
+use futures::IntoFuture;
+
+use chain_core::property::Block as _;
+
+pub struct Process {
+    multiverse: Multiverse<State>,
+}
+
+struct State {
+    block: Block,
+}
+
+impl State {
+    pub fn new(block: Block) -> Self {
+        Self { block }
+    }
+}
+
+impl Process {
+    pub fn new() -> Self {
+        Self {
+            multiverse: Multiverse::<State>::new(),
+        }
+    }
+
+    pub fn handle_input(
+        &mut self,
+        info: &ThreadServiceInfo,
+        blockchain: &Blockchain,
+        input: Input<ExplorerMsg>,
+    ) {
+        let logger = info.logger();
+        let bquery = match input {
+            Input::Shutdown => {
+                return;
+            }
+            Input::Input(msg) => msg,
+        };
+
+        match bquery {
+            ExplorerMsg::NewBlock(header) => {
+                //I don't really understand what's the purpose of the gcroot yet
+                let _gcroot: Result<GCRoot, ()> = blockchain
+                    .storage()
+                    .get(header.hash())
+                    .or_else(|storage_error| {
+                        error!(logger, "{}", storage_error);
+                        Err(())
+                    })
+                    .and_then(|block| {
+                        debug!(
+                            logger,
+                            "storing blockhash: {} with chain_length: {}",
+                            header.hash(),
+                            header.chain_length()
+                        );
+
+                        block
+                            .map(|some_block| self.store_block(some_block))
+                            .unwrap_or_else(|| Err(error!(logger, "Block is not in storage")))
+                    })
+                    .wait();
+            }
+        };
+    }
+
+    fn store_block(&mut self, block: Block) -> Result<GCRoot, ()> {
+        let header = &block.header;
+        let _gcroot =
+            self.multiverse
+                .insert(header.chain_length(), header.hash(), State::new(block));
+
+        Ok(_gcroot)
+    }
+
+    fn _get_block_by_chain_length(_length: ChainLength) {
+        unimplemented!()
+    }
+}

--- a/jormungandr/src/explorer.rs
+++ b/jormungandr/src/explorer.rs
@@ -12,6 +12,8 @@ use tokio::prelude::Future;
 pub struct Process {
     multiverse: Multiverse<Ref>,
     // This is kind of the same thing the multiverse holds (with Ref instead of BlockId)
+    // FIXME: The constructor of `ChainLength` is private, so querying this thing could be
+    // a problem
     chain_length_to_hash: HashMap<ChainLength, Vec<Ref>>,
     blockchain: Blockchain,
 }

--- a/jormungandr/src/explorer.rs
+++ b/jormungandr/src/explorer.rs
@@ -2,7 +2,7 @@ use super::blockchain::{Blockchain, Ref};
 use crate::blockcfg::ChainLength;
 use crate::blockchain::Multiverse;
 use crate::intercom::ExplorerMsg;
-use crate::utils::task::{Input, ThreadServiceInfo};
+use crate::utils::task::{Input, TokioServiceInfo};
 use chain_impl_mockchain::multiverse::GCRoot;
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -25,11 +25,15 @@ impl Process {
         }
     }
 
-    pub fn handle_input(&mut self, info: &ThreadServiceInfo, input: Input<ExplorerMsg>) {
+    pub fn handle_input(
+        &mut self,
+        info: &TokioServiceInfo,
+        input: Input<ExplorerMsg>,
+    ) -> Result<(), ()> {
         let _logger = info.logger();
         let bquery = match input {
             Input::Shutdown => {
-                return;
+                return Ok(());
             }
             Input::Input(msg) => msg,
         };
@@ -39,6 +43,8 @@ impl Process {
                 let _gcroot = self.store_ref(new_block_ref);
             }
         };
+
+        Ok(())
     }
 
     fn store_ref(&mut self, new_block_ref: Ref) -> impl Future<Item = GCRoot, Error = Infallible> {

--- a/jormungandr/src/explorer.rs
+++ b/jormungandr/src/explorer.rs
@@ -1,67 +1,145 @@
 use super::blockchain::{Blockchain, Ref};
-use crate::blockcfg::ChainLength;
+use crate::blockcfg::{ChainLength, FragmentId};
 use crate::blockchain::Multiverse;
 use crate::intercom::ExplorerMsg;
 use crate::utils::task::{Input, TokioServiceInfo};
+use chain_core::property::Fragment;
 use chain_impl_mockchain::multiverse::GCRoot;
+use chain_storage::error::Error as StorageError;
+use futures::lazy;
 use std::collections::HashMap;
 use std::convert::Infallible;
-use tokio::prelude::Future;
+use std::{error, fmt};
+use tokio::prelude::*;
+use tokio::sync::lock::Lock;
+
+#[derive(Debug)]
+pub enum Error {
+    BlockNotFound,
+    StorageError(StorageError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::BlockNotFound => write!(f, "block not found"),
+            Error::StorageError(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl error::Error for Error {}
 
 #[derive(Clone)]
-pub struct Process {
+pub struct ExplorerDB {
     multiverse: Multiverse<Ref>,
     // This is kind of the same thing the multiverse holds (with Ref instead of BlockId)
     // FIXME: The constructor of `ChainLength` is private, so querying this thing could be
     // a problem
-    chain_length_to_hash: HashMap<ChainLength, Vec<Ref>>,
-    blockchain: Blockchain,
+    chain_length_to_hash: Lock<HashMap<ChainLength, Vec<Ref>>>,
+    transaction_to_block: Lock<HashMap<FragmentId, Ref>>,
 }
 
-impl Process {
-    pub fn new(blockchain: Blockchain) -> Self {
+impl ExplorerDB {
+    pub fn new() -> Self {
         Self {
             multiverse: Multiverse::<Ref>::new(),
-            chain_length_to_hash: HashMap::new(),
-            blockchain,
+            chain_length_to_hash: Lock::new(HashMap::new()),
+            transaction_to_block: Lock::new(HashMap::new()),
         }
+    }
+
+    pub fn store_ref(
+        &mut self,
+        new_block_ref: Ref,
+    ) -> impl Future<Item = GCRoot, Error = Infallible> {
+        let chain_length = new_block_ref.chain_length();
+        let header_hash = new_block_ref.hash();
+
+        // Clone things to move into closures, this is just cloning locks
+        let mut map = self.chain_length_to_hash.clone();
+        let multiverse = self.multiverse.clone();
+
+        future::poll_fn(move || Ok(map.poll_lock()))
+            // Store in chain_length_to_hash
+            .map(move |mut guard| {
+                guard
+                    .entry(chain_length)
+                    .or_insert(Vec::new())
+                    .push(new_block_ref.clone());
+                new_block_ref
+            })
+            // Store in the multiverse
+            .and_then(move |inserted_ref| {
+                multiverse.insert(chain_length, header_hash, inserted_ref)
+            })
+    }
+
+    fn index_transactions(
+        &mut self,
+        new_block_ref: Ref,
+        blockchain: Blockchain,
+    ) -> impl Future<Item = (), Error = Error> {
+        let mut map = self.transaction_to_block.clone();
+        blockchain
+            .storage()
+            .get(new_block_ref.hash())
+            .map_err(|err| Error::StorageError(err))
+            .join(future::poll_fn(move || Ok(map.poll_lock())))
+            .and_then(move |(block, mut guard)| {
+                if let Some(b) = block {
+                    for fragment in b.contents.iter() {
+                        guard.insert(fragment.id(), new_block_ref.clone());
+                    }
+                } else {
+                    return future::err(Error::BlockNotFound);
+                }
+                future::ok(())
+            })
+    }
+}
+
+#[derive(Clone)]
+pub struct Process {}
+
+impl Process {
+    pub fn new() -> Self {
+        Self {}
     }
 
     pub fn handle_input(
         &mut self,
         info: &TokioServiceInfo,
         input: Input<ExplorerMsg>,
-    ) -> Result<(), ()> {
+        explorer_db: &mut ExplorerDB,
+        blockchain: &Blockchain,
+    ) -> impl Future<Item = (), Error = ()> {
         let _logger = info.logger();
         let bquery = match input {
             Input::Shutdown => {
-                return Ok(());
+                return future::ok(());
             }
             Input::Input(msg) => msg,
         };
 
+        let mut explorer_db = explorer_db.clone();
+        let blockchain = blockchain.clone();
+        let logger = info.logger().clone();
         match bquery {
-            ExplorerMsg::NewBlock(new_block_ref) => {
-                let _gcroot = self.store_ref(new_block_ref);
-            }
-        };
-
-        Ok(())
-    }
-
-    fn store_ref(&mut self, new_block_ref: Ref) -> impl Future<Item = GCRoot, Error = Infallible> {
-        let chain_length = new_block_ref.chain_length();
-        let header_hash = new_block_ref.hash();
-
-        self.chain_length_to_hash
-            .entry(chain_length)
-            .or_insert(Vec::new())
-            .push(new_block_ref.clone());
-
-        let gc_root = self
-            .multiverse
-            .insert(chain_length, header_hash, new_block_ref.clone());
-
-        gc_root
+            ExplorerMsg::NewBlock(new_block_ref) => info.spawn(lazy(move || {
+                explorer_db
+                    .store_ref(new_block_ref.clone())
+                    .map_err(|_| unreachable!())
+                    .join(
+                        explorer_db
+                            .index_transactions(new_block_ref, blockchain)
+                            .map_err(move |err| {
+                                error!(logger, "Explorer error: {}", err);
+                            }),
+                    )
+                    .map(move |_| ())
+            })),
+        }
+        future::ok::<(), ()>(())
     }
 }

--- a/jormungandr/src/explorer.rs
+++ b/jormungandr/src/explorer.rs
@@ -3,7 +3,6 @@ use crate::blockcfg::ChainLength;
 use crate::blockchain::Multiverse;
 use crate::intercom::ExplorerMsg;
 use crate::utils::task::{Input, ThreadServiceInfo};
-use chain_impl_mockchain::block::HeaderHash;
 use chain_impl_mockchain::multiverse::GCRoot;
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -42,7 +41,7 @@ impl Process {
         };
     }
 
-    fn store_ref(&mut self, new_block_ref: Ref) -> GCRoot {
+    fn store_ref(&mut self, new_block_ref: Ref) -> impl Future<Item = GCRoot, Error = Infallible> {
         let chain_length = new_block_ref.chain_length();
         let header_hash = new_block_ref.hash();
 

--- a/jormungandr/src/explorer.rs
+++ b/jormungandr/src/explorer.rs
@@ -1,4 +1,4 @@
-use super::blockchain::Blockchain;
+use super::blockchain::{Blockchain, Ref};
 use crate::blockcfg::Block;
 use crate::blockcfg::ChainLength;
 use crate::intercom::ExplorerMsg;
@@ -6,27 +6,21 @@ use crate::utils::task::{Input, ThreadServiceInfo};
 use chain_impl_mockchain::multiverse::{GCRoot, Multiverse};
 use futures::Future;
 use futures::IntoFuture;
+use std::collections::{HashMap, HashSet};
 
 use chain_core::property::Block as _;
 
 pub struct Process {
-    multiverse: Multiverse<State>,
-}
-
-struct State {
-    block: Block,
-}
-
-impl State {
-    pub fn new(block: Block) -> Self {
-        Self { block }
-    }
+    multiverse: Multiverse<Ref>,
+    // This is kind of the same thing the multiverse holds (with Ref instead of BlockId)
+    chain_length_to_hash: HashMap<ChainLength, Vec<Ref>>,
 }
 
 impl Process {
     pub fn new() -> Self {
         Self {
-            multiverse: Multiverse::<State>::new(),
+            multiverse: Multiverse::<Ref>::new(),
+            chain_length_to_hash: HashMap::new(),
         }
     }
 
@@ -45,42 +39,25 @@ impl Process {
         };
 
         match bquery {
-            ExplorerMsg::NewBlock(header) => {
-                //I don't really understand what's the purpose of the gcroot yet
-                let _gcroot: Result<GCRoot, ()> = blockchain
-                    .storage()
-                    .get(header.hash())
-                    .or_else(|storage_error| {
-                        error!(logger, "{}", storage_error);
-                        Err(())
-                    })
-                    .and_then(|block| {
-                        debug!(
-                            logger,
-                            "storing blockhash: {} with chain_length: {}",
-                            header.hash(),
-                            header.chain_length()
-                        );
-
-                        block
-                            .map(|some_block| self.store_block(some_block))
-                            .unwrap_or_else(|| Err(error!(logger, "Block is not in storage")))
-                    })
-                    .wait();
+            ExplorerMsg::NewBlock(new_block_ref) => {
+                let _gcroot = self.store_ref(new_block_ref);
             }
         };
     }
 
-    fn store_block(&mut self, block: Block) -> Result<GCRoot, ()> {
-        let header = &block.header;
-        let _gcroot =
-            self.multiverse
-                .insert(header.chain_length(), header.hash(), State::new(block));
+    fn store_ref(&mut self, new_block_ref: Ref) -> GCRoot {
+        let chain_length = new_block_ref.chain_length();
+        let header_hash = new_block_ref.hash();
 
-        Ok(_gcroot)
-    }
+        self.chain_length_to_hash
+            .entry(chain_length)
+            .or_insert(Vec::new())
+            .push(new_block_ref.clone());
 
-    fn _get_block_by_chain_length(_length: ChainLength) {
-        unimplemented!()
+        let gc_root = self
+            .multiverse
+            .insert(chain_length, header_hash, new_block_ref.clone());
+
+        gc_root
     }
 }

--- a/jormungandr/src/explorer.rs
+++ b/jormungandr/src/explorer.rs
@@ -1,36 +1,33 @@
 use super::blockchain::{Blockchain, Ref};
-use crate::blockcfg::Block;
 use crate::blockcfg::ChainLength;
+use crate::blockchain::Multiverse;
 use crate::intercom::ExplorerMsg;
 use crate::utils::task::{Input, ThreadServiceInfo};
-use chain_impl_mockchain::multiverse::{GCRoot, Multiverse};
-use futures::Future;
-use futures::IntoFuture;
-use std::collections::{HashMap, HashSet};
+use chain_impl_mockchain::block::HeaderHash;
+use chain_impl_mockchain::multiverse::GCRoot;
+use std::collections::HashMap;
+use std::convert::Infallible;
+use tokio::prelude::Future;
 
-use chain_core::property::Block as _;
-
+#[derive(Clone)]
 pub struct Process {
     multiverse: Multiverse<Ref>,
     // This is kind of the same thing the multiverse holds (with Ref instead of BlockId)
     chain_length_to_hash: HashMap<ChainLength, Vec<Ref>>,
+    blockchain: Blockchain,
 }
 
 impl Process {
-    pub fn new() -> Self {
+    pub fn new(blockchain: Blockchain) -> Self {
         Self {
             multiverse: Multiverse::<Ref>::new(),
             chain_length_to_hash: HashMap::new(),
+            blockchain,
         }
     }
 
-    pub fn handle_input(
-        &mut self,
-        info: &ThreadServiceInfo,
-        blockchain: &Blockchain,
-        input: Input<ExplorerMsg>,
-    ) {
-        let logger = info.logger();
+    pub fn handle_input(&mut self, info: &ThreadServiceInfo, input: Input<ExplorerMsg>) {
+        let _logger = info.logger();
         let bquery = match input {
             Input::Shutdown => {
                 return;

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -1,5 +1,6 @@
 use crate::blockcfg::{Block, Epoch, Fragment, FragmentId, Header, HeaderHash};
 use crate::network::p2p::topology::NodeId;
+use blockchain::Ref;
 use futures::prelude::*;
 use futures::sync::{mpsc, oneshot};
 use jormungandr_lib::interfaces::FragmentOrigin;
@@ -351,9 +352,8 @@ pub enum NetworkMsg {
 }
 
 /// Messages to the explorer task
-#[derive(Debug)]
 pub enum ExplorerMsg {
-    NewBlock(Header),
+    NewBlock(Ref),
 }
 
 #[cfg(test)]

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -350,5 +350,12 @@ pub enum NetworkMsg {
     },
 }
 
+/// Messages to the explorer task
+
+#[derive(Debug)]
+pub enum ExplorerMsg {
+    NewBlock(Header),
+}
+
 #[cfg(test)]
 mod tests {}

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -351,7 +351,6 @@ pub enum NetworkMsg {
 }
 
 /// Messages to the explorer task
-
 #[derive(Debug)]
 pub enum ExplorerMsg {
     NewBlock(Header),

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -140,12 +140,13 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
     let explorer = {
         if bootstrapped_node.settings.explorer {
             let blockchain = blockchain.clone();
-            let mut explorer_task = explorer::Process::new(blockchain);
+            let mut explorer_task = explorer::Process::new();
+            let mut explorer_db = explorer::ExplorerDB::new();
 
             let context = explorer_task.clone();
 
             let task_msg_box = services.spawn_future_with_inputs("explorer", move |info, input| {
-                explorer_task.handle_input(info, input)
+                explorer_task.handle_input(info, input, &mut explorer_db, &blockchain)
             });
             Some((task_msg_box, context))
         } else {

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -144,8 +144,8 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
 
             let context = explorer_task.clone();
 
-            let task_msg_box = services.spawn_with_inputs("explorer", move |info, input| {
-                explorer_task.handle_input(info, input);
+            let task_msg_box = services.spawn_future_with_inputs("explorer", move |info, input| {
+                explorer_task.handle_input(info, input)
             });
             Some((task_msg_box, context))
         } else {

--- a/jormungandr/src/rest/mod.rs
+++ b/jormungandr/src/rest/mod.rs
@@ -33,6 +33,7 @@ pub struct Context {
     pub leadership_logs: LeadershipLogs,
     pub server: Lock<Option<Server>>,
     pub enclave: Enclave,
+    pub explorer: Option<crate::explorer::Process>,
 }
 
 pub fn start_rest_server(config: &Rest, mut context: Context) -> Result<Server, ConfigError> {

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -61,6 +61,11 @@ pub struct StartArguments {
     /// or from the network.
     #[structopt(long = "genesis-block-hash", parse(try_from_str))]
     pub block_0_hash: Option<HeaderHash>,
+
+    // TODO: Explorer mode description
+    // Maybe a config file variable is better
+    #[structopt(long = "enable-explorer")]
+    pub explorer: bool,
 }
 
 #[derive(StructOpt, Debug)]

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -62,10 +62,9 @@ pub struct StartArguments {
     #[structopt(long = "genesis-block-hash", parse(try_from_str))]
     pub block_0_hash: Option<HeaderHash>,
 
-    // TODO: Explorer mode description
-    // Maybe a config file variable is better
+    /// Start the explorer task and enable associated query endpoints.
     #[structopt(long = "enable-explorer")]
-    pub explorer: bool,
+    pub explorer_enabled: Option<bool>,
 }
 
 #[derive(StructOpt, Debug)]

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -64,7 +64,7 @@ pub struct StartArguments {
 
     /// Start the explorer task and enable associated query endpoints.
     #[structopt(long = "enable-explorer")]
-    pub explorer_enabled: Option<bool>,
+    pub explorer_enabled: bool,
 }
 
 #[derive(StructOpt, Debug)]

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
 
     pub rest: Option<Rest>,
     pub p2p: P2pConfig,
+
+    pub explorer: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -27,7 +27,7 @@ pub struct Config {
     pub rest: Option<Rest>,
     pub p2p: P2pConfig,
 
-    pub explorer: Option<bool>,
+    pub explorer: Option<Explorer>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -114,6 +114,11 @@ pub struct InterestLevel(pub poldercast::InterestLevel);
 pub struct TrustedPeer {
     pub address: Address,
     pub id: NodeId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Explorer {
+    pub enabled: bool,
 }
 
 impl Default for Mempool {

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -28,6 +28,7 @@ pub struct Settings {
     pub rest: Option<Rest>,
     pub mempool: Mempool,
     pub leadership: Leadership,
+    pub explorer: bool,
 }
 
 pub struct RawSettings {
@@ -116,6 +117,8 @@ impl RawSettings {
             (None, Some(hash)) => Block0Info::Hash(hash.clone()),
         };
 
+        let explorer = command_arguments.explorer.clone();
+
         Ok(Settings {
             storage: storage,
             block_0: block0_info,
@@ -124,6 +127,7 @@ impl RawSettings {
             rest: config.rest,
             mempool: config.mempool,
             leadership: config.leadership,
+            explorer,
         })
     }
 }

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -119,7 +119,7 @@ impl RawSettings {
 
         let explorer = match command_arguments.explorer_enabled.or(config.explorer) {
             Some(flag) => flag,
-            None => false
+            None => false,
         };
 
         Ok(Settings {

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -117,10 +117,8 @@ impl RawSettings {
             (None, Some(hash)) => Block0Info::Hash(hash.clone()),
         };
 
-        let explorer = match command_arguments.explorer_enabled.or(config.explorer) {
-            Some(flag) => flag,
-            None => false,
-        };
+        let explorer = command_arguments.explorer_enabled
+            || config.explorer.map_or(false, |settings| settings.enabled);
 
         Ok(Settings {
             storage: storage,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -117,7 +117,10 @@ impl RawSettings {
             (None, Some(hash)) => Block0Info::Hash(hash.clone()),
         };
 
-        let explorer = command_arguments.explorer.clone();
+        let explorer = match command_arguments.explorer_enabled.or(config.explorer) {
+            Some(flag) => flag,
+            None => false
+        };
 
         Ok(Settings {
             storage: storage,


### PR DESCRIPTION
# About #694. (Draft)

## Summary

- Add flag `--enable-explorer` to the command line start arguments.
Note: Maybe a config from the configuration file is better.
- Add explorer Task
- Send messages from the Block task when the feature was enabled (only when a Leadership block is processed, for now)
