### PR TITLE
Offer content service on the server Node

### DIFF
--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -49,8 +49,7 @@ impl Node for NodeService {
     }
 
     fn content_service(&mut self) -> Option<&mut Self::ContentService> {
-        // Not implemented yet
-        None
+        Some(self)
     }
 
     fn gossip_service(&mut self) -> Option<&mut Self::GossipService> {


### PR DESCRIPTION
The fragment methods failed as not implemented, need to provide the `ContentService` instance.

Fixes #754