### PR TITLE
Make bump_peer_for_block_fetch miss non-fatal

### DIFF
--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -95,16 +95,14 @@ impl PeerMap {
     }
 
     pub fn bump_peer_for_block_fetch(&mut self, id: NodeId) {
-        let node = self
-            .map
-            .get_mut(&id)
-            .expect("peer must be present in the map");
-        unsafe {
-            let node_ptr = node.as_mut().as_ptr();
-            if !self.block_cursor.is_last(node_ptr) {
-                self.block_cursor.on_unlink_node(node_ptr);
-                node.unlink();
-                self.block_cursor.push_last(node_ptr);
+        if let Some(node) = self.map.get_mut(&id) {
+            unsafe {
+                let node_ptr = node.as_mut().as_ptr();
+                if !self.block_cursor.is_last(node_ptr) {
+                    self.block_cursor.on_unlink_node(node_ptr);
+                    node.unlink();
+                    self.block_cursor.push_last(node_ptr);
+                }
             }
         }
     }


### PR DESCRIPTION
In `network::p2p::comm::PeerMap::bump_peer_for_block_fetch`,
don't panic if the node to bump is no longer in the map.
This can happen in the wild if an announcement is processed after the peer comms entry is removed from the map due to (probably) a subscription stream having closed.