### PR TITLE
network: Get rid of DefaultExecutor

### DIFF
--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -1,104 +1,80 @@
 use super::{grpc, BlockConfig};
 use crate::blockcfg::{Block, HeaderHash};
-use crate::blockchain::{
-    self, Blockchain, Error as BlockchainError, PreCheckedHeader, Ref, Tip, MAIN_BRANCH_TAG,
-};
+use crate::blockchain::{self, Blockchain, Error as BlockchainError, PreCheckedHeader, Ref, Tip};
 use crate::settings::start::network::Peer;
 use chain_core::property::HasHeader;
-use chain_storage::error::Error as StorageError;
 use network_core::client::{BlockService, Client as _};
 use network_core::error::Error as NetworkError;
 use network_grpc::client::Connection;
 use slog::Logger;
+use thiserror::Error;
 use tokio::prelude::*;
-use tokio::runtime::current_thread;
+use tokio::runtime::Runtime;
 
-use std::error;
-use std::fmt::{self, Debug, Display};
+use std::fmt::Debug;
+use std::io;
 use std::sync::Arc;
 
-type ConnectError = network_grpc::client::ConnectError<std::io::Error>;
-
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    Connect(ConnectError),
-    ClientNotReady(NetworkError),
-    PullRequestFailed(NetworkError),
-    PullStreamFailed(NetworkError),
-    HeaderCheckFailed(BlockchainError),
+    #[error("runtime initialization failed")]
+    RuntimeInit { source: io::Error },
+    #[error("failed to connect to bootstrap peer")]
+    Connect { source: grpc::ConnectError },
+    #[error("connection broken")]
+    ClientNotReady { source: NetworkError },
+    #[error("bootstrap pull request failed")]
+    PullRequestFailed { source: NetworkError },
+    #[error("bootstrap pull stream failed")]
+    PullStreamFailed { source: NetworkError },
+    #[error("block header check failed")]
+    HeaderCheckFailed { source: BlockchainError },
+    #[error("received block {0} is already present")]
     BlockAlreadyPresent(HeaderHash),
+    #[error("received block {0} is not connected to the block chain")]
     BlockMissingParent(HeaderHash),
-    ApplyBlockFailed(BlockchainError),
-    ChainSelectionFailed(blockchain::ProcessError),
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-        match self {
-            Connect(_) => write!(f, "failed to connect to bootstrap peer"),
-            ClientNotReady(_) => write!(f, "connection broken"),
-            PullRequestFailed(_) => write!(f, "bootstrap pull request failed"),
-            PullStreamFailed(_) => write!(f, "bootstrap pull stream failed"),
-            HeaderCheckFailed(_) => write!(f, "block header check failed"),
-            BlockAlreadyPresent(hash) => write!(f, "received block {} is already present", hash),
-            BlockMissingParent(hash) => write!(
-                f,
-                "received block {} is not connected to the block chain",
-                hash
-            ),
-            ApplyBlockFailed(_) => write!(f, "failed to apply block to the blockchain"),
-            ChainSelectionFailed(_) => write!(f, "failed to select the new tip"),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        use self::Error::*;
-        match self {
-            Connect(e) => Some(e),
-            ClientNotReady(e) => Some(e),
-            PullRequestFailed(e) => Some(e),
-            PullStreamFailed(e) => Some(e),
-            HeaderCheckFailed(e) => Some(e),
-            BlockAlreadyPresent(_) => None,
-            BlockMissingParent(_) => None,
-            ApplyBlockFailed(e) => Some(e),
-            ChainSelectionFailed(e) => Some(e),
-        }
-    }
+    #[error("failed to apply block to the blockchain")]
+    ApplyBlockFailed { source: BlockchainError },
+    #[error("failed to select the new tip")]
+    ChainSelectionFailed { source: blockchain::ProcessError },
 }
 
 pub fn bootstrap_from_peer(
     peer: Peer,
     blockchain: Blockchain,
     branch: Tip,
-    logger: &Logger,
+    logger: Logger,
 ) -> Result<Arc<Ref>, Error> {
     info!(logger, "connecting to bootstrap peer {}", peer.connection);
 
-    let blockchain2 = blockchain.clone();
+    let runtime = Runtime::new().map_err(|e| Error::RuntimeInit { source: e })?;
 
-    let bootstrap = grpc::connect(peer.address(), None)
-        .map_err(Error::Connect)
-        .and_then(|client: Connection<BlockConfig>| client.ready().map_err(Error::ClientNotReady))
+    let blockchain2 = blockchain.clone();
+    let logger2 = logger.clone();
+
+    let bootstrap = grpc::connect(peer.address(), None, runtime.executor())
+        .map_err(|e| Error::Connect { source: e })
+        .and_then(|client: Connection<BlockConfig>| {
+            client
+                .ready()
+                .map_err(|e| Error::ClientNotReady { source: e })
+        })
         .join(branch.get_ref().map_err(|_| unreachable!()))
-        .and_then(|(mut client, tip)| {
+        .and_then(move |(mut client, tip)| {
             let tip_hash = tip.hash();
             debug!(logger, "pulling blocks starting from {}", tip_hash);
             client
                 .pull_blocks_to_tip(&[tip_hash])
-                .map_err(Error::PullRequestFailed)
-                .and_then(|stream| bootstrap_from_stream(blockchain, tip, stream, logger.clone()))
+                .map_err(|e| Error::PullRequestFailed { source: e })
+                .and_then(move |stream| bootstrap_from_stream(blockchain, tip, stream, logger))
         })
         .and_then(move |tip| {
-            blockchain::process_new_ref(logger.clone(), blockchain2, branch, tip.clone())
-                .map_err(Error::ChainSelectionFailed)
+            blockchain::process_new_ref(logger2, blockchain2, branch, tip.clone())
+                .map_err(|e| Error::ChainSelectionFailed { source: e })
                 .map(|()| tip)
         });
 
-    current_thread::block_on_all(bootstrap)
+    runtime.block_on_all(bootstrap)
 }
 
 fn bootstrap_from_stream<S>(
@@ -113,7 +89,7 @@ where
 {
     let fold_logger = logger.clone();
     stream
-        .map_err(Error::PullStreamFailed)
+        .map_err(|e| Error::PullStreamFailed { source: e })
         .fold(tip, move |_, block| {
             handle_block(blockchain.clone(), block, fold_logger.clone())
         })
@@ -133,7 +109,7 @@ fn handle_block(
     let mut end_blockchain = blockchain.clone();
     blockchain
         .pre_check_header(header, true)
-        .map_err(Error::HeaderCheckFailed)
+        .map_err(|e| Error::HeaderCheckFailed { source: e })
         .and_then(|pre_checked| match pre_checked {
             PreCheckedHeader::AlreadyPresent { header, .. } => {
                 Err(Error::BlockAlreadyPresent(header.hash()))
@@ -146,11 +122,11 @@ fn handle_block(
         .and_then(move |(header, parent_ref)| {
             blockchain
                 .post_check_header(header, parent_ref)
-                .map_err(Error::HeaderCheckFailed)
+                .map_err(|e| Error::HeaderCheckFailed { source: e })
         })
         .and_then(move |post_checked| {
             end_blockchain
                 .apply_and_store_block(post_checked, block)
-                .map_err(Error::ApplyBlockFailed)
+                .map_err(|e| Error::ApplyBlockFailed { source: e })
         })
 }

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -35,7 +35,7 @@ pub fn connect(
         channels,
         logger: state.logger,
     });
-    let cf = grpc::connect(addr, Some(node_id));
+    let cf = grpc::connect(addr, Some(node_id), state.global.executor.clone());
     let handle = ConnectHandle { receiver };
     let future = ConnectFuture {
         sender: Some(sender),

--- a/jormungandr/src/network/grpc/client.rs
+++ b/jormungandr/src/network/grpc/client.rs
@@ -9,56 +9,41 @@ use http::{HttpTryFrom, Uri};
 use hyper::client::connect::{Destination, HttpConnector};
 use network_core::client::{BlockService, Client as _};
 use network_core::error as core_error;
-use network_grpc::client::{Connect, ConnectError};
+use network_grpc::client::Connect;
 use slog::Logger;
+use thiserror::Error;
+use tokio::runtime::{Runtime, TaskExecutor};
+
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::slice;
-use std::{error::Error, fmt};
-use tokio::{executor::DefaultExecutor, runtime};
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum FetchBlockError {
-    Connect { source: ConnectError<io::Error> },
-    Ready { source: core_error::Error },
+    #[error("runtime initialization failed")]
+    RuntimeInit { source: io::Error },
+    #[error("connection to peer failed")]
+    Connect { source: ConnectError },
+    #[error("connection broken")]
+    ClientNotReady { source: core_error::Error },
+    #[error("block request failed")]
     GetBlocks { source: core_error::Error },
+    #[error("block response stream failed")]
     GetBlocksStream { source: core_error::Error },
+    #[error("no blocks received")]
     NoBlocks,
-}
-
-impl fmt::Display for FetchBlockError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            FetchBlockError::Connect { .. } => write!(f, "connection to peer failed"),
-            FetchBlockError::Ready { .. } => write!(f, "gRPC client is not ready to send request"),
-            FetchBlockError::GetBlocks { .. } => write!(f, "block request failed"),
-            FetchBlockError::GetBlocksStream { .. } => write!(f, "block response stream failed"),
-            FetchBlockError::NoBlocks => write!(f, "no blocks in the stream"),
-        }
-    }
-}
-
-impl Error for FetchBlockError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            FetchBlockError::Connect { source } => Some(source),
-            FetchBlockError::Ready { source } => Some(source),
-            FetchBlockError::GetBlocks { source } => Some(source),
-            FetchBlockError::GetBlocksStream { source } => Some(source),
-            FetchBlockError::NoBlocks => None,
-        }
-    }
 }
 
 pub type Connection = network_grpc::client::Connection<BlockConfig>;
 pub type ConnectFuture =
-    network_grpc::client::ConnectFuture<BlockConfig, HttpConnector, DefaultExecutor>;
+    network_grpc::client::ConnectFuture<BlockConfig, HttpConnector, TaskExecutor>;
+pub type ConnectError = network_grpc::client::ConnectError<io::Error>;
 
-pub fn connect(addr: SocketAddr, node_id: Option<NodeId>) -> ConnectFuture {
+pub fn connect(addr: SocketAddr, node_id: Option<NodeId>, executor: TaskExecutor) -> ConnectFuture {
     let uri = destination_uri(addr);
     let mut connector = HttpConnector::new(2);
     connector.set_nodelay(true);
-    let mut builder = Connect::new(connector, DefaultExecutor::current());
+    let mut builder = Connect::new(connector, executor);
     if let Some(id) = node_id {
         builder.node_id(id);
     }
@@ -78,20 +63,21 @@ fn destination_uri(addr: SocketAddr) -> Uri {
 // This function is used during node bootstrap to fetch the genesis block.
 pub fn fetch_block(
     peer: Peer,
-    hash: &HeaderHash,
+    hash: HeaderHash,
     logger: &Logger,
 ) -> Result<Block, FetchBlockError> {
     info!(logger, "fetching block {}", hash);
-    let fetch = connect(peer.address(), None)
+    let runtime = Runtime::new().map_err(|e| FetchBlockError::RuntimeInit { source: e })?;
+    let fetch = connect(peer.address(), None, runtime.executor())
         .map_err(|err| FetchBlockError::Connect { source: err })
         .and_then(move |client: Connection| {
             client
                 .ready()
-                .map_err(|err| FetchBlockError::Ready { source: err })
+                .map_err(|err| FetchBlockError::ClientNotReady { source: err })
         })
         .and_then(move |mut client| {
             client
-                .get_blocks(slice::from_ref(hash))
+                .get_blocks(slice::from_ref(&hash))
                 .map_err(|err| FetchBlockError::GetBlocks { source: err })
         })
         .and_then(move |stream| {
@@ -103,5 +89,5 @@ pub fn fetch_block(
             None => Err(FetchBlockError::NoBlocks),
             Some(block) => Ok(block),
         });
-    runtime::current_thread::block_on_all(fetch)
+    runtime.block_on_all(fetch)
 }

--- a/jormungandr/src/network/grpc/mod.rs
+++ b/jormungandr/src/network/grpc/mod.rs
@@ -4,7 +4,9 @@ mod server;
 use super::{p2p::topology as p2p, BlockConfig};
 use crate::blockcfg::{Block, BlockDate, Fragment, FragmentId, Header, HeaderHash};
 
-pub use self::client::{connect, fetch_block, ConnectFuture, Connection, FetchBlockError};
+pub use self::client::{
+    connect, fetch_block, ConnectError, ConnectFuture, Connection, FetchBlockError,
+};
 pub use self::server::run_listen_socket;
 
 impl network_grpc::client::ProtocolConfig for BlockConfig {

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -548,10 +548,7 @@ impl Peers {
                 .block_solicitations
                 .try_send(hashes)
                 .unwrap_or_else(|e| {
-                    debug!(
-                        self.logger,
-                        "block solicitation from {} failed: {:?}", node_id, e
-                    );
+                    debug!(self.logger, "block fetch from {} failed: {:?}", node_id, e);
                     debug!(self.logger, "unsubscribing peer {}", node_id);
                     map.remove_peer(node_id);
                 });

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -77,7 +77,7 @@ pub fn prepare_block_0(
                     logger,
                     "retrieving block0 from network with hash {}", block0_id
                 );
-                network::fetch_block(&settings.network, &block0_id, logger).map_err(|e| e.into())
+                network::fetch_block(&settings.network, *block0_id, logger).map_err(|e| e.into())
             }
         }
     }


### PR DESCRIPTION
`grpc::connect` used `DefaultExecutor` to run the client. Change this to a `TaskExecutor` passed down from the network task.

This percolates into fetch and bootstrap functions, which have been changed to also use a temporary `Runtime` instead of using the current thread runtime in the functions, but spinning gRPC tasks in the `DefaultRuntime` under the hood.

Tangentially, improve error types and logging for fetch and bootstrap, converting to `thiserror`.