### PR TITLE
Fragment process clean up

### DIFF
--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -24,6 +24,7 @@ impl Pool {
         &self.logs
     }
 
+    /// Returns true if fragment was registered
     pub fn insert(
         &mut self,
         origin: FragmentOrigin,
@@ -46,7 +47,7 @@ impl Pool {
                             guard.insert(fragment);
 
                             let log = FragmentLog::new(id.into(), origin);
-                            logs.insert(log).map(|()| true)
+                            logs.insert(log)
                         },
                     ))
                 }

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -2,6 +2,7 @@ use crate::{
     blockcfg::{HeaderContentEvalContext, Ledger, LedgerParameters},
     fragment::{selection::FragmentSelectionAlgorithm, Fragment, Logs},
 };
+use chain_core::property::Fragment as _;
 use jormungandr_lib::interfaces::{FragmentLog, FragmentOrigin};
 use std::time::Duration;
 use tokio::{prelude::*, sync::lock::Lock, timer};
@@ -30,8 +31,6 @@ impl Pool {
         origin: FragmentOrigin,
         fragment: Fragment,
     ) -> impl Future<Item = bool, Error = ()> {
-        use chain_core::property::Fragment as _;
-
         let mut pool_lock = self.pool.clone();
         let mut logs = self.logs.clone();
         future::poll_fn(move || Ok(pool_lock.poll_lock())).and_then(move |mut pool| {
@@ -77,17 +76,13 @@ impl Pool {
 }
 
 pub(super) mod internal {
-    use crate::fragment::{Fragment, FragmentId, PoolEntry};
-    use chain_core::property::Fragment as _;
+    use super::*;
+    use crate::fragment::{FragmentId, PoolEntry};
     use std::{
         collections::{hash_map::Entry, BTreeMap, HashMap, VecDeque},
         sync::Arc,
-        time::Duration,
     };
-    use tokio::{
-        prelude::*,
-        timer::{self, delay_queue, DelayQueue},
-    };
+    use tokio::timer::{delay_queue, DelayQueue};
 
     pub struct Pool {
         pub entries: HashMap<FragmentId, (Arc<PoolEntry>, Fragment, delay_queue::Key)>,

--- a/jormungandr/src/fragment/process.rs
+++ b/jormungandr/src/fragment/process.rs
@@ -70,17 +70,12 @@ impl Process {
                     // for other message we don't want to receive them through this interface, and possibly
                     // put them in another pool.
 
-                    let mut pool = self.pool.clone();
                     let stats_counter = stats_counter.clone();
-
-                    A(B(stream::iter_ok(txs).for_each(move |tx| {
-                        let stats_counter = stats_counter.clone();
-                        pool.insert(origin, tx).map(move |inserted| {
-                            if inserted {
-                                stats_counter.add_tx_recv_cnt(1)
-                            }
-                        })
-                    })))
+                    A(B(self
+                        .pool
+                        .clone()
+                        .insert_all(origin, txs)
+                        .map(move |count| stats_counter.add_tx_recv_cnt(count))))
                 }
                 TransactionMsg::GetTransactions(_txids, _handler) => {
                     // this function is no yet implemented, this is not handled in the

--- a/jormungandr/src/fragment/selection.rs
+++ b/jormungandr/src/fragment/selection.rs
@@ -58,10 +58,6 @@ impl FragmentSelectionAlgorithm for OldestFirst {
         let mut ledger_simulation = ledger.clone();
 
         while let Some(fragment) = pool.remove_oldest() {
-            if total >= self.max_per_block {
-                break;
-            }
-
             let id = fragment.id();
             match ledger_simulation.apply_fragment(ledger_params, &fragment, metadata) {
                 Ok(ledger_new) => {
@@ -86,6 +82,9 @@ impl FragmentSelectionAlgorithm for OldestFirst {
                     };
                     logs.modify(&id.into(), FragmentStatus::Rejected { reason: error })
                 }
+            }
+            if total >= self.max_per_block {
+                break;
             }
         }
     }

--- a/jormungandr/src/fragment/selection.rs
+++ b/jormungandr/src/fragment/selection.rs
@@ -4,6 +4,7 @@ use crate::{
     blockcfg::{BlockBuilder, HeaderContentEvalContext, Ledger, LedgerParameters},
     fragment::FragmentId,
 };
+use chain_core::property::Fragment as _;
 use jormungandr_lib::interfaces::FragmentStatus;
 
 pub enum SelectionOutput {
@@ -56,13 +57,12 @@ impl FragmentSelectionAlgorithm for OldestFirst {
         let mut total = 0usize;
         let mut ledger_simulation = ledger.clone();
 
-        while let Some(id) = pool.entries_by_time.pop_front() {
+        while let Some(fragment) = pool.remove_oldest() {
             if total >= self.max_per_block {
                 break;
             }
 
-            let fragment = pool.remove(&id).unwrap();
-
+            let id = fragment.id();
             match ledger_simulation.apply_fragment(ledger_params, &fragment, metadata) {
                 Ok(ledger_new) => {
                     self.builder.message(fragment);


### PR DESCRIPTION
Clean up fragment process, most notably:
- Move source of truth about which fragments are already pooled from logs to pool itself
- Fix logger and pool overwriting duplicate entries while inserting
- Remove need for obtaining and dropping pool and logger locks for each fragment, now it's once for all fragments
- Fix FragmentSelectionAlgorithm dropping last block if block is full

I hope these are good changes and I didn't misunderstand anything. Network API trimming comping up next.