### PR TITLE
Try trusted peers in random order

### DIFF
--- a/jormungandr/src/network/grpc/client.rs
+++ b/jormungandr/src/network/grpc/client.rs
@@ -1,18 +1,54 @@
 use crate::{
     blockcfg::{Block, HeaderHash},
     network::p2p::topology::NodeId,
-    network::{BlockConfig, FetchBlockError},
+    network::BlockConfig,
     settings::start::network::Peer,
 };
 use futures::prelude::*;
 use http::{HttpTryFrom, Uri};
 use hyper::client::connect::{Destination, HttpConnector};
 use network_core::client::{BlockService, Client as _};
-use network_grpc::client::{Connect, ConnectFuture};
+use network_core::error as core_error;
+use network_grpc::client::{Connect, ConnectError, ConnectFuture};
 use slog::Logger;
+use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::slice;
+use std::{error::Error, fmt};
 use tokio::{executor::DefaultExecutor, runtime};
+
+#[derive(Debug)]
+pub enum FetchBlockError {
+    Connect { source: ConnectError<io::Error> },
+    Ready { source: core_error::Error },
+    GetBlocks { source: core_error::Error },
+    GetBlocksStream { source: core_error::Error },
+    NoBlocks,
+}
+
+impl fmt::Display for FetchBlockError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FetchBlockError::Connect { .. } => write!(f, "connection to peer failed"),
+            FetchBlockError::Ready { .. } => write!(f, "gRPC client is not ready to send request"),
+            FetchBlockError::GetBlocks { .. } => write!(f, "block request failed"),
+            FetchBlockError::GetBlocksStream { .. } => write!(f, "block response stream failed"),
+            FetchBlockError::NoBlocks => write!(f, "no blocks in the stream"),
+        }
+    }
+}
+
+impl Error for FetchBlockError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            FetchBlockError::Connect { source } => Some(source),
+            FetchBlockError::Ready { source } => Some(source),
+            FetchBlockError::GetBlocks { source } => Some(source),
+            FetchBlockError::GetBlocksStream { source } => Some(source),
+            FetchBlockError::NoBlocks => None,
+        }
+    }
+}
 
 pub type Connection = network_grpc::client::Connection<BlockConfig>;
 
@@ -46,15 +82,13 @@ pub fn fetch_block(
     hash: &HeaderHash,
     logger: &Logger,
 ) -> Result<Block, FetchBlockError> {
-    info!(logger, "fetching block {} from {}", hash, peer.connection);
+    info!(logger, "fetching block {}", hash);
     let fetch = connect(peer.address(), None)
-        .map_err(|err| FetchBlockError::Connect {
-            source: Box::new(err),
-        })
+        .map_err(|err| FetchBlockError::Connect { source: err })
         .and_then(move |client: Connection| {
-            client.ready().map_err(|err| FetchBlockError::Connect {
-                source: Box::new(err),
-            })
+            client
+                .ready()
+                .map_err(|err| FetchBlockError::Ready { source: err })
         })
         .and_then(move |mut client| {
             client
@@ -64,7 +98,7 @@ pub fn fetch_block(
         .and_then(move |stream| {
             stream
                 .into_future()
-                .map_err(|(err, _)| FetchBlockError::GetBlocks { source: err })
+                .map_err(|(err, _)| FetchBlockError::GetBlocksStream { source: err })
         })
         .and_then(|(maybe_block, _)| match maybe_block {
             None => Err(FetchBlockError::NoBlocks),

--- a/jormungandr/src/network/grpc/mod.rs
+++ b/jormungandr/src/network/grpc/mod.rs
@@ -4,7 +4,7 @@ mod server;
 use super::{p2p::topology as p2p, BlockConfig};
 use crate::blockcfg::{Block, BlockDate, Fragment, FragmentId, Header, HeaderHash};
 
-pub use self::client::{connect, fetch_block, Connection};
+pub use self::client::{connect, fetch_block, Connection, FetchBlockError};
 pub use self::server::run_listen_socket;
 
 impl network_grpc::client::ProtocolConfig for BlockConfig {


### PR DESCRIPTION
Randomize order of peers for bootstrapping the blockchain and for fetching of the inital block.
Change `fetch_block` implementation to try all trusted peers in a randomized sequence.

Fixes #824