### PR TITLE
Explorer scenario test

### DIFF
--- a/jormungandr-scenario-tests/src/graphql.rs
+++ b/jormungandr-scenario-tests/src/graphql.rs
@@ -1,0 +1,42 @@
+/* Helpers to make GraphQL queries easier, probably could be replaced by some graphl library */
+
+use chain_impl_mockchain::fragment::FragmentId;
+use jormungandr_lib::crypto::hash::Hash;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct GraphQLResponse {
+    data: serde_json::Value,
+    errors: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct GraphQLQuery {
+    query: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ExplorerTransaction {
+    pub id: Hash,
+}
+
+impl TryFrom<GraphQLResponse> for ExplorerTransaction {
+    type Error = serde_json::Error;
+
+    fn try_from(response: GraphQLResponse) -> Result<ExplorerTransaction, Self::Error> {
+        // FIXME: Do this properly
+        Ok(ExplorerTransaction {
+            id: serde_json::from_str(&response.data["transaction"]["id"].to_string())?,
+        })
+    }
+}
+
+impl ExplorerTransaction {
+    pub fn build_query(id: FragmentId) -> GraphQLQuery {
+        let hash = Hash::from(id);
+        GraphQLQuery {
+            query: format!(r#"{{transaction(id: "{}") {{ id }} }}"#, hash),
+        }
+    }
+}

--- a/jormungandr-scenario-tests/src/lib.rs
+++ b/jormungandr-scenario-tests/src/lib.rs
@@ -7,6 +7,7 @@ pub mod node;
 mod programs;
 #[macro_use]
 pub mod scenario;
+mod graphql;
 mod slog;
 pub mod style;
 mod wallet;

--- a/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -47,6 +47,8 @@ pub struct NodeConfig {
     pub rest: Rest,
 
     pub p2p: P2pConfig,
+
+    pub explorer: Explorer,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,6 +64,11 @@ pub struct P2pConfig {
     /// the rendezvous points for the peer to connect to in order to initiate
     /// the p2p discovery from.
     pub trusted_peers: Vec<poldercast::Address>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Explorer {
+    pub enabled: bool,
 }
 
 /// Node Secret(s)
@@ -404,6 +411,7 @@ impl NodeConfig {
         NodeConfig {
             rest: Rest::prepare(context),
             p2p: P2pConfig::prepare(context),
+            explorer: Explorer { enabled: true },
         }
     }
 }


### PR DESCRIPTION
# Summary

Experimental test case:

- Add a test case that creates a transaction and asks the explorer for it
- Add a loop for running all the tests

Things to improve
-  Probably a way to enable and disable the explorer in the `prepare_scenario!` macro, as it's always enabled this way.
- I'm not sure catching the panics is really the best way of handling failures.
- Reporting errors better?
- Timeouts, maybe
- Ergonomics for registering tests, instead of just adding them all in the `main` function?
- Introduce some kind of way for making graphql queries easily.
- Query more fields of the transaction