### PR TITLE
stop the node if we detect a panic in a runtime

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -491,7 +491,10 @@ impl Blockchain {
             .and_then(move |block_ref| {
                 storage
                     .put_block(block)
-                    .map_err(|e| e.into())
+                    .or_else(|err| match err {
+                        StorageError::BlockAlreadyPresent => Ok(()),
+                        err => Err(err.into()),
+                    })
                     .and_then(move |()| Ok(block_ref))
             })
     }

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -100,6 +100,7 @@ impl From<chain_storage::error::Error> for Error {
             CannotIterate => core_error::Code::Internal,
             BackendError(_) => core_error::Code::Internal,
             Block0InFuture => core_error::Code::Internal,
+            BlockAlreadyPresent => core_error::Code::Internal,
         };
         Error {
             code,


### PR DESCRIPTION
Currently if the node experience a panic, we may not detect it due to log overloading. This will make sure the node stops as soon as one of the runtime environment detects a panic or any exceptions.