### PR TITLE
Mempool and Leadership logs GC setting and fixes

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -16,6 +16,8 @@
 - [Configuration](./configuration/introduction.md)
     - [Logging](./configuration/logging.md)
     - [Node network](./configuration/network.md)
+    - [Fragment Pool](./configuration/mempool.md)
+    - [Leader Events](./configuration/leadership.md)
 
 - [jcli](./jcli/introduction.md)
     - [Cryptographic keys](./jcli/key.md)

--- a/doc/configuration/leadership.md
+++ b/doc/configuration/leadership.md
@@ -1,0 +1,13 @@
+The `leadership` field in your node config file is not mandatory, by default it is set
+as follow:
+
+```yaml
+leadership:
+    log_ttl: 1h
+    garbage_collection_interval: 15m
+```
+
+* `log_ttl` describes for how long the node will keep logs of leader events.
+  This is link to the data you receives from the REST leadership logs end point;
+* `garbage_collection_interval` describes the interval between 2 garbage collection
+  runs: i.e. when the node removes item logs that have timed out

--- a/doc/configuration/mempool.md
+++ b/doc/configuration/mempool.md
@@ -1,0 +1,21 @@
+When running an active node (BFT leader or stake pool) it is interesting to be
+able to make choices on how to manage the pending transactions: how long to keep
+them, how to prioritize them etc.
+
+The `mempool` field in your node config file is not mandatory, by default it is set
+as follow:
+
+```yaml
+mempool:
+    fragment_ttl: 30m
+    log_ttl: 1h
+    garbage_collection_interval: 15m
+```
+
+* `fragment_ttl` describes for how long the node shall keep a fragment (a _transaction_)
+  pending in the pool before being discarded;
+* `log_ttl` describes for how long the node will keep logs of pending/accepted/rejected
+  fragments in the pool; This is link to the data you receives from the REST fragment
+  logs end point;
+* `garbage_collection_interval` describes the interval between 2 garbage collection
+  runs: i.e. when the node removes item (fragments or logs) that have timed out. 

--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -1,7 +1,7 @@
 
 There's 2 differents network interfaces which are covered by their respective section:
 
-```
+```yaml
 rest:
    ...
 p2p:

--- a/jormungandr-lib/src/time.rs
+++ b/jormungandr-lib/src/time.rs
@@ -289,6 +289,12 @@ impl From<time::Duration> for Duration {
     }
 }
 
+impl From<Duration> for time::Duration {
+    fn from(Duration(duration): Duration) -> Self {
+        duration
+    }
+}
+
 impl From<SecondsSinceUnixEpoch> for SystemTime {
     fn from(seconds: SecondsSinceUnixEpoch) -> SystemTime {
         SystemTime::from_secs_since_epoch(seconds.0)

--- a/jormungandr/src/fragment/logs.rs
+++ b/jormungandr/src/fragment/logs.rs
@@ -54,8 +54,7 @@ impl Logs {
     }
 
     pub fn poll_purge(&mut self) -> impl Future<Item = (), Error = timer::Error> {
-        let mut lock = self.0.clone();
-        future::poll_fn(move || Ok(lock.poll_lock()))
+        self.inner()
             .and_then(move |mut guard| future::poll_fn(move || guard.poll_purge()))
     }
 
@@ -65,7 +64,7 @@ impl Logs {
             .and_then(|guard| future::ok(guard.logs().cloned().collect()))
     }
 
-    pub(super) fn inner(&self) -> impl Future<Item = LockGuard<internal::Logs>, Error = ()> {
+    pub(super) fn inner<E>(&self) -> impl Future<Item = LockGuard<internal::Logs>, Error = E> {
         let mut lock = self.0.clone();
         future::poll_fn(move || Ok(lock.poll_lock()))
     }

--- a/jormungandr/src/fragment/logs.rs
+++ b/jormungandr/src/fragment/logs.rs
@@ -133,11 +133,15 @@ pub(super) mod internal {
         }
 
         pub fn poll_purge(&mut self) -> Poll<(), timer::Error> {
-            while let Some(entry) = try_ready!(self.expirations.poll()) {
-                self.entries.remove(entry.get_ref());
+            loop {
+                match self.expirations.poll()? {
+                    Async::NotReady => return Ok(Async::Ready(())),
+                    Async::Ready(None) => return Ok(Async::Ready(())),
+                    Async::Ready(Some(entry)) => {
+                        self.entries.remove(entry.get_ref());
+                    }
+                }
             }
-
-            Ok(Async::Ready(()))
         }
 
         pub fn logs<'a>(&'a self) -> impl Iterator<Item = &'a FragmentLog> {

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -109,6 +109,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
     let blockchain = bootstrapped_node.blockchain;
     // TODO: make this value configuration
     let leadership_logs = leadership::Logs::new(Duration::from_secs(3 * 24 * 3600));
+    let leadership_garbage_collection_interval = Duration::from_secs(3600 / 4);
 
     let stats_counter = StatsCounter::default();
 
@@ -212,6 +213,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
             leadership::LeadershipModule::start(
                 info,
                 leadership_logs,
+                leadership_garbage_collection_interval,
                 enclave,
                 fragment_pool,
                 blockchain_tip,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -1,8 +1,8 @@
 mod config;
 pub mod network;
 
-use self::config::Config;
 pub use self::config::Rest;
+use self::config::{Config, Leadership, Mempool};
 use self::network::Protocol;
 use crate::rest::Error as RestError;
 use crate::settings::logging::{self, LogFormat, LogOutput, LogSettings};
@@ -24,8 +24,10 @@ pub struct Settings {
     pub network: network::Configuration,
     pub storage: Option<PathBuf>,
     pub block_0: Block0Info,
-    pub leadership: Vec<PathBuf>,
+    pub secrets: Vec<PathBuf>,
     pub rest: Option<Rest>,
+    pub mempool: Mempool,
+    pub leadership: Leadership,
 }
 
 pub struct RawSettings {
@@ -92,12 +94,12 @@ impl RawSettings {
             (None, None) => None,
         };
 
-        let mut leadership = command_arguments.secret.clone();
+        let mut secrets = command_arguments.secret.clone();
         if let Some(secret_files) = config.secret_files {
-            leadership.extend(secret_files);
+            secrets.extend(secret_files);
         }
 
-        if leadership.is_empty() {
+        if secrets.is_empty() {
             warn!(
                 logger,
                 "Node started without path to the stored secret keys"
@@ -118,8 +120,10 @@ impl RawSettings {
             storage: storage,
             block_0: block0_info,
             network: network,
-            leadership,
+            secrets,
             rest: config.rest,
+            mempool: config.mempool,
+            leadership: config.leadership,
         })
     }
 }

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -14,7 +14,7 @@ use slog::Logger;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::mpsc;
 
-pub type NodeStorage = Box<BlockStore<Block = Block> + Send + Sync>;
+pub type NodeStorage = Box<dyn BlockStore<Block = Block> + Send + Sync>;
 
 /// prepare the block storage from the given settings
 ///


### PR DESCRIPTION
- allow configuration of the different durations for the mempool and leadership logs
- add some documentations for the new settings
- fixes #591 : don't report the log purge as _not ready_ if there are not expired items yet or we will block all threads.