### PR TITLE
Get the trusted peer list from the CLI and make `--config` optional

### DIFF
--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -175,15 +175,18 @@ pub fn run(params: TaskParams) {
 
     // open the port for listening/accepting other peers to connect too
     let listen = global_state.config.listen();
+    use futures::future::Either;
     let listener = if let Some(listen) = listen {
         match listen.protocol {
-            Protocol::Grpc => {
-                grpc::run_listen_socket(listen, global_state.clone(), channels.clone())
-            }
+            Protocol::Grpc => Either::A(grpc::run_listen_socket(
+                listen,
+                global_state.clone(),
+                channels.clone(),
+            )),
             Protocol::Ntt => unimplemented!(),
         }
     } else {
-        unimplemented!()
+        Either::B(futures::future::ok(()))
     };
 
     let addrs = global_state

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -27,6 +27,13 @@ pub struct StartArguments {
     #[structopt(long = "genesis-block", parse(try_from_str))]
     pub block_0_path: Option<PathBuf>,
 
+    /// set a trusted peer in the multiformat format (e.g.: '/ip4/192.168.0.1/tcp/8029')
+    ///
+    /// This is the trusted peer the node will connect to initially to download the initial
+    /// block0 and fast fetch missing blocks since last start of the node.
+    #[structopt(long = "trusted-peer", parse(try_from_str))]
+    pub trusted_peer: Vec<poldercast::Address>,
+
     /// set the genesis block hash (the hash of the block0) so we can retrieve the
     /// genesis block (and the blockchain configuration) from the existing storage
     /// or from the network.

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -12,7 +12,8 @@ use std::{collections::BTreeMap, fmt, net::SocketAddr, path::PathBuf};
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
-    pub secret_files: Option<Vec<PathBuf>>,
+    #[serde(default)]
+    pub secret_files: Vec<PathBuf>,
     pub storage: Option<PathBuf>,
     pub log: Option<ConfigLogSettings>,
 

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -61,7 +61,7 @@ pub struct Cors {
 #[serde(deny_unknown_fields)]
 pub struct P2pConfig {
     /// The public address to which other peers may connect to
-    pub public_address: Address,
+    pub public_address: Option<Address>,
 
     /// The socket address to listen on, if different from the public address.
     /// The format is "{ip_address}:{port}".

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -15,7 +15,6 @@ custom_error! {pub Error
    ConfigIo { source: std::io::Error } = "Cannot read the node configuration file: {source}",
    Config { source: serde_yaml::Error } = "Error while parsing the node configuration file: {source}",
    Rest { source: RestError } = "The Rest configuration is invalid: {source}",
-   MissingNodeConfig = "--config is mandatory to start the node",
    ExpectedBlock0Info = "Cannot start the node without the information to retrieve the genesis block",
    TooMuchBlock0Info = "Use only `--genesis-block-hash' or `--genesis-block'",
    ListenAddressNotValid = "In the node configuration file, the `p2p.listen_address` value is not a valid address. Use format `/ip4/x.x.x.x/tcp/4920",
@@ -40,12 +39,11 @@ pub struct RawSettings {
 
 impl RawSettings {
     pub fn load(command_line: CommandLine) -> Result<Self, Error> {
-        let config_file = if let Some(node_config) = &command_line.start_arguments.node_config {
-            File::open(node_config)?
+        let config = if let Some(node_config) = &command_line.start_arguments.node_config {
+            Some(serde_yaml::from_reader(File::open(node_config)?)?)
         } else {
-            return Err(Error::MissingNodeConfig);
+            None
         };
-        let config = serde_yaml::from_reader(config_file)?;
         Ok(Self {
             command_line,
             config,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -145,7 +145,7 @@ fn generate_network(
 ) -> Result<network::Configuration, Error> {
     let p2p = &config.p2p;
     let network = network::Configuration {
-        public_address: Some(p2p.public_address.clone()),
+        public_address: p2p.public_address.clone(),
         listen_address: match &p2p.listen_address {
             None => None,
             Some(v) => {

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -35,7 +35,7 @@ pub struct Settings {
 
 pub struct RawSettings {
     command_line: CommandLine,
-    config: Config,
+    config: Option<Config>,
 }
 
 impl RawSettings {
@@ -63,21 +63,21 @@ impl RawSettings {
 
     fn logger_level(&self) -> FilterLevel {
         let cmd_level = self.command_line.log_level.clone();
-        let config_log = self.config.log.as_ref();
+        let config_log = self.config.as_ref().and_then(|cfg| cfg.log.as_ref());
         let config_level = config_log.and_then(|log| log.level.clone());
         cmd_level.or(config_level).unwrap_or(FilterLevel::Info)
     }
 
     fn logger_format(&self) -> LogFormat {
         let cmd_format = self.command_line.log_format.clone();
-        let config_log = self.config.log.as_ref();
+        let config_log = self.config.as_ref().and_then(|cfg| cfg.log.as_ref());
         let config_format = config_log.and_then(|logger| logger.format.clone());
         cmd_format.or(config_format).unwrap_or(LogFormat::Plain)
     }
 
     fn logger_output(&self) -> LogOutput {
         let cmd_output = self.command_line.log_output.clone();
-        let config_log = self.config.log.as_ref();
+        let config_log = self.config.as_ref().and_then(|cfg| cfg.log.as_ref());
         let config_output = config_log.and_then(|logger| logger.output.clone());
         cmd_output.or(config_output).unwrap_or(LogOutput::Stderr)
     }
@@ -95,21 +95,24 @@ impl RawSettings {
         let command_arguments = &command_line.start_arguments;
         let network = generate_network(&command_arguments, &config)?;
 
-        let storage = match (command_arguments.storage.as_ref(), config.storage) {
+        let storage = match (
+            command_arguments.storage.as_ref(),
+            config.as_ref().map_or(None, |cfg| cfg.storage.as_ref()),
+        ) {
             (Some(path), _) => Some(path.clone()),
             (None, Some(path)) => Some(path.clone()),
             (None, None) => None,
         };
 
         let mut secrets = command_arguments.secret.clone();
-        if let Some(secret_files) = config.secret_files {
+        if let Some(secret_files) = config.as_ref().map(|cfg| cfg.secret_files.clone()) {
             secrets.extend(secret_files);
         }
 
         if secrets.is_empty() {
             warn!(
                 logger,
-                "Node started without path to the stored secret keys"
+                "Node started without path to the stored secret keys (not a stake pool or a BFT leader)"
             );
         };
 
@@ -124,26 +127,52 @@ impl RawSettings {
         };
 
         let explorer = command_arguments.explorer_enabled
-            || config.explorer.map_or(false, |settings| settings.enabled);
+            || config.as_ref().map_or(false, |cfg| {
+                cfg.explorer
+                    .as_ref()
+                    .map_or(false, |settings| settings.enabled)
+            });
 
         Ok(Settings {
             storage: storage,
             block_0: block0_info,
             network: network,
             secrets,
-            rest: config.rest,
-            mempool: config.mempool,
-            leadership: config.leadership,
+            rest: config.as_ref().map_or(None, |cfg| cfg.rest.clone()),
+            mempool: config
+                .as_ref()
+                .map_or(Mempool::default(), |cfg| cfg.mempool.clone()),
+            leadership: config
+                .as_ref()
+                .map_or(Leadership::default(), |cfg| cfg.leadership.clone()),
             explorer,
         })
     }
 }
 
 fn generate_network(
-    _command_arguments: &StartArguments,
-    config: &Config,
+    command_arguments: &StartArguments,
+    config: &Option<Config>,
 ) -> Result<network::Configuration, Error> {
-    let p2p = &config.p2p;
+    let mut p2p = if let Some(cfg) = config {
+        cfg.p2p.clone()
+    } else {
+        config::P2pConfig {
+            public_address: None,
+            listen_address: None,
+            trusted_peers: None,
+            topics_of_interest: None,
+        }
+    };
+
+    if p2p.trusted_peers.is_some() {
+        p2p.trusted_peers
+            .as_mut()
+            .map(|peers| peers.extend(command_arguments.trusted_peer.clone()));
+    } else if !command_arguments.trusted_peer.is_empty() {
+        p2p.trusted_peers = Some(command_arguments.trusted_peer.clone())
+    }
+
     let network = network::Configuration {
         public_address: p2p.public_address.clone(),
         listen_address: match &p2p.listen_address {
@@ -158,11 +187,7 @@ fn generate_network(
         },
         trusted_peers: p2p.trusted_peers.clone().unwrap_or(vec![]),
         protocol: Protocol::Grpc,
-        subscriptions: config
-            .p2p
-            .topics_of_interest
-            .clone()
-            .unwrap_or(BTreeMap::new()),
+        subscriptions: p2p.topics_of_interest.clone().unwrap_or(BTreeMap::new()),
         timeout: std::time::Duration::from_secs(15),
     };
 


### PR DESCRIPTION
This makes the config optional and we can now get the list of trusted peers from the command line.

also a quick hack for node without a `listen_address`.