### PR TITLE
Logging fixes

### DIFF
--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -132,9 +132,10 @@ fn handle_block(
     logger: Logger,
 ) -> impl Future<Item = Arc<Ref>, Error = Error> {
     let header = block.header();
-    debug!(
+    trace!(
         logger,
-        "received block from the bootstrap node: {:#?}", header
+        "received block from the bootstrap node: {:#?}",
+        header
     );
     let mut end_blockchain = blockchain.clone();
     blockchain

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -385,7 +385,7 @@ pub fn bootstrap(
     let mut bootstrapped = false;
 
     for peer in config.trusted_peers.iter() {
-        let logger = logger.new(o!("network" => "bootstrap", "peer" => peer.to_string()));
+        let logger = logger.new(o!("peer" => peer.to_string()));
         if let Some(address) = peer.to_socketaddr() {
             let peer = Peer::new(address, Protocol::Grpc);
             let res =

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -27,7 +27,9 @@ impl NodeService {
     pub fn new(channels: Channels, global_state: GlobalStateR) -> Self {
         NodeService {
             channels,
-            logger: global_state.logger().new(o!(::log::KEY_TASK => "server")),
+            logger: global_state
+                .logger()
+                .new(o!(::log::KEY_SUB_TASK => "server")),
             global_state,
         }
     }


### PR DESCRIPTION
Some improvements to logging:

- Use "sub_task" key more consistently in network logs.
- Don't dump headers of bootstrap blocks in the debug log, lowered to trace.