### PR TITLE
network: Rewrite the client state machine

### DIFF
--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -3,7 +3,7 @@ use super::super::{
     p2p::{comm::PeerComms, topology},
     Channels, ConnectionState,
 };
-use super::{Client, ClientBuilder, GlobalStateR};
+use super::{Client, ClientBuilder, GlobalStateR, InboundSubscriptions};
 use crate::blockcfg::{Block, Fragment, HeaderHash};
 use network_core::client::{self as core_client};
 use network_core::client::{BlockService, FragmentService, GossipService, P2pService};
@@ -151,16 +151,6 @@ where
     }
 }
 
-pub struct InboundSubscriptions<T>
-where
-    T: BlockService + FragmentService + GossipService,
-{
-    pub node_id: topology::NodeId,
-    pub block_events: <T as BlockService>::BlockSubscription,
-    pub fragments: <T as FragmentService>::FragmentSubscription,
-    pub gossip: <T as GossipService>::GossipSubscription,
-}
-
 fn poll_client_ready<T, E>(client: &mut T) -> Poll<(), ConnectError<E>>
 where
     T: core_client::Client,
@@ -180,9 +170,6 @@ where
     F::Item: BlockService<Block = Block>,
     F::Item: FragmentService<Fragment = Fragment>,
     F::Item: GossipService<Node = topology::NodeData>,
-    <F::Item as BlockService>::UploadBlocksFuture: Send + 'static,
-    <F::Item as FragmentService>::FragmentSubscription: Send + 'static,
-    <F::Item as GossipService>::GossipSubscription: Send + 'static,
 {
     type Item = Client<F::Item>;
     type Error = ConnectError<F::Error>;

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -15,14 +15,18 @@ mod subscription;
 
 // Constants
 
-mod chain_pull {
+mod chunk_sizes {
     // Size of chunks to split processing of chain pull streams.
     // Apart from sizing data chunks for intercom messages, it also
     // determines how many blocks will be requested per each GetBlocks request
     // distributed between different peers.
     //
     // This may need to be made into a configuration parameter.
-    pub const CHUNK_SIZE: usize = 32;
+    pub const CHAIN_PULL: usize = 32;
+
+    // The maximum number of fragments to buffer from an incoming subscription
+    // while waiting for the fragment task to become ready to process them.
+    pub const FRAGMENTS: usize = 128;
 }
 
 use self::p2p::{

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -1,5 +1,5 @@
 use super::{
-    chain_pull,
+    chunk_sizes,
     inbound::InboundProcessing,
     p2p::comm::{BlockEventSubscription, Subscription},
     p2p::topology,
@@ -174,7 +174,7 @@ impl BlockService for NodeService {
             subscriber,
             self.global_state.clone(),
             self.channels.block_box.clone(),
-            logger.clone(),
+            &logger,
         );
 
         let subscription = self
@@ -194,7 +194,7 @@ pub struct ChainHeadersSinkFuture {
 
 impl ChainHeadersSinkFuture {
     fn new(mbox: MessageBox<BlockMsg>) -> Self {
-        let (handle, sink) = intercom::stream_request(chain_pull::CHUNK_SIZE);
+        let (handle, sink) = intercom::stream_request(chunk_sizes::CHAIN_PULL);
         let inner = mbox.send(BlockMsg::ChainHeaders(handle));
         ChainHeadersSinkFuture {
             inner,
@@ -245,7 +245,7 @@ impl FragmentService for NodeService {
             subscriber,
             self.global_state.clone(),
             self.channels.transaction_box.clone(),
-            self.logger().new(o!("node_id" => subscriber.to_string())),
+            &self.logger().new(o!("node_id" => subscriber.to_string())),
         );
 
         let subscription = self.global_state.peers.serve_fragments(subscriber);
@@ -270,7 +270,7 @@ impl GossipService for NodeService {
             inbound,
             subscriber,
             self.global_state.clone(),
-            self.logger().new(o!("node_id" => subscriber.to_string())),
+            &self.logger().new(o!("node_id" => subscriber.to_string())),
         );
 
         let subscription = self.global_state.peers.serve_gossip(subscriber);

--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -1,6 +1,6 @@
 use super::{
     p2p::topology::{NodeData, NodeId},
-    GlobalState, GlobalStateR,
+    GlobalStateR,
 };
 use crate::{
     blockcfg::{Fragment, Header},
@@ -9,7 +9,6 @@ use crate::{
     utils::async_msg::MessageBox,
 };
 use futures::prelude::*;
-use futures::sink;
 use jormungandr_lib::interfaces::FragmentOrigin;
 use network_core::error as core_error;
 use network_core::gossip::{Gossip, Node as _};
@@ -20,136 +19,74 @@ pub fn process_block_announcements<S>(
     node_id: NodeId,
     global_state: GlobalStateR,
     block_box: MessageBox<BlockMsg>,
-    logger: Logger,
+    logger: &Logger,
 ) where
     S: Stream<Item = Header, Error = core_error::Error> + Send + 'static,
 {
-    let state = global_state.clone();
+    let sink = BlockAnnouncementProcessor::new(block_box, node_id, global_state.clone(), logger);
+    let logger = sink.logger.clone();
     let stream_err_logger = logger.clone();
-    let sink_err_logger = logger.clone();
-    let stream = inbound
-        .map_err(move |err| {
-            debug!(
-                stream_err_logger,
-                "block subscription stream failure: {:?}", err
-            );
-        })
-        .map(move |header| {
-            state.peers.refresh_peer_on_block(node_id);
-            BlockMsg::AnnouncedBlock(header, node_id)
-        });
-    global_state.spawn(
-        block_box
-            .sink_map_err(move |_| {
-                error!(
-                    sink_err_logger,
-                    "failed to send block announcement to the block task"
-                );
-            })
-            .send_all(stream)
-            .map(move |_| {
-                debug!(logger, "block subscription ended");
-            }),
-    );
-}
-
-pub fn process_block_announcement(
-    header: Header,
-    node_id: NodeId,
-    global_state: &GlobalState,
-    block_box: MessageBox<BlockMsg>,
-) -> SendingBlockMsg {
-    global_state.peers.refresh_peer_on_block(node_id);
-    let future = block_box.send(BlockMsg::AnnouncedBlock(header, node_id));
-    SendingBlockMsg { inner: future }
-}
-
-#[must_use = "futures do nothing unless polled"]
-pub struct SendingBlockMsg {
-    inner: sink::Send<MessageBox<BlockMsg>>,
-}
-
-impl Future for SendingBlockMsg {
-    type Item = MessageBox<BlockMsg>;
-    type Error = core_error::Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll().map_err(|_e| {
-            core_error::Error::new(
-                core_error::Code::Aborted,
-                "the node stopped processing blocks",
-            )
-        })
-    }
+    let stream = inbound.map_err(move |e| {
+        debug!(
+            stream_err_logger,
+            "block subscription stream failure";
+            "error" => ?e,
+        );
+    });
+    global_state.spawn(sink.send_all(stream).map(move |_| {
+        debug!(logger, "block subscription ended by the peer");
+    }));
 }
 
 pub fn process_fragments<S>(
     inbound: S,
     node_id: NodeId,
     global_state: GlobalStateR,
-    transaction_box: MessageBox<TransactionMsg>,
-    logger: Logger,
+    fragment_box: MessageBox<TransactionMsg>,
+    logger: &Logger,
 ) where
     S: Stream<Item = Fragment, Error = core_error::Error> + Send + 'static,
 {
-    let state = global_state.clone();
+    let sink = FragmentProcessor::new(fragment_box, node_id, global_state.clone(), logger);
+    let logger = sink.logger.clone();
     let stream_err_logger = logger.clone();
-    let sink_err_logger = logger.clone();
     let stream = inbound
-        .map_err(move |err| {
+        .map_err(move |e| {
             debug!(
                 stream_err_logger,
-                "fragment subscription stream failure: {:?}", err
+                "fragment subscription stream failure";
+                "error" => ?e,
             );
         })
-        .map(move |fragment| {
-            state.peers.refresh_peer_on_fragment(node_id);
-            TransactionMsg::SendTransaction(FragmentOrigin::Network, vec![fragment])
-        });
-    global_state.spawn(
-        transaction_box
-            .sink_map_err(move |_| {
-                error!(
-                    sink_err_logger,
-                    "failed to send fragment to the transaction task"
-                );
-            })
-            .send_all(stream)
-            .map(move |_| {
-                debug!(logger, "fragment subscription ended");
-            }),
-    );
+        // TODO: chunkify the fragment stream non-greedily
+        .map(|fragment| vec![fragment]);
+    global_state.spawn(sink.send_all(stream).map(move |_| {
+        debug!(logger, "fragment subscription ended by the peer");
+    }));
 }
 
-pub fn process_gossip<S>(inbound: S, node_id: NodeId, global_state: GlobalStateR, logger: Logger)
+pub fn process_gossip<S>(inbound: S, node_id: NodeId, global_state: GlobalStateR, logger: &Logger)
 where
     S: Stream<Item = Gossip<NodeData>, Error = core_error::Error> + Send + 'static,
 {
-    let state = global_state.clone();
+    let processor = GossipProcessor::new(node_id, global_state.clone(), logger);
+    let logger = processor.logger.clone();
     let err_logger = logger.clone();
     global_state.spawn(
         inbound
+            .map_err(move |e| {
+                debug!(
+                    err_logger,
+                    "gossip subscription stream failure";
+                    "error" => ?e,
+                );
+            })
             .for_each(move |gossip| {
-                trace!(logger, "received gossip: {:?}", gossip);
-                let (nodes, filtered_out): (Vec<_>, Vec<_>) =
-                    gossip.into_nodes().partition(|node| {
-                        filter_gossip_node(node, &state.config)
-                            || (node.id() == node_id && node.address().is_none())
-                    });
-                if filtered_out.len() > 0 {
-                    debug!(logger, "nodes dropped from gossip: {:?}", filtered_out);
-                }
-                if !state.peers.refresh_peer_on_gossip(node_id) {
-                    debug!(
-                        logger,
-                        "received gossip from node {} that is not in the peer map", node_id
-                    );
-                }
-                state.topology.update(nodes);
+                processor.process_item(gossip);
                 Ok(())
             })
-            .map_err(move |err| {
-                debug!(err_logger, "gossip subscription stream failure: {:?}", err);
+            .map(move |_| {
+                debug!(logger, "gossip subscription ended by the peer");
             }),
     );
 }
@@ -159,5 +96,195 @@ fn filter_gossip_node(node: &NodeData, config: &Configuration) -> bool {
         node.has_valid_address()
     } else {
         node.is_global()
+    }
+}
+
+#[must_use = "sinks do nothing unless polled"]
+pub struct BlockAnnouncementProcessor {
+    mbox: MessageBox<BlockMsg>,
+    node_id: NodeId,
+    global_state: GlobalStateR,
+    logger: Logger,
+}
+
+impl BlockAnnouncementProcessor {
+    pub fn new(
+        mbox: MessageBox<BlockMsg>,
+        node_id: NodeId,
+        global_state: GlobalStateR,
+        logger: &Logger,
+    ) -> Self {
+        let logger = logger.new(o!("stream" => "block_events", "direction" => "in"));
+        BlockAnnouncementProcessor {
+            mbox,
+            node_id,
+            global_state,
+            logger,
+        }
+    }
+
+    pub fn message_box(&self) -> MessageBox<BlockMsg> {
+        self.mbox.clone()
+    }
+}
+
+#[must_use = "sinks do nothing unless polled"]
+pub struct FragmentProcessor {
+    mbox: MessageBox<TransactionMsg>,
+    node_id: NodeId,
+    global_state: GlobalStateR,
+    logger: Logger,
+}
+
+impl FragmentProcessor {
+    pub fn new(
+        mbox: MessageBox<TransactionMsg>,
+        node_id: NodeId,
+        global_state: GlobalStateR,
+        logger: &Logger,
+    ) -> Self {
+        let logger = logger.new(o!("stream" => "fragments", "direction" => "in"));
+        FragmentProcessor {
+            mbox,
+            node_id,
+            global_state,
+            logger,
+        }
+    }
+}
+
+pub struct GossipProcessor {
+    node_id: NodeId,
+    global_state: GlobalStateR,
+    logger: Logger,
+}
+
+impl GossipProcessor {
+    pub fn new(node_id: NodeId, global_state: GlobalStateR, logger: &Logger) -> Self {
+        let logger = logger.new(o!("stream" => "gossip", "direction" => "in"));
+        GossipProcessor {
+            node_id,
+            global_state,
+            logger,
+        }
+    }
+
+    pub fn process_item(&self, gossip: Gossip<NodeData>) {
+        trace!(self.logger, "received gossip: {:?}", gossip);
+        let (nodes, filtered_out): (Vec<_>, Vec<_>) = gossip.into_nodes().partition(|node| {
+            filter_gossip_node(node, &self.global_state.config)
+                || (node.id() == self.node_id && node.address().is_none())
+        });
+        if filtered_out.len() > 0 {
+            debug!(self.logger, "nodes dropped from gossip: {:?}", filtered_out);
+        }
+        if !self.global_state.peers.refresh_peer_on_gossip(self.node_id) {
+            debug!(
+                self.logger,
+                "received gossip from node {} that is not in the peer map", self.node_id
+            );
+        }
+        self.global_state.topology.update(nodes);
+    }
+}
+
+impl Sink for BlockAnnouncementProcessor {
+    type SinkItem = Header;
+    type SinkError = ();
+
+    fn start_send(&mut self, header: Header) -> StartSend<Header, ()> {
+        let polled = self
+            .mbox
+            .start_send(BlockMsg::AnnouncedBlock(header, self.node_id))
+            .map_err(|e| {
+                error!(
+                    self.logger,
+                    "failed to send block announcement to the block task";
+                    "reason" => %e,
+                );
+            })?;
+        match polled {
+            AsyncSink::Ready => {
+                self.global_state.peers.refresh_peer_on_block(self.node_id);
+                Ok(AsyncSink::Ready)
+            }
+            AsyncSink::NotReady(BlockMsg::AnnouncedBlock(header, _)) => {
+                Ok(AsyncSink::NotReady(header))
+            }
+            AsyncSink::NotReady(_) => unreachable!(),
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), ()> {
+        self.mbox.poll_complete().map_err(|e| {
+            error!(
+                self.logger,
+                "communication channel to the block task failed";
+                "reason" => %e,
+            );
+        })
+    }
+
+    fn close(&mut self) -> Poll<(), ()> {
+        self.mbox.close().map_err(|e| {
+            warn!(
+                self.logger,
+                "failed to close communication channel to the block task";
+                "reason" => %e,
+            );
+        })
+    }
+}
+
+impl Sink for FragmentProcessor {
+    type SinkItem = Vec<Fragment>;
+    type SinkError = ();
+
+    fn start_send(&mut self, fragments: Vec<Fragment>) -> StartSend<Self::SinkItem, ()> {
+        let polled = self
+            .mbox
+            .start_send(TransactionMsg::SendTransaction(
+                FragmentOrigin::Network,
+                fragments,
+            ))
+            .map_err(|e| {
+                error!(
+                    self.logger,
+                    "failed to send fragments to the fragment task";
+                    "reason" => %e,
+                );
+            })?;
+        match polled {
+            AsyncSink::Ready => {
+                self.global_state
+                    .peers
+                    .refresh_peer_on_fragment(self.node_id);
+                Ok(AsyncSink::Ready)
+            }
+            AsyncSink::NotReady(TransactionMsg::SendTransaction(_, fragments)) => {
+                Ok(AsyncSink::NotReady(fragments))
+            }
+            AsyncSink::NotReady(_) => unreachable!(),
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), ()> {
+        self.mbox.poll_complete().map_err(|e| {
+            error!(
+                self.logger,
+                "communication channel to the fragment task failed";
+                "reason" => %e,
+            );
+        })
+    }
+
+    fn close(&mut self) -> Poll<(), ()> {
+        self.mbox.close().map_err(|e| {
+            warn!(
+                self.logger,
+                "failed to close communication channel to the fragment task";
+                "reason" => %e,
+            );
+        })
     }
 }


### PR DESCRIPTION
More disciplined polling loop organization in the form of `ProcessingOutcome` and `Progress`.
Don't spin off separate tasks for processing inbound fragment and gossip streams, as this may cause the background HTTP client to linger after the `Client`'s future has resolved.
Expose the sinks and the gossip processing state in `mod subscription` to enable code reuse in the client.

Might fix #923 and #995.