### PR TITLE
Implement connection limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,12 +943,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1338,7 +1338,7 @@ dependencies = [
  "openapiv3 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1375,6 +1375,7 @@ dependencies = [
  "jormungandr-lib 0.5.5",
  "juniper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
@@ -1473,7 +1474,7 @@ dependencies = [
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1659,15 +1660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz-sys"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,9 +1774,9 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1915,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.24"
+version = "0.10.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1923,7 +1915,7 @@ dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1933,7 +1925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.49"
+version = "0.9.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2464,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2472,7 +2464,7 @@ dependencies = [
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2757,7 +2749,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3833,7 +3825,7 @@ dependencies = [
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
-"checksum flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
+"checksum flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3"
 "checksum float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "134a8fa843d80a51a5b77d36d42bc2def9edcb0262c914861d08129fd1926600"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -3897,7 +3889,6 @@ dependencies = [
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
-"checksum miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
 "checksum miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7108aff85b876d06f22503dcce091e29f76733b2bfdd91eebce81f5e68203a10"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
@@ -3921,9 +3912,9 @@ dependencies = [
 "checksum number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbf9993e59c894e3c08aa1c2712914e9e6bf1fcbfc6bef283e2183df345a4fee"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum openapiv3 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8776c7d6a58a03d30ba278adfd54d923eb0a24e26cbf39d2b97648306935d65"
-"checksum openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)" = "8152bb5a9b5b721538462336e3bef9a539f892715e5037fda0f984577311af15"
+"checksum openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2f372b2b53ce10fb823a337aaa674e3a7d072b957c6264d0f4ff0bd86e657449"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-"checksum openssl-sys 0.9.49 (registry+https://github.com/rust-lang/crates.io-index)" = "f4fad9e54bd23bd4cbbe48fdc08a1b8091707ac869ef8508edea2fec77dcc884"
+"checksum openssl-sys 0.9.50 (registry+https://github.com/rust-lang/crates.io-index)" = "2c42dcccb832556b5926bc9ae61e8775f2a61e725ab07ab3d1e7fcf8ae62c3b6"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
@@ -3980,7 +3971,7 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0f6d896143a583047512e59ac54a215cb203c29cc941917343edea3be8df9c78"
+"checksum reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)" = "02b7e953e14c6f3102b7e8d1f1ee3abf5ecee80b427f5565c9389835cecae95c"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6381ddfe91dbb659b4b132168da15985bc84162378cf4fcdc4eb99c857d063e2"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"

--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -10,27 +10,27 @@ p2p:
 
 ## REST interface configuration
 
-- *listen*: listen address
-- *pkcs12*: certificate file (optional)
-- *cors*: (optional) CORS configuration, if not provided, CORS is disabled
-  - *allowed_origins*: (optional) allowed origins, if none provided, echos request origin
-  - *max_age_secs*: (optional) maximum CORS caching time in seconds, if none provided, caching is disabled
+- `listen`: listen address
+- `pkcs12`: certificate file (optional)
+- `cors`: (optional) CORS configuration, if not provided, CORS is disabled
+  - `allowed_origins`: (optional) allowed origins, if none provided, echos request origin
+  - `max_age_secs`: (optional) maximum CORS caching time in seconds, if none provided, caching is disabled
 
 ## P2P configuration
 
-- *trusted_peers*: (optional) the list of nodes' [multiaddr][multiaddr] to connect to in order to
+- `trusted_peers`: (optional) the list of nodes' [multiaddr][multiaddr] to connect to in order to
     bootstrap the p2p topology (and bootstrap our local blockchain);
-- *public_address*: [multiaddr][multiaddr] the address to listen from and accept connection
+- `public_address`: [multiaddr][multiaddr] the address to listen from and accept connection
     from. This is the public address that will be distributed to other peers
     of the network that may find interest into participating to the blockchain
     dissemination with the node;
 - `listen_address`: (optional) [multiaddr][multiaddr] specifies the address the node
     will listen to to receive p2p connection. Can be left empty and the node will listen
     to whatever value was given to `public_address`.
-- *topics_of_interest*: the different topics we are interested to hear about:
-    - *messages*: notify other peers this node is interested about Transactions
+- `topics_of_interest`: the different topics we are interested to hear about:
+    - `messages`: notify other peers this node is interested about Transactions
     typical setting for a non mining node: `"low"`. For a stakepool: `"high"`;
-    - *blocks*: notify other peers this node is interested about new Blocs.
+    - `blocks`: notify other peers this node is interested about new Blocs.
     typical settings for a non mining node: `"normal"`. For a stakepool: `"high"`.
 - `max_connections`: the maximum number of P2P connections this node should
     maintain. If not specified, an internal limit is used by default.

--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -31,6 +31,8 @@ p2p:
     - *messages*: notify other peers this node is interested about Transactions
     typical setting for a non mining node: `"low"`. For a stakepool: `"high"`;
     - *blocks*: notify other peers this node is interested about new Blocs.
-    typical settings for a non mining node: `"normal"`. For a stakepool: `"high"`;
+    typical settings for a non mining node: `"normal"`. For a stakepool: `"high"`.
+- `max_connections`: the maximum number of P2P connections this node should
+    maintain. If not specified, an internal limit is used by default.
 
 [multiaddr]: https://github.com/multiformats/multiaddr

--- a/doc/quickstart/02_passive_node.md
+++ b/doc/quickstart/02_passive_node.md
@@ -79,7 +79,9 @@ Description of the fields:
       - `messages`: Transactions and other ledger entries.
         Typical setting for a non-mining node: `low`. For a stakepool: `high`;
       - `blocks`: Notifications about new blocks.
-        Typical setting for a non-mining node: `normal`. For a stakepool: `high`;
+        Typical setting for a non-mining node: `normal`. For a stakepool: `high`.
+    - `max_connections`: The maximum number of simultaneous P2P connections
+      this node should maintain.
 - `explorer`: (optional) Explorer settings
     - `enabled`: True or false
 

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -12,6 +12,7 @@ Midgard Serpent
 
 [dependencies]
 actix-net = "0.2.6"
+actix-threadpool = "0.1.2"
 actix-web = { version = "0.7.18", default-features = false, features = [ "tls" ] }
 juniper = "0.13.1"
 bincode = "1.0.1"
@@ -32,6 +33,7 @@ humantime = "1.2"
 hyper = "0.12"
 jormungandr-lib = { path = "../jormungandr-lib" }
 lazy_static = "1.3"
+linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
@@ -51,7 +53,6 @@ slog-stdlog = "4.0"
 slog-term = "2.4.0"
 structopt = "^0.2"
 tokio      = "^0.1.16"
-actix-threadpool = "0.1.2"
 
 [build-dependencies]
 versionisator = "1.0"

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -23,6 +23,7 @@ extern crate hyper;
 extern crate jormungandr_lib;
 #[macro_use]
 extern crate lazy_static;
+extern crate linked_hash_map;
 extern crate native_tls;
 extern crate network_core;
 extern crate network_grpc;

--- a/jormungandr/src/network/client.rs
+++ b/jormungandr/src/network/client.rs
@@ -119,6 +119,7 @@ where
                     // managed with just the global state.
                     subscription::process_fragments(
                         fragment_sub,
+                        node_id,
                         state.global.clone(),
                         channels.transaction_box.clone(),
                         logger.clone(),

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -14,6 +14,7 @@ mod service;
 mod subscription;
 
 // Constants
+
 mod chain_pull {
     // Size of chunks to split processing of chain pull streams.
     // Apart from sizing data chunks for intercom messages, it also
@@ -106,12 +107,14 @@ impl GlobalState {
                 .map(|trusted_peer| poldercast::Node::new_with(trusted_peer)),
         ));
 
+        let peers = Peers::new(config.max_connections, logger.clone());
+
         GlobalState {
             block0_hash,
             config,
             topology,
             node,
-            peers: Peers::new(logger.clone()),
+            peers,
             logger,
         }
     }

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -204,9 +204,9 @@ pub struct Peers {
 }
 
 impl Peers {
-    pub fn new(logger: Logger) -> Self {
+    pub fn new(capacity: usize, logger: Logger) -> Self {
         Peers {
-            mutex: Mutex::new(peer_map::PeerMap::new()),
+            mutex: Mutex::new(peer_map::PeerMap::new(capacity)),
             logger,
         }
     }
@@ -216,9 +216,9 @@ impl Peers {
         map.insert_peer(id, comms)
     }
 
-    pub fn remove_peer(&self, id: topology::NodeId) -> bool {
+    pub fn remove_peer(&self, id: topology::NodeId) {
         let mut map = self.mutex.lock().unwrap();
-        map.remove_peer(id)
+        map.remove_peer(id);
     }
 
     pub fn subscribe_to_block_events(&self, id: topology::NodeId) -> BlockEventSubscription {

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -339,9 +339,9 @@ impl Peers {
         }
     }
 
-    pub fn bump_peer_for_block_fetch(&self, node_id: topology::NodeId) {
+    pub fn refresh_peer(&self, node_id: topology::NodeId) {
         let mut map = self.mutex.lock().unwrap();
-        map.bump_peer_for_block_fetch(node_id);
+        map.refresh_peer_comms(node_id);
     }
 
     pub fn fetch_blocks(&self, hashes: Vec<HeaderHash>) {
@@ -366,12 +366,11 @@ impl Peers {
 
     pub fn solicit_blocks(&self, node_id: topology::NodeId, hashes: Vec<HeaderHash>) {
         let mut map = self.mutex.lock().unwrap();
-        match map.entry(node_id) {
-            Some(mut entry) => {
+        match map.refresh_peer_comms(node_id) {
+            Some(comms) => {
                 debug!(self.logger, "sending block solicitation to {}", node_id;
                        "hashes" => ?hashes);
-                entry
-                    .comms()
+                comms
                     .block_solicitations
                     .try_send(hashes)
                     .unwrap_or_else(|e| {
@@ -380,7 +379,7 @@ impl Peers {
                             "block solicitation from {} failed: {:?}", node_id, e
                         );
                         debug!(self.logger, "unsubscribing peer {}", node_id);
-                        entry.remove();
+                        map.remove_peer(node_id);
                     });
             }
             None => {
@@ -395,12 +394,11 @@ impl Peers {
 
     pub fn pull_headers(&self, node_id: topology::NodeId, from: Vec<HeaderHash>, to: HeaderHash) {
         let mut map = self.mutex.lock().unwrap();
-        match map.entry(node_id) {
-            Some(mut entry) => {
+        match map.refresh_peer_comms(node_id) {
+            Some(comms) => {
                 debug!(self.logger, "pulling headers from {}", node_id;
                        "from" => ?from, "to" => ?to);
-                entry
-                    .comms()
+                comms
                     .chain_pulls
                     .try_send(ChainPullRequest { from, to })
                     .unwrap_or_else(|e| {
@@ -409,7 +407,7 @@ impl Peers {
                             "sending header pull solicitation to {} failed: {:?}", node_id, e
                         );
                         debug!(self.logger, "unsubscribing peer {}", node_id);
-                        entry.remove();
+                        map.remove_peer(node_id);
                     });
             }
             None => {

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -25,8 +25,8 @@ impl PeerMap {
         }
     }
 
-    pub fn peer_comms(&mut self, id: NodeId) -> Option<&mut PeerComms> {
-        self.map.get_mut(&id)
+    pub fn refresh_peer_comms(&mut self, id: NodeId) -> Option<&mut PeerComms> {
+        self.map.get_refresh(&id)
     }
 
     pub fn ensure_peer_comms(&mut self, id: NodeId) -> &mut PeerComms {
@@ -50,12 +50,6 @@ impl PeerMap {
             .iter_mut()
             .next_back()
             .map(|(&id, comms)| (id, comms))
-    }
-
-    pub fn bump_peer_for_block_fetch(&mut self, id: NodeId) {
-        // It's OK for the entry to be missing because it might have been
-        // removed by the time peer's traffic is processed.
-        let _ = self.map.get_refresh(&id);
     }
 
     fn evict_if_full(&mut self) {

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -1,294 +1,80 @@
 use super::PeerComms;
 use crate::network::p2p::topology::NodeId;
 
-use std::collections::{hash_map, HashMap};
-use std::pin::Pin;
-use std::ptr::NonNull;
+use linked_hash_map::LinkedHashMap;
 
 pub struct PeerMap {
-    map: HashMap<NodeId, Pin<Box<Node>>>,
-    block_cursor: BlockFetchCursor,
+    map: LinkedHashMap<NodeId, PeerComms>,
+    capacity: usize,
 }
 
-unsafe impl Send for PeerMap {}
-
 impl PeerMap {
-    pub fn new() -> Self {
+    pub fn new(capacity: usize) -> Self {
         PeerMap {
-            map: HashMap::new(),
-            block_cursor: BlockFetchCursor::Empty,
+            map: LinkedHashMap::new(),
+            capacity,
         }
     }
 
     pub fn entry<'a>(&'a mut self, id: NodeId) -> Option<Entry<'a>> {
-        use std::collections::hash_map::Entry::*;
+        use linked_hash_map::Entry::*;
 
         match self.map.entry(id) {
             Vacant(_) => None,
-            Occupied(entry) => Some(Entry {
-                inner: entry,
-                block_cursor: &mut self.block_cursor,
-            }),
+            Occupied(entry) => Some(Entry { inner: entry }),
         }
     }
 
     pub fn peer_comms(&mut self, id: NodeId) -> Option<&mut PeerComms> {
-        match self.map.get_mut(&id) {
-            None => None,
-            Some(pin) => Some(&mut pin.comms),
-        }
+        self.map.get_mut(&id)
     }
 
     pub fn ensure_peer_comms(&mut self, id: NodeId) -> &mut PeerComms {
-        use std::collections::hash_map::Entry::*;
-
-        let node_ptr = match self.map.entry(id) {
-            Occupied(mut entry) => entry.get_mut().as_mut().as_ptr(),
-            Vacant(entry) => {
-                let node = Box::pin(Node::new(id, PeerComms::new()));
-                let node = entry.insert(node);
-                let node_ptr = node.as_mut().as_ptr();
-                unsafe {
-                    // Add the node, but don't reset the cursor
-                    // as the block subscription has not been established yet.
-                    self.block_cursor.add_last(node_ptr);
-                }
-                node_ptr
-            }
-        };
-        unsafe { &mut (*node_ptr.as_ptr()).comms }
+        if !self.map.contains_key(&id) {
+            self.insert_peer(id, PeerComms::new());
+        }
+        self.map.get_mut(&id).unwrap()
     }
 
     pub fn insert_peer(&mut self, id: NodeId, comms: PeerComms) {
-        use std::collections::hash_map::Entry::*;
-
-        let mut node = Box::pin(Node::new(id, comms));
-        let node_ptr = match self.map.entry(id) {
-            Occupied(mut entry) => {
-                unsafe {
-                    let old_node = entry.get_mut();
-                    let old_node_ptr = old_node.as_mut().as_ptr();
-                    self.block_cursor.on_unlink_node(old_node_ptr);
-                    old_node.unlink();
-                }
-                let node_ptr = node.as_mut().as_ptr();
-                entry.insert(node);
-                node_ptr
-            }
-            Vacant(entry) => entry.insert(node).as_mut().as_ptr(),
-        };
-        unsafe {
-            self.block_cursor.push_last(node_ptr);
-        }
+        self.evict_if_full();
+        self.map.insert(id, comms);
     }
 
-    pub fn remove_peer(&mut self, id: NodeId) -> bool {
-        match self.entry(id) {
-            Some(entry) => {
-                entry.remove();
-                true
-            }
-            None => false,
-        }
+    pub fn remove_peer(&mut self, id: NodeId) -> Option<PeerComms> {
+        self.map.remove(&id)
     }
 
     pub fn next_peer_for_block_fetch(&mut self) -> Option<(NodeId, &mut PeerComms)> {
-        unsafe {
-            match self.block_cursor.next() {
-                None => None,
-                Some(node_ptr) => {
-                    let node = node_ptr.as_ref();
-                    Some((node.id, &mut (*node_ptr.as_ptr()).comms))
-                }
-            }
-        }
+        self.map
+            .iter_mut()
+            .next_back()
+            .map(|(&id, comms)| (id, comms))
     }
 
     pub fn bump_peer_for_block_fetch(&mut self, id: NodeId) {
-        if let Some(node) = self.map.get_mut(&id) {
-            unsafe {
-                let node_ptr = node.as_mut().as_ptr();
-                if !self.block_cursor.is_last(node_ptr) {
-                    self.block_cursor.on_unlink_node(node_ptr);
-                    node.unlink();
-                    self.block_cursor.push_last(node_ptr);
-                }
-            }
-        }
-    }
-}
-
-// State for round-robin block fetching cursor.
-enum BlockFetchCursor {
-    // Placeholder when no entries exist in the map.
-    Empty,
-    Ptrs {
-        // The last node in the fetch order.
-        last: NonNull<Node>,
-        // Cursor for the next node to fetch blocks from.
-        // If None, start from last.
-        next_back: Option<NonNull<Node>>,
-    },
-}
-
-impl BlockFetchCursor {
-    fn is_last(&self, node_ptr: NonNull<Node>) -> bool {
-        match self {
-            BlockFetchCursor::Empty => false,
-            BlockFetchCursor::Ptrs { last, .. } => *last == node_ptr,
-        }
+        // It's OK for the entry to be missing because it might have been
+        // removed by the time peer's traffic is processed.
+        let _ = self.map.get_refresh(&id);
     }
 
-    unsafe fn next(&mut self) -> Option<NonNull<Node>> {
-        match self {
-            BlockFetchCursor::Empty => None,
-            BlockFetchCursor::Ptrs {
-                ref last,
-                ref mut next_back,
-            } => {
-                let next_ptr = next_back.unwrap_or(*last);
-                let next = next_ptr.as_ref();
-                *next_back = next.prev;
-                Some(next_ptr)
-            }
-        }
-    }
-
-    unsafe fn add_last(&mut self, mut node_ptr: NonNull<Node>) {
-        debug_assert!(node_ptr.as_mut().prev.is_none());
-        debug_assert!(node_ptr.as_mut().next.is_none());
-        match self {
-            BlockFetchCursor::Empty => {
-                *self = BlockFetchCursor::Ptrs {
-                    last: node_ptr,
-                    next_back: None,
-                };
-            }
-            BlockFetchCursor::Ptrs {
-                last: ref mut last_ptr,
-                ..
-            } => {
-                let last = last_ptr.as_mut();
-                last.next = Some(node_ptr);
-                let node = node_ptr.as_mut();
-                node.prev = Some(*last_ptr);
-                *last_ptr = node_ptr;
-            }
-        }
-    }
-
-    unsafe fn push_last(&mut self, mut node_ptr: NonNull<Node>) {
-        debug_assert!(node_ptr.as_mut().prev.is_none());
-        debug_assert!(node_ptr.as_mut().next.is_none());
-        *self = match self {
-            BlockFetchCursor::Empty => BlockFetchCursor::Ptrs {
-                last: node_ptr,
-                next_back: None,
-            },
-            BlockFetchCursor::Ptrs {
-                last: ref mut last_ptr,
-                ..
-            } => {
-                let last = last_ptr.as_mut();
-                last.next = Some(node_ptr);
-                let node = node_ptr.as_mut();
-                node.prev = Some(*last_ptr);
-                BlockFetchCursor::Ptrs {
-                    last: node_ptr,
-                    next_back: None,
-                }
-            }
-        }
-    }
-
-    // This must be called before the unlink method is called on the node.
-    unsafe fn on_unlink_node(&mut self, node_ptr: NonNull<Node>) {
-        match self {
-            BlockFetchCursor::Ptrs {
-                ref mut last,
-                ref mut next_back,
-            } => {
-                let node = node_ptr.as_ref();
-                if *next_back == Some(node_ptr) {
-                    *next_back = node.prev;
-                }
-                if *last == node_ptr {
-                    match node.prev {
-                        None => {
-                            *self = BlockFetchCursor::Empty;
-                        }
-                        Some(prev_ptr) => {
-                            *last = prev_ptr;
-                        }
-                    }
-                }
-            }
-            BlockFetchCursor::Empty => {
-                unreachable!("cursor is empty while a node is being removed")
-            }
-        }
-    }
-}
-
-// Map node, pinned and linked through in linear order of recent use.
-struct Node {
-    // The node ID, duplicated in the value structure
-    // to access when navigating "sideways" in the order.
-    id: NodeId,
-    // The structurally unpinned peer communications entry.
-    comms: PeerComms,
-    // Pointer to the previous node.
-    prev: Option<NonNull<Node>>,
-    // Pointer to the next node.
-    next: Option<NonNull<Node>>,
-}
-
-impl Node {
-    fn new(id: NodeId, comms: PeerComms) -> Self {
-        Node {
-            id,
-            comms,
-            prev: None,
-            next: None,
-        }
-    }
-
-    fn as_ptr(self: Pin<&mut Node>) -> NonNull<Node> {
-        unsafe { NonNull::new_unchecked(self.get_mut()) }
-    }
-
-    // Require a mutable borrow on self because this modifies
-    // adjacent nodes.
-    unsafe fn unlink(&mut self) {
-        let prev = self.prev;
-        if let Some(mut prev_ptr) = prev {
-            prev_ptr.as_mut().next = self.next;
-            self.prev = None;
-        }
-        if let Some(mut next_ptr) = self.next {
-            next_ptr.as_mut().prev = prev;
-            self.next = None;
+    fn evict_if_full(&mut self) {
+        if self.map.len() >= self.capacity {
+            self.map.pop_front();
         }
     }
 }
 
 pub struct Entry<'a> {
-    inner: hash_map::OccupiedEntry<'a, NodeId, Pin<Box<Node>>>,
-    block_cursor: &'a mut BlockFetchCursor,
+    inner: linked_hash_map::OccupiedEntry<'a, NodeId, PeerComms>,
 }
 
 impl<'a> Entry<'a> {
     pub fn comms(&mut self) -> &mut PeerComms {
-        &mut self.inner.get_mut().comms
+        self.inner.get_mut()
     }
 
-    pub fn remove(mut self) {
-        let node = self.inner.get_mut();
-        let node_ptr = node.as_mut().as_ptr();
-        unsafe {
-            self.block_cursor.on_unlink_node(node_ptr);
-            node.unlink();
-        }
+    pub fn remove(self) {
         self.inner.remove();
     }
 }

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -239,6 +239,7 @@ impl FragmentService for NodeService {
     {
         subscription::process_fragments(
             inbound,
+            subscriber,
             self.global_state.clone(),
             self.channels.transaction_box.clone(),
             self.logger().clone(),

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -172,7 +172,7 @@ impl BlockService for NodeService {
             subscriber,
             self.global_state.clone(),
             self.channels.block_box.clone(),
-            self.logger().clone(),
+            self.logger().new(o!("node_id" => subscriber.to_string())),
         );
 
         let subscription = self
@@ -242,7 +242,7 @@ impl FragmentService for NodeService {
             subscriber,
             self.global_state.clone(),
             self.channels.transaction_box.clone(),
-            self.logger().clone(),
+            self.logger().new(o!("node_id" => subscriber.to_string())),
         );
 
         let subscription = self.global_state.peers.subscribe_to_fragments(subscriber);
@@ -263,7 +263,11 @@ impl GossipService for NodeService {
     where
         In: Stream<Item = Gossip<Self::Node>, Error = core_error::Error> + Send + 'static,
     {
-        subscription::process_gossip(inbound, self.global_state.clone(), self.logger().clone());
+        subscription::process_gossip(
+            inbound,
+            self.global_state.clone(),
+            self.logger().new(o!("node_id" => subscriber.to_string())),
+        );
 
         let subscription = self.global_state.peers.subscribe_to_gossip(subscriber);
         future::ok(subscription)

--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -53,7 +53,6 @@ where
     )
 }
 
-// TODO: convert this function and all uses of it to async
 pub fn process_block_announcement(
     header: Header,
     node_id: NodeId,

--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -35,7 +35,7 @@ where
             );
         })
         .map(move |header| {
-            global_state.peers.bump_peer_for_block_fetch(node_id);
+            global_state.peers.refresh_peer(node_id);
             BlockMsg::AnnouncedBlock(header, node_id)
         });
     tokio::spawn(
@@ -59,7 +59,7 @@ pub fn process_block_announcement(
     global_state: &GlobalState,
     block_box: MessageBox<BlockMsg>,
 ) -> SendingBlockMsg {
-    global_state.peers.bump_peer_for_block_fetch(node_id);
+    global_state.peers.refresh_peer(node_id);
     let future = block_box.send(BlockMsg::AnnouncedBlock(header, node_id));
     SendingBlockMsg { inner: future }
 }
@@ -85,7 +85,8 @@ impl Future for SendingBlockMsg {
 
 pub fn process_fragments<S>(
     inbound: S,
-    _state: GlobalStateR,
+    node_id: NodeId,
+    global_state: GlobalStateR,
     transaction_box: MessageBox<TransactionMsg>,
     logger: Logger,
 ) -> tokio::executor::Spawn
@@ -101,7 +102,10 @@ where
                 "fragment subscription stream failure: {:?}", err
             );
         })
-        .map(|fragment| TransactionMsg::SendTransaction(FragmentOrigin::Network, vec![fragment]));
+        .map(move |fragment| {
+            global_state.peers.refresh_peer(node_id);
+            TransactionMsg::SendTransaction(FragmentOrigin::Network, vec![fragment])
+        });
     tokio::spawn(
         transaction_box
             .sink_map_err(move |_| {

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -82,6 +82,10 @@ pub struct P2pConfig {
     /// best possible neighborhood.
     pub topics_of_interest: Option<BTreeMap<Topic, InterestLevel>>,
 
+    /// Limit on the number of simultaneous connections.
+    /// If not specified, an internal default limit is used.
+    pub max_connections: Option<usize>,
+
     /// Whether to allow non-public IP addresses on the network.
     /// The default is to not allow advertising non-public IP addresses.
     #[serde(default)]
@@ -133,6 +137,7 @@ impl Default for P2pConfig {
             listen_address: None,
             trusted_peers: None,
             topics_of_interest: None,
+            max_connections: None,
             allow_private_addresses: false,
         }
     }

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -181,6 +181,9 @@ fn generate_network(
         trusted_peers: p2p.trusted_peers.clone().unwrap_or(vec![]),
         protocol: Protocol::Grpc,
         subscriptions: p2p.topics_of_interest.clone().unwrap_or(BTreeMap::new()),
+        max_connections: p2p
+            .max_connections
+            .unwrap_or(network::DEFAULT_MAX_CONNECTIONS),
         timeout: std::time::Duration::from_secs(15),
         allow_private_addresses: p2p.allow_private_addresses,
     };

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -33,6 +33,10 @@ pub struct Listen {
     pub timeout: Duration,
 }
 
+/// The limit on the number of simultaneous P2P connections
+/// used unless the corresponding configuration option is specified.
+pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
+
 const DEFAULT_TIMEOUT_MICROSECONDS: u64 = 500_000;
 
 ///
@@ -57,6 +61,9 @@ pub struct Configuration {
 
     /// the topic we are interested to hear about
     pub subscriptions: BTreeMap<Topic, InterestLevel>,
+
+    /// Maximum allowed number of peer connections.
+    pub max_connections: usize,
 
     /// the default value for the timeout for inactive connection
     pub timeout: Duration,


### PR DESCRIPTION
Add configurable maximum number of peer connections, evicted on last recently used principle.
"Used" is currently understood as receiving blocks and fragments via the respective subscriptions, and sending block solicitations and pull requests for which we are probably interested in hearing back.
Gossip circulation does not affect the last used order.

The block fetch cursor in `PeerMap` has been erased in favor of a `LinkedHashMap` with global order for all uses.

Fixes #872