### PR TITLE
experiment with new interface for multi nodes testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bawawa"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bech32"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,23 +1283,33 @@ version = "0.3.2"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bawawa 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-addr 0.1.0",
+ "chain-core 0.1.0",
  "chain-crypto 0.1.0",
+ "chain-impl-mockchain 0.1.0",
  "custom_error 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "galvanic-test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jcli 0.3.2",
  "jormungandr 0.3.2",
  "jormungandr-lib 0.3.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1498,6 +1520,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-named-pipes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mio-uds"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1549,15 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "socket2 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2838,6 +2880,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-process"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-reactor"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3420,6 +3480,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base-x 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "76f4eae81729e69bb1819a26c6caac956cc429238388091f98cb6cd858f16443"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum bawawa 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cc7b73915d202a5a483782d63db9523de1a8c7b9764dfe3b2f9279db7d0cfbe4"
 "checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
 "checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
@@ -3546,8 +3607,10 @@ dependencies = [
 "checksum miniz_oxide 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c061edee74a88eb35d876ce88b94d77a0448a201de111c244b70d047f5820516"
 "checksum miniz_oxide_c_api 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6c675792957b0d19933816c4e1d56663c341dd9bfa31cb2140ff2267c1d8ecf4"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
+"checksum mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edf4fc746c5c977923b802d86fc9a95ca79a27d8c487613f68830d68d07c7b27"
 "checksum multiaddr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46c47add5e6a96020ca53393aebf77193fd5f578a4e7a73ab505f41e4be06e8c"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
@@ -3687,6 +3750,7 @@ dependencies = [
 "checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
+"checksum tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afbd6ef1b8cc2bd2c2b580d882774d443ebb1c6ceefe35ba9ea4ab586c89dbe8"
 "checksum tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
 "checksum tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"
 "checksum tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2162248ff317e2bc713b261f242b69dbb838b85248ed20bb21df56d60ea4cae7"

--- a/jormungandr-integration-tests/Cargo.toml
+++ b/jormungandr-integration-tests/Cargo.toml
@@ -5,15 +5,18 @@ authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 edition = "2018"
 
 [dependencies]
-chain-crypto    = { path = "../chain-deps/chain-crypto" }
-chain-addr      = { path = "../chain-deps/chain-addr" }
+chain-core           = { path = "../chain-deps/chain-core" }
+chain-crypto         = { path = "../chain-deps/chain-crypto" }
+chain-addr           = { path = "../chain-deps/chain-addr" }
+chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 jormungandr-lib = { path = "../jormungandr-lib" }
 rand = "0.6"
+rand_core = "0.3"
 rand_chacha = "0.1"
-regex = "1.1.2"
+regex = "1.1"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0.38"
+serde_json = "1.0"
 serde_yaml = "0.8"
 quickcheck = "0.8"
 galvanic-test = "0.2.0"
@@ -22,6 +25,14 @@ assert_fs = "0.11"
 mktemp = "0.4.0"
 lazy_static = "1.3"
 custom_error = "1.7"
+poldercast = { version = "0.3.1", features = [ "serde_derive" ] }
+
+slog = "2"
+bawawa = "0.1.4"
+bytes = "0.4"
+error-chain = "0.12"
+tokio = "0.1"
+reqwest = "0.9"
 
 [dev-dependencies]
 jormungandr = { path = "../jormungandr" }

--- a/jormungandr-integration-tests/src/common/configuration/mod.rs
+++ b/jormungandr-integration-tests/src/common/configuration/mod.rs
@@ -71,7 +71,7 @@ pub fn get_openapi_path() -> PathBuf {
 
 lazy_static! {
     static ref NEXT_AVAILABLE_PORT_NUMBER: AtomicU16 = {
-        let initial_port = rand::thread_rng().gen_range(6000, 60000);
+        let initial_port = rand::thread_rng().gen_range(6000, 10999);
         AtomicU16::new(initial_port)
     };
 }

--- a/jormungandr-integration-tests/src/lib.rs
+++ b/jormungandr-integration-tests/src/lib.rs
@@ -1,12 +1,17 @@
-#![cfg(test)]
-
 #[macro_use(lazy_static)]
 extern crate lazy_static;
+#[macro_use(error_chain, bail)]
+extern crate error_chain;
 
+#[cfg(test)]
 pub mod common;
+#[cfg(test)]
 pub mod jcli;
+#[cfg(test)]
 pub mod jormungandr;
+#[cfg(test)]
 pub mod networking;
+#[cfg(test)]
 pub mod non_functional;
 
-// The purpose of this file is to allow cargo correctly detect tests located in subfolders. It acts like lib.rs file.
+pub mod v2;

--- a/jormungandr-integration-tests/src/v2/mod.rs
+++ b/jormungandr-integration-tests/src/v2/mod.rs
@@ -37,6 +37,7 @@ fn scenario_1() {
     .unwrap();
 
     scenario.spawn_node("node1", true).unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(1));
     scenario.spawn_node("node2", false).unwrap();
 
     std::thread::sleep(std::time::Duration::from_secs(10));

--- a/jormungandr-integration-tests/src/v2/mod.rs
+++ b/jormungandr-integration-tests/src/v2/mod.rs
@@ -1,0 +1,50 @@
+/**
+# Example
+
+*/
+mod programs;
+#[macro_use]
+pub mod scenario;
+pub mod node;
+mod slog;
+mod wallet;
+
+pub use self::node::Node;
+pub use self::programs::{JCLI, JORMUNGANDR};
+pub use self::scenario::{NodeAlias, WalletAlias, WalletType};
+pub use self::slog::{Error as SlogCodecError, SlogCodec};
+pub use self::wallet::Wallet;
+
+#[test]
+fn scenario_1() {
+    let mut context = scenario::Context::new();
+
+    let mut scenario = prepare_scenario! {
+        &mut context,
+        topology [
+            "node1",
+            "node2" -> "node1",
+        ]
+        blockchain {
+            consensus = Bft,
+            leaders = [ "node1", "node2" ],
+            initials = [
+                account "faucet1" with 1_000_000_000,
+                account "faucet2" with 2_000_000_000 delegates to "node2",
+            ],
+        }
+    }
+    .unwrap();
+
+    scenario.spawn_node("node1", true).unwrap();
+    scenario.spawn_node("node2", false).unwrap();
+
+    std::thread::sleep(std::time::Duration::from_secs(10));
+
+    let node1_tip_hash = scenario.get_tip("node1").unwrap();
+    println!("got tip from node 1: {}", node1_tip_hash);
+
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    let _node2_block = scenario.get_block("node2", &node1_tip_hash).unwrap();
+    println!("got block {} from node2", node1_tip_hash);
+}

--- a/jormungandr-integration-tests/src/v2/mod.rs
+++ b/jormungandr-integration-tests/src/v2/mod.rs
@@ -27,6 +27,8 @@ fn scenario_1() {
         ]
         blockchain {
             consensus = Bft,
+            number_of_slots_per_epoch = 10,
+            slot_duration = 1,
             leaders = [ "node1", "node2" ],
             initials = [
                 account "faucet1" with 1_000_000_000,
@@ -40,12 +42,21 @@ fn scenario_1() {
     std::thread::sleep(std::time::Duration::from_secs(1));
     scenario.spawn_node("node2", false).unwrap();
 
-    std::thread::sleep(std::time::Duration::from_secs(10));
+    std::thread::sleep(std::time::Duration::from_secs(20));
 
     let node1_tip_hash = scenario.get_tip("node1").unwrap();
+    let node2_tip_hash = scenario.get_tip("node2").unwrap();
     println!("got tip from node 1: {}", node1_tip_hash);
+    println!("got tip from node 2: {}", node2_tip_hash);
 
     std::thread::sleep(std::time::Duration::from_secs(1));
-    let _node2_block = scenario.get_block("node2", &node1_tip_hash).unwrap();
+    let node1_block = scenario.get_block("node1", &node2_tip_hash).unwrap();
     println!("got block {} from node2", node1_tip_hash);
+    let node2_block = scenario.get_block("node2", &node1_tip_hash).unwrap();
+    println!("got block {} from node2", node1_tip_hash);
+
+    dbg!(&node1_block);
+    dbg!(&node2_block);
+
+    assert_eq!(node1_tip_hash, node2_tip_hash);
 }

--- a/jormungandr-integration-tests/src/v2/node.rs
+++ b/jormungandr-integration-tests/src/v2/node.rs
@@ -1,0 +1,100 @@
+use crate::v2::{
+    scenario::{settings::NodeSetting, NodeBlock0},
+    NodeAlias, JORMUNGANDR,
+};
+use bawawa::Process;
+use mktemp::Temp;
+
+error_chain! {
+    errors {
+        CannotCreateTemporaryDirectory {
+            description("Cannot create a temporary directory")
+        }
+
+        CannotSpawnNode {
+            description("Cannot spawn the node"),
+        }
+    }
+}
+
+pub struct Node {
+    alias: NodeAlias,
+
+    #[allow(unused)]
+    temp_dir: Temp,
+
+    process: Process,
+}
+
+const NODE_CONFIG: &str = "node_config.yaml";
+const NODE_SECRET: &str = "node_secret.yaml";
+
+impl Node {
+    pub fn alias(&self) -> &NodeAlias {
+        &self.alias
+    }
+
+    pub fn process(&self) -> &Process {
+        &self.process
+    }
+
+    pub fn process_mut(&mut self) -> &mut Process {
+        &mut self.process
+    }
+
+    pub fn spawn(alias: &str, node_settings: &NodeSetting, block0: NodeBlock0) -> Result<Self> {
+        let mut command = JORMUNGANDR.clone();
+        let temp_dir = Temp::new_dir().chain_err(|| ErrorKind::CannotCreateTemporaryDirectory)?;
+
+        let config_file = {
+            let mut dir = temp_dir.clone().release();
+            dir.push(NODE_CONFIG);
+            dir
+        };
+        let config_secret = {
+            let mut dir = temp_dir.clone().release();
+            dir.push(NODE_SECRET);
+            dir
+        };
+
+        serde_yaml::to_writer(
+            std::fs::File::create(&config_file)
+                .chain_err(|| format!("Cannot create file {:?}", config_file))?,
+            node_settings.config(),
+        )
+        .chain_err(|| format!("cannot write in {:?}", config_file))?;
+
+        serde_yaml::to_writer(
+            std::fs::File::create(&config_secret)
+                .chain_err(|| format!("Cannot create file {:?}", config_secret))?,
+            node_settings.secrets(),
+        )
+        .chain_err(|| format!("cannot write in {:?}", config_secret))?;
+
+        command.arguments(&[
+            "--config",
+            &config_file.display().to_string(),
+            "--secret",
+            &config_secret.display().to_string(),
+        ]);
+
+        match block0 {
+            NodeBlock0::File(path) => {
+                command.arguments(&["--genesis-block", &path.display().to_string()]);
+            }
+            NodeBlock0::Hash(hash) => {
+                command.arguments(&["--genesis-block-hash", &hash.to_string()]);
+            }
+        }
+
+        let process = Process::spawn(command).chain_err(|| ErrorKind::CannotSpawnNode)?;
+
+        Ok(Node {
+            alias: alias.into(),
+
+            temp_dir,
+
+            process,
+        })
+    }
+}

--- a/jormungandr-integration-tests/src/v2/programs.rs
+++ b/jormungandr-integration-tests/src/v2/programs.rs
@@ -1,0 +1,100 @@
+use bawawa::{Command, Program};
+use error_chain::ChainedError as _;
+
+const JORMUNGANDR_PROGRAM_NAME: &str = "jormungandr";
+const JCLI_PROGRAM_NAME: &str = "jcli";
+
+lazy_static! {
+    /// this is a bit of a hack to try to get the binary directory
+    /// of the executable we are testing.
+    ///
+    /// it should resolve to the `/target/{profile}/`
+    static ref BIN_DIRECTORY: std::path::PathBuf = {
+        let mut output_directory = std::env::current_exe().unwrap();
+
+        output_directory.pop();
+        output_directory.pop();
+        output_directory
+    };
+}
+
+lazy_static! {
+    /// the bawawa `Command` for `jormungandr`.
+    pub static ref JORMUNGANDR: Command = { prepare_command(JORMUNGANDR_PROGRAM_NAME) };
+    /// the bawawa `Command` for `jcli`.
+    pub static ref JCLI: Command = { prepare_command(JCLI_PROGRAM_NAME) };
+}
+
+/// internal function to prepare a bawawa `Command` for `jormungandr` and `jcli`
+///
+/// if the program could not be found in the $PATH or the current path then this
+/// function will print the error reported by `bawawa` and then will `panic!` so
+/// the tests are not executed.
+fn prepare_command(program_name: &str) -> Command {
+    let mut exe = BIN_DIRECTORY.clone();
+    exe.push(program_name);
+    match Program::new(exe.display().to_string()) {
+        Ok(program) => Command::new(program),
+        Err(error) => {
+            eprintln!("{}", error.display_chain().to_string());
+            panic!(
+                "the program {} is necessary for the execution of the tests but could not be found in  {}",
+                program_name,
+                BIN_DIRECTORY.display()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bawawa::{Process, Result, StandardOutput};
+    use tokio::prelude::*;
+
+    /// this tests `jormungandr` version is consistent with the version
+    /// we know of.
+    ///
+    /// This is mainly testing we are testing the appropriate version
+    /// of jormungandr. However this test is not *very* strong.
+    ///
+    #[test]
+    fn check_jormungandr_version() -> Result<()> {
+        let mut cmd = JORMUNGANDR.clone();
+        cmd.arguments(&["--version"]);
+
+        let mut captured_version = Process::spawn(cmd)?
+            .capture_stdout(tokio::codec::LinesCodec::new())
+            .wait();
+
+        assert_eq!(
+            captured_version.next().unwrap()?,
+            format!("{} {}", JORMUNGANDR_PROGRAM_NAME, env!("CARGO_PKG_VERSION"))
+        );
+
+        Ok(())
+    }
+
+    /// this tests `jcli` version is consistent with the version
+    /// we know of.
+    ///
+    /// This is mainly testing we are testing the appropriate version
+    /// of jcli. However this test is not *very* strong.
+    ///
+    #[test]
+    fn check_jcli_version() -> Result<()> {
+        let mut cmd = JCLI.clone();
+        cmd.arguments(&["--version"]);
+
+        let mut captured_version = Process::spawn(cmd)?
+            .capture_stdout(tokio::codec::LinesCodec::new())
+            .wait();
+
+        assert_eq!(
+            captured_version.next().unwrap()?,
+            format!("{} {}", JCLI_PROGRAM_NAME, env!("CARGO_PKG_VERSION"))
+        );
+
+        Ok(())
+    }
+}

--- a/jormungandr-integration-tests/src/v2/scenario/blockchain.rs
+++ b/jormungandr-integration-tests/src/v2/scenario/blockchain.rs
@@ -1,19 +1,28 @@
 use crate::v2::scenario::{ConsensusVersion, NodeAlias, Wallet, WalletAlias};
+use jormungandr_lib::interfaces::{NumberOfSlotsPerEpoch, SlotDuration};
 use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct Blockchain {
     consensus: ConsensusVersion,
+    slots_per_epoch: NumberOfSlotsPerEpoch,
+    slot_duration: SlotDuration,
     leaders: Vec<NodeAlias>,
     wallets: HashMap<WalletAlias, Wallet>,
 }
 
 impl Blockchain {
-    pub fn new(consensus: ConsensusVersion) -> Self {
+    pub fn new(
+        consensus: ConsensusVersion,
+        slots_per_epoch: NumberOfSlotsPerEpoch,
+        slot_duration: SlotDuration,
+    ) -> Self {
         Blockchain {
             consensus,
             leaders: Vec::new(),
             wallets: HashMap::new(),
+            slots_per_epoch,
+            slot_duration,
         }
     }
 
@@ -27,6 +36,14 @@ impl Blockchain {
 
     pub fn consensus(&self) -> &ConsensusVersion {
         &self.consensus
+    }
+
+    pub fn slots_per_epoch(&self) -> &NumberOfSlotsPerEpoch {
+        &self.slots_per_epoch
+    }
+
+    pub fn slot_duration(&self) -> &SlotDuration {
+        &self.slot_duration
     }
 
     pub fn leaders<'a>(&'a self) -> impl Iterator<Item = &'a NodeAlias> {

--- a/jormungandr-integration-tests/src/v2/scenario/blockchain.rs
+++ b/jormungandr-integration-tests/src/v2/scenario/blockchain.rs
@@ -1,0 +1,39 @@
+use crate::v2::scenario::{ConsensusVersion, NodeAlias, Wallet, WalletAlias};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Blockchain {
+    consensus: ConsensusVersion,
+    leaders: Vec<NodeAlias>,
+    wallets: HashMap<WalletAlias, Wallet>,
+}
+
+impl Blockchain {
+    pub fn new(consensus: ConsensusVersion) -> Self {
+        Blockchain {
+            consensus,
+            leaders: Vec::new(),
+            wallets: HashMap::new(),
+        }
+    }
+
+    pub fn add_leader<S: Into<NodeAlias>>(&mut self, alias: S) {
+        self.leaders.push(alias.into())
+    }
+
+    pub fn add_wallet(&mut self, wallet: Wallet) {
+        self.wallets.insert(wallet.alias().clone(), wallet);
+    }
+
+    pub fn consensus(&self) -> &ConsensusVersion {
+        &self.consensus
+    }
+
+    pub fn leaders<'a>(&'a self) -> impl Iterator<Item = &'a NodeAlias> {
+        self.leaders.iter()
+    }
+
+    pub fn wallets<'a>(&'a self) -> impl Iterator<Item = &'a Wallet> {
+        self.wallets.values()
+    }
+}

--- a/jormungandr-integration-tests/src/v2/scenario/mod.rs
+++ b/jormungandr-integration-tests/src/v2/scenario/mod.rs
@@ -221,7 +221,7 @@ impl Context<ChaChaRng> {
         Context {
             rng,
             seed,
-            next_available_rest_port_number: 8_000,
+            next_available_rest_port_number: 11_000,
             next_available_grpc_port_number: 12_000,
         }
     }

--- a/jormungandr-integration-tests/src/v2/scenario/mod.rs
+++ b/jormungandr-integration-tests/src/v2/scenario/mod.rs
@@ -1,0 +1,255 @@
+mod blockchain;
+pub mod settings;
+mod topology;
+mod wallet;
+
+pub use self::{
+    blockchain::Blockchain,
+    topology::{Node, NodeAlias, Topology, TopologyBuilder},
+    wallet::{Wallet, WalletAlias, WalletType},
+};
+pub use chain_impl_mockchain::{
+    block::{Block, ConsensusVersion, HeaderHash},
+    value::Value,
+};
+use mktemp::Temp;
+use rand_chacha::ChaChaRng;
+use rand_core::{RngCore, SeedableRng};
+use std::{collections::BTreeMap, net::SocketAddr};
+
+error_chain! {
+    links {
+        Node(crate::v2::node::Error, crate::v2::node::ErrorKind);
+    }
+
+    foreign_links {
+        Io(std::io::Error);
+        Reqwest(reqwest::Error);
+        BlockFormatErrror(chain_core::mempack::ReadError);
+    }
+
+    errors {
+        NodeNotFound(node: String) {
+            description("Node not found"),
+            display("No node with alias {}", node),
+        }
+
+        InvalidHeaderHash {
+            description("Invalid header hash"),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! prepare_scenario {
+    (
+        $context:expr,
+        topology [
+            $($topology_tt:tt $(-> $node_link:tt)*),+ $(,)*
+        ]
+        blockchain {
+            consensus = $blockchain_consensus:tt,
+            leaders = [ $($node_leader:tt),* $(,)* ],
+            initials = [
+                $(account $initial_wallet_name:tt with $initial_wallet_funds:tt $(delegates to $initial_wallet_delegate_to:tt)* ),+ $(,)*
+            ] $(,)*
+        }
+    ) => {{
+        let mut topology_builder = $crate::v2::scenario::TopologyBuilder::new();
+        $(
+            #[allow(unused_mut)]
+            let mut node = $crate::v2::scenario::Node::new($topology_tt);
+            $(
+                node.add_trusted_peer($node_link);
+            )*
+            topology_builder.register_node(node);
+        )*
+        let topology : $crate::v2::scenario::Topology = topology_builder.build();
+
+        let mut blockchain = $crate::v2::scenario::Blockchain::new(
+            $crate::v2::scenario::ConsensusVersion::$blockchain_consensus
+        );
+
+        $(
+            let node_leader = $node_leader.to_owned();
+            blockchain.add_leader(node_leader);
+        )*
+
+        $(
+            #[allow(unused_mut)]
+            let mut wallet = $crate::v2::scenario::Wallet::new_account(
+                $initial_wallet_name.to_owned(),
+                $crate::v2::scenario::Value($initial_wallet_funds)
+            );
+
+            $(
+                assert!(
+                    wallet.delegate().is_none(),
+                    "we only support delegating once for now, fix delegation for wallet \"{}\"",
+                    $initial_wallet_name
+                );
+                *wallet.delegate_mut() = Some($initial_wallet_delegate_to.to_owned());
+            )*
+
+
+            blockchain.add_wallet(wallet);
+        )*
+
+        let settings = $crate::v2::scenario::settings::Settings::prepare(
+            topology,
+            blockchain,
+            $context
+        );
+
+        $crate::v2::scenario::Scenario::new(settings)
+    }};
+}
+
+pub enum NodeBlock0 {
+    Hash(HeaderHash),
+    File(std::path::PathBuf),
+}
+
+pub struct Scenario {
+    settings: settings::Settings,
+
+    block0_file: Temp,
+    block0_hash: HeaderHash,
+
+    nodes: BTreeMap<NodeAlias, crate::v2::node::Node>,
+}
+
+/// scenario context with all the details to setup the necessary port number
+/// a pseudo random number generator (and its original seed).
+///
+pub struct Context<RNG: RngCore + Sized> {
+    rng: RNG,
+
+    seed: [u8; 32],
+
+    next_available_rest_port_number: u16,
+    next_available_grpc_port_number: u16,
+}
+
+impl Scenario {
+    pub fn new(settings: settings::Settings) -> Result<Self> {
+        use chain_core::property::Serialize as _;
+        let block0_file = Temp::new_file()?;
+
+        let file = std::fs::File::create(&block0_file)?;
+
+        let block0 = settings.block0.to_block();
+        let block0_hash = block0.header.hash();
+
+        block0.serialize(file)?;
+
+        Ok(Scenario {
+            settings,
+            block0_file,
+            block0_hash,
+            nodes: BTreeMap::new(),
+        })
+    }
+
+    pub fn spawn_node(&mut self, node_alias: &str, with_block0: bool) -> Result<&crate::v2::Node> {
+        let node_setting = if let Some(node_setting) = self.settings.nodes.get(node_alias) {
+            node_setting
+        } else {
+            bail!(ErrorKind::NodeNotFound(node_alias.to_owned()))
+        };
+
+        let block0_setting = if with_block0 {
+            NodeBlock0::File(self.block0_file.as_path().into())
+        } else {
+            NodeBlock0::Hash(self.block0_hash.clone())
+        };
+        let node = crate::v2::node::Node::spawn("node1", node_setting, block0_setting)?;
+
+        self.nodes.insert(node_alias.to_owned(), node);
+
+        Ok(self.nodes.get(node_alias).unwrap())
+    }
+
+    pub fn get_tip(&self, node_alias: &str) -> Result<HeaderHash> {
+        let node_setting = if let Some(node_setting) = self.settings.nodes.get(node_alias) {
+            node_setting
+        } else {
+            bail!(ErrorKind::NodeNotFound(node_alias.to_owned()))
+        };
+
+        let address = node_setting.config.rest.listen.clone();
+        let hash = reqwest::get(&format!("http://{}/api/v0/tip", address))?.text()?;
+
+        hash.parse().chain_err(|| ErrorKind::InvalidHeaderHash)
+    }
+
+    pub fn get_block(&self, node_alias: &str, hash: &HeaderHash) -> Result<Block> {
+        use chain_core::mempack::Readable as _;
+
+        let node_setting = if let Some(node_setting) = self.settings.nodes.get(node_alias) {
+            node_setting
+        } else {
+            bail!(ErrorKind::NodeNotFound(node_alias.to_owned()))
+        };
+
+        let address = node_setting.config.rest.listen.clone();
+        let mut blob = Vec::with_capacity(4096);
+        let _size = reqwest::get(&format!("http://{}/api/v0/block/{}", address, hash))?
+            .copy_to(&mut blob)?;
+
+        let mut buf = chain_core::mempack::ReadBuf::from(&blob);
+
+        let block = Block::read(&mut buf)?;
+        Ok(block)
+    }
+
+    pub fn node(&self, node_alias: &str) -> Option<&crate::v2::Node> {
+        self.nodes.get(node_alias)
+    }
+
+    pub fn node_mut(&mut self, node_alias: &str) -> Option<&mut crate::v2::Node> {
+        self.nodes.get_mut(node_alias)
+    }
+}
+
+impl Context<ChaChaRng> {
+    pub fn new() -> Self {
+        let mut seed = [0; 32];
+        rand::rngs::OsRng::new().unwrap().fill_bytes(&mut seed);
+        let rng = ChaChaRng::from_seed(seed);
+
+        Context {
+            rng,
+            seed,
+            next_available_rest_port_number: 8_000,
+            next_available_grpc_port_number: 12_000,
+        }
+    }
+}
+
+impl<RNG: RngCore> Context<RNG> {
+    pub fn generate_new_rest_listen_address(&mut self) -> SocketAddr {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let port_number = self.next_available_rest_port_number;
+        self.next_available_rest_port_number += 1;
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port_number)
+    }
+
+    pub fn generate_new_grpc_public_address(&mut self) -> String {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let port_number = self.next_available_grpc_port_number;
+        self.next_available_grpc_port_number += 1;
+
+        let address = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
+        format!("/ip4/{}/tcp/{}", address, port_number)
+    }
+
+    /// retrieve the original seed of the pseudo random generator
+    #[inline]
+    pub fn seed(&self) -> &[u8; 32] {
+        &self.seed
+    }
+}

--- a/jormungandr-integration-tests/src/v2/scenario/mod.rs
+++ b/jormungandr-integration-tests/src/v2/scenario/mod.rs
@@ -12,6 +12,7 @@ pub use chain_impl_mockchain::{
     block::{Block, ConsensusVersion, HeaderHash},
     value::Value,
 };
+pub use jormungandr_lib::interfaces::{NumberOfSlotsPerEpoch, SlotDuration};
 use mktemp::Temp;
 use rand_chacha::ChaChaRng;
 use rand_core::{RngCore, SeedableRng};
@@ -49,6 +50,8 @@ macro_rules! prepare_scenario {
         ]
         blockchain {
             consensus = $blockchain_consensus:tt,
+            number_of_slots_per_epoch = $slots_per_epoch:tt,
+            slot_duration = $slot_duration:tt,
             leaders = [ $($node_leader:tt),* $(,)* ],
             initials = [
                 $(account $initial_wallet_name:tt with $initial_wallet_funds:tt $(delegates to $initial_wallet_delegate_to:tt)* ),+ $(,)*
@@ -67,7 +70,9 @@ macro_rules! prepare_scenario {
         let topology : $crate::v2::scenario::Topology = topology_builder.build();
 
         let mut blockchain = $crate::v2::scenario::Blockchain::new(
-            $crate::v2::scenario::ConsensusVersion::$blockchain_consensus
+            $crate::v2::scenario::ConsensusVersion::$blockchain_consensus,
+            $crate::v2::scenario::NumberOfSlotsPerEpoch::new($slots_per_epoch).expect("valid number of slots per epoch"),
+            $crate::v2::scenario::SlotDuration::new($slot_duration).expect("valid slot duration in seconds"),
         );
 
         $(

--- a/jormungandr-integration-tests/src/v2/scenario/settings.rs
+++ b/jormungandr-integration-tests/src/v2/scenario/settings.rs
@@ -1,0 +1,370 @@
+use crate::v2::{
+    scenario::{
+        Blockchain as BlockchainTemplate, Context, Node as NodeTemplate,
+        Topology as TopologyTemplate, Wallet as WalletTemplate,
+    },
+    NodeAlias, Wallet, WalletAlias, WalletType,
+};
+use chain_crypto::{Curve25519_2HashDH, Ed25519, SumEd25519_12};
+use chain_impl_mockchain::{block::ConsensusVersion, fee::LinearFee};
+use jormungandr_lib::{
+    crypto::{hash::Hash, key::SigningKey},
+    interfaces::{Block0Configuration, BlockchainConfiguration, Initial, InitialUTxO},
+};
+use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, net::SocketAddr};
+
+#[derive(Debug)]
+pub struct Settings {
+    pub nodes: HashMap<NodeAlias, NodeSetting>,
+
+    pub wallets: HashMap<WalletAlias, Wallet>,
+
+    pub block0: Block0Configuration,
+}
+
+/// contains all the data to start or interact with a node
+#[derive(Debug)]
+pub struct NodeSetting {
+    /// for reference purpose only
+    pub alias: NodeAlias,
+
+    /// node secret, this will be passed to the node at start
+    /// up of the node. It may contains the necessary crypto
+    /// for the node to be a blockchain leader (BFT leader or
+    /// stake pool)
+    pub secret: NodeSecret,
+
+    pub config: NodeConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct NodeConfig {
+    pub rest: Rest,
+
+    pub p2p: P2pConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Rest {
+    pub listen: SocketAddr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct P2pConfig {
+    /// The public address to which other peers may connect to
+    pub public_address: String,
+
+    /// the node identifier
+    pub id: poldercast::Id,
+
+    /// the rendezvous points for the peer to connect to in order to initiate
+    /// the p2p discovery from.
+    pub trusted_peers: Vec<TrustedPeer>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TrustedPeer {
+    address: String,
+    id: poldercast::Id,
+}
+
+/// Node Secret(s)
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct NodeSecret {
+    bft: Option<Bft>,
+    genesis: Option<GenesisPraos>,
+}
+
+/// hold the node's bft secret setting
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct Bft {
+    signing_key: SigningKey<Ed25519>,
+}
+
+/// the genesis praos setting
+///
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct GenesisPraos {
+    node_id: Hash,
+    sig_key: SigningKey<SumEd25519_12>,
+    vrf_key: SigningKey<Curve25519_2HashDH>,
+}
+
+impl Settings {
+    pub fn prepare<RNG>(
+        topology: TopologyTemplate,
+        blockchain: BlockchainTemplate,
+        context: &mut Context<RNG>,
+    ) -> Self
+    where
+        RNG: RngCore + CryptoRng,
+    {
+        let mut settings = Settings {
+            nodes: topology
+                .aliases()
+                .map(|alias| (alias.clone(), NodeSetting::prepare(alias.clone(), context)))
+                .collect(),
+            wallets: HashMap::new(),
+            block0: Block0Configuration {
+                blockchain_configuration: BlockchainConfiguration::new(
+                    chain_addr::Discrimination::Test,
+                    ConsensusVersion::Bft,
+                    LinearFee::new(1, 2, 3),
+                ),
+                initial: Vec::new(),
+            },
+        };
+
+        settings.populate_trusted_peers(topology.into_iter());
+        settings.populate_block0_blockchain_configuration(&blockchain, context);
+        settings.populate_block0_blockchain_initials(blockchain.wallets(), context);
+
+        settings
+    }
+
+    fn populate_block0_blockchain_initials<'a, RNG, I>(
+        &'a mut self,
+        wallet_templates: I,
+        context: &mut Context<RNG>,
+    ) where
+        RNG: RngCore + CryptoRng,
+        I: Iterator<Item = &'a WalletTemplate>,
+    {
+        let discrimination = self.block0.blockchain_configuration.discrimination;
+
+        for wallet_template in wallet_templates {
+            // TODO: check the wallet does not already exist ?
+            let wallet = match wallet_template.wallet_type() {
+                WalletType::UTxO => Wallet::generate_utxo(&mut context.rng),
+                WalletType::Account => Wallet::generate_account(&mut context.rng),
+            };
+
+            let initial_address = wallet.address(discrimination);
+
+            // TODO add support for sharing fragment with multiple utxos
+            let initial_fragment = Initial::Fund(vec![InitialUTxO {
+                address: initial_address,
+                value: (*wallet_template.value()).into(),
+            }]);
+
+            self.wallets
+                .insert(wallet_template.alias().clone(), wallet.clone());
+            self.block0.initial.push(initial_fragment);
+
+            if let Some(delegation) = wallet_template.delegate() {
+                use chain_impl_mockchain::certificate::{
+                    Certificate, CertificateContent, StakeDelegation,
+                };
+                use chain_impl_mockchain::stake::StakePoolId;
+
+                // 1. retrieve the public data (we may need to create a stake pool
+                //    registration here)
+                let stake_pool_id: StakePoolId = if let Some(node) = self.nodes.get_mut(delegation)
+                {
+                    if let Some(genesis) = &node.secret.genesis {
+                        StakePoolId::from(genesis.node_id.clone().into_hash())
+                    } else {
+                        // create and register the stake pool
+                        use chain_impl_mockchain::{
+                            leadership::genesis::GenesisPraosLeader, stake::StakePoolInfo,
+                        };
+                        use rand::{distributions::Standard, Rng as _};
+                        let serial: u128 = context.rng.sample(Standard);
+                        let kes_signing_key = SigningKey::generate(&mut context.rng);
+                        let vrf_signing_key = SigningKey::generate(&mut context.rng);
+                        let stake_pool_info = StakePoolInfo {
+                            serial,
+                            owners: Vec::new(),
+                            initial_key: GenesisPraosLeader {
+                                kes_public_key: kes_signing_key.identifier().into_public_key(),
+                                vrf_public_key: vrf_signing_key.identifier().into_public_key(),
+                            },
+                        };
+                        let node_id = stake_pool_info.to_id();
+                        node.secret.genesis = Some(GenesisPraos {
+                            sig_key: kes_signing_key,
+                            vrf_key: vrf_signing_key,
+                            node_id: {
+                                let bytes: [u8; 32] = node_id.clone().into();
+                                bytes.into()
+                            },
+                        });
+
+                        let stake_pool_registration_certificate = Certificate {
+                            signatures: Vec::new(),
+                            content: CertificateContent::StakePoolRegistration(stake_pool_info),
+                        };
+
+                        self.block0
+                            .initial
+                            .push(Initial::Cert(stake_pool_registration_certificate.into()));
+
+                        node_id
+                    }
+                } else {
+                    // delegating to a node that does not exist in the topology
+                    // so generate valid stake pool registration and delegation
+                    // to that node.
+                    unimplemented!("delegating stake to a stake pool that is not a node is not supported (yet)")
+                };
+
+                // 2. retrieve the wallet delegation identifier
+                let stake_key_id = if let Some(stake_key_id) = wallet.stake_key() {
+                    stake_key_id
+                } else {
+                    unimplemented!(
+                        "delegation from a wallet that is not an Account is not supported (yet)"
+                    )
+                };
+
+                // 3. create delegation certificate and add it to the block0.initial array
+                let delegation_certificate = Certificate {
+                    content: CertificateContent::StakeDelegation(StakeDelegation {
+                        stake_key_id,           // 2
+                        pool_id: stake_pool_id, // 1
+                    }),
+                    signatures: Vec::new(), // Leave empty
+                };
+
+                self.block0
+                    .initial
+                    .push(Initial::Cert(delegation_certificate.into()));
+            }
+        }
+    }
+
+    fn populate_block0_blockchain_configuration<RNG>(
+        &mut self,
+        blockchain: &BlockchainTemplate,
+        context: &mut Context<RNG>,
+    ) where
+        RNG: RngCore + CryptoRng,
+    {
+        let mut blockchain_configuration = &mut self.block0.blockchain_configuration;
+
+        // TODO blockchain_configuration.block0_date = ;
+        blockchain_configuration.discrimination = chain_addr::Discrimination::Test;
+        blockchain_configuration.block0_consensus = *blockchain.consensus();
+        blockchain_configuration.consensus_leader_ids = {
+            let mut leader_ids = Vec::new();
+            for leader_alias in blockchain.leaders() {
+                let identifier = if let Some(node) = self.nodes.get_mut(leader_alias) {
+                    if let Some(bft) = &node.secret.bft {
+                        bft.signing_key.identifier()
+                    } else {
+                        let signing_key = SigningKey::generate(&mut context.rng);
+                        let identifier = signing_key.identifier();
+                        node.secret.bft = Some(Bft { signing_key });
+                        identifier
+                    }
+                } else {
+                    SigningKey::<Ed25519>::generate(&mut context.rng).identifier()
+                };
+                leader_ids.push(identifier.into());
+            }
+            leader_ids
+        };
+        // TODO blockchain_configuration.linear_fees = ;
+        // TODO blockchain_configuration.slots_per_epoch = ;
+        // TODO blockchain_configuration.slot_duration = ;
+        // TODO blockchain_configuration.kes_update_speed = ;
+        // TODO blockchain_configuration.consensus_genesis_praos_active_slot_coeff = ;
+        // TODO blockchain_configuration.bft_slots_ratio = ;
+    }
+
+    fn populate_trusted_peers<I>(&mut self, i: I)
+    where
+        I: Iterator<Item = (NodeAlias, NodeTemplate)>,
+    {
+        for (alias, node_template) in i {
+            let mut trusted_peers = Vec::new();
+
+            for trusted_peer in node_template.trusted_peers() {
+                let trusted_peer = self.nodes.get(trusted_peer).unwrap();
+
+                trusted_peers.push(trusted_peer.config.p2p.make_trusted_peer_setting());
+            }
+
+            let node = self.nodes.get_mut(&alias).unwrap();
+            node.config.p2p.trusted_peers = trusted_peers;
+        }
+    }
+}
+
+impl NodeSetting {
+    fn prepare<RNG>(alias: NodeAlias, context: &mut Context<RNG>) -> Self
+    where
+        RNG: RngCore + CryptoRng,
+    {
+        NodeSetting {
+            alias,
+            config: NodeConfig::prepare(context),
+            secret: NodeSecret::prepare(context),
+        }
+    }
+
+    pub fn config(&self) -> &NodeConfig {
+        &self.config
+    }
+
+    pub fn secrets(&self) -> &NodeSecret {
+        &self.secret
+    }
+}
+
+impl NodeSecret {
+    pub fn prepare<RNG>(_context: &mut Context<RNG>) -> Self
+    where
+        RNG: RngCore + CryptoRng,
+    {
+        NodeSecret {
+            bft: None,
+            genesis: None,
+        }
+    }
+}
+
+impl NodeConfig {
+    pub fn prepare<RNG>(context: &mut Context<RNG>) -> Self
+    where
+        RNG: RngCore,
+    {
+        NodeConfig {
+            rest: Rest::prepare(context),
+            p2p: P2pConfig::prepare(context),
+        }
+    }
+}
+
+impl Rest {
+    pub fn prepare<RNG>(context: &mut Context<RNG>) -> Self
+    where
+        RNG: RngCore,
+    {
+        Rest {
+            listen: context.generate_new_rest_listen_address(),
+        }
+    }
+}
+
+impl P2pConfig {
+    pub fn prepare<RNG>(context: &mut Context<RNG>) -> Self
+    where
+        RNG: RngCore,
+    {
+        P2pConfig {
+            public_address: context.generate_new_grpc_public_address(),
+            id: poldercast::Id::generate(&mut context.rng),
+            trusted_peers: Vec::new(),
+        }
+    }
+
+    fn make_trusted_peer_setting(&self) -> TrustedPeer {
+        TrustedPeer {
+            id: self.id.clone(),
+            address: self.public_address.clone(),
+        }
+    }
+}

--- a/jormungandr-integration-tests/src/v2/scenario/settings.rs
+++ b/jormungandr-integration-tests/src/v2/scenario/settings.rs
@@ -266,9 +266,10 @@ impl Settings {
             }
             leader_ids
         };
+        blockchain_configuration.slots_per_epoch = *blockchain.slots_per_epoch();
+        blockchain_configuration.slot_duration = *blockchain.slot_duration();
+
         // TODO blockchain_configuration.linear_fees = ;
-        // TODO blockchain_configuration.slots_per_epoch = ;
-        // TODO blockchain_configuration.slot_duration = ;
         // TODO blockchain_configuration.kes_update_speed = ;
         // TODO blockchain_configuration.consensus_genesis_praos_active_slot_coeff = ;
         // TODO blockchain_configuration.bft_slots_ratio = ;

--- a/jormungandr-integration-tests/src/v2/scenario/topology.rs
+++ b/jormungandr-integration-tests/src/v2/scenario/topology.rs
@@ -1,0 +1,96 @@
+use std::{borrow::Borrow, collections::HashMap, hash::Hash};
+
+pub type NodeAlias = String;
+
+#[derive(Debug)]
+pub struct Node {
+    alias: NodeAlias,
+
+    trusted_peers: Vec<NodeAlias>,
+}
+
+#[derive(Debug)]
+pub struct Topology {
+    nodes: HashMap<NodeAlias, Node>,
+}
+
+pub struct TopologyBuilder {
+    nodes: HashMap<NodeAlias, Node>,
+}
+
+impl Node {
+    pub fn new<S: Into<NodeAlias>>(alias: S) -> Self {
+        Node {
+            alias: alias.into(),
+            trusted_peers: Vec::new(),
+        }
+    }
+
+    pub fn alias(&self) -> &NodeAlias {
+        &self.alias
+    }
+
+    pub fn add_trusted_peer<S: Into<NodeAlias>>(&mut self, peer: S) {
+        self.trusted_peers.push(peer.into())
+    }
+
+    pub fn trusted_peers<'a>(&'a self) -> impl Iterator<Item = &'a NodeAlias> {
+        self.trusted_peers.iter()
+    }
+}
+
+impl Topology {
+    pub fn node<K>(&self, alias: &K) -> Option<&Node>
+    where
+        NodeAlias: Borrow<K>,
+        K: Hash + Eq,
+    {
+        self.nodes.get(alias)
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = (NodeAlias, Node)> {
+        self.nodes.into_iter()
+    }
+
+    pub fn aliases<'a>(&'a self) -> impl Iterator<Item = &'a NodeAlias> {
+        self.nodes.keys()
+    }
+
+    pub fn format_into_graphviz_dot<W: std::io::Write>(&self, mut writer: W) -> std::io::Result<W> {
+        writeln!(writer, "digraph NodeTopology {{")?;
+
+        for node in self.nodes.values() {
+            for edge in node.trusted_peers() {
+                writeln!(writer, "  {} -> {}", node.alias(), edge)?;
+            }
+        }
+
+        writeln!(writer, "}}")?;
+
+        Ok(writer)
+    }
+}
+
+impl TopologyBuilder {
+    pub fn new() -> Self {
+        TopologyBuilder {
+            nodes: HashMap::new(),
+        }
+    }
+
+    pub fn register_node(&mut self, node: Node) {
+        self.nodes.insert(node.alias().clone(), node);
+    }
+
+    pub fn build(self) -> Topology {
+        for node in self.nodes.values() {
+            for trusted_peer in node.trusted_peers() {
+                if !self.nodes.contains_key(trusted_peer) {
+                    panic!("Trusted peer has not been defined")
+                }
+            }
+        }
+
+        Topology { nodes: self.nodes }
+    }
+}

--- a/jormungandr-integration-tests/src/v2/scenario/wallet.rs
+++ b/jormungandr-integration-tests/src/v2/scenario/wallet.rs
@@ -1,0 +1,57 @@
+use crate::v2::scenario::NodeAlias;
+use chain_impl_mockchain::value::Value;
+
+pub type WalletAlias = String;
+
+#[derive(Debug)]
+pub enum WalletType {
+    Account,
+    UTxO,
+}
+
+#[derive(Debug)]
+pub struct Wallet {
+    alias: WalletAlias,
+    value: Value,
+    wallet_type: WalletType,
+    delegate: Option<NodeAlias>,
+}
+
+impl Wallet {
+    pub fn new_account<S: Into<WalletAlias>>(alias: S, value: Value) -> Self {
+        Self::new(alias, value, WalletType::Account)
+    }
+    pub fn new_utxo<S: Into<WalletAlias>>(alias: S, value: Value) -> Self {
+        Self::new(alias, value, WalletType::UTxO)
+    }
+
+    #[inline]
+    fn new<S: Into<WalletAlias>>(alias: S, value: Value, wallet_type: WalletType) -> Self {
+        Wallet {
+            alias: alias.into(),
+            value,
+            wallet_type,
+            delegate: None,
+        }
+    }
+
+    pub fn alias(&self) -> &WalletAlias {
+        &self.alias
+    }
+
+    pub fn wallet_type(&self) -> &WalletType {
+        &self.wallet_type
+    }
+
+    pub fn value(&self) -> &Value {
+        &self.value
+    }
+
+    pub fn delegate(&self) -> &Option<NodeAlias> {
+        &self.delegate
+    }
+
+    pub fn delegate_mut(&mut self) -> &mut Option<NodeAlias> {
+        &mut self.delegate
+    }
+}

--- a/jormungandr-integration-tests/src/v2/slog.rs
+++ b/jormungandr-integration-tests/src/v2/slog.rs
@@ -1,0 +1,103 @@
+use bytes::BytesMut;
+use serde_json::{Map, Value};
+use std::convert::TryFrom;
+use tokio::codec::Decoder;
+
+#[derive(Debug, Clone)]
+pub struct StructuredLog {
+    level: slog::Level,
+    message: String,
+
+    full_log: serde_json::Map<String, Value>,
+}
+
+/// Structural log decoder
+///
+/// For the testing purpose of jormungandr we will assume the structural
+/// logs to always be in JSON output format
+///
+pub struct SlogCodec(tokio::codec::LinesCodec);
+
+error_chain! {
+    foreign_links {
+        Io(::std::io::Error);
+    }
+
+    errors {
+        InvalidJSON {
+            description("Invalid log format, expected JSON object"),
+            display("Invalid log format, expected JSON object"),
+        }
+
+        FieldNotFound(key: String) {
+            description("Field not found"),
+            display("Field not found in the SLOG: {}", key),
+        }
+
+        InvalidValue(value: Value) {
+            description("Cannot parse value"),
+            display("cannot parse value `{}`", value),
+        }
+
+        InvalidLog {
+            description("Invalid log"),
+            display("Invalid log format, cannot parse"),
+        }
+    }
+}
+
+impl TryFrom<Map<String, Value>> for StructuredLog {
+    type Error = Error;
+
+    fn try_from(map: Map<String, Value>) -> Result<Self> {
+        let level = map_get(&map, "level")
+            .and_then(value_is_str)
+            .and_then(|s| s.parse().map_err(|()| ErrorKind::InvalidLog.into()))
+            .chain_err(|| "`level`")?;
+        let message = map_get(&map, "msg")
+            .and_then(value_is_str)
+            .and_then(|s| s.parse().chain_err(|| ErrorKind::InvalidLog))
+            .chain_err(|| "`msg`")?;
+        Ok(StructuredLog {
+            level,
+            message,
+            full_log: map,
+        })
+    }
+}
+
+impl Decoder for SlogCodec {
+    type Item = StructuredLog;
+    type Error = Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>> {
+        let line = self.0.decode(buf)?;
+
+        if let Some(line) = line {
+            serde_json::from_str(&line)
+                .chain_err(|| ErrorKind::InvalidJSON)
+                .and_then(|map: Map<_, _>| StructuredLog::try_from(map))
+                .map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[inline]
+fn map_get<'a>(map: &'a Map<String, Value>, key: &str) -> Result<&'a Value> {
+    if let Some(value) = map.get(key) {
+        Ok(value)
+    } else {
+        Err(ErrorKind::FieldNotFound(key.to_owned()).into())
+    }
+}
+
+#[inline]
+fn value_is_str<'a>(value: &'a Value) -> Result<&'a str> {
+    if let Value::String(string) = value {
+        Ok(&string)
+    } else {
+        Err(ErrorKind::InvalidValue(value.to_owned()).into())
+    }
+}

--- a/jormungandr-integration-tests/src/v2/wallet/account.rs
+++ b/jormungandr-integration-tests/src/v2/wallet/account.rs
@@ -1,0 +1,113 @@
+use crate::v2::wallet::{ErrorKind, Result, ResultExt};
+use chain_addr::Discrimination;
+use chain_impl_mockchain::{
+    account,
+    fee::{FeeAlgorithm, LinearFee},
+    transaction::{
+        AccountIdentifier, Balance, Input, Transaction, TransactionSignDataHash, Witness,
+    },
+    txbuilder::{self, TransactionBuilder},
+    value::Value,
+};
+use jormungandr_lib::{
+    crypto::{
+        account::{Identifier, SigningKey},
+        hash::Hash,
+    },
+    interfaces::Address,
+};
+use rand_core::{CryptoRng, RngCore};
+
+/// wallet for an account
+#[derive(Debug, Clone)]
+pub struct Wallet {
+    /// the spending key
+    signing_key: SigningKey,
+
+    /// the identifier of the account
+    identifier: Identifier,
+
+    /// the counter as we know of this value needs to be in sync
+    /// with what is in the blockchain
+    internal_counter: account::SpendingCounter,
+}
+
+impl Wallet {
+    pub fn generate<RNG>(rng: &mut RNG) -> Self
+    where
+        RNG: CryptoRng + RngCore,
+    {
+        let signing_key = SigningKey::generate(rng);
+        let identifier = signing_key.identifier();
+        Wallet {
+            signing_key,
+            identifier,
+            internal_counter: account::SpendingCounter::zero(),
+        }
+    }
+
+    pub fn address(&self, discrimination: Discrimination) -> Address {
+        self.identifier().to_address(discrimination).into()
+    }
+
+    pub fn internal_counter(&self) -> &account::SpendingCounter {
+        &self.internal_counter
+    }
+
+    pub fn stake_key(&self) -> AccountIdentifier {
+        AccountIdentifier::from_single_account(self.identifier().clone().to_inner())
+    }
+
+    pub fn identifier(&self) -> &Identifier {
+        &self.identifier
+    }
+
+    pub fn signing_key(&self) -> &SigningKey {
+        &self.signing_key
+    }
+
+    pub fn mk_witness(
+        &self,
+        block0_hash: &Hash,
+        signing_data: &TransactionSignDataHash,
+    ) -> Result<Witness> {
+        Ok(Witness::new_account(
+            &block0_hash.clone().into_hash(),
+            signing_data,
+            self.internal_counter(),
+            self.signing_key().as_ref(),
+        ))
+    }
+
+    pub fn add_input<Extra: Clone>(
+        &self,
+        txbuilder: &mut TransactionBuilder<chain_addr::Address, Extra>,
+        fees: &LinearFee,
+    ) -> Result<txbuilder::OutputPolicy>
+    where
+        LinearFee: FeeAlgorithm<Transaction<chain_addr::Address, Extra>>,
+    {
+        let identifier: chain_impl_mockchain::account::Identifier =
+            self.identifier().to_inner().into();
+        let balance = txbuilder
+            .get_balance(fees)
+            .chain_err(|| ErrorKind::CannotComputeBalance)?;
+        let value = match balance {
+            Balance::Negative(value) => value,
+            Balance::Zero => bail!(ErrorKind::TransactionAlreadyBalanced),
+            Balance::Positive(value) => {
+                bail!(ErrorKind::TransactionAlreadyExtraValue(value.into()))
+            }
+        };
+
+        // we are going to add an input
+        let value = (value + Value(fees.coefficient))
+            .chain_err(|| ErrorKind::CannotAddCostOfExtraInput(fees.coefficient))?;
+
+        let input = Input::from_account_single(identifier, value);
+
+        txbuilder.add_input(&input);
+
+        Ok(txbuilder::OutputPolicy::Forget)
+    }
+}

--- a/jormungandr-integration-tests/src/v2/wallet/mod.rs
+++ b/jormungandr-integration-tests/src/v2/wallet/mod.rs
@@ -1,0 +1,144 @@
+mod account;
+mod utxo;
+
+use chain_addr::Discrimination;
+use chain_impl_mockchain::{fee::LinearFee, fragment::Fragment, transaction::AccountIdentifier};
+use jormungandr_lib::{
+    crypto::hash::Hash,
+    interfaces::{Address, Value},
+};
+use rand_core::{CryptoRng, RngCore};
+
+error_chain! {
+    foreign_links {
+        Io(::std::io::Error);
+    }
+
+    errors {
+        CannotAddInput {
+            description("Cannot add input to the transaction"),
+        }
+
+        CannotMakeWitness {
+            description("Cannot make witness for the transaction"),
+        }
+
+        CannotComputeBalance {
+            description("Cannot compute the transaction's balance")
+        }
+
+        CannotAddCostOfExtraInput(fee: u64) {
+            description("cannot compute the new fees for adding the new input")
+            display("Cannot compute the new fees of {} for a new input", fee),
+        }
+
+        TransactionAlreadyBalanced {
+            description("Transaction already balanced")
+        }
+
+        TransactionAlreadyExtraValue(value: Value) {
+            description("Transaction has already more inputs than needed"),
+            display("The transaction has {} value extra than necessary", value),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Inner {
+    Account(account::Wallet),
+    UTxO(utxo::Wallet),
+}
+
+/// wallet to utilise when testing jormungandr
+///
+/// This can be used for a faucet
+#[derive(Debug, Clone)]
+pub struct Wallet {
+    inner: Inner,
+}
+
+impl Wallet {
+    pub fn generate_account<RNG>(rng: &mut RNG) -> Self
+    where
+        RNG: CryptoRng + RngCore,
+    {
+        Wallet {
+            inner: Inner::Account(account::Wallet::generate(rng)),
+        }
+    }
+
+    pub fn generate_utxo<RNG>(rng: &mut RNG) -> Self
+    where
+        RNG: CryptoRng + RngCore,
+    {
+        Wallet {
+            inner: Inner::UTxO(utxo::Wallet::generate(rng)),
+        }
+    }
+
+    pub fn address(&self, discrimination: Discrimination) -> Address {
+        match &self.inner {
+            Inner::Account(account) => account.address(discrimination),
+            Inner::UTxO(_utxo) => unimplemented!(),
+        }
+    }
+
+    pub fn stake_key(&self) -> Option<AccountIdentifier> {
+        match &self.inner {
+            Inner::Account(account) => Some(account.stake_key()),
+            Inner::UTxO(_utxo) => unimplemented!(),
+        }
+    }
+
+    /// simple function to create a transaction with only one output to the given
+    /// address and of the given Value.
+    ///
+    pub fn transaction_to(
+        &mut self,
+        block0_hash: &Hash,
+        fees: &LinearFee,
+        address: Address,
+        value: Value,
+    ) -> Result<Fragment> {
+        use chain_impl_mockchain::txbuilder::{
+            GeneratedTransaction, TransactionBuilder, TransactionFinalizer,
+        };
+
+        let mut txbuilder = TransactionBuilder::new();
+
+        txbuilder.add_output(address.into(), value.into());
+
+        let output_policy = match &mut self.inner {
+            Inner::Account(account) => account
+                .add_input(&mut txbuilder, fees)
+                .chain_err(|| "Cannot get inputs from the account")?,
+            Inner::UTxO(_utxo) => unimplemented!(),
+        };
+
+        let (_, tx) = txbuilder
+            .finalize(fees, output_policy)
+            .chain_err(|| "Cannot finalize the transaction")?;
+        let mut finalizer = TransactionFinalizer::new_trans(tx);
+
+        let sign_data = finalizer.get_txid();
+
+        let witness = match &mut self.inner {
+            Inner::Account(account) => account
+                .mk_witness(block0_hash, &sign_data)
+                .chain_err(|| "Cannot create witness from account")?,
+            Inner::UTxO(_utxo) => unimplemented!(),
+        };
+
+        finalizer
+            .set_witness(0, witness)
+            .chain_err(|| "Cannot add witness")?;
+
+        match finalizer
+            .build()
+            .chain_err(|| "Cannot generate the finalized transaction")?
+        {
+            GeneratedTransaction::Type1(transaction) => Ok(Fragment::Transaction(transaction)),
+            _ => unimplemented!(),
+        }
+    }
+}

--- a/jormungandr-integration-tests/src/v2/wallet/utxo.rs
+++ b/jormungandr-integration-tests/src/v2/wallet/utxo.rs
@@ -1,0 +1,63 @@
+use jormungandr_lib::{crypto::key, interfaces::UTxOInfo};
+use rand_chacha::ChaChaRng;
+use rand_core::{CryptoRng, RngCore, SeedableRng};
+
+pub type SpendingKey = key::SigningKey<chain_crypto::Ed25519>;
+pub type Identifier = key::Identifier<chain_crypto::Ed25519>;
+
+/// wallet for an account
+#[derive(Debug, Clone)]
+pub struct Wallet {
+    /// this is the root seed of the wallet, everytime we will require
+    /// the wallet to update we will update the rng, we keep the `seed`
+    /// so we may reproduce the steps of the wallet
+    seed: [u8; 32],
+
+    rng: ChaChaRng,
+
+    /// the spending key
+    signing_keys: Vec<SpendingKey>,
+
+    /// utxos with the index in the `signing_keys` so we can later
+    /// sign the witness for the next transaction,
+    utxos: Vec<(usize, UTxOInfo)>,
+}
+
+impl Wallet {
+    pub fn generate<RNG>(rng: &mut RNG) -> Self
+    where
+        RNG: CryptoRng + RngCore,
+    {
+        let mut seed = [0; 32];
+        rng.fill_bytes(&mut seed);
+
+        seed.into()
+    }
+
+    pub fn generate_new_signing_key(&mut self) -> &SpendingKey {
+        let key = key::SigningKey::generate(&mut self.rng);
+
+        self.signing_keys.push(key);
+
+        self.signing_keys.get(self.signing_keys.len() - 1).unwrap()
+    }
+
+    pub fn signing_keys<'a>(&'a self) -> impl Iterator<Item = &'a SpendingKey> {
+        self.signing_keys.iter()
+    }
+}
+
+impl From<[u8; 32]> for Wallet {
+    fn from(seed: [u8; 32]) -> Self {
+        let mut wallet = Wallet {
+            signing_keys: Vec::new(),
+            seed: seed.clone(),
+            rng: ChaChaRng::from_seed(seed),
+            utxos: Vec::new(),
+        };
+
+        wallet.generate_new_signing_key();
+
+        wallet
+    }
+}

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
@@ -23,16 +23,16 @@ pub struct BlockchainConfiguration {
     ///
     /// any value between 0 (1/1/1970) and 1099511627775 (20/08/4147) is valid
     #[serde(default)]
-    block0_date: SecondsSinceUnixEpoch,
+    pub block0_date: SecondsSinceUnixEpoch,
 
     /// the address discrimination (test or production)
     #[serde(with = "DiscriminationDef")]
-    discrimination: Discrimination,
+    pub discrimination: Discrimination,
 
     /// the type of consensus to utilise from the starting point of the
     /// blockchain. `bft` or `genesis`
     #[serde(with = "ConsensusVersionDef")]
-    block0_consensus: ConsensusVersion,
+    pub block0_consensus: ConsensusVersion,
 
     /// the list of consensus leaders
     ///
@@ -46,7 +46,7 @@ pub struct BlockchainConfiguration {
     ///
     /// If the `consensus_version` is `bft`. This value cannot be left empty.
     #[serde(default)]
-    consensus_leader_ids: Vec<ConsensusLeaderId>,
+    pub consensus_leader_ids: Vec<ConsensusLeaderId>,
 
     /// the linear fee settings.
     ///
@@ -57,17 +57,17 @@ pub struct BlockchainConfiguration {
     /// `constant + coefficient * (num_inputs + num_outputs) [+ certificate]`
     ///
     #[serde(with = "LinearFeeDef")]
-    linear_fees: LinearFee,
+    pub linear_fees: LinearFee,
 
     /// number of slots in one given epoch. The default value is `720`.
     ///
     #[serde(default)]
-    slots_per_epoch: NumberOfSlotsPerEpoch,
+    pub slots_per_epoch: NumberOfSlotsPerEpoch,
 
     /// the number of seconds between the creation of 2 slots. The default
     /// is `5` seconds.
     #[serde(default)]
-    slot_duration: SlotDuration,
+    pub slot_duration: SlotDuration,
 
     /// number of seconds between 2 required KES Key updates.
     ///
@@ -76,34 +76,34 @@ pub struct BlockchainConfiguration {
     /// cannot reuse a key that was valid at a given state when
     /// to create a fork.
     #[serde(default)]
-    kes_update_speed: KESUpdateSpeed,
+    pub kes_update_speed: KESUpdateSpeed,
 
     /// the active slot coefficient to determine the minimal stake
     /// in order to participate to the consensus.
     ///
     /// default value is 0.1
     #[serde(default)]
-    consensus_genesis_praos_active_slot_coeff: ActiveSlotCoefficient,
+    pub consensus_genesis_praos_active_slot_coeff: ActiveSlotCoefficient,
 
     /// allow BFT and Genesis Praos to live together by allocating some
     /// slots to the `consensus_leader_ids` (the BFT Leaders).
     ///
     /// default value is 0.22.
     #[serde(default)]
-    bft_slots_ratio: BFTSlotsRatio,
+    pub bft_slots_ratio: BFTSlotsRatio,
 
     /// TODO: need some love
     /// this value is left for compatibility only but should be removed or
     /// replaced by something more meaningful: max block size (in bytes)
     #[serde(default)]
-    max_number_of_transactions_per_block: Option<u32>,
+    pub max_number_of_transactions_per_block: Option<u32>,
 
     /// TODO: need some love
     /// this value is left for compatibility only be should be removed
     /// or replaced by something more meaningful or merged with
     /// `slots_per_epoch`.
     #[serde(default)]
-    epoch_stability_depth: Option<u32>,
+    pub epoch_stability_depth: Option<u32>,
 }
 
 impl From<BlockchainConfiguration> for ConfigParams {

--- a/jormungandr-lib/src/interfaces/block0_configuration/leader_id.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/leader_id.rs
@@ -1,3 +1,4 @@
+use crate::crypto::key::Identifier;
 use chain_crypto::{bech32::Bech32 as _, Ed25519, PublicKey};
 use chain_impl_mockchain::{config::ConfigParam, leadership::bft::LeaderId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -23,6 +24,12 @@ impl TryFrom<ConfigParam> for ConsensusLeaderId {
 impl From<ConsensusLeaderId> for ConfigParam {
     fn from(consensus_leader_id: ConsensusLeaderId) -> Self {
         ConfigParam::AddBftLeader(consensus_leader_id.0)
+    }
+}
+
+impl From<Identifier<Ed25519>> for ConsensusLeaderId {
+    fn from(identifier: Identifier<Ed25519>) -> Self {
+        ConsensusLeaderId(LeaderId::from(identifier.into_public_key()))
     }
 }
 


### PR DESCRIPTION
This new code provide new experiment to describe more complex test setup
it is still at early stage now as there is still a lot to do but it provides
a better overview on how to describe tests from an higher point of new

fix #437 

the real value is here:

```rust
    // new context of execution, will hold the pseudo random generator and all
    // necessary jazz
    let mut context = scenario::Context::new();

    // the scenario initial description
    let mut scenario = prepare_scenario! {
        &mut context,

        // the initial topology as defined in the config files of each node
        //
        // here we will describe 2 nodes (1 and 2) with node2 having node1
        // as a trusted peer.
        topology [
            "node1",
            "node2" -> "node1",
        ]

        // here we define the actual blockchain initial setup (the block0).
        //
        // it starts as BFT consensus with node 1 and 2 as BFT leaders,
        // the cryptographic material will be generated automatically from the `context` and
        // will be associated to the appropriate nodes.
        //
        // we also describes 2 initials funds, here 2 accounts for faucet 1 and 2.
        // with an implicitly created delegation certificate to node 2 (also the node 2
        // will also have the cryptographic material generated for a stake pool and the
        // certificate will be automatically generated).
        blockchain {
            consensus = Bft,
            leaders = [ "node1", "node2" ],
            initials = [
                account "faucet1" with 1_000_000_000,
                account "faucet2" with 2_000_000_000 delegates to "node2",
            ],
        }
    }
    .unwrap();
```