### PR TITLE
Start REST server before bootstrap

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -101,6 +101,7 @@ pub struct BootstrappedNode {
     new_epoch_notifier: tokio::sync::mpsc::Receiver<self::leadership::NewEpochToSchedule>,
     logger: Logger,
     explorer_db: Option<explorer::ExplorerDB>,
+    rest_server: Option<(rest::Server, rest::Context)>,
 }
 
 const FRAGMENT_TASK_QUEUE_LEN: usize = 1024;
@@ -262,8 +263,8 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         });
     }
 
-    let rest_server = match bootstrapped_node.settings.rest {
-        Some(rest) => {
+    let rest_server = match bootstrapped_node.rest_server {
+        Some((server, context)) => {
             let logger = bootstrapped_node
                 .logger
                 .new(o!(::log::KEY_TASK => "rest"))
@@ -280,10 +281,8 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 enclave,
                 explorer: explorer.as_ref().map(|(_msg_box, context)| context.clone()),
             };
-            let context = rest::Context::new();
             context.set_full(full_context);
-            let explorer_enabled = bootstrapped_node.settings.explorer;
-            Some(rest::start_rest_server(&rest, explorer_enabled, context)?)
+            Some(server)
         }
         None => None,
     };
@@ -315,6 +314,7 @@ fn bootstrap(initialized_node: InitializedNode) -> Result<BootstrappedNode, star
         block0,
         storage,
         logger,
+        rest_server,
     } = initialized_node;
     let bootstrap_logger = logger.new(o!(log::KEY_TASK => "bootstrap"));
 
@@ -366,6 +366,7 @@ fn bootstrap(initialized_node: InitializedNode) -> Result<BootstrappedNode, star
         new_epoch_notifier,
         logger,
         explorer_db,
+        rest_server,
     })
 }
 
@@ -374,6 +375,7 @@ pub struct InitializedNode {
     pub block0: blockcfg::Block,
     pub storage: start_up::NodeStorage,
     pub logger: Logger,
+    pub rest_server: Option<(rest::Server, rest::Context)>,
 }
 
 fn initialize_node() -> Result<InitializedNode, start_up::Error> {
@@ -399,6 +401,16 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let init_logger = logger.new(o!(log::KEY_TASK => "init"));
     info!(init_logger, "Starting {}", env!("FULL_VERSION"),);
     let settings = raw_settings.try_into_settings(&init_logger)?;
+
+    let rest_server = match &settings.rest {
+        Some(rest) => {
+            let context = rest::Context::new();
+            let server = rest::start_rest_server(rest, settings.explorer, context.clone())?;
+            Some((server, context))
+        }
+        None => None,
+    };
+
     let storage = start_up::prepare_storage(&settings, &init_logger)?;
 
     // TODO: load network module here too (if needed)
@@ -414,6 +426,7 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
         block0,
         storage,
         logger,
+        rest_server,
     })
 }
 

--- a/jormungandr/src/rest/explorer/handlers.rs
+++ b/jormungandr/src/rest/explorer/handlers.rs
@@ -20,10 +20,13 @@ pub fn graphiql(_context: State<Context>) -> impl Responder {
 
 pub fn graphql(context: State<Context>, data: Json<GraphQLRequest>) -> ActixFuture!() {
     context
-        .explorer
-        .clone()
-        .ok_or(ErrorServiceUnavailable("Explorer not enabled"))
-        .into_future()
+        .try_full_fut()
+        .and_then(|context| {
+            context
+                .explorer
+                .clone()
+                .ok_or(ErrorServiceUnavailable("Explorer not enabled"))
+        })
         .and_then(move |explorer| {
             // Run the query in a threadpool, as Juniper is synchronous
             actix_threadpool::run(move || {

--- a/jormungandr/src/rest/mod.rs
+++ b/jormungandr/src/rest/mod.rs
@@ -8,12 +8,12 @@ pub mod v0;
 pub use self::server::{Error, Server};
 
 use actix_web::dev::Resource;
+use actix_web::error::{Error as ActixError, ErrorInternalServerError, ErrorServiceUnavailable};
 use actix_web::middleware::cors::Cors;
 use actix_web::App;
-use futures::{future, Future};
+use futures::{Future, IntoFuture};
 use slog::Logger;
-use std::convert::Infallible;
-use tokio::sync::lock::Lock;
+use std::sync::{Arc, RwLock};
 
 use crate::blockchain::{Blockchain, Tip};
 use crate::fragment::Logs;
@@ -27,6 +27,49 @@ use crate::utils::async_msg::MessageBox;
 
 #[derive(Clone)]
 pub struct Context {
+    full: Arc<RwLock<Option<Arc<FullContext>>>>,
+    server: Arc<RwLock<Option<Arc<Server>>>>,
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Context {
+            full: Default::default(),
+            server: Default::default(),
+        }
+    }
+
+    pub fn set_full(&self, full_context: FullContext) {
+        *self.full.write().expect("Context state poisoned") = Some(Arc::new(full_context));
+    }
+
+    pub fn try_full_fut(&self) -> impl Future<Item = Arc<FullContext>, Error = ActixError> {
+        self.try_full().into_future()
+    }
+
+    pub fn try_full(&self) -> Result<Arc<FullContext>, ActixError> {
+        self.full
+            .read()
+            .expect("Context state poisoned")
+            .clone()
+            .ok_or_else(|| ErrorServiceUnavailable("Full REST context not available yet"))
+    }
+
+    fn set_server(&self, server: Server) {
+        *self.server.write().expect("Context server poisoned") = Some(Arc::new(server));
+    }
+
+    pub fn server(&self) -> Result<Arc<Server>, ActixError> {
+        self.server
+            .read()
+            .expect("Context server poisoned")
+            .clone()
+            .ok_or_else(|| ErrorInternalServerError("Server not set in context"))
+    }
+}
+
+#[derive(Clone)]
+pub struct FullContext {
     pub logger: Logger,
     pub stats_counter: StatsCounter,
     pub blockchain: Blockchain,
@@ -35,15 +78,17 @@ pub struct Context {
     pub transaction_task: MessageBox<TransactionMsg>,
     pub logs: Logs,
     pub leadership_logs: LeadershipLogs,
-    pub server: Lock<Option<Server>>,
     pub enclave: Enclave,
     pub explorer: Option<crate::explorer::Explorer>,
 }
 
-pub fn start_rest_server(config: &Rest, mut context: Context) -> Result<Server, ConfigError> {
+pub fn start_rest_server(
+    config: &Rest,
+    explorer_enabled: bool,
+    context: Context,
+) -> Result<Server, ConfigError> {
     let app_context = context.clone();
     let cors_cfg = config.cors.clone();
-    let explorer_enabled = app_context.explorer.is_some();
     let server = Server::start(config.pkcs12.clone(), config.listen.clone(), move || {
         let mut apps = vec![build_app(
             app_context.clone(),
@@ -63,10 +108,7 @@ pub fn start_rest_server(config: &Rest, mut context: Context) -> Result<Server, 
 
         apps
     })?;
-    future::poll_fn(|| Ok(context.server.poll_lock()))
-        .wait()
-        .unwrap_or_else(|e: Infallible| match e {})
-        .replace(server.clone());
+    context.set_server(server.clone());
     Ok(server)
 }
 

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -14,22 +14,25 @@ use chain_impl_mockchain::value::{Value, ValueError};
 
 use crate::blockchain::Ref;
 use crate::intercom::{self, NetworkMsg, TransactionMsg};
-use crate::network::p2p::comm::PeerStats;
-use crate::network::p2p::topology::NodeId;
 use crate::secure::NodeSecret;
 use bytes::{Bytes, IntoBuf};
-use futures::{future, Future, IntoFuture, Stream};
-use std::convert::Infallible;
+use futures::{Future, IntoFuture, Stream};
 use std::str::FromStr;
 use std::sync::Arc;
 
-pub use crate::rest::Context;
+pub use crate::rest::{Context, FullContext};
 
 macro_rules! ActixFuture {
     () => { impl Future<Item = impl Responder + 'static, Error = impl Into<Error> + 'static> + 'static }
 }
 
 fn chain_tip_fut<'a>(context: &State<Context>) -> impl Future<Item = Arc<Ref>, Error = Error> {
+    context
+        .try_full_fut()
+        .and_then(|context| chain_tip_fut_raw(&*context))
+}
+
+fn chain_tip_fut_raw<'a>(context: &FullContext) -> impl Future<Item = Arc<Ref>, Error = Error> {
     context
         .blockchain_tip
         .get_ref()
@@ -68,17 +71,20 @@ fn parse_account_id(id_hex: &str) -> Result<Identifier, Error> {
 }
 
 pub fn get_message_logs(context: State<Context>) -> ActixFuture!() {
-    context
-        .logs
-        .logs()
-        .map_err(|_| ErrorInternalServerError("Failed to get logs"))
-        .map(Json)
+    context.try_full_fut().and_then(|context| {
+        context
+            .logs
+            .logs()
+            .map_err(|_| ErrorInternalServerError("Failed to get logs"))
+            .map(Json)
+    })
 }
 
-pub fn post_message(context: State<Context>, message: Bytes) -> Result<HttpResponse, Error> {
+pub fn post_message(context: State<Context>, message: Bytes) -> Result<impl Responder, Error> {
     let fragment = Fragment::deserialize(message.into_buf()).map_err(ErrorBadRequest)?;
     let msg = TransactionMsg::SendTransaction(FragmentOrigin::Rest, vec![fragment]);
     context
+        .try_full()?
         .transaction_task
         .clone()
         .try_send(msg)
@@ -91,9 +97,10 @@ pub fn get_tip(context: State<Context>) -> ActixFuture!() {
 }
 
 pub fn get_stats_counter(context: State<Context>) -> ActixFuture!() {
-    let stats = context.stats_counter.clone();
-    chain_tip_fut(&context)
-        .and_then(move |tip| {
+    context
+        .try_full_fut()
+        .and_then(|context| chain_tip_fut_raw(&*context).map(|tip| (context, tip)))
+        .and_then(move |(context, tip)| {
             let header = tip.header().clone();
             context
                 .blockchain
@@ -104,9 +111,9 @@ pub fn get_stats_counter(context: State<Context>) -> ActixFuture!() {
                     Ok(None) => Err(ErrorInternalServerError("Could not find block for tip")),
                     Err(e) => Err(ErrorInternalServerError(e)),
                 })
-                .map(move |contents| (contents, header))
+                .map(move |contents| (context, contents, header))
         })
-        .and_then(move |(contents, tip_header)| {
+        .and_then(move |(context, contents, tip_header)| {
             let mut block_tx_count = 0;
             let mut block_input_sum = Value::zero();
             let mut block_fee_sum = Value::zero();
@@ -130,6 +137,7 @@ pub fn get_stats_counter(context: State<Context>) -> ActixFuture!() {
                 .map_err(|e| {
                     ErrorInternalServerError(format!("Block value calculation error: {}", e))
                 })?;
+            let stats = &context.stats_counter;
             Ok(Json(json!({
                 "txRecvCnt": stats.tx_recv_cnt(),
                 "blockRecvCnt": stats.block_recv_cnt(),
@@ -146,9 +154,11 @@ pub fn get_stats_counter(context: State<Context>) -> ActixFuture!() {
 }
 
 pub fn get_block_id(context: State<Context>, block_id_hex: Path<String>) -> ActixFuture!() {
-    parse_block_hash(&block_id_hex)
+    context
+        .try_full()
+        .and_then(|context| parse_block_hash(&block_id_hex).map(|block_id| (context, block_id)))
         .into_future()
-        .and_then(move |block_id| {
+        .and_then(|(context, block_id)| {
             context
                 .blockchain
                 .storage()
@@ -175,10 +185,12 @@ pub fn get_block_next_id(
     block_id_hex: Path<String>,
     query_params: Query<QueryParams>,
 ) -> ActixFuture!() {
-    parse_block_hash(&block_id_hex)
+    context
+        .try_full()
+        .and_then(|context| parse_block_hash(&block_id_hex).map(|block_id| (context, block_id)))
         .into_future()
-        .and_then(|block_id| {
-            chain_tip_fut(&context).and_then(move |tip| {
+        .and_then(|(context, block_id)| {
+            chain_tip_fut_raw(&context).and_then(move |tip| {
                 context
                     .blockchain
                     .storage()
@@ -237,78 +249,83 @@ pub fn get_stake_distribution(context: State<Context>) -> ActixFuture!() {
 }
 
 pub fn get_settings(context: State<Context>) -> ActixFuture!() {
-    chain_tip_fut(&context).map(move |blockchain_tip| {
-        let ledger = blockchain_tip.ledger();
-        let static_params = ledger.get_static_parameters();
-        let consensus_version = ledger.consensus_version();
-        let current_params = blockchain_tip.epoch_ledger_parameters();
-        let fees = current_params.fees;
-        let slot_duration = blockchain_tip.time_frame().slot_duration();
-        let slots_per_epoch = blockchain_tip
-            .epoch_leadership_schedule()
-            .era()
-            .slots_per_epoch();
-        Json(json!({
-            "block0Hash": static_params.block0_initial_hash.to_string(),
-            "block0Time": SystemTime::from_secs_since_epoch(static_params.block0_start_time.0),
-            "currSlotStartTime": context.stats_counter.slot_start_time().map(SystemTime::from),
-            "consensusVersion": consensus_version.to_string(),
-            "fees":{
-                "constant": fees.constant,
-                "coefficient": fees.coefficient,
-                "certificate": fees.certificate,
-            },
-            "maxTxsPerBlock": 255, // TODO?
-            "slotDuration": slot_duration,
-            "slotsPerEpoch": slots_per_epoch,
-        }))
-    })
+    context
+        .try_full_fut()
+        .and_then(|context| chain_tip_fut_raw(&context).map(move |tip| (context, tip)))
+        .map(|(context, blockchain_tip)| {
+            let ledger = blockchain_tip.ledger();
+            let static_params = ledger.get_static_parameters();
+            let consensus_version = ledger.consensus_version();
+            let current_params = blockchain_tip.epoch_ledger_parameters();
+            let fees = current_params.fees;
+            let slot_duration = blockchain_tip.time_frame().slot_duration();
+            let slots_per_epoch = blockchain_tip
+                .epoch_leadership_schedule()
+                .era()
+                .slots_per_epoch();
+            Json(json!({
+                "block0Hash": static_params.block0_initial_hash.to_string(),
+                "block0Time": SystemTime::from_secs_since_epoch(static_params.block0_start_time.0),
+                "currSlotStartTime": context.stats_counter.slot_start_time().map(SystemTime::from),
+                "consensusVersion": consensus_version.to_string(),
+                "fees":{
+                    "constant": fees.constant,
+                    "coefficient": fees.coefficient,
+                    "certificate": fees.certificate,
+                },
+                "maxTxsPerBlock": 255, // TODO?
+                "slotDuration": slot_duration,
+                "slotsPerEpoch": slots_per_epoch,
+            }))
+        })
 }
 
-pub fn get_shutdown(context: State<Context>) -> ActixFuture!() {
+pub fn get_shutdown(context: State<Context>) -> Result<impl Responder, Error> {
     // Server finishes ongoing tasks before stopping, so user will get response to this request
     // Node should be shutdown automatically when server stopping is finished
-    future::poll_fn(move || Ok(context.server.clone().poll_lock())).then(|server_res| {
-        server_res
-            .unwrap_or_else(|e: Infallible| match e {})
-            .as_ref()
-            .ok_or_else(|| ErrorInternalServerError("Server not set in context"))
-            .map(|server| server.stop())
-            .map(|_| HttpResponse::Ok().finish())
+    context.try_full()?;
+    context.server().map(|server| {
+        server.stop();
+        HttpResponse::Ok().finish()
     })
 }
 
-pub fn get_leaders(context: State<Context>) -> impl Responder {
-    Json(json! {
-        context.enclave.get_leaderids()
-    })
+pub fn get_leaders(context: State<Context>) -> Result<impl Responder, Error> {
+    Ok(Json(json! {
+        context.try_full()?.enclave.get_leaderids()
+    }))
 }
 
-pub fn post_leaders(secret: Json<NodeSecret>, context: State<Context>) -> impl Responder {
+pub fn post_leaders(
+    secret: Json<NodeSecret>,
+    context: State<Context>,
+) -> Result<impl Responder, Error> {
     let leader = Leader {
         bft_leader: secret.bft(),
         genesis_leader: secret.genesis(),
     };
-    let leader_id = context.enclave.add_leader(leader);
-    Json(leader_id)
+    let leader_id = context.try_full()?.enclave.add_leader(leader);
+    Ok(Json(leader_id))
 }
 
 pub fn delete_leaders(
     context: State<Context>,
     leader_id: Path<EnclaveLeaderId>,
 ) -> Result<impl Responder, Error> {
-    match context.enclave.remove_leader(*leader_id) {
+    match context.try_full()?.enclave.remove_leader(*leader_id) {
         true => Ok(HttpResponse::Ok().finish()),
         false => Err(ErrorNotFound("Leader with given ID not found")),
     }
 }
 
 pub fn get_leaders_logs(context: State<Context>) -> ActixFuture!() {
-    context
-        .leadership_logs
-        .logs()
-        .map(Json)
-        .map_err(|_| ErrorInternalServerError("Failed to get leader logs"))
+    context.try_full_fut().and_then(|context| {
+        context
+            .leadership_logs
+            .logs()
+            .map(Json)
+            .map_err(|_| ErrorInternalServerError("Failed to get leader logs"))
+    })
 }
 
 pub fn get_stake_pools(context: State<Context>) -> ActixFuture!() {
@@ -324,26 +341,28 @@ pub fn get_stake_pools(context: State<Context>) -> ActixFuture!() {
 }
 
 pub fn get_network_stats(context: State<Context>) -> ActixFuture!() {
-    let (reply_handle, reply_future) =
-        intercom::unary_reply::<_, intercom::Error>(context.logger.clone());
-    context
-        .network_task
-        .clone()
-        .try_send(NetworkMsg::PeerStats(reply_handle))
-        .map_err(ErrorInternalServerError)
-        .into_future()
-        .and_then(move |_| reply_future.map_err(ErrorInternalServerError))
-        .map(|peer_stats| {
-            let network_stats = peer_stats
-                .into_iter()
-                .map(|(node_id, stats)| json! ({
-                    "nodeId": node_id.to_string(),
-                    "establishedAt": SystemTime::from(stats.connection_established()),
-                    "lastBlockReceived": stats.last_block_received().map(SystemTime::from),
-                    "lastFragmentReceived": stats.last_fragment_received().map(SystemTime::from),
-                    "lastGossipReceived": stats.last_gossip_received().map(SystemTime::from),
-                }))
-                .collect::<Vec<_>>();
-            Json(network_stats)
-        })
+    context.try_full_fut().and_then(|context| {
+        let (reply_handle, reply_future) =
+            intercom::unary_reply::<_, intercom::Error>(context.logger.clone());
+        context
+            .network_task
+            .clone()
+            .try_send(NetworkMsg::PeerStats(reply_handle))
+            .map_err(ErrorInternalServerError)
+            .into_future()
+            .and_then(move |_| reply_future.map_err(ErrorInternalServerError))
+            .map(|peer_stats| {
+                let network_stats = peer_stats
+                    .into_iter()
+                    .map(|(node_id, stats)| json! ({
+                        "nodeId": node_id.to_string(),
+                        "establishedAt": SystemTime::from(stats.connection_established()),
+                        "lastBlockReceived": stats.last_block_received().map(SystemTime::from),
+                        "lastFragmentReceived": stats.last_fragment_received().map(SystemTime::from),
+                        "lastGossipReceived": stats.last_gossip_received().map(SystemTime::from),
+                    }))
+                    .collect::<Vec<_>>();
+                Json(network_stats)
+            })
+    })
 }

--- a/jormungandr/src/rest/v0/mod.rs
+++ b/jormungandr/src/rest/v0/mod.rs
@@ -39,7 +39,7 @@ pub fn resources() -> Vec<(
         ("/stake_pools", &|r| {
             r.get().with_async(handlers::get_stake_pools)
         }),
-        ("/shutdown", &|r| r.get().with_async(handlers::get_shutdown)),
+        ("/shutdown", &|r| r.get().with(handlers::get_shutdown)),
         ("/message", &|r| r.post().with(handlers::post_message)),
         ("/node/stats", &|r| {
             r.get().with_async(handlers::get_stats_counter)


### PR DESCRIPTION
First part of https://github.com/input-output-hk/jormungandr/issues/857

Makes server work during bootstrap, but not with very useful functionality yet. Almost all routes return 503 during that phase. That will be changed in next PR with `node/stats` extended and available during bootstrap.