### PR TITLE
Fix node that do not sync when no Public Address is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bech32"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bincode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1124,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "hex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1370,7 @@ dependencies = [
  "actix-net 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-threadpool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-addr 0.1.0",
@@ -1383,7 +1394,7 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
- "poldercast 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1421,7 +1432,7 @@ dependencies = [
  "jormungandr-lib 0.5.6+lock",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1474,7 +1485,7 @@ dependencies = [
  "jormungandr-lib 0.5.6+lock",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2082,11 +2093,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "poldercast"
-version = "0.7.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multiaddr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3778,6 +3789,7 @@ dependencies = [
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bawawa 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8a0b511f881feae65eb88a002da86c4346f2fc09135ac0934d420ef79cc7ee1"
 "checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
+"checksum bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0089c35ab7c6f2bc55ab23f769913f0ac65b1023e7e74638a1f43128dd5df2"
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
 "checksum blake2b_simd 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5850aeee1552f495dd0250014cf64b82b7c8879a89d83b33bbdace2cc4f63182"
@@ -3869,6 +3881,7 @@ dependencies = [
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
@@ -3953,7 +3966,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum platforms 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
-"checksum poldercast 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "78cc4cb1a3cd43fcc4da646375e6127dca1b7ead08d49f9c3174d3deb008f956"
+"checksum poldercast 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3837921273c88ea886f87dbeeaa03a80fef43a59eacd3a7221a3aac2a86a63ef"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
- "poldercast 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1432,7 +1432,7 @@ dependencies = [
  "jormungandr-lib 0.5.6+lock",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1485,7 +1485,7 @@ dependencies = [
  "jormungandr-lib 0.5.6+lock",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2093,7 +2093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "poldercast"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cryptoxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3966,7 +3966,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum platforms 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
-"checksum poldercast 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3837921273c88ea886f87dbeeaa03a80fef43a59eacd3a7221a3aac2a86a63ef"
+"checksum poldercast 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a6cb19e27333196586ffecd1ef052067320aa03a2d3deba6538c5093ca5eb0b9"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/doc/configuration/introduction.md
+++ b/doc/configuration/introduction.md
@@ -12,9 +12,12 @@ log:
   format: json
 p2p:
   trusted_peers:
-    - "/ip4/104.24.28.11/tcp/8299"
-    - "/ip4/104.24.29.11/tcp/8299"
+    - address: "/ip4/104.24.28.11/tcp/8299"
+      id: ed25519_pk1tyz2drx5kvsp49fk0gunkl8ktlhjc976zj5erqwavnpfmrexxxnscxln75
+    - address: "/ip4/104.24.29.11/tcp/8299"
+      id: ed25519_pk13j4eata8e567xwdqp6wjeu8wa7dsut3kj0u3tgulrsmyvveq9qxqeqr3kc
   public_address: "/ip4/127.0.0.1/tcp/8080"
+  private_id: ed25519_sk1n649x7zrmt38q6dtqkvj769wru4vpkfnrppw6d83qd7jh3uhux7qwhg8q3
   topics_of_interest:
     messages: low
     blocks: normal

--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -19,11 +19,14 @@ p2p:
 ## P2P configuration
 
 - `trusted_peers`: (optional) the list of nodes' [multiaddr][multiaddr] to connect to in order to
-    bootstrap the p2p topology (and bootstrap our local blockchain);
+    bootstrap the p2p topology (and bootstrap our local blockchain) with the associated `public_id`.
 - `public_address`: [multiaddr][multiaddr] the address to listen from and accept connection
     from. This is the public address that will be distributed to other peers
     of the network that may find interest into participating to the blockchain
     dissemination with the node;
+- `private_id`: a cryptographic secret key of type `Ed25519`. See [`jcli key`] for more info
+  on how to generate a key. If not set, a random key will be generated.
+  The associated public key is the node's unique identifier on the network.
 - `listen_address`: (optional) [multiaddr][multiaddr] specifies the address the node
     will listen to to receive p2p connection. Can be left empty and the node will listen
     to whatever value was given to `public_address`.
@@ -36,3 +39,5 @@ p2p:
     maintain. If not specified, an internal limit is used by default.
 
 [multiaddr]: https://github.com/multiformats/multiaddr
+
+[`jcli key`]: ../jcli/key.md

--- a/doc/quickstart/02_passive_node.md
+++ b/doc/quickstart/02_passive_node.md
@@ -33,11 +33,8 @@ rest:
 
 p2p:
   trusted_peers:
-    - "/ip4/104.24.28.11/tcp/8299"
-  public_address: "/ip4/u.v.x.y/tcp/8299"
-  topics_of_interest:
-    messages: low
-    blocks: normal
+    - address: "/ip4/104.24.28.11/tcp/8299"
+      id: ed25519_pk14uednfkcqq2u2w4uhy7saahyqapn78huu8fj7tv84rqeer78hcvs8h6r6u
 ```
 
 Description of the fields:
@@ -66,8 +63,9 @@ Description of the fields:
       - `allowed_origins`: (optional) allowed origins, if none provided, echos request origin
       - `max_age_secs`: (optional) maximum CORS caching time in seconds, if none provided, caching is disabled
 - `p2p`: P2P network settings
-    - `trusted_peers`: (optional) the list of nodes's [multiaddr][multiaddr] to connect to in order to
-      bootstrap the P2P topology (and bootstrap our local blockchain);
+    - `trusted_peers`: (optional) the list of nodes's [multiaddr][multiaddr] with their associated `public_id`
+      to connect to in order to bootstrap the P2P topology (and bootstrap our local blockchain);
+    - `private_id`: the node's private key ([`Ed25519`]) that will be used to identify this node to the network
     - `public_address`: [multiaddr][multiaddr] string specifying address of the
       P2P service. This is the public address that will be distributed to other
       peers of the network that may find interest in participating to the
@@ -106,3 +104,5 @@ or, in case you only have the yaml file
 ```sh
 cat genesis.yaml | jcli genesis encode | jcli genesis hash
 ```
+
+[`Ed25519`]: ../jcli/key.md

--- a/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
+++ b/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
@@ -16,6 +16,7 @@ pub struct JormungandrConfig {
     pub node_config: NodeConfig,
     pub secret_model: SecretModel,
     pub log_file_path: PathBuf,
+    pub public_id: String,
 }
 
 impl JormungandrConfig {
@@ -38,6 +39,12 @@ impl JormungandrConfig {
     }
 
     pub fn from(genesis_yaml: GenesisYaml, node_config: NodeConfig) -> Self {
+        use chain_crypto::Ed25519;
+        use jormungandr_lib::crypto::key::SigningKey;
+
+        let prv = SigningKey::<Ed25519>::from_bech32_str(&node_config.p2p.private_id).unwrap();
+        let p = prv.identifier();
+
         JormungandrConfig {
             genesis_block_path: PathBuf::from(""),
             genesis_block_hash: String::from(""),
@@ -47,6 +54,7 @@ impl JormungandrConfig {
             genesis_yaml: genesis_yaml,
             node_config: node_config,
             secret_model: SecretModel::empty(),
+            public_id: p.to_bech32_str(),
         }
     }
 }

--- a/jormungandr-integration-tests/src/common/configuration/node_config_model.rs
+++ b/jormungandr-integration-tests/src/common/configuration/node_config_model.rs
@@ -18,10 +18,17 @@ pub struct Rest {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Peer2Peer {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trusted_peers: Option<Vec<String>>,
+    pub trusted_peers: Option<Vec<TrustedPeer>>,
     pub public_address: String,
+    pub private_id: String,
     pub listen_address: String,
     pub topics_of_interest: TopicsOfInterest,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TrustedPeer {
+    pub address: String,
+    pub id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -53,6 +60,10 @@ impl NodeConfig {
         let rest_port = super::get_available_port();
         let public_address_port = super::get_available_port();
         let storage_file = file_utils::get_path_in_temp("storage");
+        let private_id =
+            jormungandr_lib::crypto::key::SigningKey::<chain_crypto::Ed25519>::generate(
+                &mut rand::rngs::OsRng::new().unwrap(),
+            );
 
         NodeConfig {
             storage: Some(String::from(storage_file.as_os_str().to_str().unwrap())),
@@ -70,6 +81,7 @@ impl NodeConfig {
                     DEFAULT_HOST,
                     public_address_port.to_string()
                 ),
+                private_id: private_id.to_bech32_str(),
                 listen_address: format!(
                     "/ip4/{}/tcp/{}",
                     DEFAULT_HOST,

--- a/jormungandr-integration-tests/src/common/startup/configuration_builder.rs
+++ b/jormungandr-integration-tests/src/common/startup/configuration_builder.rs
@@ -1,14 +1,14 @@
 use crate::common::configuration::{
     genesis_model::{Fund, GenesisYaml, Initial, LinearFees},
     jormungandr_config::JormungandrConfig,
-    node_config_model::{Log, NodeConfig},
+    node_config_model::{Log, NodeConfig, TrustedPeer},
     secret_model::SecretModel,
 };
 use crate::common::file_utils;
 use crate::common::jcli_wrapper;
 pub struct ConfigurationBuilder {
     funds: Vec<Fund>,
-    trusted_peers: Option<Vec<String>>,
+    trusted_peers: Option<Vec<TrustedPeer>>,
     public_address: Option<String>,
     listen_address: Option<String>,
     block0_hash: Option<String>,
@@ -114,7 +114,7 @@ impl ConfigurationBuilder {
         self
     }
 
-    pub fn with_trusted_peers(&mut self, trusted_peers: Vec<String>) -> &mut Self {
+    pub fn with_trusted_peers(&mut self, trusted_peers: Vec<TrustedPeer>) -> &mut Self {
         self.trusted_peers = Some(trusted_peers.clone());
         self
     }

--- a/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
@@ -1,4 +1,4 @@
-use crate::common::configuration::node_config_model::Log;
+use crate::common::configuration::node_config_model::{Log, TrustedPeer};
 use crate::common::startup;
 
 #[test]
@@ -20,7 +20,10 @@ pub fn test_jormungandr_passive_node_starts_successfully() {
     let _jormungandr_leader = startup::start_jormungandr_node_as_leader(&mut leader_config);
 
     let mut passive_config = startup::ConfigurationBuilder::new()
-        .with_trusted_peers(vec![leader_config.node_config.p2p.public_address.clone()])
+        .with_trusted_peers(vec![TrustedPeer {
+            address: leader_config.node_config.p2p.public_address.clone(),
+            id: leader_config.public_id.clone(),
+        }])
         .with_block_hash(leader_config.genesis_block_hash)
         .build();
 

--- a/jormungandr-integration-tests/src/networking/communication.rs
+++ b/jormungandr-integration-tests/src/networking/communication.rs
@@ -1,4 +1,5 @@
 use crate::common::configuration::genesis_model::Fund;
+use crate::common::configuration::node_config_model::TrustedPeer;
 use crate::common::jcli_wrapper;
 use crate::common::jcli_wrapper::jcli_transaction_wrapper::JCLITransactionWrapper;
 use crate::common::startup;
@@ -19,7 +20,10 @@ pub fn two_nodes_communication() {
     let _leader_jormungandr = startup::start_jormungandr_node_as_leader(&mut leader_config);
 
     let mut trusted_node_config = startup::ConfigurationBuilder::new()
-        .with_trusted_peers(vec![leader_config.node_config.p2p.public_address.clone()])
+        .with_trusted_peers(vec![TrustedPeer {
+            address: leader_config.node_config.p2p.public_address.clone(),
+            id: leader_config.public_id.clone(),
+        }])
         .with_block_hash(leader_config.genesis_block_hash.clone())
         .build();
 

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -37,7 +37,7 @@ linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = { version = "0.8.2", features = [ "serde_derive" ] }
+poldercast = { version = "0.8.3", features = [ "serde_derive" ] }
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -37,7 +37,7 @@ linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = { version = "0.7.1", features = [ "serde_derive" ] }
+poldercast = { version = "0.8.2", features = [ "serde_derive" ] }
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"
@@ -54,6 +54,7 @@ slog-term = "2.4.0"
 structopt = "^0.2"
 tokio      = "^0.1.16"
 tk-listen = "0.2"
+bech32 = "0.7"
 
 [build-dependencies]
 versionisator = "1.0.2"

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -1,6 +1,7 @@
 extern crate actix_net;
 extern crate actix_threadpool;
 extern crate actix_web;
+extern crate bech32;
 extern crate bincode;
 extern crate bytes;
 extern crate chain_addr;

--- a/jormungandr/src/network/client.rs
+++ b/jormungandr/src/network/client.rs
@@ -50,7 +50,7 @@ where
     S: P2pService<NodeId = topology::NodeId>,
     S: BlockService<Block = Block>,
     S: FragmentService<Fragment = Fragment>,
-    S: GossipService<Node = topology::Node>,
+    S: GossipService<Node = topology::NodeData>,
     S::UploadBlocksFuture: Send + 'static,
     S::FragmentSubscription: Send + 'static,
     S::GossipSubscription: Send + 'static,
@@ -487,7 +487,7 @@ pub fn connect(
 
     // TODO: we need to filter the `addr` to prevent to connect to invalid address
 
-    grpc::connect(addr, Some(state.global.as_ref().node.id()))
+    grpc::connect(addr, Some(state.global.as_ref().topology.node().id()))
         .map_err(move |e| {
             if let Some(e) = e.connect_error() {
                 info!(connect_err_logger, "error connecting to peer"; "reason" => %e);

--- a/jormungandr/src/network/grpc/mod.rs
+++ b/jormungandr/src/network/grpc/mod.rs
@@ -14,6 +14,6 @@ impl network_grpc::client::ProtocolConfig for BlockConfig {
     type BlockDate = BlockDate;
     type Fragment = Fragment;
     type FragmentId = FragmentId;
-    type Node = p2p::Node;
+    type Node = p2p::NodeData;
     type NodeId = p2p::NodeId;
 }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -414,6 +414,7 @@ fn connect_and_propagate_with<F>(
                     "peer responded with different node id: {}", connected_node_id
                 );
                 state.peers.remove_peer(node_id);
+                state.topology.evict_node(node_id);
             };
 
             state.peers.insert_peer(connected_node_id, comms);

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -132,11 +132,9 @@ impl GlobalState {
         let mut topology = P2pTopology::new(node, logger.clone());
         topology.set_poldercast_modules();
         topology.add_module(topology::modules::TrustedPeers::new_with(
-            config
-                .trusted_peers
-                .iter()
-                .cloned()
-                .map(|trusted_peer| poldercast::NodeData::new_with([0; 32].into(), trusted_peer)),
+            config.trusted_peers.iter().cloned().map(|trusted_peer| {
+                poldercast::NodeData::new_with(trusted_peer.id, trusted_peer.address)
+            }),
         ));
 
         let peers = Peers::new(config.max_connections, logger.clone());
@@ -438,7 +436,7 @@ fn trusted_peers_shuffled(config: &Configuration) -> Vec<SocketAddr> {
     let mut peers = config
         .trusted_peers
         .iter()
-        .filter_map(|peer| peer.to_socketaddr())
+        .filter_map(|peer| peer.address.to_socketaddr())
         .collect::<Vec<_>>();
     let mut rng = rand::thread_rng();
     peers.shuffle(&mut rng);

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -84,6 +84,10 @@ impl Node {
 }
 
 impl NodeData {
+    pub fn poldercast_address(&self) -> &Option<poldercast::Address> {
+        self.0.address()
+    }
+
     pub fn has_valid_address(&self) -> bool {
         let addr = match self.address() {
             None => return false,

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -29,13 +29,15 @@ impl From<bincode::Error> for Error {
     }
 }
 
-#[derive(Clone, Debug)]
 pub struct Node(poldercast::Node);
+
+#[derive(Clone, Debug)]
+pub struct NodeData(poldercast::NodeData);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct NodeId(pub poldercast::Id);
 
-impl gossip::Node for Node {
+impl gossip::Node for NodeData {
     type Id = NodeId;
 
     #[inline]
@@ -56,27 +58,32 @@ impl gossip::Node for Node {
 impl gossip::NodeId for NodeId {}
 
 impl Node {
-    #[inline]
-    pub fn new(address: Option<Address>) -> Self {
-        if let Some(address) = address {
-            Node(poldercast::Node::new_with(address))
+    pub fn new(private_id: poldercast::PrivateId, address: Option<Address>) -> Self {
+        Node(if let Some(address) = address {
+            poldercast::Node::new_with(private_id, address)
         } else {
-            Node(poldercast::Node::new(
-                &mut rand::rngs::OsRng::new().unwrap(),
-            ))
-        }
+            poldercast::Node::new(private_id)
+        })
+    }
+
+    pub fn data(&self) -> NodeData {
+        NodeData(self.0.data().clone())
     }
 
     pub fn add_message_subscription(&mut self, interest_level: InterestLevel) {
         self.0
+            .data_mut()
             .add_subscription(Subscription::new(NEW_MESSAGES_TOPIC.into(), interest_level));
     }
 
     pub fn add_block_subscription(&mut self, interest_level: InterestLevel) {
         self.0
+            .data_mut()
             .add_subscription(Subscription::new(NEW_BLOCKS_TOPIC.into(), interest_level));
     }
+}
 
+impl NodeData {
     pub fn has_valid_address(&self) -> bool {
         let addr = match self.address() {
             None => return false,
@@ -149,7 +156,7 @@ impl Node {
 
 impl fmt::Display for NodeId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", u64::from(self.0))
+        self.0.fmt(f)
     }
 }
 
@@ -159,7 +166,7 @@ pub struct P2pTopology {
     logger: Logger,
 }
 
-impl property::Serialize for Node {
+impl property::Serialize for NodeData {
     type Error = Error;
 
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
@@ -167,12 +174,13 @@ impl property::Serialize for Node {
     }
 }
 
-impl property::Deserialize for Node {
+impl property::Deserialize for NodeData {
     type Error = Error;
 
     fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
-        let inner = bincode::deserialize_from(reader)?;
-        Ok(Node(inner))
+        bincode::deserialize_from(reader)
+            .map(NodeData)
+            .map_err(Into::into)
     }
 }
 
@@ -222,16 +230,16 @@ impl P2pTopology {
 
     /// Returns a list of neighbors selected in this turn
     /// to contact for event dissemination.
-    pub fn view(&self) -> impl Iterator<Item = Node> {
+    pub fn view(&self) -> impl Iterator<Item = NodeData> {
         let topology = self.lock.read().unwrap();
-        topology.view().into_iter().map(Node)
+        topology.view().into_iter().map(NodeData)
     }
 
     /// this is the function to utilise when we receive a gossip in order
     /// to update the P2P Topology internal state
     pub fn update<I>(&self, new_nodes: I)
     where
-        I: IntoIterator<Item = Node>,
+        I: IntoIterator<Item = NodeData>,
     {
         let tree = new_nodes
             .into_iter()
@@ -240,7 +248,7 @@ impl P2pTopology {
         self.update_tree(tree)
     }
 
-    fn update_tree(&self, new_nodes: BTreeMap<poldercast::Id, poldercast::Node>) {
+    fn update_tree(&self, new_nodes: BTreeMap<poldercast::Id, poldercast::NodeData>) {
         // Poldercast API should be better than this
         debug!(self.logger, "updating P2P local topology");
         self.lock.write().unwrap().update(new_nodes)
@@ -248,7 +256,7 @@ impl P2pTopology {
 
     /// this is the function to utilise in order to select gossips to share
     /// with a given node
-    pub fn select_gossips(&self, gossip_recipient: &Node) -> impl Iterator<Item = Node> {
+    pub fn select_gossips(&self, gossip_recipient: &NodeData) -> impl Iterator<Item = NodeData> {
         debug!(
             self.logger,
             "selecting gossips for {}",
@@ -258,26 +266,30 @@ impl P2pTopology {
         topology
             .select_gossips(&gossip_recipient.0)
             .into_iter()
-            .map(|(_, v)| Node(v))
+            .map(|(_, v)| NodeData(v))
     }
 
     pub fn evict_node(&self, id: NodeId) {
         let mut topology = self.lock.write().unwrap();
         topology.evict_node(id.0);
     }
+
+    pub fn node(&self) -> NodeData {
+        NodeData(self.lock.read().unwrap().node().data().clone())
+    }
 }
 
 pub mod modules {
-    use poldercast::{topology::Module, Id, Node};
+    use poldercast::{topology::Module, Id, NodeData};
     use std::collections::BTreeMap;
 
     pub struct TrustedPeers {
-        peers: Vec<Node>,
+        peers: Vec<NodeData>,
     }
     impl TrustedPeers {
         pub fn new_with<I>(nodes: I) -> Self
         where
-            I: IntoIterator<Item = Node>,
+            I: IntoIterator<Item = NodeData>,
         {
             TrustedPeers {
                 peers: nodes.into_iter().collect(),
@@ -289,20 +301,20 @@ pub mod modules {
         fn name(&self) -> &'static str {
             "trusted-peers"
         }
-        fn update(&mut self, _our_node: &Node, _known_nodes: &BTreeMap<Id, Node>) {
+        fn update(&mut self, _our_node: &NodeData, _known_nodes: &BTreeMap<Id, NodeData>) {
             // DO NOTHING
         }
         fn select_gossips(
             &self,
-            _our_node: &Node,
-            _gossip_recipient: &Node,
-            _known_nodes: &BTreeMap<Id, Node>,
-        ) -> BTreeMap<Id, Node> {
+            _our_node: &NodeData,
+            _gossip_recipient: &NodeData,
+            _known_nodes: &BTreeMap<Id, NodeData>,
+        ) -> BTreeMap<Id, NodeData> {
             // Never gossip about our trusted nodes, this could breach network
             // trust
             BTreeMap::new()
         }
-        fn view(&self, _: &BTreeMap<Id, Node>, view: &mut BTreeMap<Id, Node>) {
+        fn view(&self, _: &BTreeMap<Id, NodeData>, view: &mut BTreeMap<Id, NodeData>) {
             const MAX_TRUSTED_PEER_VIEW: usize = 4;
             let count = std::cmp::max(
                 MAX_TRUSTED_PEER_VIEW,

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -61,7 +61,7 @@ impl P2pService for NodeService {
     type NodeId = topology::NodeId;
 
     fn node_id(&self) -> topology::NodeId {
-        self.global_state.node.id()
+        self.global_state.topology.node().id()
     }
 }
 
@@ -251,8 +251,8 @@ impl FragmentService for NodeService {
 }
 
 impl GossipService for NodeService {
-    type Node = topology::Node;
-    type GossipSubscription = Subscription<Gossip<topology::Node>>;
+    type Node = topology::NodeData;
+    type GossipSubscription = Subscription<Gossip<topology::NodeData>>;
     type GossipSubscriptionFuture = FutureResult<Self::GossipSubscription, core_error::Error>;
 
     fn gossip_subscription<In>(

--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -1,5 +1,5 @@
 use super::{
-    p2p::topology::{Node, NodeId},
+    p2p::topology::{NodeData, NodeId},
     GlobalState, GlobalStateR,
 };
 use crate::{
@@ -123,7 +123,7 @@ pub fn process_fragments<S>(
 
 pub fn process_gossip<S>(inbound: S, node_id: NodeId, global_state: GlobalStateR, logger: Logger)
 where
-    S: Stream<Item = Gossip<Node>, Error = core_error::Error> + Send + 'static,
+    S: Stream<Item = Gossip<NodeData>, Error = core_error::Error> + Send + 'static,
 {
     let state = global_state.clone();
     let err_logger = logger.clone();
@@ -152,7 +152,7 @@ where
     );
 }
 
-fn filter_gossip_node(node: &Node, config: &Configuration) -> bool {
+fn filter_gossip_node(node: &NodeData, config: &Configuration) -> bool {
     if config.allow_private_addresses {
         node.has_valid_address()
     } else {

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -1,4 +1,4 @@
-use crate::settings::LOG_FILTER_LEVEL_POSSIBLE_VALUES;
+use crate::settings::{start::config::TrustedPeer, LOG_FILTER_LEVEL_POSSIBLE_VALUES};
 use slog::FilterLevel;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -32,7 +32,7 @@ pub struct StartArguments {
     /// This is the trusted peer the node will connect to initially to download the initial
     /// block0 and fast fetch missing blocks since last start of the node.
     #[structopt(long = "trusted-peer", parse(try_from_str))]
-    pub trusted_peer: Vec<poldercast::Address>,
+    pub trusted_peer: Vec<TrustedPeer>,
 
     /// set the genesis block hash (the hash of the block0) so we can retrieve the
     /// genesis block (and the blockchain configuration) from the existing storage

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -3,7 +3,8 @@ use crate::{
     settings::logging::{LogFormat, LogOutput},
     settings::LOG_FILTER_LEVEL_POSSIBLE_VALUES,
 };
-use jormungandr_lib::time::Duration;
+use chain_crypto::Ed25519;
+use jormungandr_lib::{crypto::key::SigningKey, time::Duration};
 use poldercast;
 use serde::{de::Error as _, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use slog::FilterLevel;
@@ -60,7 +61,7 @@ pub struct Cors {
     pub max_age_secs: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct P2pConfig {
     /// The public address to which other peers may connect to
@@ -71,6 +72,8 @@ pub struct P2pConfig {
     /// The IP address can be specified as 0.0.0.0 or :: to listen on
     /// all network interfaces.
     pub listen_address: Option<Address>,
+
+    pub private_id: Option<SigningKey<Ed25519>>,
 
     /// the rendezvous points for the peer to connect to in order to initiate
     /// the p2p discovery from.
@@ -135,6 +138,7 @@ impl Default for P2pConfig {
         P2pConfig {
             public_address: None,
             listen_address: None,
+            private_id: None,
             trusted_peers: None,
             topics_of_interest: None,
             max_connections: None,

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -178,7 +178,24 @@ impl Default for Leadership {
 impl std::str::FromStr for TrustedPeer {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        unimplemented!()
+        let mut split = s.split('@');
+
+        let address = if let Some(address) = split.next() {
+            address
+                .parse::<poldercast::Address>()
+                .map(Address)
+                .map_err(|e| e.to_string())?
+        } else {
+            return Err("Missing address component".to_owned());
+        };
+
+        let id = if let Some(id) = split.next() {
+            Identifier::from_bech32_str(id).map_err(|e| e.to_string())?
+        } else {
+            return Err("Missing id component".to_owned());
+        };
+
+        Ok(TrustedPeer { address, id })
     }
 }
 

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -4,7 +4,10 @@ use crate::{
     settings::LOG_FILTER_LEVEL_POSSIBLE_VALUES,
 };
 use chain_crypto::Ed25519;
-use jormungandr_lib::{crypto::key::SigningKey, time::Duration};
+use jormungandr_lib::{
+    crypto::key::{Identifier, SigningKey},
+    time::Duration,
+};
 use poldercast;
 use serde::{de::Error as _, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use slog::FilterLevel;
@@ -77,7 +80,7 @@ pub struct P2pConfig {
 
     /// the rendezvous points for the peer to connect to in order to initiate
     /// the p2p discovery from.
-    pub trusted_peers: Option<Vec<poldercast::Address>>,
+    pub trusted_peers: Option<Vec<TrustedPeer>>,
     /// the topic subscriptions
     ///
     /// When connecting to different nodes we will expose these too in order to
@@ -93,6 +96,13 @@ pub struct P2pConfig {
     /// The default is to not allow advertising non-public IP addresses.
     #[serde(default)]
     pub allow_private_addresses: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrustedPeer {
+    pub address: Address,
+    pub id: Identifier<Ed25519>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -162,6 +172,13 @@ impl Default for Leadership {
             log_ttl: Duration::new(3600, 0),
             garbage_collection_interval: Duration::new(3600 / 4, 0),
         }
+    }
+}
+
+impl std::str::FromStr for TrustedPeer {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
     }
 }
 

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -1,4 +1,4 @@
-mod config;
+pub mod config;
 pub mod network;
 
 use self::config::{Config, Leadership, Mempool};
@@ -169,7 +169,7 @@ fn generate_network(
         p2p.trusted_peers = Some(command_arguments.trusted_peer.clone())
     }
 
-    let private_id = if let Some(b) = config.as_ref().and_then(|cfg| cfg.p2p.private_id.as_ref()) {
+    let private_id = if let Some(b) = p2p.private_id.as_ref() {
         use bech32::FromBase32 as _;
 
         let (_, data) = bech32::decode(&b.to_bech32_str()).unwrap();
@@ -195,7 +195,13 @@ fn generate_network(
                 }
             }
         },
-        trusted_peers: p2p.trusted_peers.clone().unwrap_or(vec![]),
+        trusted_peers: p2p
+            .trusted_peers
+            .clone()
+            .unwrap_or(vec![])
+            .into_iter()
+            .map(Into::into)
+            .collect(),
         protocol: Protocol::Grpc,
         subscriptions: p2p.topics_of_interest.clone().unwrap_or(BTreeMap::new()),
         max_connections: p2p

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -178,7 +178,7 @@ fn generate_network(
         bytes.copy_from_slice(&data);
         PrivateId::from(bytes)
     } else {
-        let mut rng = rand::rngs::OsRng::new().unwrap();
+        let mut rng = rand::thread_rng();
         PrivateId::generate(&mut rng)
     };
 

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -7,6 +7,9 @@ use self::network::Protocol;
 use crate::rest::Error as RestError;
 use crate::settings::logging::{self, LogFormat, LogOutput, LogSettings};
 use crate::settings::{command_arguments::*, Block0Info};
+use chain_crypto::Ed25519;
+use jormungandr_lib::crypto::key::SigningKey;
+use poldercast::PrivateId;
 use slog::{FilterLevel, Logger};
 
 use std::{collections::BTreeMap, fs::File, path::PathBuf};
@@ -166,8 +169,22 @@ fn generate_network(
         p2p.trusted_peers = Some(command_arguments.trusted_peer.clone())
     }
 
+    let private_id = if let Some(b) = config.as_ref().and_then(|cfg| cfg.p2p.private_id.as_ref()) {
+        use bech32::FromBase32 as _;
+
+        let (_, data) = bech32::decode(&b.to_bech32_str()).unwrap();
+        let data = Vec::<u8>::from_base32(&data).unwrap();
+        let mut bytes = [0; 32];
+        bytes.copy_from_slice(&data);
+        PrivateId::from(bytes)
+    } else {
+        let mut rng = rand::rngs::OsRng::new().unwrap();
+        PrivateId::generate(&mut rng)
+    };
+
     let network = network::Configuration {
         public_address: p2p.public_address.clone(),
+        private_id,
         listen_address: match &p2p.listen_address {
             None => None,
             Some(v) => {

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -1,6 +1,7 @@
-use std::{collections::BTreeMap, net::SocketAddr, str, time::Duration};
-
+use crate::network::p2p::topology::NodeId;
 use crate::settings::start::config::{Address, InterestLevel, Topic};
+use poldercast::PrivateId;
+use std::{collections::BTreeMap, net::SocketAddr, str, time::Duration};
 
 /// Protocol to use for a connection.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -41,12 +42,14 @@ const DEFAULT_TIMEOUT_MICROSECONDS: u64 = 500_000;
 
 ///
 /// The network static configuration settings
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct Configuration {
     /// Optional public IP address to advertise.
     /// Also used as the binding address unless the `listen` field
     /// is set with an address value.
     pub public_address: Option<Address>,
+
+    pub private_id: PrivateId,
 
     /// Local socket address to listen to, if different from public address.
     /// The IP address can be given as 0.0.0.0 or :: to bind to all
@@ -100,6 +103,14 @@ impl Listen {
 }
 
 impl Configuration {
+    pub fn private_id(&self) -> &PrivateId {
+        &self.private_id
+    }
+
+    pub fn public_id(&self) -> NodeId {
+        NodeId(self.private_id().id())
+    }
+
     /// Returns the listener configuration, if the options defining it
     /// were set.
     pub fn listen(&self) -> Option<Listen> {

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -57,7 +57,7 @@ pub struct Configuration {
     pub listen_address: Option<SocketAddr>,
 
     /// list of trusted addresses
-    pub trusted_peers: Vec<poldercast::Address>,
+    pub trusted_peers: Vec<TrustedPeer>,
 
     /// the protocol to utilise for the p2p network
     pub protocol: Protocol,
@@ -73,6 +73,29 @@ pub struct Configuration {
 
     /// Whether to allow non-public IP addresses in gossip
     pub allow_private_addresses: bool,
+}
+
+#[derive(Clone)]
+pub struct TrustedPeer {
+    pub address: poldercast::Address,
+    pub id: poldercast::Id,
+}
+
+impl From<super::config::TrustedPeer> for TrustedPeer {
+    fn from(tp: super::config::TrustedPeer) -> Self {
+        use bech32::FromBase32 as _;
+
+        let (_, data) = bech32::decode(&tp.id.to_bech32_str()).unwrap();
+        let data = Vec::<u8>::from_base32(&data).unwrap();
+        let mut bytes = [0; 32];
+        bytes.copy_from_slice(&data);
+        let id = poldercast::Id::from(bytes);
+
+        TrustedPeer {
+            address: tp.address.0,
+            id,
+        }
+    }
 }
 
 impl Peer {


### PR DESCRIPTION
will help with #860 

This address multiple items:

* put in place the initial tooling for node id authentication;
* put the required system for the non publicly reachable node to continue to receive propagation

This comes with a breaking change though...

Now the trusted peers will need to create cryptographic material to identify them selves for the other nodes (see `private_id` in the `config.yaml` for the node):

When a node wants to be publicly reachable and wants to advertise themselves as trusted peers they will have to give a public key along their public address:

to generate that key:

```
jcli key generate --type Ed25519
```

and add the output of that command in the node's config file:

```yaml
p2p:
    private_id: ed25519_sk1z30an6rtv26z8fyjdgqgcjtxt9fph7n7pw93g86ayrntx62vgz7sy4hfjs
    public_address: /ip4/x.y.z.t/tcp/8010
```

That node will them publicly announce the `public_address` and the associated public key of the `private_id`, to get the public key:

```
echo ed25519_sk1z30an6rtv26z8fyjdgqgcjtxt9fph7n7pw93g86ayrntx62vgz7sy4hfjs | jcli key to-public
```

And now to connect to that nodes user will need to either add the associated public key of the trusted peer:

```yaml
p2p:
    trusted_peers:
        - address /ip4/x.y.z.t/tcp/8010
          ed25519_pk1hs2208lr8w5lq9wmfm674d5zafaplr0xl7pml40nacg6jp2z0umsqzs3fr
```

or add it in the command line parameter:

```
jormungandr --trusted-peer /ip4/x.y.z.t/tcp/8010@ed25519_pk1hs2208lr8w5lq9wmfm674d5zafaplr0xl7pml40nacg6jp2z0umsqzs3fr --genesis-block-hash a0f92...
```