### PR TITLE
[Tests] Fixed test_genesis_stake_pool_with_utxo_faucet_starts_successfully

### DIFF
--- a/jormungandr-integration-tests/src/common/data/address.rs
+++ b/jormungandr-integration-tests/src/common/data/address.rs
@@ -15,7 +15,7 @@ pub struct Delegation {
     pub private_key: String,
     pub public_key: String,
     pub address: String,
-    pub delegation_address: String,
+    pub delegation_key: String,
 }
 
 pub trait AddressDataProvider {

--- a/jormungandr-integration-tests/src/common/startup/mod.rs
+++ b/jormungandr-integration-tests/src/common/startup/mod.rs
@@ -62,38 +62,25 @@ pub fn create_new_account_address() -> Account {
 }
 
 pub fn create_new_delegation_address() -> Delegation {
-    let private_key = jcli_wrapper::assert_key_generate_default();
-    let public_key = jcli_wrapper::assert_key_to_public_default(&private_key);
-    let address = jcli_wrapper::assert_address_single(&public_key, Discrimination::Test);
-
     let private_delegation_key = jcli_wrapper::assert_key_generate_default();
     let public_delegation_key = jcli_wrapper::assert_key_to_public_default(&private_delegation_key);
-    let delegation_address =
-        jcli_wrapper::assert_address_single(&public_delegation_key, Discrimination::Test);
-
-    let utxo_with_delegation = Delegation {
-        private_key,
-        public_key,
-        address,
-        delegation_address,
-    };
-    println!(
-        "New utxo with delegation generated: {:?}",
-        &utxo_with_delegation
-    );
-    utxo_with_delegation
+    create_new_delegation_address_for(&public_delegation_key)
 }
 
-pub fn create_new_delegation_address_for(delegation_address: &str) -> Delegation {
+pub fn create_new_delegation_address_for(delegation_public_key: &str) -> Delegation {
     let private_key = jcli_wrapper::assert_key_generate_default();
     let public_key = jcli_wrapper::assert_key_to_public_default(&private_key);
-    let address = jcli_wrapper::assert_address_single(&public_key, Discrimination::Test);
+    let address = jcli_wrapper::assert_address_delegation(
+        &public_key,
+        delegation_public_key,
+        Discrimination::Test,
+    );
 
     let utxo_with_delegation = Delegation {
         private_key: private_key,
         public_key: public_key,
         address: address,
-        delegation_address: delegation_address.to_string(),
+        delegation_key: delegation_public_key.to_string(),
     };
     println!(
         "New utxo with delegation generated: {:?}",

--- a/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
@@ -64,7 +64,6 @@ pub fn test_genesis_stake_pool_with_account_faucet_starts_successfully() {
 }
 
 #[test]
-#[ignore] // due to bug https://github.com/input-output-hk/jormungandr/issues/465
 pub fn test_genesis_stake_pool_with_utxo_faucet_starts_successfully() {
     // stake key
     let stake_key = startup::create_new_key_pair("Ed25519Extended");
@@ -79,7 +78,7 @@ pub fn test_genesis_stake_pool_with_utxo_faucet_starts_successfully() {
 
     // note we use the faucet as the owner to this pool
     let stake_key = faucet.private_key;
-    let stake_key_pub = faucet.public_key;
+    let stake_key_pub = faucet.delegation_key;
 
     let stake_key_file = file_utils::create_file_in_temp("stake_key.sk", &stake_key);
 
@@ -102,7 +101,7 @@ pub fn test_genesis_stake_pool_with_utxo_faucet_starts_successfully() {
     );
 
     let mut config = startup::ConfigurationBuilder::new()
-        .with_block0_consensus("genesis")
+        .with_block0_consensus("genesis_praos")
         .with_bft_slots_ratio("0".to_owned())
         .with_consensus_genesis_praos_active_slot_coeff("0.1")
         .with_consensus_leaders_ids(vec![leader.public_key.clone()])


### PR DESCRIPTION
- uncommented ignore attribute
- Changed genesis -> genesis_praos as a consensus parameter
- Fixed delegation address setup (which caused invalid account error during start of the node)

fixes #465 