### PR TITLE
Allow non reachable nodes, use actual interests and fix in mempool's logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
- "poldercast 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2081,6 +2081,19 @@ name = "poldercast"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cryptoxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiaddr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "poldercast"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "multiaddr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3937,6 +3950,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum poldercast 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37afa752ff93607da510cc71c4c7d374f334167ca7134716b582846bfd00f4b0"
+"checksum poldercast 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "67a39f0b9863f56504e755df370603a3a2f384dd55e494fb108186d491de1fbb"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/jormungandr-integration-tests/Cargo.toml
+++ b/jormungandr-integration-tests/Cargo.toml
@@ -25,7 +25,7 @@ assert_fs = "0.11"
 mktemp = "0.4.0"
 lazy_static = "1.3"
 custom_error = "1.7"
-poldercast = { version = "0.4.0", features = [ "serde_derive" ] }
+poldercast = { version = "*", features = [ "serde_derive" ] }
 jormungandr = { path = "../jormungandr" }
 jcli = { path = "../jcli" }
 

--- a/jormungandr-scenario-tests/Cargo.toml
+++ b/jormungandr-scenario-tests/Cargo.toml
@@ -20,7 +20,7 @@ chain-addr           = { path = "../chain-deps/chain-addr" }
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 chain-time           = { path = "../chain-deps/chain-time" }
 jormungandr-lib = { path = "../jormungandr-lib" }
-poldercast = { version = "0.4.0", features = [ "serde_derive" ] }
+poldercast = { version = "*", features = [ "serde_derive" ] }
 rand = "0.6"
 rand_core = "0.3"
 rand_chacha = "0.1"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -38,7 +38,7 @@ lazy_static = "1.3"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = { version = "0.4.0", features = [ "serde_derive" ] }
+poldercast = { version = "0.5.1", features = [ "serde_derive" ] }
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"

--- a/jormungandr/src/fragment/logs.rs
+++ b/jormungandr/src/fragment/logs.rs
@@ -29,7 +29,7 @@ impl Logs {
     }
 
     pub fn exists(&self, fragment_id: FragmentId) -> impl Future<Item = bool, Error = ()> {
-        self.run_on_inner(move |inner| inner.exists(fragment_id.into()))
+        self.run_on_inner(move |inner| inner.exists(&fragment_id.into()))
     }
 
     pub fn exist_all(
@@ -116,14 +116,14 @@ pub(super) mod internal {
             }
         }
 
-        pub fn exists(&self, fragment_id: Hash) -> bool {
-            self.entries.contains_key(&fragment_id)
+        pub fn exists(&self, fragment_id: &Hash) -> bool {
+            self.entries.contains_key(fragment_id)
         }
 
         pub fn exist_all(&self, fragment_ids: impl IntoIterator<Item = Hash>) -> Vec<bool> {
             fragment_ids
                 .into_iter()
-                .map(|fragment_id| self.exists(fragment_id))
+                .map(|fragment_id| self.exists(&fragment_id))
                 .collect()
         }
 

--- a/jormungandr/src/fragment/logs.rs
+++ b/jormungandr/src/fragment/logs.rs
@@ -55,7 +55,10 @@ impl Logs {
     ) -> impl Future<Item = (), Error = ()> {
         self.run_on_inner(move |inner| {
             for fragment_id in fragment_ids {
-                inner.modify(&fragment_id.into(), status.clone())
+                let id = fragment_id.into();
+                if inner.exists(&id) {
+                    inner.modify(&id, status.clone())
+                }
             }
         })
     }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -84,12 +84,7 @@ type GlobalStateR = Arc<GlobalState>;
 impl GlobalState {
     /// the network global state
     pub fn new(block0_hash: HeaderHash, config: Configuration, logger: Logger) -> Self {
-        let node_address = config
-            .public_address
-            .clone()
-            .expect("only support the full nodes for now")
-            .0
-            .into();
+        let node_address = config.public_address.clone().map(|addr| addr.0.into());
         let mut node = topology::Node::new(node_address);
 
         // TODO: load the subscriptions from the config
@@ -103,7 +98,7 @@ impl GlobalState {
                 .trusted_peers
                 .iter()
                 .cloned()
-                .map(|trusted_peer| poldercast::Node::new(trusted_peer)),
+                .map(|trusted_peer| poldercast::Node::new_with(trusted_peer)),
         ));
 
         GlobalState {

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -87,9 +87,17 @@ impl GlobalState {
         let node_address = config.public_address.clone().map(|addr| addr.0.into());
         let mut node = topology::Node::new(node_address);
 
+        use self::p2p::topology::{NEW_BLOCKS_TOPIC, NEW_MESSAGES_TOPIC};
+
         // TODO: load the subscriptions from the config
-        node.add_message_subscription(topology::InterestLevel::High);
-        node.add_block_subscription(topology::InterestLevel::High);
+        for (topic, interest) in config.subscriptions.iter() {
+            if topic.0 == NEW_BLOCKS_TOPIC.into() {
+                node.add_block_subscription(interest.0)
+            }
+            if topic.0 == NEW_MESSAGES_TOPIC.into() {
+                node.add_message_subscription(interest.0)
+            }
+        }
 
         let mut topology = P2pTopology::new(node.clone(), logger.clone());
         topology.set_poldercast_modules();

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -41,7 +41,11 @@ impl gossip::Node for Node {
 
     #[inline]
     fn address(&self) -> Option<SocketAddr> {
-        self.0.address().to_socketaddr()
+        if let Some(address) = self.0.address() {
+            address.to_socketaddr()
+        } else {
+            None
+        }
     }
 }
 
@@ -49,8 +53,14 @@ impl gossip::NodeId for NodeId {}
 
 impl Node {
     #[inline]
-    pub fn new(address: Address) -> Self {
-        Node(poldercast::Node::new(address))
+    pub fn new(address: Option<Address>) -> Self {
+        if let Some(address) = address {
+            Node(poldercast::Node::new_with(address))
+        } else {
+            Node(poldercast::Node::new(
+                &mut rand::rngs::OsRng::new().unwrap(),
+            ))
+        }
     }
 
     pub fn add_message_subscription(&mut self, interest_level: InterestLevel) {


### PR DESCRIPTION
closes #796 : now nodes that are not reachable are not forced to add an IP address in the config file for `public_address`. They will still participate to the gossiping but not include themselves.