### PR TITLE
Add certificate query for transaction

### DIFF
--- a/jormungandr/src/explorer/graphql/scalars.rs
+++ b/jormungandr/src/explorer/graphql/scalars.rs
@@ -1,0 +1,94 @@
+use crate::blockcfg;
+use chain_crypto::bech32::Bech32;
+use chain_impl_mockchain::value;
+use juniper;
+use std::convert::TryFrom;
+
+#[derive(juniper::GraphQLScalarValue)]
+pub struct Slot(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
+/// Custom scalar type that represents a block's position in the blockchain.
+/// It's a either 0 (the genesis block) or a positive number in string representation.
+pub struct ChainLength(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
+pub struct PoolId(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
+pub struct Value(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
+pub struct EpochNumber(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
+pub struct BlockCount(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
+pub struct Serial(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
+pub struct PublicKey(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
+pub struct TimeOffsetSeconds(pub String);
+
+/*------------------------------*/
+/*------- Conversions ---------*/
+/*----------------------------*/
+
+impl From<blockcfg::ChainLength> for ChainLength {
+    fn from(length: blockcfg::ChainLength) -> ChainLength {
+        ChainLength(u32::from(length).to_string())
+    }
+}
+
+impl TryFrom<ChainLength> for blockcfg::ChainLength {
+    type Error = std::num::ParseIntError;
+    fn try_from(length: ChainLength) -> Result<blockcfg::ChainLength, Self::Error> {
+        length.0.parse::<u32>().map(blockcfg::ChainLength::from)
+    }
+}
+
+impl From<&value::Value> for Value {
+    fn from(v: &value::Value) -> Value {
+        Value(format!("{}", v))
+    }
+}
+
+impl From<blockcfg::Epoch> for EpochNumber {
+    fn from(e: blockcfg::Epoch) -> EpochNumber {
+        EpochNumber(format!("{}", e))
+    }
+}
+
+impl TryFrom<EpochNumber> for blockcfg::Epoch {
+    type Error = std::num::ParseIntError;
+    fn try_from(e: EpochNumber) -> Result<blockcfg::Epoch, Self::Error> {
+        e.0.parse::<u32>()
+    }
+}
+
+impl From<u32> for BlockCount {
+    fn from(number: u32) -> BlockCount {
+        BlockCount(format!("{}", number))
+    }
+}
+
+impl From<u128> for Serial {
+    fn from(number: u128) -> Serial {
+        Serial(format!("{}", number))
+    }
+}
+
+impl From<&chain_crypto::PublicKey<chain_crypto::Ed25519>> for PublicKey {
+    fn from(pk: &chain_crypto::PublicKey<chain_crypto::Ed25519>) -> PublicKey {
+        PublicKey(pk.to_bech32_str())
+    }
+}
+
+impl From<chain_time::TimeOffsetSeconds> for TimeOffsetSeconds {
+    fn from(time: chain_time::TimeOffsetSeconds) -> TimeOffsetSeconds {
+        TimeOffsetSeconds(format!("{}", u64::from(time)))
+    }
+}

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -7,6 +7,7 @@ use crate::blockcfg::{Block, BlockDate, ChainLength, Epoch, Fragment, FragmentId
 use chain_addr::{Address, Discrimination};
 use chain_core::property::Block as _;
 use chain_core::property::Fragment as _;
+use chain_impl_mockchain::certificate::Certificate;
 use chain_impl_mockchain::transaction::{AuthenticatedTransaction, InputEnum, Witness};
 use chain_impl_mockchain::value::Value;
 
@@ -32,9 +33,10 @@ pub struct ExplorerBlock {
 
 #[derive(Clone)]
 pub struct ExplorerTransaction {
-    id: FragmentId,
-    inputs: Vec<ExplorerInput>,
-    outputs: Vec<ExplorerOutput>,
+    pub id: FragmentId,
+    pub inputs: Vec<ExplorerInput>,
+    pub outputs: Vec<ExplorerOutput>,
+    pub certificate: Option<Certificate>,
 }
 
 /// Unified Input representation for utxo and account inputs as used in the graphql API
@@ -85,6 +87,8 @@ impl ExplorerBlock {
                             discrimination,
                             prev_transactions,
                             prev_blocks,
+                            //certificate
+                            None,
                         ),
                     )),
                     Fragment::OwnerStakeDelegation(auth_tx) => Some((
@@ -95,6 +99,9 @@ impl ExplorerBlock {
                             discrimination,
                             prev_transactions,
                             prev_blocks,
+                            Some(Certificate::OwnerStakeDelegation(
+                                auth_tx.transaction.extra.clone(),
+                            )),
                         ),
                     )),
                     Fragment::StakeDelegation(auth_tx) => Some((
@@ -105,6 +112,9 @@ impl ExplorerBlock {
                             discrimination,
                             prev_transactions,
                             prev_blocks,
+                            Some(Certificate::StakeDelegation(
+                                auth_tx.transaction.extra.clone(),
+                            )),
                         ),
                     )),
                     Fragment::PoolRegistration(auth_tx) => Some((
@@ -115,6 +125,9 @@ impl ExplorerBlock {
                             discrimination,
                             prev_transactions,
                             prev_blocks,
+                            Some(Certificate::PoolRegistration(
+                                auth_tx.transaction.extra.clone(),
+                            )),
                         ),
                     )),
                     Fragment::PoolManagement(auth_tx) => Some((
@@ -125,6 +138,9 @@ impl ExplorerBlock {
                             discrimination,
                             prev_transactions,
                             prev_blocks,
+                            Some(Certificate::PoolManagement(
+                                auth_tx.transaction.extra.clone(),
+                            )),
                         ),
                     )),
                     _ => None,
@@ -166,6 +182,7 @@ impl ExplorerTransaction {
         discrimination: Discrimination,
         transactions: &Transactions,
         blocks: &Blocks,
+        certificate: Option<Certificate>,
     ) -> ExplorerTransaction {
         let outputs = auth_tx.transaction.outputs.iter();
         let inputs = auth_tx.transaction.inputs.iter();
@@ -218,6 +235,7 @@ impl ExplorerTransaction {
             id: *id,
             inputs: new_inputs,
             outputs: new_outputs,
+            certificate,
         }
     }
 

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -20,7 +20,6 @@ use crate::intercom::ExplorerMsg;
 use crate::utils::task::{Input, TokioServiceInfo};
 use chain_addr::{Address, Discrimination};
 use chain_core::property::Block as _;
-use chain_core::property::Fragment as _;
 use chain_impl_mockchain::multiverse::GCRoot;
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -43,11 +42,11 @@ pub struct ExplorerDB {
     /// performed using the state of this branch, the HeaderHash is used as key for the
     /// multiverse, and the ChainLength is used in the updating process.
     longest_chain_tip: Lock<(HeaderHash, ChainLength)>,
-    blockchain_config: BlockchainConfig,
+    pub blockchain_config: BlockchainConfig,
 }
 
 #[derive(Clone)]
-struct BlockchainConfig {
+pub struct BlockchainConfig {
     /// Used to construct `Address` from `AccountIndentifier` when processing transaction
     /// inputs
     discrimination: Discrimination,


### PR DESCRIPTION
Summary

- Store the certificates in the transactions
- Move custom scalars to a submodule
- Add the certificate as a field in the Transaction

Example query:

```graphql
{
  transaction(id: "4eb6662f057d204c2f31386d765d4a38a1e6c7fb00778a9d5d9e7233a261f4ac") {
    id
    certificate {
      __typename
      ... on StakeDelegation {
        account {
          id
        }
        pool {
          id
        }
      }
      ... on PoolRegistration {
        pool {
          id
        }
        serial
        startValidity
        managementThreshold
        owners
      }
    }
  }
}
```

Result currently implemented as: 

```graphql
union Certificate = StakeDelegation | OwnerStakeDelegation | PoolRegistration
```

The problem with this interface is that it is that graphql unions can't have unions or interfaces as types, so it is not possible to map  the PoolManagement to a union too:

```rust
pub enum PoolManagement {
    Update(PoolOwnersSigned<PoolUpdate>),
    Retirement(PoolOwnersSigned<PoolRetirement>),
}
```

One alternative is to make two types:

```graphql
type PoolManagementUpdate {}
type PoolManagementRetirement {}
```

The other is to implement `Certificate` as a interface with a tag (interfaces must have at least one field) instead as a union:

```graphql
enum CertificateType {
  StakeDelegation
  OwnerStakeDelegation
  PoolRegistration
  PoolManagement
}

interface Certificate {
  type: CertificateType
}
```
One cons of this alternative is that the `type` field is redundant with the auto-generated  `__typename`
