### PR TITLE
go through the whole list of trusted peers on the network

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -313,12 +313,19 @@ fn bootstrap(initialized_node: InitializedNode) -> Result<BootstrappedNode, star
         block_cache_ttl,
     )?;
 
-    network::bootstrap(
+    let bootstrapped = network::bootstrap(
         &settings.network,
         blockchain.clone(),
         blockchain_tip.clone(),
         &bootstrap_logger,
     )?;
+
+    if !bootstrapped {
+        // TODO, the node didn't manage to connect to any other nodes
+        // for the initial bootstrap, that may be an error however
+        // it is not necessarily an error, especially in the case the node is
+        // the first ever to wake
+    }
 
     Ok(BootstrappedNode {
         settings,

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -5,7 +5,7 @@
 //! transactions...);
 //!
 
-mod bootstrap;
+pub mod bootstrap;
 mod client;
 mod grpc;
 mod inbound;

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -146,6 +146,12 @@ impl Address {
     }
 }
 
+impl std::fmt::Display for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl Serialize for Address {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Here we try to connect to any of our trusted peers for the initial bootstrap. This is not a mandatory action to do as it only helps us get closer to the general state of the whole network.