### PR TITLE
dropping *BSD builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-musl
 
     # *BSD
-    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
-    - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
+    # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+    # - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
 
     # for building the documentation we disable all the `cross'
     # specific build


### PR DESCRIPTION
we have had little feedback from the community utilising this specific
platform. Especially we are having issues releasing a proper binary for
FreeBSD and NetBSD, dropping official support until further notice/interest?