### PR TITLE
Per-peer statistics on items received via subscription channels

### DIFF
--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -1,4 +1,5 @@
 use crate::blockcfg::{Block, Epoch, Fragment, FragmentId, Header, HeaderHash};
+use crate::network::p2p::comm::PeerStats;
 use crate::network::p2p::topology::NodeId;
 use blockchain::Checkpoints;
 use futures::prelude::*;
@@ -423,7 +424,7 @@ pub enum PropagateMsg {
 }
 
 /// Messages to the network task.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum NetworkMsg {
     Propagate(PropagateMsg),
     GetBlocks(Vec<HeaderHash>),
@@ -433,6 +434,7 @@ pub enum NetworkMsg {
         from: Checkpoints,
         to: HeaderHash,
     },
+    PeerStats(ReplyHandle<Vec<(NodeId, PeerStats)>>),
 }
 
 /// Messages to the explorer task

--- a/jormungandr/src/network/client.rs
+++ b/jormungandr/src/network/client.rs
@@ -124,7 +124,12 @@ where
                         channels.transaction_box.clone(),
                         logger.clone(),
                     );
-                    subscription::process_gossip(gossip_sub, state.global.clone(), logger.clone());
+                    subscription::process_gossip(
+                        gossip_sub,
+                        node_id,
+                        state.global.clone(),
+                        logger.clone(),
+                    );
 
                     // Plug the block solicitations and header pulls to be handled
                     // via client requests.

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -312,6 +312,11 @@ fn handle_network_input(
             state.peers.pull_headers(node_id, from.into(), to);
             Ok(())
         }
+        NetworkMsg::PeerStats(reply) => {
+            let stats = state.peers.stats();
+            reply.reply_ok(stats);
+            Ok(())
+        }
     })
 }
 

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -456,4 +456,9 @@ impl Peers {
             }
         }
     }
+
+    pub fn stats(&self) -> Vec<(topology::NodeId, PeerStats)> {
+        let mut map = self.mutex.lock().unwrap();
+        map.stats()
+    }
 }

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -10,6 +10,7 @@ use network_core::subscription::{BlockEvent, ChainPullRequest};
 use slog::Logger;
 
 use std::sync::Mutex;
+use std::time::SystemTime;
 
 // Buffer size determines the number of stream items pending processing that
 // can be buffered before back pressure is applied to the inbound half of
@@ -145,6 +146,7 @@ pub struct PeerComms {
     chain_pulls: CommHandle<ChainPullRequest<HeaderHash>>,
     fragments: CommHandle<Fragment>,
     gossip: CommHandle<Gossip<topology::Node>>,
+    stats: PeerStats,
 }
 
 impl PeerComms {
@@ -192,6 +194,13 @@ impl PeerComms {
     pub fn subscribe_to_gossip(&mut self) -> Subscription<Gossip<topology::Node>> {
         self.gossip.subscribe()
     }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PeerStats {
+    last_block_received: Option<SystemTime>,
+    last_fragment_received: Option<SystemTime>,
+    last_gossip_received: Option<SystemTime>,
 }
 
 /// The collection of currently connected peer nodes.
@@ -339,9 +348,37 @@ impl Peers {
         }
     }
 
-    pub fn refresh_peer(&self, node_id: topology::NodeId) {
+    pub fn refresh_peer_on_block(&self, node_id: topology::NodeId) -> bool {
         let mut map = self.mutex.lock().unwrap();
-        map.refresh_peer_comms(node_id);
+        match map.refresh_peer_comms(node_id) {
+            Some(comms) => {
+                comms.stats.last_block_received = Some(SystemTime::now());
+                true
+            }
+            None => false,
+        }
+    }
+
+    pub fn refresh_peer_on_fragment(&self, node_id: topology::NodeId) -> bool {
+        let mut map = self.mutex.lock().unwrap();
+        match map.refresh_peer_comms(node_id) {
+            Some(comms) => {
+                comms.stats.last_fragment_received = Some(SystemTime::now());
+                true
+            }
+            None => false,
+        }
+    }
+
+    pub fn refresh_peer_on_gossip(&self, node_id: topology::NodeId) -> bool {
+        let mut map = self.mutex.lock().unwrap();
+        match map.refresh_peer_comms(node_id) {
+            Some(comms) => {
+                comms.stats.last_gossip_received = Some(SystemTime::now());
+                true
+            }
+            None => false,
+        }
     }
 
     pub fn fetch_blocks(&self, hashes: Vec<HeaderHash>) {

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -1,4 +1,4 @@
-use super::PeerComms;
+use super::{PeerComms, PeerStats};
 use crate::network::p2p::topology::NodeId;
 
 use linked_hash_map::LinkedHashMap;
@@ -50,6 +50,13 @@ impl PeerMap {
             .iter_mut()
             .next_back()
             .map(|(&id, comms)| (id, comms))
+    }
+
+    pub fn stats(&self) -> Vec<(NodeId, PeerStats)> {
+        self.map
+            .iter()
+            .map(|(id, comms)| (*id, comms.stats.clone()))
+            .collect()
     }
 
     fn evict_if_full(&mut self) {

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -265,6 +265,7 @@ impl GossipService for NodeService {
     {
         subscription::process_gossip(
             inbound,
+            subscriber,
             self.global_state.clone(),
             self.logger().new(o!("node_id" => subscriber.to_string())),
         );


### PR DESCRIPTION
Timestamps on last received block, fragment, and gossip are registered per communication peer
and can be retrieved with a `NetworkMsg` command to the network task.

Addresses #846