### PR TITLE
Remove fragments added to block from fragment pool V1

### DIFF
--- a/jormungandr/src/fragment/logs.rs
+++ b/jormungandr/src/fragment/logs.rs
@@ -48,6 +48,18 @@ impl Logs {
         self.run_on_inner(move |inner| inner.modify(&fragment_id.into(), status))
     }
 
+    pub fn modify_all(
+        &mut self,
+        fragment_ids: impl IntoIterator<Item = FragmentId>,
+        status: FragmentStatus,
+    ) -> impl Future<Item = (), Error = ()> {
+        self.run_on_inner(move |inner| {
+            for fragment_id in fragment_ids {
+                inner.modify(&fragment_id.into(), status.clone())
+            }
+        })
+    }
+
     pub fn remove(&mut self, fragment_id: FragmentId) -> impl Future<Item = (), Error = ()> {
         self.run_on_inner(move |inner| inner.remove(&fragment_id.into()))
     }

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -3,7 +3,7 @@ use crate::network::p2p::topology::NodeId;
 use blockchain::{Checkpoints, Ref};
 use futures::prelude::*;
 use futures::sync::{mpsc, oneshot};
-use jormungandr_lib::interfaces::FragmentOrigin;
+use jormungandr_lib::interfaces::{BlockDate, FragmentOrigin};
 use network_core::error as core_error;
 use slog::Logger;
 use std::{
@@ -327,6 +327,7 @@ pub fn stream_request<T, E>(buffer: usize) -> (RequestStreamHandle<T>, RequestSi
 #[derive(Debug)]
 pub enum TransactionMsg {
     SendTransaction(FragmentOrigin, Vec<Fragment>),
+    RemoveTransactions(Vec<FragmentId>, BlockDate),
 }
 
 /// Client messages, mainly requests from connected peers to our node.

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -166,6 +166,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
     let block_task = {
         let mut blockchain = blockchain.clone();
         let mut blockchain_tip = blockchain_tip.clone();
+        let mut fragment_msgbox = fragment_msgbox.clone();
         let mut explorer_msg_box = explorer.as_ref().map(|(msg_box, _context)| msg_box.clone());
         let stats_counter = stats_counter.clone();
         services.spawn_future_with_inputs("block", move |info, input| {
@@ -176,6 +177,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 &stats_counter,
                 &mut new_epoch_announcements,
                 &mut network_msgbox,
+                &mut fragment_msgbox,
                 &mut explorer_msg_box,
                 input,
             )


### PR DESCRIPTION
The naive fix for https://github.com/input-output-hk/jormungandr/issues/795. Whenever block is received from the network and added to the blockchain remove all its fragments from fragment pool. No rollback support. Should be enough to fix https://github.com/input-output-hk/jormungandr/issues/742.