### PR TITLE
Testing scenario managing test flow

### DIFF
--- a/jormungandr-scenario-tests/src/main.rs
+++ b/jormungandr-scenario-tests/src/main.rs
@@ -97,6 +97,7 @@ use rand_chacha::ChaChaRng;
 
 pub fn scenario_1(mut context: Context<ChaChaRng>) {
     let scenario_settings = prepare_scenario! {
+        "simple network example",
         &mut context,
         topology [
             "node1",

--- a/jormungandr-scenario-tests/src/main.rs
+++ b/jormungandr-scenario-tests/src/main.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate jormungandr_scenario_tests;
 
-use jormungandr_scenario_tests::{prepare_command, style, Context, Controller, Seed};
+use jormungandr_scenario_tests::{prepare_command, style, Context, Seed};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -16,6 +16,19 @@ struct CommandArgs {
     #[structopt(long = "jcli", default_value = "jcli")]
     jcli: PathBuf,
 
+    /// set a directory in which the tests will be run, allowing every details
+    /// to be save persistently. By default it will create temporary directories
+    /// and will delete the files and documents
+    #[structopt(long = "root-dir")]
+    testing_directory: Option<PathBuf>,
+
+    /// document the different scenario, creating markdown and dot (graphviz) files
+    /// describing the tests initial setup
+    ///
+    /// The files are created within the `--root-dir`  directory.
+    #[structopt(long = "document")]
+    generate_documentation: bool,
+
     /// to set if to reproduce an existing test
     #[structopt(long = "seed")]
     seed: Option<Seed>,
@@ -29,8 +42,16 @@ fn main() {
     let seed = command_args
         .seed
         .unwrap_or_else(|| Seed::generate(rand::rngs::OsRng::new().unwrap()));
+    let testing_directory = command_args.testing_directory;
+    let generate_documentation = command_args.generate_documentation;
 
-    let mut context = Context::new(seed, jormungandr, jcli);
+    let mut context = Context::new(
+        seed,
+        jormungandr,
+        jcli,
+        testing_directory,
+        generate_documentation,
+    );
 
     introduction(&context);
 
@@ -93,7 +114,7 @@ pub fn scenario_1(mut context: Context<ChaChaRng>) {
         }
     };
 
-    let mut controller = Controller::new(scenario_settings, context).unwrap();
+    let mut controller = scenario_settings.build(context).unwrap();
 
     let node1 = controller.spawn_node("node1", true).unwrap();
     let node2 = controller.spawn_node("node2", false).unwrap();

--- a/jormungandr-scenario-tests/src/node.rs
+++ b/jormungandr-scenario-tests/src/node.rs
@@ -247,8 +247,11 @@ impl Node {
     }
 
     fn progress_bar_start(&self) {
-        self.progress_bar
-            .set_style(indicatif::ProgressStyle::default_spinner().tick_chars("/|\\- "));
+        self.progress_bar.set_style(
+            indicatif::ProgressStyle::default_spinner()
+                .template("{spinner:.green} {wide_msg}")
+                .tick_chars(style::TICKER),
+        );
         self.progress_bar.enable_steady_tick(100);
         self.progress_bar.set_message(&format!(
             "{} {} ... [{}]",

--- a/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -1,50 +1,124 @@
 use crate::{
-    scenario::{settings::Settings, ContextChaCha, ErrorKind, Result},
+    scenario::{settings::Settings, Blockchain, ContextChaCha, ErrorKind, Result, Topology},
     style, Node, NodeBlock0, NodeController,
 };
 use chain_impl_mockchain::block::HeaderHash;
 use indicatif::{MultiProgress, ProgressBar};
-use mktemp::Temp;
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio::prelude::*;
 use tokio::runtime;
+
+pub struct ControllerBuilder {
+    title: String,
+    controller_progress: ProgressBar,
+
+    topology: Option<Topology>,
+    blockchain: Option<Blockchain>,
+    settings: Option<Settings>,
+}
 
 pub struct Controller {
     settings: Arc<Settings>,
 
     context: ContextChaCha,
 
-    block0_file: Temp,
+    working_directory: PathBuf,
+
+    block0_file: PathBuf,
     block0_hash: HeaderHash,
 
     progress_bar: Arc<MultiProgress>,
     progress_bar_thread: Option<std::thread::JoinHandle<()>>,
 
-    startup_progress_bar: ProgressBar,
-
     runtime: runtime::Runtime,
 }
 
+impl ControllerBuilder {
+    pub fn new(title: &str) -> Self {
+        let controller_progress = ProgressBar::new(10);
+        controller_progress.set_prefix(&format!("{} {}", *style::icons::scenario, title));
+        controller_progress.set_message("building...");
+        controller_progress.set_style(
+            indicatif::ProgressStyle::default_spinner()
+                .template("{spinner:.green} {prefix:.bold.dim} [{bar:10.cyan/blue}] [{elapsed_precise}] {wide_msg}")
+                .tick_chars(style::TICKER)
+        );
+        controller_progress.enable_steady_tick(100);
+
+        ControllerBuilder {
+            title: title.to_owned(),
+            controller_progress,
+            topology: None,
+            blockchain: None,
+            settings: None,
+        }
+    }
+
+    pub fn set_topology(&mut self, topology: Topology) {
+        self.controller_progress.inc(1);
+        self.topology = Some(topology)
+    }
+
+    pub fn set_blockchain(&mut self, blockchain: Blockchain) {
+        self.controller_progress.inc(1);
+        self.blockchain = Some(blockchain)
+    }
+
+    pub fn build_settings(&mut self, context: &mut ContextChaCha) {
+        self.controller_progress.inc(1);
+        let topology = std::mem::replace(&mut self.topology, None).unwrap();
+        let blockchain = std::mem::replace(&mut self.blockchain, None).unwrap();
+        self.settings = Some(Settings::prepare(topology, blockchain, context));
+        self.controller_progress.inc(5);
+    }
+
+    pub fn build(self, context: ContextChaCha) -> Result<Controller> {
+        let working_directory = context.working_directory().join(&self.title);
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .create(&working_directory)?;
+        if context.generate_documentation() {
+            self.document(&working_directory)?;
+        }
+        self.controller_progress.finish_and_clear();
+        self.summary();
+        Controller::new(self.settings.unwrap(), context, working_directory)
+    }
+
+    fn summary(&self) {
+        println!(
+            r###"
+# Running {title}
+        "###,
+            title = style::scenario_title.apply_to(&self.title)
+        )
+    }
+
+    fn document(&self, path: &Path) -> Result<()> {
+        if let Some(settings) = &self.settings {
+            let file = std::fs::File::create(&path.join("initial_setup.dot"))?;
+
+            settings.dottify(file)?;
+        }
+
+        Ok(())
+    }
+}
+
 impl Controller {
-    pub fn new(settings: Settings, context: ContextChaCha) -> Result<Self> {
+    fn new(settings: Settings, context: ContextChaCha, working_directory: PathBuf) -> Result<Self> {
         use chain_core::property::Serialize as _;
 
         let block0 = settings.block0.to_block();
         let block0_hash = block0.header.hash();
 
-        let block0_file = Temp::new_file()?;
+        let block0_file = working_directory.join("block0.bin");
         let file = std::fs::File::create(&block0_file)?;
         block0.serialize(file)?;
         let progress_bar = Arc::new(MultiProgress::new());
-        let startup_progress_bar = ProgressBar::new(10);
-        startup_progress_bar.set_prefix(&format!("{} context", *style::icons::scenario));
-        startup_progress_bar.set_message("initializing...");
-        startup_progress_bar.set_style(
-            indicatif::ProgressStyle::default_spinner()
-                .template("{spinner:.green} {prefix:.bold.dim} [{bar:10.cyan/blue}] [{elapsed_precise}] {wide_msg}")
-                .tick_chars(style::TICKER)
-        );
-        startup_progress_bar.enable_steady_tick(100);
 
         Ok(Controller {
             settings: Arc::new(settings),
@@ -53,8 +127,8 @@ impl Controller {
             block0_hash,
             progress_bar,
             progress_bar_thread: None,
-            startup_progress_bar,
             runtime: runtime::Runtime::new()?,
+            working_directory,
         })
     }
 
@@ -74,7 +148,14 @@ impl Controller {
         let pb = ProgressBar::new_spinner();
         let pb = self.progress_bar.add(pb);
 
-        let node = Node::spawn(&self.context, pb, node_alias, node_setting, block0_setting)?;
+        let node = Node::spawn(
+            &self.context,
+            pb,
+            node_alias,
+            node_setting,
+            block0_setting,
+            &self.working_directory,
+        )?;
         let controller = node.controller();
 
         self.runtime.executor().spawn(node);
@@ -84,8 +165,6 @@ impl Controller {
 
     pub fn monitor_nodes(&mut self) {
         let pb = Arc::clone(&self.progress_bar);
-
-        self.startup_progress_bar.finish_with_message("done");
         self.progress_bar_thread = Some(std::thread::spawn(move || {
             pb.join().unwrap();
         }));

--- a/jormungandr-scenario-tests/src/scenario/mod.rs
+++ b/jormungandr-scenario-tests/src/scenario/mod.rs
@@ -41,6 +41,7 @@ error_chain! {
 #[macro_export]
 macro_rules! prepare_scenario {
     (
+        $title:expr,
         $context:expr,
         topology [
             $($topology_tt:tt $(-> $node_link:tt)*),+ $(,)*
@@ -55,7 +56,7 @@ macro_rules! prepare_scenario {
             ] $(,)*
         }
     ) => {{
-        let mut builder = $crate::scenario::ControllerBuilder::new("title...");
+        let mut builder = $crate::scenario::ControllerBuilder::new($title);
         let mut topology_builder = $crate::scenario::TopologyBuilder::new();
         $(
             #[allow(unused_mut)]

--- a/jormungandr-scenario-tests/src/scenario/mod.rs
+++ b/jormungandr-scenario-tests/src/scenario/mod.rs
@@ -8,7 +8,7 @@ mod wallet;
 pub use self::{
     blockchain::Blockchain,
     context::{Context, ContextChaCha, Seed},
-    controller::Controller,
+    controller::{Controller, ControllerBuilder},
     topology::{Node, NodeAlias, Topology, TopologyBuilder},
     wallet::{Wallet, WalletAlias, WalletType},
 };
@@ -55,6 +55,7 @@ macro_rules! prepare_scenario {
             ] $(,)*
         }
     ) => {{
+        let mut builder = $crate::scenario::ControllerBuilder::new("title...");
         let mut topology_builder = $crate::scenario::TopologyBuilder::new();
         $(
             #[allow(unused_mut)]
@@ -65,6 +66,7 @@ macro_rules! prepare_scenario {
             topology_builder.register_node(node);
         )*
         let topology : $crate::scenario::Topology = topology_builder.build();
+        builder.set_topology(topology);
 
         let mut blockchain = $crate::scenario::Blockchain::new(
             $crate::scenario::ConsensusVersion::$blockchain_consensus,
@@ -96,11 +98,10 @@ macro_rules! prepare_scenario {
 
             blockchain.add_wallet(wallet);
         )*
+        builder.set_blockchain(blockchain);
 
-        $crate::scenario::settings::Settings::prepare(
-            topology,
-            blockchain,
-            $context
-        )
+        builder.build_settings($context);
+
+        builder
     }};
 }

--- a/jormungandr-scenario-tests/src/scenario/topology.rs
+++ b/jormungandr-scenario-tests/src/scenario/topology.rs
@@ -2,14 +2,14 @@ use std::{borrow::Borrow, collections::HashMap, hash::Hash};
 
 pub type NodeAlias = String;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Node {
     alias: NodeAlias,
 
     trusted_peers: Vec<NodeAlias>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Topology {
     nodes: HashMap<NodeAlias, Node>,
 }

--- a/jormungandr-scenario-tests/src/scenario/wallet.rs
+++ b/jormungandr-scenario-tests/src/scenario/wallet.rs
@@ -3,13 +3,13 @@ use chain_impl_mockchain::value::Value;
 
 pub type WalletAlias = String;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WalletType {
     Account,
     UTxO,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Wallet {
     alias: WalletAlias,
     value: Value,
@@ -53,5 +53,15 @@ impl Wallet {
 
     pub fn delegate_mut(&mut self) -> &mut Option<NodeAlias> {
         &mut self.delegate
+    }
+
+    pub(crate) fn dot_label(&self) -> String {
+        let t: crate::style::icons::Icon = if self.wallet_type == WalletType::Account {
+            *crate::style::icons::account
+        } else {
+            *crate::style::icons::wallet
+        };
+
+        format!("\"{}{}\\nfunds = {}\"", &self.alias, t, self.value)
     }
 }

--- a/jormungandr-scenario-tests/src/style.rs
+++ b/jormungandr-scenario-tests/src/style.rs
@@ -24,9 +24,9 @@ pub mod icons {
 
         pub static ref scenario: Icon = Icon::new("\u{1f4c3}", "");
 
-        pub static ref wallet: Icon = Icon::new("\u{1f45b}", "");
+        pub static ref wallet: Icon = Icon::new("\u{1f45b}", "[wallet]");
 
-        pub static ref account: Icon = Icon::new("\u{1f4b3}", "");
+        pub static ref account: Icon = Icon::new("\u{1f4b3}", "[utxo]");
 
         pub static ref transaction: Icon = Icon::new("\u{1f9fe}", "");
 
@@ -55,6 +55,8 @@ lazy_static! {
     pub static ref success: Style = Style::new().green().bold();
 
     pub static ref info: Style = Style::new().cyan().bold();
+
+    pub static ref scenario_title: Style = Style::new().bold();
 }
 
 pub const TICKER: &str = "▖▗▝▘ ";

--- a/jormungandr-scenario-tests/src/style.rs
+++ b/jormungandr-scenario-tests/src/style.rs
@@ -22,6 +22,8 @@ pub mod icons {
         /// icon associated the `jcli` command line binary
         pub static ref jormungandr: Icon = Icon::new("\u{1f40d}", "");
 
+        pub static ref scenario: Icon = Icon::new("\u{1f4c3}", "");
+
         pub static ref wallet: Icon = Icon::new("\u{1f45b}", "");
 
         pub static ref account: Icon = Icon::new("\u{1f4b3}", "");
@@ -54,3 +56,5 @@ lazy_static! {
 
     pub static ref info: Style = Style::new().cyan().bold();
 }
+
+pub const TICKER: &str = "▖▗▝▘ ";

--- a/jormungandr-scenario-tests/src/wallet/mod.rs
+++ b/jormungandr-scenario-tests/src/wallet/mod.rs
@@ -1,6 +1,7 @@
 mod account;
 mod utxo;
 
+use crate::scenario::Wallet as WalletTemplate;
 use chain_addr::Discrimination;
 use chain_impl_mockchain::{fee::LinearFee, fragment::Fragment, transaction::AccountIdentifier};
 use jormungandr_lib::{
@@ -55,24 +56,28 @@ enum Inner {
 #[derive(Debug, Clone)]
 pub struct Wallet {
     inner: Inner,
+
+    template: WalletTemplate,
 }
 
 impl Wallet {
-    pub fn generate_account<RNG>(rng: &mut RNG) -> Self
+    pub fn generate_account<RNG>(template: WalletTemplate, rng: &mut RNG) -> Self
     where
         RNG: CryptoRng + RngCore,
     {
         Wallet {
             inner: Inner::Account(account::Wallet::generate(rng)),
+            template,
         }
     }
 
-    pub fn generate_utxo<RNG>(rng: &mut RNG) -> Self
+    pub fn generate_utxo<RNG>(template: WalletTemplate, rng: &mut RNG) -> Self
     where
         RNG: CryptoRng + RngCore,
     {
         Wallet {
             inner: Inner::UTxO(utxo::Wallet::generate(rng)),
+            template,
         }
     }
 
@@ -88,6 +93,10 @@ impl Wallet {
             Inner::Account(account) => Some(account.stake_key()),
             Inner::UTxO(_utxo) => unimplemented!(),
         }
+    }
+
+    pub(crate) fn template(&self) -> &WalletTemplate {
+        &self.template
     }
 
     /// simple function to create a transaction with only one output to the given


### PR DESCRIPTION
* test within a persistent directory if supplied;
* displaying the running tests initial setup;

The new options `--document` (used along `--root-dir`) allows to generate a dot file `initial_setup.dot` for each scenario in the test suite. This allows QA and Dev to have a visual representation of what is being tested.

## current example

This is the example as generated from `scenario_1`, the one that runs by default

![initial_setup2](https://user-images.githubusercontent.com/5445840/63527346-d79f8500-c4f8-11e9-8907-22448143ab99.png)

It shows the initial state of the test:

* 1 node `node1` as a **BFT** leader;
* 1 node `node2` as a **Stake Pool**;
* 2 wallets of type _account_ with `faucet2` delegating to `node2` stake pool

## more complex example of initial setup (not committed yet)

![initial_setup3](https://user-images.githubusercontent.com/5445840/63527731-8774f280-c4f9-11e9-8049-bada883b0a4d.png)

