### PR TITLE
Implement pagination for transactions

### DIFF
--- a/jormungandr/src/explorer/graphql/connections.rs
+++ b/jormungandr/src/explorer/graphql/connections.rs
@@ -259,7 +259,6 @@ where
     if let Some(first) = pagination_arguments.first {
         to = min(
             from.checked_add(u64::try_from(first).unwrap())
-                .map(|n| n - 1)
                 .unwrap_or(to),
             to,
         );
@@ -269,7 +268,6 @@ where
     if let Some(last) = pagination_arguments.last {
         from = max(
             to.checked_sub(u64::try_from(last).unwrap())
-                .map(|n| n + 1)
                 .unwrap_or(from),
             from,
         );

--- a/jormungandr/src/explorer/graphql/connections.rs
+++ b/jormungandr/src/explorer/graphql/connections.rs
@@ -174,7 +174,12 @@ where
                 start_cursor,
                 end_cursor,
             },
-            total_count: (upper_bound - lower_bound).into(),
+            total_count: (upper_bound
+                .checked_sub(lower_bound)
+                .expect("upper_bound to be >= than lower_bound")
+                .checked_add(1)
+                .unwrap())
+            .into(),
         })
     }
 }

--- a/jormungandr/src/explorer/graphql/connections.rs
+++ b/jormungandr/src/explorer/graphql/connections.rs
@@ -170,6 +170,8 @@ where
                 let has_previous_page = page.lower_bound > lower_bound;
 
                 let total_count = upper_bound
+                    .checked_add(1)
+                    .unwrap()
                     .checked_sub(lower_bound)
                     .expect("upper_bound should be >= than lower_bound")
                     .into();

--- a/jormungandr/src/explorer/graphql/connections.rs
+++ b/jormungandr/src/explorer/graphql/connections.rs
@@ -54,98 +54,6 @@ impl TransactionEdge {
     }
 }
 
-pub struct PageInfo {
-    pub has_next_page: bool,
-    pub has_previous_page: bool,
-    pub start_cursor: Option<IndexCursor>,
-    pub end_cursor: Option<IndexCursor>,
-}
-
-pub struct Connection<E, C> {
-    page_info: PageInfo,
-    edges: Vec<E>,
-    total_count: C,
-}
-
-pub struct TransactionEdge {
-    node: Transaction,
-    cursor: IndexCursor,
-}
-
-pub struct BlockEdge {
-    pub node: Block,
-    pub cursor: IndexCursor,
-}
-
-pub trait Edge {
-    type Node;
-    fn new(node: Self::Node, cursor: IndexCursor) -> Self;
-
-    fn cursor<'a>(&'a self) -> &'a IndexCursor;
-}
-
-impl<E, C> Connection<E, C>
-where
-    E: Edge,
-    C: From<u32>,
-    E::Node: Clone,
-{
-    pub fn new<I>(
-        lower_bound: u32,
-        upper_bound: u32,
-        first: Option<i32>,
-        last: Option<i32>,
-        before: Option<IndexCursor>,
-        after: Option<IndexCursor>,
-        get_node_range: impl Fn(I, I) -> Vec<(E::Node, I)>,
-    ) -> FieldResult<Connection<E, C>>
-    where
-        u32: From<I>,
-        I: From<u32> + Clone,
-    {
-        let before: Option<u32> = before.map(|i: IndexCursor| -> u32 { i.into() });
-        let after: Option<u32> = after.map(|i: IndexCursor| -> u32 { i.into() });
-
-        let (from, to) =
-            compute_range_boundaries(lower_bound, upper_bound, last, before, first, after)?;
-
-        let has_next_page = to < upper_bound;
-        let has_previous_page = from > lower_bound;
-        let edges: Vec<_> = get_node_range(I::from(from), I::from(to))
-            .iter()
-            .map(|(hash, node_pagination_identifier)| {
-                E::new(
-                    (*hash).clone(),
-                    IndexCursor::from(u32::from(node_pagination_identifier.clone())),
-                )
-            })
-            .collect();
-
-        let start_cursor = edges.first().map(|e| e.cursor().clone());
-        let end_cursor = edges
-            .last()
-            .map(|e| e.cursor().clone())
-            .or(start_cursor.clone());
-
-        Ok(Connection {
-            edges,
-            page_info: PageInfo {
-                has_next_page,
-                has_previous_page,
-                start_cursor,
-                end_cursor,
-            },
-            total_count: (upper_bound
-                .checked_sub(lower_bound)
-                .expect("upper_bound to be >= than lower_bound"))
-            .into(),
-        })
-    }
-}
-
-pub type BlockConnection = Connection<BlockEdge, BlockCount>;
-pub type TransactionConnection = Connection<TransactionEdge, TransactionCount>;
-
 #[juniper::object(
     Context = Context,
     name = "BlockConnection"
@@ -184,6 +92,116 @@ impl TransactionConnection {
     }
 }
 
+pub struct PageInfo {
+    pub has_next_page: bool,
+    pub has_previous_page: bool,
+    pub start_cursor: Option<IndexCursor>,
+    pub end_cursor: Option<IndexCursor>,
+}
+
+pub struct Connection<E, C> {
+    page_info: PageInfo,
+    edges: Vec<E>,
+    total_count: C,
+}
+
+pub struct TransactionEdge {
+    node: Transaction,
+    cursor: IndexCursor,
+}
+
+pub struct BlockEdge {
+    pub node: Block,
+    pub cursor: IndexCursor,
+}
+
+pub trait Edge {
+    type Node;
+    fn new(node: Self::Node, cursor: IndexCursor) -> Self;
+
+    fn cursor<'a>(&'a self) -> &'a IndexCursor;
+}
+
+pub struct ValidatedPaginationArguments<I> {
+    first: Option<u32>,
+    last: Option<u32>,
+    before: Option<I>,
+    after: Option<I>,
+}
+
+pub struct PaginationArguments<I> {
+    pub first: Option<i32>,
+    pub last: Option<i32>,
+    pub before: Option<I>,
+    pub after: Option<I>,
+}
+
+impl<E, C> Connection<E, C>
+where
+    E: Edge,
+    C: From<u64>,
+    E::Node: Clone,
+{
+    pub fn new<I>(
+        lower_bound: I,
+        upper_bound: I,
+        pagination_arguments: ValidatedPaginationArguments<I>,
+        get_node_range: impl Fn(I, I) -> Vec<(E::Node, I)>,
+    ) -> FieldResult<Connection<E, C>>
+    where
+        I: TryFrom<u64>,
+        u64: From<I>,
+        I: Clone,
+        IndexCursor: From<I>,
+    {
+        let lower_bound: u64 = lower_bound.into();
+        let upper_bound: u64 = upper_bound.into();
+        let pagination_arguments = pagination_arguments.cursors_into::<u64>();
+
+        let [from, to] = compute_range_boundaries(lower_bound, upper_bound, pagination_arguments)?;
+
+        let has_next_page = to < upper_bound;
+        let has_previous_page = from > lower_bound;
+
+        let index_from = I::try_from(from)
+            .map_err(|_| "page range is out of boundaries")
+            .unwrap();
+        let index_to = I::try_from(to)
+            .map_err(|_| "page range is out of boundaries")
+            .unwrap();
+
+        let edges: Vec<_> = get_node_range(index_from, index_to)
+            .iter()
+            .map(|(hash, node_pagination_identifier)| {
+                E::new((*hash).clone(), node_pagination_identifier.clone().into())
+            })
+            .collect();
+
+        let start_cursor = edges.first().map(|e| e.cursor().clone());
+        let end_cursor = edges
+            .last()
+            .map(|e| e.cursor().clone())
+            .or(start_cursor.clone());
+
+        Ok(Connection {
+            edges,
+            page_info: PageInfo {
+                has_next_page,
+                has_previous_page,
+                start_cursor,
+                end_cursor,
+            },
+            total_count: (upper_bound
+                .checked_sub(lower_bound)
+                .expect("upper_bound to be >= than lower_bound"))
+            .into(),
+        })
+    }
+}
+
+pub type BlockConnection = Connection<BlockEdge, BlockCount>;
+pub type TransactionConnection = Connection<TransactionEdge, TransactionCount>;
+
 impl Edge for TransactionEdge {
     type Node = HeaderHash;
     fn new(node: Self::Node, cursor: IndexCursor) -> TransactionEdge {
@@ -213,59 +231,105 @@ impl Edge for BlockEdge {
 }
 
 fn compute_range_boundaries(
-    lower_bound: u32,
-    upper_bound: u32,
-    last: Option<i32>,
-    before: Option<u32>,
-    first: Option<i32>,
-    after: Option<u32>,
-) -> FieldResult<(u32, u32)> {
+    lower_bound: u64,
+    upper_bound: u64,
+    pagination_arguments: ValidatedPaginationArguments<u64>,
+) -> FieldResult<[u64; 2]>
+where
+{
     use std::cmp::{max, min};
+
     // Compute the required range of blocks in two variables: [from, to]
     // Both ends are inclusive
-    let mut from = match after {
+    let mut from: u64 = match pagination_arguments.after {
         Some(cursor) => max(cursor + 1, lower_bound),
         // If `after` is not set, start from the beginning
         None => lower_bound,
-    };
+    }
+    .into();
 
-    let mut to = match before {
+    let mut to: u64 = match pagination_arguments.before {
         Some(cursor) => min(cursor - 1, upper_bound),
         // If `before` is not set, start from the beginning
         None => upper_bound,
-    };
+    }
+    .into();
 
     // Move `to` enough values to make the result have `first` blocks
-    if let Some(first) = first {
-        if first < 0 {
-            return Err(
-                ErrorKind::ArgumentError("first argument should be positive".to_owned()).into(),
-            );
-        } else {
-            to = min(
-                from.checked_add(u32::try_from(first).unwrap())
-                    .map(|n| n - 1)
-                    .unwrap_or(to),
-                to,
-            );
-        }
+    if let Some(first) = pagination_arguments.first {
+        to = min(
+            from.checked_add(u64::try_from(first).unwrap())
+                .map(|n| n - 1)
+                .unwrap_or(to),
+            to,
+        );
     }
 
     // Move `from` enough values to make the result have `last` blocks
-    if let Some(last) = last {
-        if last < 0 {
-            return Err(
-                ErrorKind::ArgumentError("last argument should be positive".to_owned()).into(),
-            );
-        } else {
-            from = max(
-                to.checked_sub(u32::try_from(last).unwrap())
-                    .map(|n| n + 1)
-                    .unwrap_or(from),
-                from,
-            );
-        }
+    if let Some(last) = pagination_arguments.last {
+        from = max(
+            to.checked_sub(u64::try_from(last).unwrap())
+                .map(|n| n + 1)
+                .unwrap_or(from),
+            from,
+        );
     }
 
-    Ok((from, to))
+    Ok([from, to])
+}
+
+impl<I> PaginationArguments<I> {
+    pub fn validate(self) -> FieldResult<ValidatedPaginationArguments<I>> {
+        let first = self
+            .first
+            .map(|signed| -> FieldResult<u32> {
+                if signed < 0 {
+                    return Err(ErrorKind::ArgumentError(
+                        "first argument should be positive".to_owned(),
+                    )
+                    .into());
+                } else {
+                    Ok(u32::try_from(signed).unwrap())
+                }
+            })
+            .transpose()?;
+
+        let last = self
+            .last
+            .map(|signed| -> FieldResult<u32> {
+                if signed < 0 {
+                    return Err(ErrorKind::ArgumentError(
+                        "last argument should be positive".to_owned(),
+                    )
+                    .into());
+                } else {
+                    Ok(u32::try_from(signed).unwrap())
+                }
+            })
+            .transpose()?;
+
+        let before = self.before;
+        let after = self.after;
+
+        Ok(ValidatedPaginationArguments {
+            first,
+            after,
+            last,
+            before,
+        })
+    }
+}
+
+impl<I> ValidatedPaginationArguments<I> {
+    fn cursors_into<T>(self) -> ValidatedPaginationArguments<T>
+    where
+        T: From<I>,
+    {
+        ValidatedPaginationArguments {
+            after: self.after.map(T::from),
+            before: self.before.map(T::from),
+            first: self.first,
+            last: self.last,
+        }
+    }
 }

--- a/jormungandr/src/explorer/graphql/connections.rs
+++ b/jormungandr/src/explorer/graphql/connections.rs
@@ -1,63 +1,9 @@
 use super::error::ErrorKind;
-use super::scalars::BlockCount;
-use super::{Block, Context};
-use blockcfg::{self, HeaderHash};
-use juniper::{FieldResult, ParseScalarResult, ParseScalarValue, Value};
+use super::scalars::{BlockCount, IndexCursor, TransactionCount};
+use super::{Block, Context, Transaction};
+use crate::blockcfg::HeaderHash;
+use juniper::FieldResult;
 use std::convert::TryFrom;
-
-#[derive(Clone)]
-pub struct BlockCursor(blockcfg::ChainLength);
-
-juniper::graphql_scalar!(BlockCursor where Scalar = <S> {
-    description: "Opaque cursor to use in block pagination, a client should not rely in its representation"
-
-    // FIXME: Cursors are recommended to be opaque, but I'm not sure it is worth to
-    // obfuscate its representation
-    resolve(&self) -> Value {
-        Value::scalar(self.0.to_string())
-    }
-
-    from_input_value(v: &InputValue) -> Option<BlockCursor> {
-        v.as_scalar_value::<String>()
-         .and_then(|s| s.parse::<u32>().ok())
-         .map(|n| BlockCursor(blockcfg::ChainLength::from(n)))
-    }
-
-    from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, S> {
-        <String as ParseScalarValue<S>>::from_str(value)
-    }
-});
-
-impl From<u32> for BlockCursor {
-    fn from(number: u32) -> BlockCursor {
-        BlockCursor(blockcfg::ChainLength::from(number))
-    }
-}
-
-impl From<BlockCursor> for u32 {
-    fn from(number: BlockCursor) -> u32 {
-        number.0.into()
-    }
-}
-
-impl From<blockcfg::ChainLength> for BlockCursor {
-    fn from(length: blockcfg::ChainLength) -> BlockCursor {
-        BlockCursor(length)
-    }
-}
-
-impl From<BlockCursor> for blockcfg::ChainLength {
-    fn from(c: BlockCursor) -> blockcfg::ChainLength {
-        c.0.into()
-    }
-}
-
-pub struct PageInfo {
-    pub has_next_page: bool,
-    pub has_previous_page: bool,
-    pub start_cursor: BlockCursor,
-    pub end_cursor: BlockCursor,
-}
 
 #[juniper::object(
     Context = Context
@@ -71,18 +17,13 @@ impl PageInfo {
         self.has_previous_page
     }
 
-    pub fn start_cursor(&self) -> &BlockCursor {
+    pub fn start_cursor(&self) -> &Option<IndexCursor> {
         &self.start_cursor
     }
 
-    pub fn end_cursor(&self) -> &BlockCursor {
+    pub fn end_cursor(&self) -> &Option<IndexCursor> {
         &self.end_cursor
     }
-}
-
-pub struct BlockEdge {
-    pub node: Block,
-    pub cursor: BlockCursor,
 }
 
 #[juniper::object(
@@ -94,15 +35,9 @@ impl BlockEdge {
     }
 
     /// A cursor for use in pagination
-    pub fn cursor(&self) -> &BlockCursor {
+    pub fn cursor(&self) -> &IndexCursor {
         &self.cursor
     }
-}
-
-pub struct BlockConnection {
-    pub page_info: PageInfo,
-    pub edges: Vec<BlockEdge>,
-    pub total_count: BlockCount,
 }
 
 #[juniper::object(
@@ -110,16 +45,137 @@ pub struct BlockConnection {
 )]
 impl BlockConnection {
     pub fn page_info(&self) -> &PageInfo {
-        &self.page_info
+        &self.0.page_info
     }
 
     pub fn edges(&self) -> &Vec<BlockEdge> {
-        &self.edges
+        &self.0.edges
     }
 
     /// A count of the total number of objects in this connection, ignoring pagination.
     pub fn total_count(&self) -> &BlockCount {
-        &self.total_count
+        &self.0.total_count
+    }
+}
+
+#[juniper::object(
+    Context = Context
+)]
+impl TransactionConnection {
+    pub fn page_info(&self) -> &PageInfo {
+        &self.0.page_info
+    }
+
+    pub fn edges(&self) -> &Vec<TransactionEdge> {
+        &self.0.edges
+    }
+
+    /// A count of the total number of objects in this connection, ignoring pagination.
+    pub fn total_count(&self) -> &TransactionCount {
+        &self.0.total_count
+    }
+}
+
+#[juniper::object(
+    Context = Context
+)]
+impl TransactionEdge {
+    pub fn node(&self) -> &Transaction {
+        &self.node
+    }
+
+    /// A cursor for use in pagination
+    pub fn cursor(&self) -> &IndexCursor {
+        &self.cursor
+    }
+}
+
+pub struct PageInfo {
+    pub has_next_page: bool,
+    pub has_previous_page: bool,
+    pub start_cursor: Option<IndexCursor>,
+    pub end_cursor: Option<IndexCursor>,
+}
+
+pub struct Connection<E, C> {
+    page_info: PageInfo,
+    edges: Vec<E>,
+    total_count: C,
+}
+
+pub struct BlockConnection(Connection<BlockEdge, BlockCount>);
+pub struct TransactionConnection(Connection<TransactionEdge, TransactionCount>);
+
+struct TransactionEdge {
+    node: Transaction,
+    cursor: IndexCursor,
+}
+
+pub struct BlockEdge {
+    pub node: Block,
+    pub cursor: IndexCursor,
+}
+
+pub trait Edge {
+    type Node;
+    fn new(node: Self::Node, cursor: IndexCursor) -> Self;
+
+    fn cursor<'a>(&'a self) -> &'a IndexCursor;
+}
+
+impl<E, C> Connection<E, C>
+where
+    E: Edge,
+    C: From<u32>,
+    E::Node: Clone,
+{
+    pub fn new<I>(
+        lower_bound: u32,
+        upper_bound: u32,
+        first: Option<i32>,
+        last: Option<i32>,
+        before: Option<IndexCursor>,
+        after: Option<IndexCursor>,
+        get_node_range: impl Fn(I, I) -> Vec<(E::Node, I)>,
+    ) -> FieldResult<Connection<E, C>>
+    where
+        u32: From<I>,
+        I: From<u32> + Clone,
+    {
+        let before: Option<u32> = before.map(|i: IndexCursor| -> u32 { i.into() });
+        let after: Option<u32> = after.map(|i: IndexCursor| -> u32 { i.into() });
+
+        let (from, to) =
+            compute_range_boundaries(lower_bound, upper_bound, last, before, first, after)?;
+
+        let has_next_page = to < upper_bound;
+        let has_previous_page = from > lower_bound;
+        let edges: Vec<_> = get_node_range(I::from(from), I::from(to + 1))
+            .iter()
+            .map(|(hash, node_pagination_identifier)| {
+                E::new(
+                    (*hash).clone(),
+                    IndexCursor::from(u32::from(node_pagination_identifier.clone())),
+                )
+            })
+            .collect();
+
+        let start_cursor = edges.first().map(|e| e.cursor().clone());
+        let end_cursor = edges
+            .last()
+            .map(|e| e.cursor().clone())
+            .or(start_cursor.clone());
+
+        Ok(Connection {
+            edges,
+            page_info: PageInfo {
+                has_next_page,
+                has_previous_page,
+                start_cursor,
+                end_cursor,
+            },
+            total_count: (upper_bound - lower_bound).into(),
+        })
     }
 }
 
@@ -132,91 +188,134 @@ impl BlockConnection {
         upper_bound: u32,
         first: Option<i32>,
         last: Option<i32>,
-        before: Option<u32>,
-        after: Option<u32>,
+        before: Option<IndexCursor>,
+        after: Option<IndexCursor>,
         get_block_range: impl Fn(I, I) -> Vec<(HeaderHash, I)>,
     ) -> FieldResult<BlockConnection>
     where
-        u32: From<I>,
         I: From<u32> + Clone,
+        u32: From<I>,
     {
-        use std::cmp::{max, min};
-
-        // Compute the required range of blocks in two variables: [from, to]
-        // Both ends are inclusive
-        let mut from = match after {
-            Some(cursor) => cursor + 1,
-            // If `after` is not set, start from the beginning
-            None => lower_bound,
-        };
-
-        let mut to = match before {
-            Some(cursor) => cursor - 1,
-            // If `before` is not set, start from the beginning
-            None => upper_bound,
-        };
-
-        // Move `to` enough values to make the result have `first` blocks
-        if let Some(first) = first {
-            if first < 0 {
-                return Err(ErrorKind::ArgumentError(
-                    "first argument should be positive".to_owned(),
-                )
-                .into());
-            } else {
-                to = min(
-                    from.checked_add(u32::try_from(first).unwrap())
-                        .map(|n| n - 1)
-                        .or(Some(to))
-                        .unwrap(),
-                    to,
-                );
-            }
-        }
-
-        // Move `from` enough values to make the result have `last` blocks
-        if let Some(last) = last {
-            if last < 0 {
-                return Err(ErrorKind::ArgumentError(
-                    "last argument should be positive".to_owned(),
-                )
-                .into());
-            } else {
-                from = max(
-                    to.checked_sub(u32::try_from(last).unwrap())
-                        .map(|n| n + 1)
-                        .or(Some(from))
-                        .unwrap(),
-                    from,
-                );
-            }
-        }
-
-        let has_next_page = to < upper_bound;
-        let has_previous_page = from > lower_bound;
-        let edges: Vec<_> = get_block_range(from.into(), (to + 1).into())
-            .iter()
-            .map(|(hash, block_pagination_identifier)| BlockEdge {
-                node: Block::from_valid_hash(*hash),
-                cursor: BlockCursor::from(u32::from(block_pagination_identifier.clone())),
-            })
-            .collect();
-
-        let start_cursor = edges.first().expect("to be at least 1 edge").cursor.clone();
-        let end_cursor = edges
-            .last()
-            .map(|e| e.cursor.clone())
-            .unwrap_or(start_cursor.clone());
-
-        Ok(BlockConnection {
-            edges,
-            page_info: PageInfo {
-                has_next_page,
-                has_previous_page,
-                start_cursor,
-                end_cursor,
-            },
-            total_count: (upper_bound - lower_bound).into(),
-        })
+        Connection::new(
+            lower_bound,
+            upper_bound,
+            first,
+            last,
+            before,
+            after,
+            get_block_range,
+        )
+        .map(BlockConnection)
     }
+}
+
+impl TransactionConnection {
+    pub fn new(
+        lower_bound: u32,
+        upper_bound: u32,
+        first: Option<i32>,
+        last: Option<i32>,
+        before: Option<IndexCursor>,
+        after: Option<IndexCursor>,
+        get_transaction_range: impl Fn(u32, u32) -> Vec<(HeaderHash, u32)>,
+    ) -> FieldResult<TransactionConnection> {
+        Connection::new(
+            lower_bound,
+            upper_bound,
+            first,
+            last,
+            before,
+            after,
+            get_transaction_range,
+        )
+        .map(TransactionConnection)
+    }
+}
+
+impl Edge for TransactionEdge {
+    type Node = HeaderHash;
+    fn new(node: Self::Node, cursor: IndexCursor) -> TransactionEdge {
+        TransactionEdge {
+            node: Transaction::from_valid_id(node),
+            cursor,
+        }
+    }
+
+    fn cursor(&self) -> &IndexCursor {
+        &self.cursor
+    }
+}
+
+impl Edge for BlockEdge {
+    type Node = HeaderHash;
+    fn new(node: Self::Node, cursor: IndexCursor) -> Self {
+        BlockEdge {
+            node: Block::from_valid_hash(node),
+            cursor,
+        }
+    }
+
+    fn cursor<'a>(&'a self) -> &'a IndexCursor {
+        &self.cursor
+    }
+}
+
+fn compute_range_boundaries(
+    lower_bound: u32,
+    upper_bound: u32,
+    last: Option<i32>,
+    before: Option<u32>,
+    first: Option<i32>,
+    after: Option<u32>,
+) -> FieldResult<(u32, u32)> {
+    use std::cmp::{max, min};
+    // Compute the required range of blocks in two variables: [from, to]
+    // Both ends are inclusive
+    let mut from = match after {
+        Some(cursor) => cursor + 1,
+        // If `after` is not set, start from the beginning
+        None => lower_bound,
+    };
+
+    let mut to = match before {
+        Some(cursor) => cursor - 1,
+        // If `before` is not set, start from the beginning
+        None => upper_bound,
+    };
+
+    // Move `to` enough values to make the result have `first` blocks
+    if let Some(first) = first {
+        if first < 0 {
+            return Err(
+                ErrorKind::ArgumentError("first argument should be positive".to_owned()).into(),
+            );
+        } else {
+            to = min(
+                from.checked_add(u32::try_from(first).unwrap())
+                    .map(|n| n - 1)
+                    .or(Some(to))
+                    .unwrap(),
+                to,
+            );
+        }
+    }
+
+    // Move `from` enough values to make the result have `last` blocks
+    if let Some(last) = last {
+        if last < 0 {
+            return Err(
+                ErrorKind::ArgumentError("last argument should be positive".to_owned()).into(),
+            );
+        } else {
+            from = max(
+                to.checked_sub(u32::try_from(last).unwrap())
+                    .map(|n| n + 1)
+                    .or(Some(from))
+                    .unwrap(),
+                from,
+            );
+        }
+    }
+
+    Ok((from, to))
 }

--- a/jormungandr/src/explorer/graphql/connections.rs
+++ b/jormungandr/src/explorer/graphql/connections.rs
@@ -150,7 +150,7 @@ where
 
         let has_next_page = to < upper_bound;
         let has_previous_page = from > lower_bound;
-        let edges: Vec<_> = get_node_range(I::from(from), I::from(to + 1))
+        let edges: Vec<_> = get_node_range(I::from(from), I::from(to))
             .iter()
             .map(|(hash, node_pagination_identifier)| {
                 E::new(
@@ -176,9 +176,7 @@ where
             },
             total_count: (upper_bound
                 .checked_sub(lower_bound)
-                .expect("upper_bound to be >= than lower_bound")
-                .checked_add(1)
-                .unwrap())
+                .expect("upper_bound to be >= than lower_bound"))
             .into(),
         })
     }
@@ -277,13 +275,13 @@ fn compute_range_boundaries(
     // Compute the required range of blocks in two variables: [from, to]
     // Both ends are inclusive
     let mut from = match after {
-        Some(cursor) => cursor + 1,
+        Some(cursor) => max(cursor + 1, lower_bound),
         // If `after` is not set, start from the beginning
         None => lower_bound,
     };
 
     let mut to = match before {
-        Some(cursor) => cursor - 1,
+        Some(cursor) => min(cursor - 1, upper_bound),
         // If `before` is not set, start from the beginning
         None => upper_bound,
     };
@@ -298,8 +296,7 @@ fn compute_range_boundaries(
             to = min(
                 from.checked_add(u32::try_from(first).unwrap())
                     .map(|n| n - 1)
-                    .or(Some(to))
-                    .unwrap(),
+                    .unwrap_or(to),
                 to,
             );
         }
@@ -315,8 +312,7 @@ fn compute_range_boundaries(
             from = max(
                 to.checked_sub(u32::try_from(last).unwrap())
                     .map(|n| n + 1)
-                    .or(Some(from))
-                    .unwrap(),
+                    .unwrap_or(from),
                 from,
             );
         }

--- a/jormungandr/src/explorer/graphql/connections.rs
+++ b/jormungandr/src/explorer/graphql/connections.rs
@@ -43,42 +43,6 @@ impl BlockEdge {
 #[juniper::object(
     Context = Context
 )]
-impl BlockConnection {
-    pub fn page_info(&self) -> &PageInfo {
-        &self.0.page_info
-    }
-
-    pub fn edges(&self) -> &Vec<BlockEdge> {
-        &self.0.edges
-    }
-
-    /// A count of the total number of objects in this connection, ignoring pagination.
-    pub fn total_count(&self) -> &BlockCount {
-        &self.0.total_count
-    }
-}
-
-#[juniper::object(
-    Context = Context
-)]
-impl TransactionConnection {
-    pub fn page_info(&self) -> &PageInfo {
-        &self.0.page_info
-    }
-
-    pub fn edges(&self) -> &Vec<TransactionEdge> {
-        &self.0.edges
-    }
-
-    /// A count of the total number of objects in this connection, ignoring pagination.
-    pub fn total_count(&self) -> &TransactionCount {
-        &self.0.total_count
-    }
-}
-
-#[juniper::object(
-    Context = Context
-)]
 impl TransactionEdge {
     pub fn node(&self) -> &Transaction {
         &self.node
@@ -103,10 +67,7 @@ pub struct Connection<E, C> {
     total_count: C,
 }
 
-pub struct BlockConnection(Connection<BlockEdge, BlockCount>);
-pub struct TransactionConnection(Connection<TransactionEdge, TransactionCount>);
-
-struct TransactionEdge {
+pub struct TransactionEdge {
     node: Transaction,
     cursor: IndexCursor,
 }
@@ -182,56 +143,44 @@ where
     }
 }
 
+pub type BlockConnection = Connection<BlockEdge, BlockCount>;
+pub type TransactionConnection = Connection<TransactionEdge, TransactionCount>;
+
+#[juniper::object(
+    Context = Context,
+    name = "BlockConnection"
+)]
 impl BlockConnection {
-    // The lower and upper bound are used to define all the blocks this connection will show
-    // In particular, they are used to paginate Epoch blocks from first block in epoch to
-    // last.
-    pub fn new<I>(
-        lower_bound: u32,
-        upper_bound: u32,
-        first: Option<i32>,
-        last: Option<i32>,
-        before: Option<IndexCursor>,
-        after: Option<IndexCursor>,
-        get_block_range: impl Fn(I, I) -> Vec<(HeaderHash, I)>,
-    ) -> FieldResult<BlockConnection>
-    where
-        I: From<u32> + Clone,
-        u32: From<I>,
-    {
-        Connection::new(
-            lower_bound,
-            upper_bound,
-            first,
-            last,
-            before,
-            after,
-            get_block_range,
-        )
-        .map(BlockConnection)
+    pub fn page_info(&self) -> &PageInfo {
+        &self.page_info
+    }
+
+    pub fn edges(&self) -> &Vec<BlockEdge> {
+        &self.edges
+    }
+
+    /// A count of the total number of objects in this connection, ignoring pagination.
+    pub fn total_count(&self) -> &BlockCount {
+        &self.total_count
     }
 }
 
+#[juniper::object(
+    Context = Context,
+    name = "TransactionConnection"
+)]
 impl TransactionConnection {
-    pub fn new(
-        lower_bound: u32,
-        upper_bound: u32,
-        first: Option<i32>,
-        last: Option<i32>,
-        before: Option<IndexCursor>,
-        after: Option<IndexCursor>,
-        get_transaction_range: impl Fn(u32, u32) -> Vec<(HeaderHash, u32)>,
-    ) -> FieldResult<TransactionConnection> {
-        Connection::new(
-            lower_bound,
-            upper_bound,
-            first,
-            last,
-            before,
-            after,
-            get_transaction_range,
-        )
-        .map(TransactionConnection)
+    pub fn page_info(&self) -> &PageInfo {
+        &self.page_info
+    }
+
+    pub fn edges(&self) -> &Vec<TransactionEdge> {
+        &self.edges
+    }
+
+    /// A count of the total number of objects in this connection, ignoring pagination.
+    pub fn total_count(&self) -> &TransactionCount {
+        &self.total_count
     }
 }
 

--- a/jormungandr/src/explorer/graphql/error.rs
+++ b/jormungandr/src/explorer/graphql/error.rs
@@ -16,5 +16,9 @@ error_chain! {
             description("invalid argument in query"),
             display("invalid argument: {}", msg)
         }
+        InvalidCursor(msg: String) {
+            description("invalid cursor in pagination query"),
+            display("invalid cursor in pagination query: {}", msg)
+        }
     }
 }

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -117,13 +117,7 @@ impl Block {
                     let to = usize::try_from(range.upper_bound).unwrap();
 
                     (from..=to)
-                        .map(|i| {
-                            (
-                                transactions[i].id().clone(),
-                                i.try_into()
-                                    .expect("tried to paginate more than 2^32 elements"),
-                            )
-                        })
+                        .map(|i| (transactions[i].id().clone(), i.try_into().unwrap()))
                         .collect::<Vec<(FragmentId, u32)>>()
                 }
             },

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -96,17 +96,18 @@ impl Block {
             after,
             |from: u32, to: u32| {
                 use std::cmp::min;
-                transactions[usize::try_from(from).unwrap()
-                    ..min(
-                        transactions.len(),
-                        usize::try_from(to.checked_add(1).unwrap()).unwrap(),
-                    )]
+
+                let from = usize::try_from(from).unwrap();
+                let to = usize::try_from(to).unwrap();
+
+                transactions[from..min(transactions.len(), to.checked_add(1).unwrap())]
                     .iter()
                     .enumerate()
                     .map(|(i, tx)| {
                         (
                             tx.id().clone(),
-                            i.try_into().expect("tried to paginate more than 2^32 elements"),
+                            i.try_into()
+                                .expect("tried to paginate more than 2^32 elements"),
                         )
                     })
                     .collect::<Vec<(FragmentId, u32)>>()

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -83,7 +83,7 @@ impl Block {
             .sort_unstable_by_key(|tx| tx.offset_in_block);
 
         let lower_bound = 0u32;
-        let upper_bound = transactions.len().checked_sub(1).or(Some(0)).unwrap();
+        let upper_bound = transactions.len().checked_sub(1).unwrap_or(0);
 
         TransactionConnection::new(
             lower_bound,

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -89,7 +89,7 @@ impl Block {
             lower_bound,
             upper_bound
                 .try_into()
-                .expect("less than 2^32 transactions per block"),
+                .expect("tried to paginate more than 2^32 elements"),
             first,
             last,
             before,
@@ -106,7 +106,7 @@ impl Block {
                     .map(|(i, tx)| {
                         (
                             tx.id().clone(),
-                            i.try_into().expect("less than 2^32 transactions per block"),
+                            i.try_into().expect("tried to paginate more than 2^32 elements"),
                         )
                     })
                     .collect::<Vec<(FragmentId, u32)>>()

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -95,8 +95,6 @@ impl Block {
             before,
             after,
             |from: u32, to: u32| {
-                use std::cmp::min;
-
                 let from = usize::try_from(from).unwrap();
                 let to = usize::try_from(to).unwrap();
 
@@ -229,14 +227,6 @@ impl Transaction {
             id,
             block_hash: None,
         }
-    }
-
-    fn get_block_hash(id: &HeaderHash, context: &Context) -> Option<HeaderHash> {
-        context
-            .db
-            .find_block_hash_by_transaction(&id)
-            .wait()
-            .unwrap()
     }
 
     fn get_block(&self, context: &Context) -> FieldResult<ExplorerBlock> {

--- a/jormungandr/src/explorer/graphql/scalars.rs
+++ b/jormungandr/src/explorer/graphql/scalars.rs
@@ -41,7 +41,7 @@ pub struct TimeOffsetSeconds(pub String);
 pub struct IndexCursor(pub u32);
 
 juniper::graphql_scalar!(IndexCursor where Scalar = <S> {
-    description: ""
+    description: "Non-opaque cursor that can be used for offset-based pagination"
 
     resolve(&self) -> Value {
         juniper::Value::scalar(self.0.to_string())

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -326,7 +326,7 @@ impl ExplorerDB {
         })
     }
 
-    pub fn find_block_by_transaction(
+    pub fn find_block_hash_by_transaction(
         &self,
         transaction_id: &FragmentId,
     ) -> impl Future<Item = Option<HeaderHash>, Error = Infallible> {

--- a/jormungandr/src/explorer/persistent_sequence.rs
+++ b/jormungandr/src/explorer/persistent_sequence.rs
@@ -5,9 +5,8 @@ use std::collections::hash_map::DefaultHasher;
 // XXX: Maybe there is a better data structure for this?
 #[derive(Clone)]
 pub struct PersistentSequence<T> {
-    // Could be usize, but it's only used to store blocks and transactions for now
-    len: u32,
-    elements: Hamt<DefaultHasher, u32, T>,
+    len: u64,
+    elements: Hamt<DefaultHasher, u64, T>,
 }
 
 impl<T> PersistentSequence<T> {
@@ -26,11 +25,11 @@ impl<T> PersistentSequence<T> {
         }
     }
 
-    pub fn get(&self, i: u32) -> Option<&T> {
-        self.elements.lookup(&i)
+    pub fn get<I: Into<u64>>(&self, i: I) -> Option<&T> {
+        self.elements.lookup(&i.into())
     }
 
-    pub fn len(&self) -> u32 {
+    pub fn len(&self) -> u64 {
         self.len
     }
 }

--- a/jormungandr/src/explorer/persistent_sequence.rs
+++ b/jormungandr/src/explorer/persistent_sequence.rs
@@ -1,0 +1,36 @@
+use imhamt::Hamt;
+use std::collections::hash_map::DefaultHasher;
+
+// Use a Hamt to store a sequence, the indexes can be used for pagination
+// XXX: Maybe there is a better data structure for this?
+#[derive(Clone)]
+pub struct PersistentSequence<T> {
+    // Could be usize, but it's only used to store blocks and transactions for now
+    len: u32,
+    elements: Hamt<DefaultHasher, u32, T>,
+}
+
+impl<T> PersistentSequence<T> {
+    pub fn new() -> Self {
+        PersistentSequence {
+            len: 0,
+            elements: Hamt::new(),
+        }
+    }
+
+    pub fn append(&self, t: T) -> Self {
+        let len = self.len + 1;
+        PersistentSequence {
+            len,
+            elements: self.elements.insert(len - 1, t).unwrap(),
+        }
+    }
+
+    pub fn get(&self, i: u32) -> Option<&T> {
+        self.elements.lookup(&i)
+    }
+
+    pub fn len(&self) -> u32 {
+        self.len
+    }
+}


### PR DESCRIPTION
# Summary

- Add pagination for transactions by address
    - For this was necessary to remember the order, so the previous `Set` is replaced with a sequence.
- Add pagination for transactions in block
   - These are sorted by the order they are in the block
- Use offsets for pagination instead of opaque cursors in all connections (but still maintaining the Connection model)

EDIT:
This is a breaking change for the resolvers that return transactions,  the one in `Address` and the one in `Block`.
Something like this would need to be made to get the same result as before (for transactions in the genesis block):
```graphql
{
  blockByChainLength(length: "0") {
    transactions {
      edges {
        node {
          id
        }
      }
    }
  }
}
```