### PR TITLE
Don't advise build from master but from latest release tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ we recommend to use the most recent stable version of the rust compiler.
 3. Run `rustup default stable`
 4. Clone this repository: `git clone --recurse-submodules https://github.com/input-output-hk/jormungandr`
 5. Enter the repository directory: `cd jormungandr`
-6. install **jormungandr**: `cargo install --path jormungandr`
-7. install **jcli**: `cargo install --path jcli`
+6. Check latest release tag on https://github.com/input-output-hk/jormungandr/releases/latest
+7. checkout this tag ` git checkout tags/<latest release tag>`
+8. install **jormungandr**: `cargo install --path jormungandr`
+9. install **jcli**: `cargo install --path jcli`
 
 Note:
 


### PR DESCRIPTION
In the context of the closing response in issue #932 it is no longer advised to build from the master branch, but to use the latest released tag for builds.