### PR TITLE
Outline expected schema

### DIFF
--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -4,22 +4,53 @@ use chain_core::property::Block as _;
 use chain_core::property::Fragment;
 pub use juniper::http::GraphQLRequest;
 use juniper::EmptyMutation;
+use juniper::FieldError;
 use juniper::FieldResult;
 use juniper::RootNode;
 use std::str::FromStr;
-use tokio::prelude::Future;
+use tokio::prelude::*;
 
 use crate::explorer::ExplorerDB;
+use crate::explorer::{Error, ErrorKind};
+use juniper::graphql_value;
 
-#[derive(juniper::GraphQLObject)]
-/// A Block
-struct Block {
-    /// The Block unique identifier
+pub struct Block {
     hash: String,
-    /// Date the Block was included in the blockchain
     date: BlockDate,
+    chain_length: ChainLength,
+}
+
+/// A Block
+#[juniper::object(
+    Context = Context
+)]
+impl Block {
+    /// The Block unique identifier
+    pub fn hash(&self) -> &String {
+        &self.hash
+    }
+
+    /// Date the Block was included in the blockchain
+    pub fn date(&self) -> &BlockDate {
+        &self.date
+    }
+
     /// The transactions contained in the block
-    transactions: Vec<Transaction>,
+    pub fn transactions(&self) -> Vec<&Transaction> {
+        unimplemented!()
+    }
+
+    pub fn previous_block(&self) -> Option<&Block> {
+        unimplemented!()
+    }
+
+    pub fn next_block(&self) -> Option<&Block> {
+        unimplemented!()
+    }
+
+    pub fn chain_length(&self) -> &ChainLength {
+        &self.chain_length
+    }
 }
 
 impl From<blockcfg::Block> for Block {
@@ -27,70 +58,201 @@ impl From<blockcfg::Block> for Block {
         Block {
             hash: block.id().to_string(),
             date: block.date().into(),
-            transactions: block
-                .contents
-                .iter()
-                .filter_map(|fragment| {
-                    //TODO: Implement
-                    None
-                })
-                .collect(),
+            chain_length: ChainLength(u32::from(block.header.chain_length()).to_string()),
         }
     }
 }
 
-#[derive(juniper::GraphQLObject)]
-/// Block's date, composed of an Epoch and a Slot
 struct BlockDate {
     epoch: Epoch,
     slot: Slot,
 }
 
+/// Block's date, composed of an Epoch and a Slot
+#[juniper::object(
+    Context = Context
+)]
+impl BlockDate {
+    pub fn epoch(&self) -> &Epoch {
+        &self.epoch
+    }
+
+    pub fn slot(&self) -> &Slot {
+        &self.slot
+    }
+}
+
 impl From<blockcfg::BlockDate> for BlockDate {
     fn from(date: blockcfg::BlockDate) -> BlockDate {
         BlockDate {
-            epoch: Epoch(format!("{}", date.epoch)),
+            epoch: Epoch {
+                id: EpochNumber(format!("{}", date.epoch)),
+            },
             slot: Slot(format!("{}", date.slot_id)),
         }
     }
 }
 
-#[derive(juniper::GraphQLObject)]
-// A transaction in the blockchain
 struct Transaction {
-    // The hash that identifies the transaction
-    id: String,
-    // The block this transaction is in
-    block: Block,
-    inputs: Vec<TransactionInput>,
-    outputs: Vec<TransactionOutput>,
+    id: FragmentId,
+}
+
+/// A transaction in the blockchain
+#[juniper::object(
+    Context = Context
+)]
+impl Transaction {
+    /// The hash that identifies the transaction
+    pub fn id(&self) -> String {
+        format!("{}", self.id)
+    }
+
+    /// The block this transaction is in
+    pub fn block(&self, context: &Context) -> FieldResult<Block> {
+        let block_option = context
+            .db
+            .find_block_by_transaction(self.id)
+            .map_err(|err| FieldError::from(err))
+            .and_then(|hash_option| {
+                future::poll_fn(move || match hash_option {
+                    Some(hash) => context
+                        .blockchain
+                        .storage()
+                        .get(hash)
+                        .map_err(|err| FieldError::from(err))
+                        .poll(),
+                    None => Err(FieldError::new(
+                        "Couldn't find transaction in explorer",
+                        graphql_value!({ "internal_error": "Transaction is not in explorer" }),
+                    )),
+                })
+            })
+            .wait()?;
+
+        block_option
+            .ok_or(FieldError::new(
+                "Couldn't find block in storage",
+                graphql_value!({ "internal_error": "Block is not in storage" }),
+            ))
+            .map(|b| b.into())
+    }
+
+    pub fn inputs(&self) -> Vec<TransactionInput> {
+        unimplemented!()
+    }
+
+    pub fn outputs(&self) -> Vec<TransactionOutput> {
+        unimplemented!()
+    }
 }
 
 #[derive(juniper::GraphQLObject)]
 struct TransactionInput {
     amount: Lovelaces,
-    kind: TransactionInputKind,
+    address: Address,
 }
 
 #[derive(juniper::GraphQLObject)]
 struct TransactionOutput {
     amount: Lovelaces,
+    address: Address,
 }
 
-#[derive(juniper::GraphQLEnum)]
-enum TransactionInputKind {
-    Utxo,
-    Account,
+#[derive(juniper::GraphQLObject)]
+struct Address {
+    delegation: StakePool,
+    total_send: Lovelaces,
+    total_received: Lovelaces,
 }
+
+#[derive(juniper::GraphQLObject)]
+struct StakePool {
+    id: PoolId,
+}
+
+struct Status {
+    current_epoch: Epoch,
+    latest_block: Block,
+    fee: FeeSettings,
+}
+
+#[juniper::object(
+    Context = Context
+)]
+impl Status {
+    pub fn current_epoch(&self) -> &Epoch {
+        &self.current_epoch
+    }
+
+    pub fn latest_block(&self) -> &Block {
+        &self.latest_block
+    }
+
+    pub fn fee_settings(&self) -> &FeeSettings {
+        &self.fee
+    }
+}
+
+#[derive(juniper::GraphQLObject)]
+struct FeeSettings {
+    constant: Lovelaces,
+    coefficient: Lovelaces,
+    certificate: Lovelaces,
+}
+
+#[derive(juniper::GraphQLScalarValue)]
+struct PoolId(String);
 
 #[derive(juniper::GraphQLScalarValue)]
 struct Lovelaces(String);
 
 #[derive(juniper::GraphQLScalarValue)]
-struct Epoch(String);
+struct EpochNumber(String);
+
+struct Epoch {
+    id: EpochNumber,
+}
+
+#[juniper::object(
+    Context = Context
+)]
+impl Epoch {
+    pub fn id(&self) -> &EpochNumber {
+        &self.id
+    }
+
+    /// Not yet implemented
+    pub fn stake_distribution(&self) -> StakeDistribution {
+        unimplemented!()
+    }
+
+    /// Not yet implemented
+    pub fn blocks(&self) -> Vec<Block> {
+        unimplemented!()
+    }
+
+    /// Not yet implemented
+    pub fn total_blocks(&self) -> i32 {
+        unimplemented!()
+    }
+}
+
+#[derive(juniper::GraphQLObject)]
+struct StakeDistribution {
+    pools: Vec<PoolStakeDistribution>,
+}
+
+#[derive(juniper::GraphQLObject)]
+struct PoolStakeDistribution {
+    pool: StakePool,
+    delegated_stake: Lovelaces,
+}
 
 #[derive(juniper::GraphQLScalarValue)]
 struct Slot(String);
+
+#[derive(juniper::GraphQLScalarValue)]
+struct ChainLength(String);
 
 pub struct Query;
 
@@ -98,40 +260,32 @@ pub struct Query;
     Context = Context,
 )]
 impl Query {
-    fn block(id: String, context: &Context) -> FieldResult<Vec<Block>> {
+    fn block(id: String, context: &Context) -> FieldResult<Block> {
         unimplemented!();
     }
 
-    fn transaction(id: String, context: &Context) -> FieldResult<Option<Transaction>> {
+    fn block(chain_length: ChainLength) -> FieldResult<Block> {
+        unimplemented!();
+    }
+
+    fn transaction(id: String, context: &Context) -> FieldResult<Transaction> {
         // This call blocks the current thread (the call to wait), but it won't block the node's
         // thread, as queries are only executed in an exclusive runtime
         let id = FragmentId::from_str(&id)?;
-        let block_option = context
-            .db
-            .find_block_by_transaction(id, context.blockchain.clone())
-            .wait()?;
 
-        let block = match block_option {
-            Some(b) => b,
-            None => return Ok(None),
-        };
+        Ok(Transaction { id })
+    }
 
-        let tx = block
-            .contents
-            .iter()
-            .find(|fragment| fragment.id() == id)
-            .map(|tx| tx.clone())
-            // FIXME: Maybe throw some error, although this shouldn't happen
-            .ok_or_else(|| unreachable!());
+    pub fn epoch(id: EpochNumber) -> FieldResult<Epoch> {
+        unimplemented!();
+    }
 
-        tx.map(|tx| Transaction {
-            id: format!("{}", id),
-            block: block.into(),
-            // TODO: Transform this things
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-        })
-        .map(Some)
+    pub fn stake_pool(id: PoolId) -> FieldResult<StakePool> {
+        unimplemented!();
+    }
+
+    pub fn status() -> FieldResult<Status> {
+        unimplemented!();
     }
 }
 

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -1,7 +1,6 @@
 use crate::blockcfg::{self, FragmentId};
 use crate::blockchain::Blockchain;
 use chain_core::property::Block as _;
-use chain_core::property::Fragment;
 pub use juniper::http::GraphQLRequest;
 use juniper::EmptyMutation;
 use juniper::FieldError;
@@ -11,7 +10,6 @@ use std::str::FromStr;
 use tokio::prelude::*;
 
 use crate::explorer::ExplorerDB;
-use crate::explorer::{Error, ErrorKind};
 use juniper::graphql_value;
 
 pub struct Block {

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -146,21 +146,21 @@ impl Transaction {
 
 #[derive(juniper::GraphQLObject)]
 struct TransactionInput {
-    amount: Lovelaces,
+    amount: Value,
     address: Address,
 }
 
 #[derive(juniper::GraphQLObject)]
 struct TransactionOutput {
-    amount: Lovelaces,
+    amount: Value,
     address: Address,
 }
 
 #[derive(juniper::GraphQLObject)]
 struct Address {
     delegation: StakePool,
-    total_send: Lovelaces,
-    total_received: Lovelaces,
+    total_send: Value,
+    total_received: Value,
 }
 
 #[derive(juniper::GraphQLObject)]
@@ -193,16 +193,16 @@ impl Status {
 
 #[derive(juniper::GraphQLObject)]
 struct FeeSettings {
-    constant: Lovelaces,
-    coefficient: Lovelaces,
-    certificate: Lovelaces,
+    constant: Value,
+    coefficient: Value,
+    certificate: Value,
 }
 
 #[derive(juniper::GraphQLScalarValue)]
 struct PoolId(String);
 
 #[derive(juniper::GraphQLScalarValue)]
-struct Lovelaces(String);
+struct Value(String);
 
 #[derive(juniper::GraphQLScalarValue)]
 struct EpochNumber(String);
@@ -243,7 +243,7 @@ struct StakeDistribution {
 #[derive(juniper::GraphQLObject)]
 struct PoolStakeDistribution {
     pool: StakePool,
-    delegated_stake: Lovelaces,
+    delegated_stake: Value,
 }
 
 #[derive(juniper::GraphQLScalarValue)]

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -1,7 +1,7 @@
 pub mod graphql;
 
 use super::blockchain::{Blockchain, Ref};
-use crate::blockcfg::{Block, ChainLength, FragmentId, Header, HeaderHash};
+use crate::blockcfg::{ChainLength, FragmentId, Header, HeaderHash};
 use crate::blockchain::Multiverse;
 use crate::intercom::ExplorerMsg;
 use crate::utils::task::{Input, TokioServiceInfo};


### PR DESCRIPTION
# Add possible schema design matching the documented scope in #694 

This are mostly schema design changes, there are also a few things like moving the struct field syntax to the method resolvers, as that is more flexible and it's easier to not compute unnecessary things.

For reference, the resulting schema from this changes looks like this:

![graph](https://user-images.githubusercontent.com/48031343/64204498-49b68900-ce6c-11e9-9b75-c51d01d50aa7.png)

Note: As mentioned in #694, the pagination requirements are still yet to be addressed for the plural fields (blocks in Epoch, for example)
