### PR TITLE
Remove Id from the poldercast gossiping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,7 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
- "poldercast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1392,7 +1392,7 @@ dependencies = [
  "jormungandr-lib 0.3.3",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1445,7 +1445,7 @@ dependencies = [
  "jormungandr-lib 0.3.3",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2055,9 +2055,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "poldercast"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cryptoxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "multiaddr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3888,7 +3889,7 @@ dependencies = [
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
-"checksum poldercast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "815077eef8b08d674d5d33fe79ffb3e0bfae7297caa645fdba0af33df9991633"
+"checksum poldercast 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37afa752ff93607da510cc71c4c7d374f334167ca7134716b582846bfd00f4b0"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/doc/configuration/introduction.md
+++ b/doc/configuration/introduction.md
@@ -12,10 +12,8 @@ log:
   format: json
 p2p:
   trusted_peers:
-    - id: 1
-      address: "/ip4/104.24.28.11/tcp/8299"
-    - id: 2
-      address: "/ip4/104.24.29.11/tcp/8299"
+    - "/ip4/104.24.28.11/tcp/8299"
+    - "/ip4/104.24.29.11/tcp/8299"
   public_address: "/ip4/127.0.0.1/tcp/8080"
   topics_of_interest:
     messages: low

--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -18,7 +18,7 @@ p2p:
 
 ## P2P configuration
 
-- *trusted_peers*: (optional) the list of nodes to connect to in order to
+- *trusted_peers*: (optional) the list of nodes' [multiaddr][multiaddr] to connect to in order to
     bootstrap the p2p topology (and bootstrap our local blockchain);
 - *public_id*: (optional) the public identifier send to the other nodes in the
     p2p network. If not set it will be randomly generated.

--- a/doc/quickstart/02_passive_node.md
+++ b/doc/quickstart/02_passive_node.md
@@ -33,8 +33,7 @@ rest:
 
 p2p:
   trusted_peers:
-    - id: 1
-      address: "/ip4/104.24.28.11/tcp/8299"
+    - "/ip4/104.24.28.11/tcp/8299"
   public_address: "/ip4/u.v.x.y/tcp/8299"
   topics_of_interest:
     messages: low
@@ -67,7 +66,7 @@ Description of the fields:
       - `allowed_origins`: (optional) allowed origins, if none provided, echos request origin
       - `max_age_secs`: (optional) maximum CORS caching time in seconds, if none provided, caching is disabled
 - `p2p`: P2P network settings
-    - `trusted_peers`: (optional) the list of nodes to connect to in order to
+    - `trusted_peers`: (optional) the list of nodes's [multiaddr][multiaddr] to connect to in order to
       bootstrap the P2P topology (and bootstrap our local blockchain);
     - `public_id`: (optional) the public identifier sent to the other nodes
       in the P2P network. If not set it will be randomly generated.

--- a/jormungandr-integration-tests/Cargo.toml
+++ b/jormungandr-integration-tests/Cargo.toml
@@ -25,7 +25,7 @@ assert_fs = "0.11"
 mktemp = "0.4.0"
 lazy_static = "1.3"
 custom_error = "1.7"
-poldercast = { version = "0.3.1", features = [ "serde_derive" ] }
+poldercast = { version = "0.4.0", features = [ "serde_derive" ] }
 jormungandr = { path = "../jormungandr" }
 jcli = { path = "../jcli" }
 

--- a/jormungandr-integration-tests/src/common/configuration/node_config_model.rs
+++ b/jormungandr-integration-tests/src/common/configuration/node_config_model.rs
@@ -18,15 +18,9 @@ pub struct Rest {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Peer2Peer {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trusted_peers: Option<Vec<Peer>>,
+    pub trusted_peers: Option<Vec<String>>,
     pub public_address: String,
     pub topics_of_interest: TopicsOfInterest,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Peer {
-    pub id: i32,
-    pub address: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/jormungandr-integration-tests/src/common/startup/configuration_builder.rs
+++ b/jormungandr-integration-tests/src/common/startup/configuration_builder.rs
@@ -1,14 +1,14 @@
 use crate::common::configuration::{
     genesis_model::{Fund, GenesisYaml, Initial, LinearFees},
     jormungandr_config::JormungandrConfig,
-    node_config_model::{Log, NodeConfig, Peer},
+    node_config_model::{Log, NodeConfig},
     secret_model::SecretModel,
 };
 use crate::common::file_utils;
 use crate::common::jcli_wrapper;
 pub struct ConfigurationBuilder {
     funds: Vec<Fund>,
-    trusted_peers: Option<Vec<Peer>>,
+    trusted_peers: Option<Vec<String>>,
     block0_hash: Option<String>,
     block0_consensus: Option<String>,
     log: Option<Log>,
@@ -110,7 +110,7 @@ impl ConfigurationBuilder {
         self
     }
 
-    pub fn with_trusted_peers(&mut self, trusted_peers: Vec<Peer>) -> &mut Self {
+    pub fn with_trusted_peers(&mut self, trusted_peers: Vec<String>) -> &mut Self {
         self.trusted_peers = Some(trusted_peers.clone());
         self
     }

--- a/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
@@ -1,4 +1,4 @@
-use crate::common::configuration::node_config_model::{Log, Peer};
+use crate::common::configuration::node_config_model::Log;
 use crate::common::startup;
 
 #[test]
@@ -20,10 +20,7 @@ pub fn test_jormungandr_passive_node_starts_successfully() {
     let _jormungandr_leader = startup::start_jormungandr_node_as_leader(&mut leader_config);
 
     let mut passive_config = startup::ConfigurationBuilder::new()
-        .with_trusted_peers(vec![Peer {
-            id: 1,
-            address: leader_config.node_config.p2p.public_address.clone(),
-        }])
+        .with_trusted_peers(vec![leader_config.node_config.p2p.public_address.clone()])
         .with_block_hash(leader_config.genesis_block_hash)
         .build();
 

--- a/jormungandr-integration-tests/src/networking/communication.rs
+++ b/jormungandr-integration-tests/src/networking/communication.rs
@@ -1,5 +1,4 @@
 use crate::common::configuration::genesis_model::Fund;
-use crate::common::configuration::node_config_model::Peer;
 use crate::common::jcli_wrapper;
 use crate::common::jcli_wrapper::jcli_transaction_wrapper::JCLITransactionWrapper;
 use crate::common::startup;
@@ -20,10 +19,7 @@ pub fn two_nodes_communication() {
     let _leader_jormungandr = startup::start_jormungandr_node_as_leader(&mut leader_config);
 
     let mut trusted_node_config = startup::ConfigurationBuilder::new()
-        .with_trusted_peers(vec![Peer {
-            id: 1,
-            address: leader_config.node_config.p2p.public_address.clone(),
-        }])
+        .with_trusted_peers(vec![leader_config.node_config.p2p.public_address.clone()])
         .with_block_hash(leader_config.genesis_block_hash.clone())
         .build();
 

--- a/jormungandr-scenario-tests/Cargo.toml
+++ b/jormungandr-scenario-tests/Cargo.toml
@@ -20,7 +20,7 @@ chain-addr           = { path = "../chain-deps/chain-addr" }
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 chain-time           = { path = "../chain-deps/chain-time" }
 jormungandr-lib = { path = "../jormungandr-lib" }
-poldercast = { version = "0.3.1", features = [ "serde_derive" ] }
+poldercast = { version = "0.4.0", features = [ "serde_derive" ] }
 rand = "0.6"
 rand_core = "0.3"
 rand_chacha = "0.1"

--- a/jormungandr-scenario-tests/src/scenario/context.rs
+++ b/jormungandr-scenario-tests/src/scenario/context.rs
@@ -130,7 +130,7 @@ impl<RNG: RngCore> Context<RNG> {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port_number)
     }
 
-    pub fn generate_new_grpc_public_address(&mut self) -> String {
+    pub fn generate_new_grpc_public_address(&mut self) -> poldercast::Address {
         use std::net::{IpAddr, Ipv4Addr};
 
         let port_number = self
@@ -140,6 +140,8 @@ impl<RNG: RngCore> Context<RNG> {
         let address = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
         format!("/ip4/{}/tcp/{}", address, port_number)
+            .parse()
+            .unwrap()
     }
 
     /// retrieve the original seed of the pseudo random generator

--- a/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -57,20 +57,11 @@ pub struct Rest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct P2pConfig {
     /// The public address to which other peers may connect to
-    pub public_address: String,
-
-    /// the node identifier
-    pub id: poldercast::Id,
+    pub public_address: poldercast::Address,
 
     /// the rendezvous points for the peer to connect to in order to initiate
     /// the p2p discovery from.
-    pub trusted_peers: Vec<TrustedPeer>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TrustedPeer {
-    address: String,
-    id: poldercast::Id,
+    pub trusted_peers: Vec<poldercast::Address>,
 }
 
 /// Node Secret(s)
@@ -434,15 +425,11 @@ impl P2pConfig {
     {
         P2pConfig {
             public_address: context.generate_new_grpc_public_address(),
-            id: poldercast::Id::generate(&mut context.rng_mut()),
             trusted_peers: Vec::new(),
         }
     }
 
-    fn make_trusted_peer_setting(&self) -> TrustedPeer {
-        TrustedPeer {
-            id: self.id.clone(),
-            address: self.public_address.clone(),
-        }
+    fn make_trusted_peer_setting(&self) -> poldercast::Address {
+        self.public_address.clone()
     }
 }

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -38,7 +38,7 @@ lazy_static = "1.3"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = { version = "0.3.1", features = [ "serde_derive" ] }
+poldercast = { version = "0.4.0", features = [ "serde_derive" ] }
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"

--- a/jormungandr/src/network/client.rs
+++ b/jormungandr/src/network/client.rs
@@ -113,7 +113,7 @@ where
                         );
                         return Err(());
                     }
-                    let logger = state.logger().new(o!("node_id" => node_id.0.as_u128()));
+                    let logger = state.logger().new(o!("node_id" => node_id.to_string()));
 
                     // Spin off processing tasks for subscriptions that can be
                     // managed with just the global state.

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -49,8 +49,8 @@ impl gossip::NodeId for NodeId {}
 
 impl Node {
     #[inline]
-    pub fn new(id: NodeId, address: Address) -> Self {
-        Node(poldercast::Node::new(id.0, address))
+    pub fn new(address: Address) -> Self {
+        Node(poldercast::Node::new(address))
     }
 
     pub fn add_message_subscription(&mut self, interest_level: InterestLevel) {
@@ -64,16 +64,9 @@ impl Node {
     }
 }
 
-impl NodeId {
-    #[inline]
-    pub fn generate() -> Self {
-        NodeId(poldercast::Id::generate(&mut rand::thread_rng()))
-    }
-}
-
 impl fmt::Display for NodeId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0.as_u128())
+        write!(f, "{}", u64::from(self.0))
     }
 }
 
@@ -139,9 +132,9 @@ impl P2pTopology {
     /// set all the default poldercast modules (Rings, Vicinity and Cyclon)
     pub fn set_poldercast_modules(&mut self) {
         let mut topology = self.lock.write().unwrap();
-        topology.add_module(Rings::new());
-        topology.add_module(Vicinity::new());
-        topology.add_module(Cyclon::new());
+        topology.add_module(Rings::default());
+        topology.add_module(Vicinity::default());
+        topology.add_module(Cyclon::default());
     }
 
     /// Returns a list of neighbors selected in this turn

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -71,7 +71,7 @@ pub struct P2pConfig {
 
     /// the rendezvous points for the peer to connect to in order to initiate
     /// the p2p discovery from.
-    pub trusted_peers: Option<Vec<TrustedPeer>>,
+    pub trusted_peers: Option<Vec<poldercast::Address>>,
     /// the topic subscriptions
     ///
     /// When connecting to different nodes we will expose these too in order to
@@ -109,12 +109,6 @@ pub struct Topic(pub poldercast::Topic);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterestLevel(pub poldercast::InterestLevel);
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TrustedPeer {
-    pub address: Address,
-    pub id: NodeId,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Explorer {

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, net::SocketAddr, str, time::Duration};
 
 use crate::{
     network::p2p::topology::NodeId,
-    settings::start::config::{Address, InterestLevel, Topic, TrustedPeer},
+    settings::start::config::{Address, InterestLevel, Topic},
 };
 
 /// Protocol to use for a connection.
@@ -57,7 +57,7 @@ pub struct Configuration {
     pub listen_address: Option<SocketAddr>,
 
     /// list of trusted addresses
-    pub trusted_peers: Vec<TrustedPeer>,
+    pub trusted_peers: Vec<poldercast::Address>,
 
     /// the protocol to utilise for the p2p network
     pub protocol: Protocol,


### PR DESCRIPTION
It was there as part of the paper it is needed to provide a way to identify the nodes in the rings via an easily to compare and order object. the address of a node not being necessarily easy to compare and order it has been replaced to an Identifier, 64bits integer. Now these 8bytes (64bits) are derived from the hash (Blake2b 64bits) of the address. So it it is not needed to expect that from the configuration file. Our own publicly accessible interface is good enough for all our needs.