### PR TITLE
Versioning improvements for jcli and jörmungandr

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,10 @@ about: Create a report to help us improve
 **Describe the bug**
 A clear and concise description of what the bug is.
 
+**Mandatory Information**
+1. `jcli --full-version` output;
+2. `jormungandr --full-version` output;
+
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "slog-term 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versionisator 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,7 @@ dependencies = [
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "strfmt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versionisator 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3503,6 +3504,14 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "versionisator"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,6 +3973,7 @@ dependencies = [
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum versionisator 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79ceb7fdd89c5de082f5056a7c341dbbc72776a66dc751657e468fbc51261455"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -47,3 +47,6 @@ features = [ "suggestions", "color", "wrap_help" ]
 
 [dev-dependencies]
 mktemp = "0.4.0"
+
+[build-dependencies]
+versionisator = "1.0"

--- a/jcli/build.rs
+++ b/jcli/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let version = versionisator::Version::new(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME").to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
+
+    println!("cargo:rustc-env=FULL_VERSION={}", version.full());
+    println!("cargo:rustc-env=SIMPLE_VERSION={}", version.simple());
+    println!("cargo:rustc-env=SOURCE_VERSION={}", version.hash());
+}

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -54,6 +54,9 @@ structopt = "^0.2"
 tokio      = "^0.1.16"
 actix-threadpool = "0.1.2"
 
+[build-dependencies]
+versionisator = "1.0"
+
 [target.'cfg(unix)'.dependencies]
 slog-syslog = "0.12.0"
 

--- a/jormungandr/build.rs
+++ b/jormungandr/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let version = versionisator::Version::new(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME").to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
+
+    println!("cargo:rustc-env=FULL_VERSION={}", version.full());
+    println!("cargo:rustc-env=SIMPLE_VERSION={}", version.simple());
+    println!("cargo:rustc-env=SOURCE_VERSION={}", version.hash());
+}

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -341,15 +341,19 @@ pub struct InitializedNode {
 fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let command_line = CommandLine::load();
     let raw_settings = RawSettings::load(command_line)?;
+
+    if raw_settings.full_version() {
+        println!("{}", env!("FULL_VERSION"));
+        std::process::exit(0);
+    } else if raw_settings.source_version() {
+        println!("{}", env!("SOURCE_VERSION"));
+        std::process::exit(0);
+    }
+
     let logger = raw_settings.to_logger()?;
 
     let init_logger = logger.new(o!(log::KEY_TASK => "init"));
-    info!(
-        init_logger,
-        "Starting {} {}",
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION")
-    );
+    info!(init_logger, "Starting {}", env!("FULL_VERSION"),);
     let settings = raw_settings.try_into_settings(&init_logger)?;
     let storage = start_up::prepare_storage(&settings, &init_logger)?;
 

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -66,6 +66,15 @@ pub struct CommandLine {
 
     #[structopt(flatten)]
     pub start_arguments: StartArguments,
+
+    /// display full version details (software version, source version, targets and compiler used)
+    #[structopt(long = "full-version")]
+    pub full_version: bool,
+
+    /// display the sources version, allowing to check the source's hash used to compile this executable.
+    /// this option is useful for scripting retrieving the logs of the version of this application.
+    #[structopt(long = "source-version")]
+    pub source_version: bool,
 }
 
 impl CommandLine {

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -1,6 +1,5 @@
 use crate::settings::LOG_FILTER_LEVEL_POSSIBLE_VALUES;
 use slog::FilterLevel;
-use std::net::SocketAddr;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -11,34 +10,6 @@ use crate::{
 
 #[derive(StructOpt, Debug)]
 pub struct StartArguments {
-    /// The address to listen for inbound legacy protocol connections at.
-    /// The program will open a listening socket on the given address.
-    /// You might need to have special privileges to open the TCP socket
-    /// at this address.
-    #[structopt(long = "legacy-listen", parse(try_from_str))]
-    pub ntt_listen: Vec<SocketAddr>,
-
-    /// The address to listen for inbound gRPC connections at.
-    /// The program will open a listening socket on the given address.
-    /// You might need to have special privileges to open the TCP socket
-    /// at this address.
-    #[structopt(long = "grpc-listen", parse(try_from_str))]
-    pub grpc_listen: Vec<SocketAddr>,
-
-    /// List of the nodes to connect to using the legacy protocol.
-    /// These are the nodes we know we need to connect to and
-    /// start processing blocks, transactions and participate with.
-    ///
-    #[structopt(long = "legacy-connect", parse(try_from_str))]
-    pub ntt_connect: Vec<SocketAddr>,
-
-    /// List of the nodes to connect to using the grpc protocol.
-    /// These are the nodes we know we need to connect to and
-    /// start processing blocks, transactions and participate with.
-    ///
-    #[structopt(long = "grpc-connect", parse(try_from_str))]
-    pub grpc_connect: Vec<SocketAddr>,
-
     /// Path to the blockchain pool storage directory
     #[structopt(long = "storage", parse(from_os_str))]
     pub storage: Option<PathBuf>,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -46,6 +46,14 @@ impl RawSettings {
         })
     }
 
+    pub fn full_version(&self) -> bool {
+        self.command_line.full_version
+    }
+
+    pub fn source_version(&self) -> bool {
+        self.command_line.source_version
+    }
+
     pub fn to_logger(&self) -> Result<Logger, logging::Error> {
         LogSettings {
             level: self.logger_level(),


### PR DESCRIPTION
closes #719 

add option `--full-version` in addition to the original `--version` option. This allows to display more details on the outputs:

`jormungandr 0.3.3 (update-stats-and-scenario-testing-63f3f406+, debug, macos [x86_64]) - [rustc 1.37.0 (eae3437df 2019-08-13)]`

or

`jcli 0.3.3 (update-stats-and-scenario-testing-63f3f406+, debug, macos [x86_64]) - [rustc 1.37.0 (eae3437df 2019-08-13)]`