### PR TITLE
Make network task startup fail on listen failure

### DIFF
--- a/jormungandr-integration-tests/src/common/jormungandr/starter.rs
+++ b/jormungandr-integration-tests/src/common/jormungandr/starter.rs
@@ -97,9 +97,8 @@ pub fn start_jormungandr_node(config: &mut JormungandrConfig) -> JormungandrProc
     process
 }
 
-pub fn restart_jormungandr_node_as_leader(process: &mut JormungandrProcess) -> JormungandrProcess {
+pub fn restart_jormungandr_node_as_leader(process: JormungandrProcess) -> JormungandrProcess {
     let mut config = process.config.clone();
-    config.refresh_node_dynamic_params();
     std::mem::drop(process);
 
     println!("Starting node with configuration : {:?}", &config);

--- a/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -38,7 +38,7 @@ pub fn test_node_recovers_from_node_restart() {
         &jormungandr_rest_address,
     );
 
-    let _jormungandr_after_restart = starter::restart_jormungandr_node_as_leader(&mut jormungandr);
+    let jormungandr = starter::restart_jormungandr_node_as_leader(jormungandr);
 
     let actual_settings = jcli_wrapper::assert_get_rest_settings(&jormungandr_rest_address);
     let actual_utxos = jcli_wrapper::assert_rest_utxo_get(&jormungandr_rest_address);

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -220,7 +220,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
             };
             network::start(info, params)
                 // FIXME: more graceful error reporting
-                .expect("p2p network failure")
+                .map_err(|e| panic!(e))
         });
     }
 

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -217,9 +217,8 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 block0_hash,
                 input: network_queue,
                 channels,
-                logger: info.into_logger(),
             };
-            network::start(params)
+            network::start(info, params)
                 // FIXME: more graceful error reporting
                 .expect("p2p network failure")
         });

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -211,7 +211,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
             block_box: block_msgbox,
         };
 
-        services.spawn("network", move |info| {
+        services.spawn_future("network", move |info| {
             let params = network::TaskParams {
                 config,
                 block0_hash,
@@ -219,7 +219,9 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 channels,
                 logger: info.into_logger(),
             };
-            network::run(params);
+            network::start(params)
+                // FIXME: more graceful error reporting
+                .expect("p2p network failure")
         });
     }
 

--- a/jormungandr/src/network/client.rs
+++ b/jormungandr/src/network/client.rs
@@ -179,7 +179,7 @@ where
                 let node_id = self.remote_node_id;
                 let done_logger = self.logger.clone();
                 let err_logger = self.logger.clone();
-                tokio::spawn(
+                self.global_state.spawn(
                     self.service
                         .upload_blocks(stream)
                         .map(move |_| {
@@ -211,7 +211,7 @@ where
         let node_id = self.remote_node_id;
         let done_logger = self.logger.clone();
         let err_logger = self.logger.clone();
-        tokio::spawn(
+        self.global_state.spawn(
             self.service
                 .push_headers(stream)
                 .map(move |_| {
@@ -234,7 +234,7 @@ where
         let node_id = self.remote_node_id;
         let done_logger = self.logger.clone();
         let err_logger = self.logger.clone();
-        tokio::spawn(
+        self.global_state.spawn(
             self.service
                 .upload_blocks(stream)
                 .map(move |_| {
@@ -260,7 +260,7 @@ where
         let block_box = self.channels.block_box.clone();
         let logger = self.logger.clone();
         let err_logger = logger.clone();
-        tokio::spawn(
+        self.global_state.spawn(
             self.service
                 .pull_headers(&req.from, &req.to)
                 .map_err(move |e| {
@@ -302,7 +302,7 @@ where
         let block_box = self.channels.block_box.clone();
         let logger = self.logger.clone();
         let err_logger = logger.clone();
-        tokio::spawn(
+        self.global_state.spawn(
             self.service
                 .pull_blocks_to_tip(&req.from)
                 .map_err(move |e| {
@@ -344,7 +344,7 @@ where
         let block_box = self.channels.block_box.clone();
         let logger = self.logger.clone();
         let err_logger = logger.clone();
-        tokio::spawn(
+        self.global_state.spawn(
             self.service
                 .get_blocks(block_ids)
                 .map_err(move |e| {

--- a/jormungandr/src/network/grpc/server.rs
+++ b/jormungandr/src/network/grpc/server.rs
@@ -6,7 +6,7 @@ use tk_listen::ListenExt;
 use tokio::prelude::*;
 
 pub fn run_listen_socket(
-    listen: Listen,
+    listen: &Listen,
     state: GlobalStateR,
     channels: Channels,
 ) -> Result<impl Future<Item = (), Error = ()>, ListenError> {

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -13,7 +13,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::prelude::*;
-use tokio::runtime;
+use tokio::runtime::{self, TaskExecutor};
 
 // Limit on the length of a task message queue
 const MESSAGE_QUEUE_LEN: usize = 1000;
@@ -266,6 +266,12 @@ impl TokioServiceInfo {
     #[inline]
     pub fn name(&self) -> &'static str {
         self.name
+    }
+
+    /// Access the service's executor
+    #[inline]
+    pub fn executor(&self) -> &TaskExecutor {
+        &self.executor
     }
 
     /// access the service's logger

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -274,6 +274,13 @@ impl TokioServiceInfo {
         &self.logger
     }
 
+    /// Extract the service's logger, dropping the rest of the
+    /// `TokioServiceInfo` instance.
+    #[inline]
+    pub fn into_logger(self) -> Logger {
+        self.logger
+    }
+
     /// spawn a future within the service's tokio executor
     pub fn spawn<F>(&self, future: F)
     where


### PR DESCRIPTION
Convert the network task to an "official" Tokio-style task rather than hiding the tokio machinery in a thread.