### PR TITLE
provide better checkpoints than before

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -53,7 +53,7 @@ use crate::{
     blockcfg::{
         Block, Block0Error, Epoch, Header, HeaderHash, Leadership, Ledger, LedgerParameters,
     },
-    blockchain::{Branch, Branches, Multiverse, Ref, RefCache, Storage},
+    blockchain::{Branch, Branches, Checkpoints, Multiverse, Ref, RefCache, Storage},
     start_up::NodeStorage,
 };
 use chain_impl_mockchain::{leadership::Verification, ledger};
@@ -722,11 +722,11 @@ impl Blockchain {
     pub fn get_checkpoints(
         &self,
         branch: Branch,
-    ) -> impl Future<Item = Vec<HeaderHash>, Error = Error> {
+    ) -> impl Future<Item = Checkpoints, Error = Error> {
         let storage = self.storage.clone();
         branch
             .get_ref()
             .map_err(|_| unreachable!())
-            .and_then(move |tip| storage.get_checkpoints(tip.hash()).map_err(|e| e.into()))
+            .map(Checkpoints::new_from)
     }
 }

--- a/jormungandr/src/blockchain/checkpoints.rs
+++ b/jormungandr/src/blockchain/checkpoints.rs
@@ -1,0 +1,63 @@
+use crate::{blockcfg::HeaderHash, blockchain::Ref};
+use std::sync::Arc;
+
+/// list of pre-computed checkpoints from a given [`Ref`].
+///
+/// [`Ref`]: ./struct.Ref.html
+pub struct Checkpoints(Vec<HeaderHash>);
+
+impl Checkpoints {
+    /// create a new list of checkpoints from the given starting point (tip).
+    ///
+    /// The function make use of the `Ref` object pointing to previous epoch in order
+    /// to populate _interestingly_ spaced checkpoints.
+    ///
+    /// For now the algorithm provide the current block, the parent, the last block of the
+    /// previous epoch, the last block of the epoch before that... until the block0.
+    pub fn new_from(from: Arc<Ref>) -> Self {
+        let mut checkpoints = vec![from.hash(), from.block_parent_hash().clone()];
+
+        let mut ignore_prev = 0;
+        let mut current_ref = from;
+        while let Some(prev_epoch) = current_ref.last_ref_previous_epoch() {
+            current_ref = Arc::clone(prev_epoch);
+
+            for _ in 0..ignore_prev {
+                if let Some(prev_epoch) = current_ref.last_ref_previous_epoch() {
+                    current_ref = Arc::clone(&prev_epoch);
+                } else {
+                    break;
+                }
+            }
+
+            ignore_prev += 1;
+
+            checkpoints.push(current_ref.hash());
+        }
+
+        Checkpoints(checkpoints)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &HeaderHash> {
+        self.0.iter()
+    }
+
+    pub fn as_slice(&self) -> &[HeaderHash] {
+        self.0.as_slice()
+    }
+}
+
+impl AsRef<[HeaderHash]> for Checkpoints {
+    fn as_ref(&self) -> &[HeaderHash] {
+        self.as_slice()
+    }
+}
+
+impl IntoIterator for Checkpoints {
+    type Item = HeaderHash;
+    type IntoIter = ::std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}

--- a/jormungandr/src/blockchain/checkpoints.rs
+++ b/jormungandr/src/blockchain/checkpoints.rs
@@ -31,9 +31,14 @@ impl Checkpoints {
                 }
             }
 
-            ignore_prev += 1;
+            let hash = current_ref.hash();
 
-            checkpoints.push(current_ref.hash());
+            // prevent the `from`'s parent to appear twice in the event the parent is also
+            // the last block of the previous epoch.
+            if checkpoints[checkpoints.len()] != hash {
+                ignore_prev += 1;
+                checkpoints.push(hash);
+            }
         }
 
         Checkpoints(checkpoints)

--- a/jormungandr/src/blockchain/checkpoints.rs
+++ b/jormungandr/src/blockchain/checkpoints.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 /// list of pre-computed checkpoints from a given [`Ref`].
 ///
 /// [`Ref`]: ./struct.Ref.html
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Checkpoints(Vec<HeaderHash>);
 
 impl Checkpoints {
@@ -59,5 +60,11 @@ impl IntoIterator for Checkpoints {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl From<Checkpoints> for Vec<HeaderHash> {
+    fn from(checkpoints: Checkpoints) -> Self {
+        checkpoints.0
     }
 }

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -1,5 +1,6 @@
 mod branch;
 mod chain;
+mod checkpoints;
 mod multiverse;
 mod process;
 mod reference;
@@ -9,6 +10,7 @@ mod storage;
 pub use self::{
     branch::{Branch, Branches},
     chain::{Blockchain, Error, ErrorKind, PreCheckedHeader},
+    checkpoints::Checkpoints,
     multiverse::Multiverse,
     process::handle_input,
     reference::Ref,

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -1,6 +1,6 @@
 use crate::blockcfg::{Block, Epoch, Fragment, FragmentId, Header, HeaderHash};
 use crate::network::p2p::topology::NodeId;
-use blockchain::Ref;
+use blockchain::{Checkpoints, Ref};
 use futures::prelude::*;
 use futures::sync::{mpsc, oneshot};
 use jormungandr_lib::interfaces::FragmentOrigin;
@@ -415,7 +415,7 @@ pub enum NetworkMsg {
     GetNextBlock(NodeId, HeaderHash),
     PullHeaders {
         node_id: NodeId,
-        from: Vec<HeaderHash>,
+        from: Checkpoints,
         to: HeaderHash,
     },
 }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -252,7 +252,7 @@ fn handle_network_input(
             Ok(())
         }
         NetworkMsg::PullHeaders { node_id, from, to } => {
-            state.peers.pull_headers(node_id, from, to);
+            state.peers.pull_headers(node_id, from.into(), to);
             Ok(())
         }
     })


### PR DESCRIPTION
previously the checkpoints was only providing something not really useful for the other nodes to work with and we often fall back into re-downloading the whole blockchain.

Now we can leverage our great multiverse/hamt data structure and utilise the backward reference to previous block of interest. Skipping an increasingly larger of amount of epochs so after a year we still don't need to provide hundreds of header hash but a handful.