### PR TITLE
Update network.md and Jormungandr User Guide

### DIFF
--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -20,13 +20,10 @@ p2p:
 
 - `trusted_peers`: (optional) the list of nodes' [multiaddr][multiaddr] to connect to in order to
     bootstrap the p2p topology (and bootstrap our local blockchain);
-- `public_address`: [multiaddr][multiaddr] the address to listen from and accept connection
-    from. This is the public address that will be distributed to other peers
-    of the network that may find interest into participating to the blockchain
-    dissemination with the node;
-- `listen_address`: (optional) [multiaddr][multiaddr] specifies the address the node
-    will listen to to receive p2p connection. Can be left empty and the node will listen
-    to whatever value was given to `public_address`.
+-  public_address: [multiaddr] The address to listen from and accept connections. This is the external public address that will be distributed to other gossip peers on the network.  Public address port must match listen address port.
+-  listen_address:  [multiaddr] Internal address that the node will listen to for 
+    receiving p2p connections.  This connection will typically be port forwarded from 
+    your router or cable modem. Listen address port must match public address port.
 - `topics_of_interest`: the different topics we are interested to hear about:
     - `messages`: notify other peers this node is interested about Transactions
     typical setting for a non mining node: `"low"`. For a stakepool: `"high"`;


### PR DESCRIPTION
Propose changing https://input-output-hk.github.io/jormungandr/introduction.html and also testing the validity of the Ports ASAP.  I still believe they should be different with public on 3000 with the rest of the gossip peers and anything internal should be on a different port like 3100.  This would in effect make the public gossip server like a dns server with the actual jormangandr node like apache behind the firewall but all my testing has lead me to understand that I can only sync and make blocks if they are the same.  There is a huge amount of confusion surrounding this on the telegram group with no concrete answer.  There are people putting 8080 and even snmp ports in.