### PR TITLE
Fix peer map pointer update bug

### DIFF
--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -233,8 +233,6 @@ struct Node {
     next: Option<NonNull<Node>>,
 }
 
-unsafe impl Send for Node {}
-
 impl Node {
     fn new(id: NodeId, comms: PeerComms) -> Self {
         Node {

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -250,12 +250,13 @@ impl Node {
     // Require a mutable borrow on self because this modifies
     // adjacent nodes.
     unsafe fn unlink(&mut self) {
-        if let Some(mut prev_ptr) = self.prev {
+        let prev = self.prev;
+        if let Some(mut prev_ptr) = prev {
             prev_ptr.as_mut().next = self.next;
             self.prev = None;
         }
         if let Some(mut next_ptr) = self.next {
-            next_ptr.as_mut().prev = self.prev;
+            next_ptr.as_mut().prev = prev;
             self.next = None;
         }
     }


### PR DESCRIPTION
Fixed a gotcha that may be the cause of #833, #814 and a slew of other core dump issues observed.