### PR TITLE
Reuse pending client connections

### DIFF
--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -268,9 +268,9 @@ impl Peers {
         map.insert_peer(id, comms)
     }
 
-    pub fn remove_peer(&self, id: topology::NodeId) {
+    pub fn remove_peer(&self, id: topology::NodeId) -> Option<PeerComms> {
         let mut map = self.mutex.lock().unwrap();
-        map.remove_peer(id);
+        map.remove_peer(id)
     }
 
     pub fn subscribe_to_block_events(&self, id: topology::NodeId) -> BlockEventSubscription {


### PR DESCRIPTION
Claim an entry in `PeerMap` as soon as the client starts connecting.
This prevents pile-up of pending connections to the same peer when connection is slow.

Might fix #923.