### PR TITLE
be more liberal with the node's resources and trust default values

### DIFF
--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -153,9 +153,6 @@ impl Services {
     }
 
     /// Spawn the given Future in a new dedicated runtime
-    ///
-    /// * utilising one thread only;
-    /// * 2MiB stack size max
     pub fn spawn_future<F, T>(&mut self, name: &'static str, f: F)
     where
         F: FnOnce(TokioServiceInfo) -> T,
@@ -185,10 +182,6 @@ impl Services {
 
     /// Spawn a tokio service that will await messages and will be executed
     /// sequentially for every received inputs
-    ///
-    /// * utilising one thread only;
-    /// * 2MiB stack size max
-    ///
     pub fn spawn_future_with_inputs<F, Msg, T>(
         &mut self,
         name: &'static str,

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -18,9 +18,6 @@ use tokio::runtime;
 // Limit on the length of a task message queue
 const MESSAGE_QUEUE_LEN: usize = 1000;
 
-// Stack size of a task thread
-const TASK_STACK_SIZE: usize = 2 * 1024 * 1024;
-
 /// hold onto the different services created
 pub struct Services {
     logger: Logger,
@@ -166,9 +163,6 @@ impl Services {
     {
         let mut runtime = runtime::Builder::new()
             .keep_alive(None)
-            .core_threads(1)
-            .blocking_threads(1)
-            .stack_size(TASK_STACK_SIZE)
             .name_prefix(name)
             .build()
             .unwrap();


### PR DESCRIPTION
this value was set by default to simulate tough environment. Nowe we
allow tokio to make the most appropriate choice based on the system
information they detected at runtime