### PR TITLE
doc: renaming genesis to genesis_praos

### DIFF
--- a/doc/advanced/03_starting_genesis_praos_blockchain.md
+++ b/doc/advanced/03_starting_genesis_praos_blockchain.md
@@ -13,13 +13,13 @@ values/desired values:
 ```yaml
 # The Blockchain Configuration defines the settings of the blockchain.
 blockchain_configuration:
-  block0_consensus: genesis
+  block0_consensus: genesis_praos
   bft_slots_ratio: 0
   consensus_genesis_praos_active_slot_coeff: 0.1
   kes_update_speed: 43200 # 12hours
 ```
 
-`block0_consensus` set to `genesis` means you want to start a blockchain with
+`block0_consensus` set to `genesis_praos` means you want to start a blockchain with
 genesis praos as the consensus layer.
 
 `bft_slots_ratio` needs to be set to `0` (we don't support composite modes between


### PR DESCRIPTION
This change has been omitted from documentation.