### PR TITLE
Transaction update (major breaking changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,6 +1686,7 @@ dependencies = [
  "rand_core 0.3.1",
  "serde",
  "serde_yaml",
+ "typed-bytes",
 ]
 
 [[package]]

--- a/jcli/src/jcli_app/block/mod.rs
+++ b/jcli/src/jcli_app/block/mod.rs
@@ -1,4 +1,4 @@
-use chain_core::property::{Block as _, Deserialize, HasFragments, Serialize};
+use chain_core::property::{Block as _, Deserialize, Serialize};
 use chain_impl_mockchain::{
     block::Block,
     ledger::{self, Ledger},

--- a/jcli/src/jcli_app/certificate/get_stake_pool_id.rs
+++ b/jcli/src/jcli_app/certificate/get_stake_pool_id.rs
@@ -2,6 +2,7 @@ use chain_impl_mockchain::certificate::Certificate;
 use jcli_app::certificate::{read_cert, write_output, Error};
 use jormungandr_lib::interfaces::Certificate as CertificateType;
 use std::path::PathBuf;
+use std::ops::Deref;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -15,10 +16,10 @@ pub struct GetStakePoolId {
 
 impl GetStakePoolId {
     pub fn exec(self) -> Result<(), Error> {
-        let cert: CertificateType = read_cert(self.input)?.into();
+        let cert: CertificateType = read_cert(self.input.as_ref().map(|x| x.deref()))?.into();
         match cert.0 {
             Certificate::PoolRegistration(stake_pool_info) => {
-                write_output(self.output, stake_pool_info.to_id())
+                write_output(self.output.as_ref().map(|x| x.deref()), stake_pool_info.to_id())
             }
             _ => Err(Error::NotStakePoolRegistration),
         }

--- a/jcli/src/jcli_app/certificate/get_stake_pool_id.rs
+++ b/jcli/src/jcli_app/certificate/get_stake_pool_id.rs
@@ -1,8 +1,8 @@
 use chain_impl_mockchain::certificate::Certificate;
-use jcli_app::certificate::{read_cert, write_output, Error};
+use jcli_app::certificate::{read_cert_or_signed_cert, write_output, Error};
 use jormungandr_lib::interfaces::Certificate as CertificateType;
-use std::path::PathBuf;
 use std::ops::Deref;
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -16,11 +16,13 @@ pub struct GetStakePoolId {
 
 impl GetStakePoolId {
     pub fn exec(self) -> Result<(), Error> {
-        let cert: CertificateType = read_cert(self.input.as_ref().map(|x| x.deref()))?.into();
+        let cert: CertificateType =
+            read_cert_or_signed_cert(self.input.as_ref().map(|x| x.deref()))?.into();
         match cert.0 {
-            Certificate::PoolRegistration(stake_pool_info) => {
-                write_output(self.output.as_ref().map(|x| x.deref()), stake_pool_info.to_id())
-            }
+            Certificate::PoolRegistration(stake_pool_info) => write_output(
+                self.output.as_ref().map(|x| x.deref()),
+                stake_pool_info.to_id(),
+            ),
             _ => Err(Error::NotStakePoolRegistration),
         }
     }

--- a/jcli/src/jcli_app/certificate/mod.rs
+++ b/jcli/src/jcli_app/certificate/mod.rs
@@ -146,7 +146,7 @@ fn read_cert(input: Option<&Path>) -> Result<interfaces::Certificate, Error> {
     Ok(cert)
 }
 
-fn read_input(input: Option<&Path>) -> Result<String, Error> {
+pub(crate) fn read_input(input: Option<&Path>) -> Result<String, Error> {
     let reader = io::open_file_read(&input).map_err(|source| Error::InputInvalid {
         source,
         path: input.map(|x| x.to_path_buf()).unwrap_or_default(),

--- a/jcli/src/jcli_app/certificate/mod.rs
+++ b/jcli/src/jcli_app/certificate/mod.rs
@@ -2,8 +2,8 @@ use jcli_app::utils::{io, key_parser};
 use jormungandr_lib::interfaces::{self, CertificateFromStrError};
 use std::fmt::Display;
 use std::io::{BufRead, BufReader, Write};
-use std::path::{Path, PathBuf};
 use std::ops::Deref;
+use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
 mod get_stake_pool_id;
@@ -11,7 +11,7 @@ mod new_stake_delegation;
 mod new_stake_pool_registration;
 mod sign;
 
-pub(crate) use self::sign::{stake_delegation_account_binding_sign, pool_owner_sign};
+pub(crate) use self::sign::{pool_owner_sign, stake_delegation_account_binding_sign};
 
 custom_error! {pub Error
     KeyInvalid { source: key_parser::Error } = "invalid private key",

--- a/jcli/src/jcli_app/certificate/mod.rs
+++ b/jcli/src/jcli_app/certificate/mod.rs
@@ -11,6 +11,8 @@ mod new_stake_delegation;
 mod new_stake_pool_registration;
 mod sign;
 
+pub(crate) use self::sign::{stake_delegation_account_binding_sign, pool_owner_sign};
+
 custom_error! {pub Error
     KeyInvalid { source: key_parser::Error } = "invalid private key",
     Io { source: std::io::Error } = "I/O Error",

--- a/jcli/src/jcli_app/certificate/mod.rs
+++ b/jcli/src/jcli_app/certificate/mod.rs
@@ -1,8 +1,9 @@
 use jcli_app::utils::{io, key_parser};
-use jormungandr_lib::interfaces::{Certificate as CertificateType, CertificateFromStrError};
+use jormungandr_lib::interfaces::{self, CertificateFromStrError};
 use std::fmt::Display;
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::ops::Deref;
 use structopt::StructOpt;
 
 mod get_stake_pool_id;
@@ -21,6 +22,12 @@ custom_error! {pub Error
     InvalidCertificate { source: CertificateFromStrError } = "Invalid certificate",
     ManagementThresholdInvalid { got: usize, max_expected: usize }
         = "invalid management_threshold value, expected between at least 1 and {max_expected} but got {got}",
+    NoSigningKeys = "No signing keys specified (use -k or --key to specify)",
+    ExpectingOnlyOneSigningKey { got: usize }
+        = "expecting only one signing keys but got {got}",
+    OwnerStakeDelegationDoesntNeedSignature = "owner stake delegation does not need a signature",
+    KeyNotFound { index: usize }
+        = "secret key number {index} matching the expected public key has not been found",
 }
 
 #[derive(StructOpt)]
@@ -76,7 +83,7 @@ impl NewArgs {
 
 impl PrintArgs {
     pub fn exec(self) -> Result<(), Error> {
-        let cert = read_cert(self.input)?;
+        let cert = read_cert(self.input.as_ref().map(|x| x.deref()))?;
         println!("{:?}", cert);
         Ok(())
     }
@@ -95,32 +102,39 @@ impl Certificate {
     }
 }
 
-fn read_cert(input: Option<PathBuf>) -> Result<CertificateType, Error> {
+fn read_cert(input: Option<&Path>) -> Result<interfaces::Certificate, Error> {
     use std::str::FromStr as _;
 
     let cert_str = read_input(input)?;
-    let cert = CertificateType::from_str(&cert_str.trim_end())?;
+    let cert = interfaces::Certificate::from_str(&cert_str.trim_end())?;
     Ok(cert)
 }
 
-fn read_input(input: Option<PathBuf>) -> Result<String, Error> {
+fn read_input(input: Option<&Path>) -> Result<String, Error> {
     let reader = io::open_file_read(&input).map_err(|source| Error::InputInvalid {
         source,
-        path: input.unwrap_or_default(),
+        path: input.map(|x| x.to_path_buf()).unwrap_or_default(),
     })?;
     let mut input_str = String::new();
     BufReader::new(reader).read_line(&mut input_str)?;
     Ok(input_str)
 }
 
-fn write_cert(output: Option<PathBuf>, cert: CertificateType) -> Result<(), Error> {
+fn write_cert(output: Option<&Path>, cert: interfaces::Certificate) -> Result<(), Error> {
     write_output(output, cert)
 }
 
-fn write_output(output: Option<PathBuf>, data: impl Display) -> Result<(), Error> {
+fn write_signed_cert(
+    output: Option<&Path>,
+    signedcert: interfaces::SignedCertificate,
+) -> Result<(), Error> {
+    write_output(output, signedcert)
+}
+
+fn write_output(output: Option<&Path>, data: impl Display) -> Result<(), Error> {
     let mut writer = io::open_file_write(&output).map_err(|source| Error::OutputInvalid {
         source,
-        path: output.unwrap_or_default(),
+        path: output.map(|x| x.to_path_buf()).unwrap_or_default(),
     })?;
     writeln!(writer, "{}", data)?;
     Ok(())

--- a/jcli/src/jcli_app/certificate/new_stake_delegation.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_delegation.rs
@@ -4,6 +4,7 @@ use chain_impl_mockchain::transaction::AccountIdentifier;
 use jcli_app::certificate::{write_cert, Error};
 use jcli_app::utils::key_parser::parse_pub_key;
 use jormungandr_lib::interfaces::Certificate as CertificateType;
+use std::ops::Deref;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -27,6 +28,6 @@ impl StakeDelegation {
             pool_id: self.pool_id.into(),
         };
         let cert = Certificate::StakeDelegation(content);
-        write_cert(self.output, CertificateType(cert))
+        write_cert(self.output.as_ref().map(|x| x.deref()), CertificateType(cert))
     }
 }

--- a/jcli/src/jcli_app/certificate/new_stake_delegation.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_delegation.rs
@@ -28,6 +28,9 @@ impl StakeDelegation {
             pool_id: self.pool_id.into(),
         };
         let cert = Certificate::StakeDelegation(content);
-        write_cert(self.output.as_ref().map(|x| x.deref()), CertificateType(cert))
+        write_cert(
+            self.output.as_ref().map(|x| x.deref()),
+            CertificateType(cert),
+        )
     }
 }

--- a/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
@@ -7,8 +7,8 @@ use chain_impl_mockchain::{
 use chain_time::DurationSeconds;
 use jcli_app::certificate::{write_cert, Error};
 use jcli_app::utils::key_parser::parse_pub_key;
-use jormungandr_lib::interfaces::Certificate as CertificateType;
 use std::path::PathBuf;
+use std::ops::Deref;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -71,6 +71,6 @@ impl StakePoolRegistration {
         };
 
         let cert = Certificate::PoolRegistration(content);
-        write_cert(self.output, CertificateType(cert))
+        write_cert(self.output.as_ref().map(|x| x.deref()), cert.into())
     }
 }

--- a/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
@@ -7,8 +7,8 @@ use chain_impl_mockchain::{
 use chain_time::DurationSeconds;
 use jcli_app::certificate::{write_cert, Error};
 use jcli_app::utils::key_parser::parse_pub_key;
-use std::path::PathBuf;
 use std::ops::Deref;
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/jcli/src/jcli_app/certificate/sign.rs
+++ b/jcli/src/jcli_app/certificate/sign.rs
@@ -18,9 +18,11 @@ pub struct Sign {
     pub signing_keys: Vec<PathBuf>,
     /// get the certificate to sign from the given file. If no file
     /// provided, it will be read from the standard input
+    #[structopt(short = "c", long = "certificate")]
     pub input: Option<PathBuf>,
     /// write the signed certificate into the given file. If no file
     /// provided it will be written into the standard output
+    #[structopt(short = "o", long = "output")]
     pub output: Option<PathBuf>,
 }
 

--- a/jcli/src/jcli_app/certificate/sign.rs
+++ b/jcli/src/jcli_app/certificate/sign.rs
@@ -2,7 +2,7 @@ use chain_impl_mockchain::certificate::{
     Certificate, PoolOwnersSigned, PoolRegistration, SignedCertificate, StakeDelegation,
 };
 use chain_impl_mockchain::key::EitherEd25519SecretKey;
-use chain_impl_mockchain::transaction::{AccountBindingSignature, Payload, Transaction, TxBuilder, TxBuilderState, SetAuthData};
+use chain_impl_mockchain::transaction::{AccountBindingSignature, Payload, Transaction, TxBuilderState, SetAuthData};
 use chain_crypto::{Ed25519, PublicKey};
 use jcli_app::certificate::{read_cert, read_input, write_signed_cert, Error};
 use jcli_app::utils::key_parser::{self, parse_ed25519_secret_key};

--- a/jcli/src/jcli_app/certificate/sign.rs
+++ b/jcli/src/jcli_app/certificate/sign.rs
@@ -1,7 +1,12 @@
-use chain_impl_mockchain::certificate::Certificate;
-use jcli_app::certificate::{read_cert, read_input, write_cert, Error};
-use jcli_app::utils::key_parser::parse_ed25519_secret_key;
-use jormungandr_lib::interfaces::Certificate as CertificateType;
+use chain_impl_mockchain::certificate::{
+    Certificate, PoolOwnersSigned, PoolRegistration, SignedCertificate,
+};
+use chain_impl_mockchain::key::EitherEd25519SecretKey;
+use chain_impl_mockchain::transaction::{AccountBindingSignature, Payload, Transaction};
+use jcli_app::certificate::{read_cert, read_input, write_signed_cert, Error};
+use jcli_app::utils::key_parser::{self, parse_ed25519_secret_key};
+use jormungandr_lib::interfaces;
+use std::ops::Deref;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -9,7 +14,8 @@ use structopt::StructOpt;
 #[structopt(rename_all = "kebab-case")]
 pub struct Sign {
     /// path to the file with the signing key
-    pub signing_key: PathBuf,
+    #[structopt(short = "k", long = "key")]
+    pub signing_keys: Vec<PathBuf>,
     /// get the certificate to sign from the given file. If no file
     /// provided, it will be read from the standard input
     pub input: Option<PathBuf>,
@@ -20,18 +26,107 @@ pub struct Sign {
 
 impl Sign {
     pub fn exec(self) -> Result<(), Error> {
-        let mut cert: CertificateType = read_cert(self.input)?.into();
-        let key_str = read_input(Some(self.signing_key))?;
-        let private_key = parse_ed25519_secret_key(key_str.trim())?;
+        let cert: interfaces::Certificate =
+            read_cert(self.input.as_ref().map(|x| x.deref()))?.into();
 
-        /*
-        let signature = match &cert.0 {
-            Certificate::StakeDelegation(s) => s.make_certificate(&private_key),
-            Certificate::PoolRegistration(s) => s.make_certificate(&private_key),
-            Certificate::PoolManagement(s) => s.make_certificate(&private_key),
+        if self.signing_keys.len() == 0 {
+            return Err(Error::NoSigningKeys);
+        }
+
+        let keys_str: Result<Vec<String>, Error> = self
+            .signing_keys
+            .iter()
+            .map(|sk| read_input(Some(sk.as_ref())))
+            .collect();
+        let keys_str = keys_str?;
+
+        let signedcert = match cert.into() {
+            Certificate::StakeDelegation(s) => {
+                if keys_str.len() > 1 {
+                    return Err(Error::ExpectingOnlyOneSigningKey {
+                        got: keys_str.len(),
+                    });
+                }
+                let key_str = keys_str[0].clone();
+                let private_key = parse_ed25519_secret_key(key_str.trim())?;
+
+                // TODO check that it match the stake delegation account
+                // let pk = private_key.to_public();
+                let txbuilder = Transaction::block0_payload_builder(&s);
+                let sig = AccountBindingSignature::new(&private_key, &txbuilder.get_auth_data());
+
+                SignedCertificate::StakeDelegation(s, sig)
+            }
+            Certificate::PoolRegistration(s) => {
+                let sclone = s.clone();
+                pool_owner_sign(s, Some(sclone), &keys_str, |c, a| {
+                    SignedCertificate::PoolRegistration(c, a)
+                })?
+            }
+            Certificate::PoolRetirement(s) => pool_owner_sign(s, None, &keys_str, |c, a| {
+                SignedCertificate::PoolRetirement(c, a)
+            })?,
+            Certificate::PoolUpdate(s) => pool_owner_sign(s, None, &keys_str, |c, a| {
+                SignedCertificate::PoolUpdate(c, a)
+            })?,
+            Certificate::OwnerStakeDelegation(_) => {
+                return Err(Error::OwnerStakeDelegationDoesntNeedSignature)
+            }
         };
-        cert.signatures.push(signature);
-        */
-        write_cert(self.output, cert.into())
+        write_signed_cert(self.output.as_ref().map(|x| x.deref()), signedcert.into())
     }
+}
+
+fn pool_owner_sign<F, P: Payload>(
+    payload: P,
+    mreg: Option<PoolRegistration>, // if present we verify the secret key against the expectations
+    keys: &[String],
+    to_signed_certificate: F,
+) -> Result<SignedCertificate, Error>
+where
+    F: FnOnce(P, PoolOwnersSigned) -> SignedCertificate,
+{
+    let keys: Result<Vec<EitherEd25519SecretKey>, key_parser::Error> = keys
+        .iter()
+        .map(|sk| parse_ed25519_secret_key(sk.clone().trim()))
+        .collect();
+    let keys = keys?;
+
+    let keys: Vec<(u16, &EitherEd25519SecretKey)> = match mreg {
+        None => {
+            // here we don't know the order of things, so just assume sequential index from 0
+            keys.iter()
+                .enumerate()
+                .map(|(i, k)| (i as u16, k))
+                .collect()
+        }
+        Some(reg) => {
+            let pks = reg.owners;
+            let mut found = Vec::new();
+            for (isk, k) in keys.iter().enumerate() {
+                let pk = k.to_public();
+                // look for the owner's index of k
+                match pks.iter().enumerate().find(|(_, p)| *p == &pk) {
+                    None => {
+                        return Err(Error::KeyNotFound { index: isk })
+                    }
+                    Some((ipk, _)) => {
+                        found.push((ipk as u16, k))
+                    }
+                }
+            }
+            found
+        }
+    };
+
+    let txbuilder = Transaction::block0_payload_builder(&payload);
+    let auth_data = txbuilder.get_auth_data();
+
+    let mut sigs = Vec::new();
+    for (i, key) in keys.iter() {
+        let sig = AccountBindingSignature::new(key, &auth_data);
+        sigs.push((*i, sig))
+    }
+    let sig = PoolOwnersSigned { signatures: sigs };
+    Ok(to_signed_certificate(payload, sig))
 }

--- a/jcli/src/jcli_app/transaction/add_account.rs
+++ b/jcli/src/jcli_app/transaction/add_account.rs
@@ -1,5 +1,5 @@
 use chain_addr::{Address, Kind};
-use chain_impl_mockchain::transaction::{AccountIdentifier, Input, InputEnum};
+use chain_impl_mockchain::transaction::AccountIdentifier;
 use jcli_app::transaction::{common, Error};
 use jormungandr_lib::interfaces;
 use structopt::StructOpt;
@@ -30,10 +30,10 @@ impl AddAccount {
             Kind::Multisig(_) => return Err(Error::AccountAddressMultisig),
         };
 
-        transaction.add_input(Input::from_enum(InputEnum::AccountInput(
-            account_id,
-            self.value.into(),
-        )))?;
+        transaction.add_input(interfaces::TransactionInput {
+            input: interfaces::TransactionInputType::Account(account_id.into()),
+            value: self.value.into(),
+        })?;
 
         self.common.store(&transaction)
     }

--- a/jcli/src/jcli_app/transaction/auth.rs
+++ b/jcli/src/jcli_app/transaction/auth.rs
@@ -1,8 +1,7 @@
+use jcli_app::certificate::read_input;
 use jcli_app::transaction::{common, Error};
-use jormungandr_lib::interfaces::Certificate;
-use jcli_app::certificate::{read_input};
-use structopt::StructOpt;
 use std::path::PathBuf;
+use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
@@ -25,7 +24,9 @@ impl Auth {
         let keys_str: Result<Vec<String>, Error> = self
             .signing_keys
             .iter()
-            .map(|sk| read_input(Some(sk.as_ref())).map_err(|_| Error::KeyInvalid))
+            .map(|sk| {
+                read_input(Some(sk.as_ref())).map_err(|e| Error::CertificateError { error: e })
+            })
             .collect();
         let keys_str = keys_str?;
 

--- a/jcli/src/jcli_app/transaction/auth.rs
+++ b/jcli/src/jcli_app/transaction/auth.rs
@@ -1,0 +1,23 @@
+use jcli_app::transaction::{common, Error};
+use jormungandr_lib::interfaces::Certificate;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub struct Auth {
+    #[structopt(flatten)]
+    pub common: common::CommonTransaction,
+    // the value
+    //#[structopt(name = "VALUE", parse(try_from_str))]
+    //pub certificate: Certificate,
+}
+
+impl Auth {
+    pub fn exec(self) -> Result<(), Error> {
+        let mut transaction = self.common.load()?;
+
+        transaction.set_auth()?; //self.certificate.into())?;
+
+        self.common.store(&transaction)
+    }
+}

--- a/jcli/src/jcli_app/transaction/finalize.rs
+++ b/jcli/src/jcli_app/transaction/finalize.rs
@@ -1,4 +1,4 @@
-use chain_impl_mockchain::txbuilder::OutputPolicy;
+use chain_impl_mockchain::transaction::OutputPolicy;
 use jcli_app::transaction::{common, Error};
 use jormungandr_lib::interfaces;
 use structopt::StructOpt;
@@ -26,7 +26,7 @@ impl Finalize {
             Some(change) => OutputPolicy::One(change.into()),
         };
 
-        let _balance = transaction.finalize(fee_algo, output_policy)?;
+        let _balance = transaction.balance_inputs_outputs(&fee_algo, output_policy)?;
 
         self.common.store(&transaction)?;
         Ok(())

--- a/jcli/src/jcli_app/transaction/mod.rs
+++ b/jcli/src/jcli_app/transaction/mod.rs
@@ -15,6 +15,7 @@ mod staging;
 use self::staging::StagingKind;
 use chain_core::property::Serialize as _;
 use chain_impl_mockchain as chain;
+use jcli_app::certificate;
 use jcli_app::utils::error::CustomErrorFiller;
 use jcli_app::utils::key_parser;
 use std::path::PathBuf;
@@ -121,10 +122,11 @@ custom_error! { pub Error
     MakeWitnessLegacyUtxoUnsupported = "making legacy UTxO witness unsupported",
     MakeWitnessAccountCounterMissing = "making account witness requires passing spending counter",
     TxDoesntNeedPayloadAuth = "transaction type doesn't need payload authentification",
+    TxNeedPayloadAuth = "transaction type need payload authentification",
     NoSigningKeys = "No signing keys specified (use -k or --key to specify)",
     ExpectingOnlyOneSigningKey { got: usize }
         = "expecting only one signing keys but got {got}",
-    KeyInvalid = "reading key invalid",
+    CertificateError { error: certificate::Error } = "certificate error {error}",
 }
 
 /*

--- a/jcli/src/jcli_app/transaction/mod.rs
+++ b/jcli/src/jcli_app/transaction/mod.rs
@@ -120,6 +120,11 @@ custom_error! { pub Error
     InfoExpectedSingleAccount = "expected a single account, multisig is not supported yet",
     MakeWitnessLegacyUtxoUnsupported = "making legacy UTxO witness unsupported",
     MakeWitnessAccountCounterMissing = "making account witness requires passing spending counter",
+    TxDoesntNeedPayloadAuth = "transaction type doesn't need payload authentification",
+    NoSigningKeys = "No signing keys specified (use -k or --key to specify)",
+    ExpectingOnlyOneSigningKey { got: usize }
+        = "expecting only one signing keys but got {got}",
+    KeyInvalid = "reading key invalid",
 }
 
 /*

--- a/jcli/src/jcli_app/transaction/mod.rs
+++ b/jcli/src/jcli_app/transaction/mod.rs
@@ -3,6 +3,7 @@ mod add_certificate;
 mod add_input;
 mod add_output;
 mod add_witness;
+mod auth;
 mod common;
 mod finalize;
 mod info;
@@ -49,6 +50,8 @@ pub enum Transaction {
     Info(info::Info),
     /// create witnesses
     MakeWitness(mk_witness::MkWitness),
+    /// make auth
+    Auth(auth::Auth),
     /// get the message format out of a sealed transaction
     ToMessage(common::CommonTransaction),
 }
@@ -102,11 +105,11 @@ custom_error! { pub Error
     AccountAddressSingle = "invalid input account, this is a UTxO address",
     AccountAddressGroup = "invalid input account, this is a UTxO address with delegation",
     AccountAddressMultisig = "invalid input account, this is a multisig account address",
-    AddingWitnessToFinalizedTxFailed { source: chain::txbuilder::BuildError, filler: CustomErrorFiller }
+    AddingWitnessToFinalizedTxFailed { filler: CustomErrorFiller }
         = "could not add witness to finalized transaction",
-    GeneratedTxBuildingFailed { source: chain::txbuilder::BuildError, filler: CustomErrorFiller }
+    GeneratedTxBuildingFailed { filler: CustomErrorFiller }
         = "generated transaction building failed",
-    TxFinalizationFailed { source: chain::txbuilder::Error }
+    TxFinalizationFailed { source: chain::transaction::Error }
         = "transaction finalization failed",
     GeneratedTxTypeUnexpected = "unexpected generated transaction type",
     MessageSerializationFailed { source: std::io::Error, filler: CustomErrorFiller }
@@ -141,19 +144,20 @@ impl Transaction {
             Transaction::Id(common) => display_id(common),
             Transaction::Info(info) => info.exec(),
             Transaction::MakeWitness(mk_witness) => mk_witness.exec(),
+            Transaction::Auth(auth) => auth.exec(),
             Transaction::ToMessage(common) => display_message(common),
         }
     }
 }
 
 fn display_id(common: common::CommonTransaction) -> Result<(), Error> {
-    let id = common.load()?.id();
+    let id = common.load()?.transaction_sign_data_hash();
     println!("{}", id);
     Ok(())
 }
 
 fn display_message(common: common::CommonTransaction) -> Result<(), Error> {
-    let message = common.load()?.message()?;
+    let message = common.load()?.fragment()?;
     let bytes: Vec<u8> =
         message
             .serialize_as_vec()

--- a/jcli/src/jcli_app/transaction/staging.rs
+++ b/jcli/src/jcli_app/transaction/staging.rs
@@ -312,15 +312,15 @@ impl Staging {
                     Err(Error::TxNeedPayloadAuth)?
                 }
                 match &self.extra {
-                    None => self.make_fragment(&chain::transaction::NoExtra, &(), Fragment::Transaction),
-                    Some(cert) => {
-                        match cert.clone().into() {
-                            Certificate::OwnerStakeDelegation(osd) => {
-                                self.make_fragment(&osd, &(), Fragment::OwnerStakeDelegation)
-                            }
-                            _ => unreachable!(),
-                        }
+                    None => {
+                        self.make_fragment(&chain::transaction::NoExtra, &(), Fragment::Transaction)
                     }
+                    Some(cert) => match cert.clone().into() {
+                        Certificate::OwnerStakeDelegation(osd) => {
+                            self.make_fragment(&osd, &(), Fragment::OwnerStakeDelegation)
+                        }
+                        _ => unreachable!(),
+                    },
                 }
             }
             Some(signed_cert) => {

--- a/jcli/src/jcli_app/transaction/staging.rs
+++ b/jcli/src/jcli_app/transaction/staging.rs
@@ -1,11 +1,13 @@
 use chain_addr::Address;
 use chain_impl_mockchain::{
     self as chain,
+    certificate::{Certificate, SignedCertificate},
     fee::FeeAlgorithm,
     fragment::Fragment,
-    transaction::{Output, Transaction, TransactionSignDataHash},
-    txbuilder,
-    value::Value,
+    transaction::{
+        self, InputOutput, InputOutputBuilder, Output, Payload, PayloadSlice, SetAuthData, SetIOs,
+        Transaction, TransactionSignDataHash, TxBuilder, TxBuilderState,
+    },
 };
 use jcli_app::transaction::Error;
 use jcli_app::utils::error::CustomErrorFiller;
@@ -14,29 +16,22 @@ use jormungandr_lib::interfaces;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-const INPUT_PTR_SIZE: usize = 32;
-
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum StagingKind {
     Balancing,
     Finalizing,
     Sealed,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-struct Input {
-    index_or_account: u8,
-    value: interfaces::Value,
-    input_ptr: [u8; INPUT_PTR_SIZE],
+    Authed,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Staging {
     kind: StagingKind,
-    inputs: Vec<Input>,
+    inputs: Vec<interfaces::TransactionInput>,
     outputs: Vec<interfaces::TransactionOutput>,
     witnesses: Vec<interfaces::TransactionWitness>,
     extra: Option<interfaces::Certificate>,
+    extra_authed: Option<interfaces::SignedCertificate>,
 }
 
 impl std::fmt::Display for StagingKind {
@@ -45,6 +40,7 @@ impl std::fmt::Display for StagingKind {
             StagingKind::Balancing => write!(f, "balancing"),
             StagingKind::Finalizing => write!(f, "finalizing"),
             StagingKind::Sealed => write!(f, "sealed"),
+            StagingKind::Authed => write!(f, "authed"),
         }
     }
 }
@@ -57,6 +53,7 @@ impl Staging {
             outputs: Vec::new(),
             witnesses: Vec::new(),
             extra: None,
+            extra_authed: None,
         }
     }
 
@@ -82,16 +79,12 @@ impl Staging {
         })
     }
 
-    pub fn add_input(&mut self, input: chain::transaction::Input) -> Result<(), Error> {
+    pub fn add_input(&mut self, input: interfaces::TransactionInput) -> Result<(), Error> {
         if self.kind != StagingKind::Balancing {
             return Err(Error::TxKindToAddInputInvalid { kind: self.kind });
         }
 
-        Ok(self.inputs.push(Input {
-            index_or_account: input.index_or_account,
-            value: input.value.into(),
-            input_ptr: input.input_ptr,
-        }))
+        Ok(self.inputs.push(input))
     }
 
     pub fn add_output(&mut self, output: Output<Address>) -> Result<(), Error> {
@@ -117,6 +110,10 @@ impl Staging {
         Ok(self.witnesses.push(witness.into()))
     }
 
+    pub fn set_auth(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
     pub fn set_extra(&mut self, extra: chain::certificate::Certificate) -> Result<(), Error> {
         match self.kind {
             StagingKind::Balancing => Ok(self.extra = Some(extra.into())),
@@ -132,41 +129,70 @@ impl Staging {
         self.kind.to_string()
     }
 
-    fn update_tx<Extra>(&mut self, tx: Transaction<Address, Extra>) {
-        self.inputs = tx
-            .inputs
-            .into_iter()
-            .map(|input| Input {
-                index_or_account: input.index_or_account,
-                value: input.value.into(),
-                input_ptr: input.input_ptr,
-            })
-            .collect();
-        self.outputs = tx
-            .outputs
-            .into_iter()
-            .map(interfaces::TransactionOutput::from)
-            .collect();
+    fn get_inputs_outputs(&self) -> InputOutputBuilder {
+        let inputs: Vec<_> = self.inputs.iter().map(|i| i.clone().into()).collect();
+        let outputs: Vec<_> = self.outputs.iter().map(|o| o.clone().into()).collect();
+        InputOutputBuilder::new(inputs.iter(), outputs.iter()).unwrap() // TODO better error than unwrap
     }
 
-    pub fn finalize<FA>(
+    fn finalize_payload<'a, P, FA>(
         &mut self,
-        fee_algorithm: FA,
-        output_policy: chain::txbuilder::OutputPolicy,
+        payload: &P,
+        fee_algorithm: &FA,
+        output_policy: chain::transaction::OutputPolicy,
     ) -> Result<chain::transaction::Balance, Error>
     where
-        FA: FeeAlgorithm<Transaction<Address, Option<chain::certificate::Certificate>>>,
+        FA: FeeAlgorithm,
+        P: Payload,
+    {
+        let ios = self.get_inputs_outputs();
+        let pdata = payload.payload_data();
+        let (balance, added_outputs, _) =
+            ios.seal_with_output_policy(pdata.borrow(), fee_algorithm, output_policy)?;
+
+        for o in added_outputs {
+            self.add_output(o.clone().into())?;
+        }
+
+        self.kind = StagingKind::Finalizing;
+
+        Ok(balance)
+    }
+
+    pub fn balance_inputs_outputs<FA>(
+        &mut self,
+        fee_algorithm: &FA,
+        output_policy: chain::transaction::OutputPolicy,
+    ) -> Result<chain::transaction::Balance, Error>
+    where
+        FA: FeeAlgorithm,
     {
         if self.kind != StagingKind::Balancing {
             return Err(Error::TxKindToFinalizeInvalid { kind: self.kind });
         }
 
-        let (balance, tx) = txbuilder::TransactionBuilder::from(self.transaction())
-            .seal_with_output_policy(fee_algorithm, output_policy)?;
-        self.update_tx(tx);
-        self.kind = StagingKind::Finalizing;
-
-        Ok(balance)
+        match &self.extra {
+            None => {
+                self.finalize_payload(&chain::transaction::NoExtra, fee_algorithm, output_policy)
+            }
+            Some(ref c) => match c.clone().into() {
+                Certificate::PoolRegistration(c) => {
+                    self.finalize_payload(&c, fee_algorithm, output_policy)
+                }
+                Certificate::PoolUpdate(c) => {
+                    self.finalize_payload(&c, fee_algorithm, output_policy)
+                }
+                Certificate::PoolRetirement(c) => {
+                    self.finalize_payload(&c, fee_algorithm, output_policy)
+                }
+                Certificate::StakeDelegation(c) => {
+                    self.finalize_payload(&c, fee_algorithm, output_policy)
+                }
+                Certificate::OwnerStakeDelegation(c) => {
+                    self.finalize_payload(&c, fee_algorithm, output_policy)
+                }
+            },
+        }
     }
 
     pub fn seal(&mut self) -> Result<(), Error> {
@@ -184,20 +210,118 @@ impl Staging {
         Ok(self.kind = StagingKind::Sealed)
     }
 
-    pub fn message(&self) -> Result<Fragment, Error> {
-        if self.kind != StagingKind::Sealed {
-            Err(Error::TxKindToGetMessageInvalid { kind: self.kind })?
+    pub fn need_auth(&self) -> bool {
+        match &self.extra {
+            None => false,
+            Some(ref c) => {
+                let x: Certificate = c.clone().into();
+                x.need_auth()
+            }
         }
-
-        self.finalizer()?
-            .to_fragment()
-            .map_err(|source| Error::GeneratedTxBuildingFailed {
-                source,
-                filler: CustomErrorFiller,
-            })
     }
 
-    pub fn transaction(
+    fn builder_after_witness<P: Payload>(
+        &self,
+        builder: TxBuilderState<SetIOs<P>>,
+    ) -> Result<TxBuilderState<SetAuthData<P>>, Error> {
+        if self.witnesses.len() != self.inputs.len() {
+            return Err(Error::TxKindToFinalizeInvalid { kind: self.kind });
+        }
+
+        let ios = self.get_inputs_outputs().build();
+        let witnesses: Vec<_> = self.witnesses.iter().map(|w| w.clone().into()).collect();
+        Ok(builder
+            .set_ios(&ios.inputs, &ios.outputs)
+            .set_witnesses(&witnesses))
+    }
+
+    fn make_fragment<P: Payload, F>(
+        &self,
+        payload: &P,
+        auth: &P::Auth,
+        to_fragment: F,
+    ) -> Result<Fragment, Error>
+    where
+        F: FnOnce(Transaction<P>) -> Fragment,
+    {
+        let tx = self
+            .builder_after_witness(TxBuilder::new().set_payload(payload))?
+            .set_payload_auth(auth);
+        Ok(to_fragment(tx))
+    }
+
+    pub fn fragment(&self) -> Result<Fragment, Error> {
+        match &self.extra_authed {
+            None => {
+                if self.kind != StagingKind::Sealed {
+                    Err(Error::TxKindToGetMessageInvalid { kind: self.kind })?
+                }
+                assert!(self.extra.is_none());
+                self.make_fragment(&chain::transaction::NoExtra, &(), Fragment::Transaction)
+            }
+            Some(signed_cert) => {
+                if self.kind != StagingKind::Authed {
+                    Err(Error::TxKindToGetMessageInvalid { kind: self.kind })?
+                }
+                match signed_cert.clone().into() {
+                    SignedCertificate::PoolRegistration(c, a) => {
+                        self.make_fragment(&c, &a, Fragment::PoolRegistration)
+                    }
+                    SignedCertificate::PoolUpdate(c, a) => {
+                        self.make_fragment(&c, &a, Fragment::PoolUpdate)
+                    }
+                    SignedCertificate::PoolRetirement(c, a) => {
+                        self.make_fragment(&c, &a, Fragment::PoolRetirement)
+                    }
+                    SignedCertificate::StakeDelegation(c, a) => {
+                        self.make_fragment(&c, &a, Fragment::StakeDelegation)
+                    }
+                    SignedCertificate::OwnerStakeDelegation(c, a) => {
+                        self.make_fragment(&c, &a, Fragment::OwnerStakeDelegation)
+                    }
+                }
+            }
+        }
+    }
+
+    fn transaction_sign_data_hash_on<P>(
+        &self,
+        builder: TxBuilderState<SetIOs<P>>,
+    ) -> TransactionSignDataHash {
+        let inputs: Vec<transaction::Input> =
+            self.inputs.iter().map(|i| i.clone().into()).collect();
+        let outputs: Vec<_> = self.outputs.iter().map(|o| o.clone().into()).collect();
+        builder
+            .set_ios(&inputs, &outputs)
+            .get_auth_data_for_witness()
+            .hash()
+    }
+
+    pub fn transaction_sign_data_hash(&self) -> TransactionSignDataHash {
+        match &self.extra {
+            None => self.transaction_sign_data_hash_on(TxBuilder::new().set_nopayload()),
+            Some(ref c) => match c.clone().into() {
+                Certificate::PoolRegistration(c) => {
+                    self.transaction_sign_data_hash_on(TxBuilder::new().set_payload(&c))
+                }
+                Certificate::PoolUpdate(c) => {
+                    self.transaction_sign_data_hash_on(TxBuilder::new().set_payload(&c))
+                }
+                Certificate::PoolRetirement(c) => {
+                    self.transaction_sign_data_hash_on(TxBuilder::new().set_payload(&c))
+                }
+                Certificate::StakeDelegation(c) => {
+                    self.transaction_sign_data_hash_on(TxBuilder::new().set_payload(&c))
+                }
+                Certificate::OwnerStakeDelegation(c) => {
+                    self.transaction_sign_data_hash_on(TxBuilder::new().set_payload(&c))
+                }
+            },
+        }
+    }
+
+    /*
+    pub fn transaction<P>(
         &self,
     ) -> chain::transaction::Transaction<Address, Option<chain::certificate::Certificate>> {
         chain::transaction::Transaction {
@@ -205,11 +329,6 @@ impl Staging {
             outputs: self.outputs(),
             extra: self.extra.clone().map(|c| c.0),
         }
-    }
-
-    pub fn id(&self) -> TransactionSignDataHash {
-        let finalizer = chain::txbuilder::TransactionFinalizer::new(self.transaction());
-        finalizer.get_tx_sign_data_hash()
     }
 
     pub fn fees<FA>(&self, fee_algorithm: FA) -> Result<Value, Error>
@@ -246,20 +365,14 @@ impl Staging {
 
         Ok(finalizer)
     }
+    */
 
-    pub fn inputs(&self) -> Vec<chain::transaction::Input> {
-        self.inputs
-            .iter()
-            .map(|input| chain::transaction::Input {
-                index_or_account: input.index_or_account,
-                value: input.value.into(),
-                input_ptr: input.input_ptr,
-            })
-            .collect()
+    pub fn inputs(&self) -> &[interfaces::TransactionInput] {
+        &self.inputs
     }
 
-    pub fn outputs(&self) -> Vec<Output<Address>> {
-        self.outputs.iter().cloned().map(Output::from).collect()
+    pub fn outputs(&self) -> &[interfaces::TransactionOutput] {
+        &self.outputs
     }
 }
 
@@ -268,7 +381,7 @@ mod tests {
 
     use super::*;
     use chain_impl_mockchain as chain;
-    use chain_impl_mockchain::key::Hash;
+    use chain_impl_mockchain::{key::Hash, transaction::Input, value::Value};
     use std::str::FromStr;
 
     #[test]
@@ -292,14 +405,10 @@ mod tests {
         let mut staging = Staging::new();
         staging.kind = incorrect_stage.clone();
 
-        let mut input_ptr = [0u8; INPUT_PTR_SIZE];
+        let mut input_ptr = [0u8; chain::transaction::INPUT_PTR_SIZE];
         input_ptr.clone_from_slice(hash.as_ref());
 
-        let result = staging.add_input(chain::transaction::Input {
-            input_ptr: input_ptr,
-            index_or_account: 0,
-            value: Value(200),
-        });
+        let result = staging.add_input(Input::new(0, Value(200), input_ptr).into());
 
         assert!(
             result.is_err(),

--- a/jormungandr-integration-tests/src/common/configuration/genesis_model.rs
+++ b/jormungandr-integration-tests/src/common/configuration/genesis_model.rs
@@ -130,8 +130,15 @@ impl GenesisYaml {
             KeyPair::generate(&mut ChaChaRng::from_seed([2; 32]));
         let leader_1_pk = leader_1.public_key().to_bech32_str();
         let leader_2_pk = leader_2.public_key().to_bech32_str();
-        let funds = Initial::Fund(initial_funds.iter().cloned().collect());
-        let legacy = Initial::LegacyFund(legacy_funds.iter().cloned().collect());
+
+        let mut initial = Vec::new();
+        if initial_funds.len() > 0 {
+            initial.push(Initial::Fund(initial_funds.iter().cloned().collect()))
+        }
+        if legacy_funds.len() > 0 {
+            initial.push(Initial::LegacyFund(legacy_funds.iter().cloned().collect()))
+        }
+
         GenesisYaml {
             blockchain_configuration: BlockchainConfig {
                 block0_date: Some(1554185140),
@@ -153,7 +160,7 @@ impl GenesisYaml {
                 },
                 kes_update_speed: 12 * 3600,
             },
-            initial: vec![funds, legacy],
+            initial,
         }
     }
 }

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/commands.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/commands.rs
@@ -81,9 +81,11 @@ impl CertificateCommands {
         command
             .arg("certificate")
             .arg("sign")
-            .arg("-k")
+            .arg("--key")
             .arg(&signing_key.as_os_str())
+            .arg("--certificate")
             .arg(&input_file.as_os_str())
+            .arg("--output")
             .arg(&output_file.as_os_str());
         command
     }

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/commands.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/commands.rs
@@ -81,6 +81,7 @@ impl CertificateCommands {
         command
             .arg("certificate")
             .arg("sign")
+            .arg("-k")
             .arg(&signing_key.as_os_str())
             .arg(&input_file.as_os_str())
             .arg(&output_file.as_os_str());

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/wrapper.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/wrapper.rs
@@ -143,10 +143,7 @@ impl JCLICertificateWrapper {
         file_utils::read_file(&stake_delegation_signcert_file)
     }
 
-    pub fn assert_new_stake_pool_retirement(
-        &self,
-        stake_pool_id: &str,
-    ) -> String {
+    pub fn assert_new_stake_pool_retirement(&self, stake_pool_id: &str) -> String {
         let pool_id = PoolId::from_str(&stake_pool_id).unwrap();
         let start_validity = 0u64;
         let certificate = build_stake_pool_retirement_cert(pool_id, start_validity);

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/wrapper.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/wrapper.rs
@@ -143,15 +143,13 @@ impl JCLICertificateWrapper {
         file_utils::read_file(&stake_delegation_signcert_file)
     }
 
-    pub fn assert_new_signed_stake_pool_retirement(
+    pub fn assert_new_stake_pool_retirement(
         &self,
         stake_pool_id: &str,
-        private_key: &str,
     ) -> String {
         let pool_id = PoolId::from_str(&stake_pool_id).unwrap();
         let start_validity = 0u64;
-        //let signature = parse_ed25519_secret_key(&private_key).unwrap();
-        let certificate = build_stake_pool_retirement_cert(pool_id, start_validity); //, &vec![signature]);
-        format!("{}", Certificate(certificate).to_bech32().unwrap())
+        let certificate = build_stake_pool_retirement_cert(pool_id, start_validity);
+        format!("{}", Certificate::from(certificate).to_bech32().unwrap())
     }
 }

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/wrapper.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/certificate/wrapper.rs
@@ -150,9 +150,8 @@ impl JCLICertificateWrapper {
     ) -> String {
         let pool_id = PoolId::from_str(&stake_pool_id).unwrap();
         let start_validity = 0u64;
-        let signature = parse_ed25519_secret_key(&private_key).unwrap();
-        let certificate =
-            build_stake_pool_retirement_cert(pool_id, start_validity, &vec![signature]);
+        //let signature = parse_ed25519_secret_key(&private_key).unwrap();
+        let certificate = build_stake_pool_retirement_cert(pool_id, start_validity); //, &vec![signature]);
         format!("{}", Certificate(certificate).to_bech32().unwrap())
     }
 }

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/jcli_transaction_commands.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/jcli_transaction_commands.rs
@@ -181,11 +181,7 @@ impl TransactionCommands {
         command
     }
 
-    pub fn get_auth_command(
-        &self,
-        signing_key: &PathBuf,
-        staging_file: &PathBuf,
-    ) -> Command {
+    pub fn get_auth_command(&self, signing_key: &PathBuf, staging_file: &PathBuf) -> Command {
         let mut command = Command::new(configuration::get_jcli_app().as_os_str());
         command
             .arg("transaction")

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/jcli_transaction_commands.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/jcli_transaction_commands.rs
@@ -181,6 +181,22 @@ impl TransactionCommands {
         command
     }
 
+    pub fn get_auth_command(
+        &self,
+        signing_key: &PathBuf,
+        staging_file: &PathBuf,
+    ) -> Command {
+        let mut command = Command::new(configuration::get_jcli_app().as_os_str());
+        command
+            .arg("transaction")
+            .arg("auth")
+            .arg("--staging")
+            .arg(staging_file.as_os_str())
+            .arg("--key")
+            .arg(&signing_key.as_os_str());
+        command
+    }
+
     pub fn get_transaction_message_to_command(&self, staging_file: &PathBuf) -> Command {
         let mut command = Command::new(configuration::get_jcli_app().as_os_str());
         command

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/mod.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/mod.rs
@@ -233,11 +233,10 @@ impl JCLITransactionWrapper {
     }
 
     pub fn assert_add_auth(&mut self, key: &PathBuf) -> &mut Self {
-        let output =
-            process_utils::run_process_and_get_output(self.commands.get_auth_command(
-                &key,
-                &self.staging_file_path,
-            ));
+        let output = process_utils::run_process_and_get_output(
+            self.commands
+                .get_auth_command(&key, &self.staging_file_path),
+        );
         process_assert::assert_process_exited_successfully(output);
         self
     }

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/mod.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/mod.rs
@@ -232,6 +232,16 @@ impl JCLITransactionWrapper {
         process_assert::assert_process_failed(output);
     }
 
+    pub fn assert_add_auth(&mut self, key: &PathBuf) -> &mut Self {
+        let output =
+            process_utils::run_process_and_get_output(self.commands.get_auth_command(
+                &key,
+                &self.staging_file_path,
+            ));
+        process_assert::assert_process_exited_successfully(output);
+        self
+    }
+
     pub fn make_and_add_witness_default(
         &mut self,
         private_key: &str,

--- a/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -6,7 +6,7 @@ use crate::common::startup;
 use chain_addr::Discrimination;
 
 #[test]
-pub fn test_genesis_block_is_built_from_corect_yaml() {
+pub fn test_genesis_block_is_built_from_correct_yaml() {
     startup::build_genesis_block(&GenesisYaml::new());
 }
 

--- a/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
@@ -87,7 +87,8 @@ pub fn create_new_stake_pool(
         1u32,
         &account.public_key,
     );
-    let stake_pool_certificate_file = file_utils::create_file_in_temp("stake_pool.cert", &stake_pool_certificate);
+    let stake_pool_certificate_file =
+        file_utils::create_file_in_temp("stake_pool.cert", &stake_pool_certificate);
 
     //  &owner_stake_key,
 
@@ -102,8 +103,7 @@ pub fn create_new_stake_pool(
     account.confirm_transaction();
     jcli_wrapper::assert_transaction_in_block(&transaction, &jormungandr_rest_address);
 
-    let stake_pool_id =
-        certificate_wrapper.assert_get_stake_pool_id(&stake_pool_certificate_file);
+    let stake_pool_id = certificate_wrapper.assert_get_stake_pool_id(&stake_pool_certificate_file);
 
     assert!(
         jcli_wrapper::assert_rest_get_stake_pools(&jormungandr_rest_address)
@@ -123,10 +123,8 @@ pub fn delegate_stake(
     let owner_stake_key =
         file_utils::create_file_in_temp("stake_key.private_key", &account.private_key);
     let certificate_wrapper = JCLICertificateWrapper::new();
-    let stake_pool_delegation = certificate_wrapper.assert_new_stake_delegation(
-        &stake_pool_id,
-        &account.public_key,
-    );
+    let stake_pool_delegation =
+        certificate_wrapper.assert_new_stake_delegation(&stake_pool_id, &account.public_key);
 
     let settings = jcli_wrapper::assert_get_rest_settings(&jormungandr_rest_address);
     let fees: LinearFees = settings.fees.into();

--- a/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
@@ -79,28 +79,31 @@ pub fn create_new_stake_pool(
 
     let certificate_wrapper = JCLICertificateWrapper::new();
 
-    let signed_stake_pool_certificate = certificate_wrapper.assert_new_signed_stake_pool_cert(
+    let stake_pool_certificate = certificate_wrapper.assert_new_stake_pool_registration(
         &vrf_public_key,
         node_id,
         &kes_public_key,
-        &owner_stake_key,
         0u32,
         1u32,
         &account.public_key,
     );
+    let stake_pool_certificate_file = file_utils::create_file_in_temp("stake_pool.cert", &stake_pool_certificate);
+
+    //  &owner_stake_key,
 
     let transaction = JCLITransactionWrapper::new_transaction(genesis_block_hash)
         .assert_add_account(&account.address, &fee_value)
-        .assert_add_certificate(&file_utils::read_file(&signed_stake_pool_certificate))
+        .assert_add_certificate(&stake_pool_certificate)
         .assert_finalize_with_fee(&account.address, &fees)
         .seal_with_witness_for_address(account)
+        .assert_add_auth(&owner_stake_key)
         .assert_to_message();
 
     account.confirm_transaction();
     jcli_wrapper::assert_transaction_in_block(&transaction, &jormungandr_rest_address);
 
     let stake_pool_id =
-        certificate_wrapper.assert_get_stake_pool_id(&signed_stake_pool_certificate);
+        certificate_wrapper.assert_get_stake_pool_id(&stake_pool_certificate_file);
 
     assert!(
         jcli_wrapper::assert_rest_get_stake_pools(&jormungandr_rest_address)
@@ -120,10 +123,9 @@ pub fn delegate_stake(
     let owner_stake_key =
         file_utils::create_file_in_temp("stake_key.private_key", &account.private_key);
     let certificate_wrapper = JCLICertificateWrapper::new();
-    let stake_pool_delegation = certificate_wrapper.assert_new_signed_stake_pool_delegation(
+    let stake_pool_delegation = certificate_wrapper.assert_new_stake_delegation(
         &stake_pool_id,
         &account.public_key,
-        &owner_stake_key,
     );
 
     let settings = jcli_wrapper::assert_get_rest_settings(&jormungandr_rest_address);
@@ -135,6 +137,7 @@ pub fn delegate_stake(
         .assert_add_certificate(&stake_pool_delegation)
         .assert_finalize_with_fee(&account.address, &fees)
         .seal_with_witness_for_address(account)
+        .assert_add_auth(&owner_stake_key)
         .assert_to_message();
 
     account.confirm_transaction();
@@ -160,10 +163,12 @@ pub fn retire_stake_pool(
     genesis_block_hash: &str,
     jormungandr_rest_address: &str,
 ) {
+    let owner_private_key =
+        file_utils::create_file_in_temp("stake_key.private_key", &account.private_key);
+
     let certificate_wrapper = JCLICertificateWrapper::new();
 
-    let retirement_cert = certificate_wrapper
-        .assert_new_signed_stake_pool_retirement(&stake_pool_id, &account.private_key);
+    let retirement_cert = certificate_wrapper.assert_new_stake_pool_retirement(&stake_pool_id);
 
     let settings = jcli_wrapper::assert_get_rest_settings(&jormungandr_rest_address);
     let fees: LinearFees = settings.fees.into();
@@ -174,6 +179,7 @@ pub fn retire_stake_pool(
         .assert_add_certificate(&retirement_cert)
         .assert_finalize_with_fee(&account.address, &fees)
         .seal_with_witness_for_address(account)
+        .assert_add_auth(&owner_private_key)
         .assert_to_message();
 
     account.confirm_transaction();

--- a/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
@@ -103,6 +103,7 @@ pub fn test_genesis_stake_pool_with_utxo_faucet_starts_successfully() {
 
     let stake_pool_id = jcli_certificate.assert_get_stake_pool_id(&stake_pool_signcert_file);
 
+    // WRONG
     let stake_delegation_signcert = jcli_certificate.assert_new_signed_stake_pool_delegation(
         &stake_pool_id,
         &stake_key_pub,

--- a/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
@@ -83,10 +83,12 @@ pub fn test_genesis_stake_pool_with_utxo_faucet_starts_successfully() {
     let pool_kes = startup::create_new_key_pair("SumEd25519_12");
 
     // note we use the faucet as the owner to this pool
-    let stake_key = faucet.private_key;
-    let stake_key_pub = faucet.delegation_key;
+    let owner_key = faucet.private_key;
+    let owner_pubkey = faucet.public_key;
+    let stake_key_pub = &faucet.delegation_key;
 
-    let stake_key_file = file_utils::create_file_in_temp("stake_key.sk", &stake_key);
+    let owner_key_file = file_utils::create_file_in_temp("owner_key.sk", &owner_key);
+    let stake_key_file = file_utils::create_file_in_temp("stake_key.sk", &stake_key.private_key);
 
     let jcli_certificate = JCLICertificateWrapper::new();
 
@@ -94,10 +96,10 @@ pub fn test_genesis_stake_pool_with_utxo_faucet_starts_successfully() {
         &pool_kes.public_key,
         "1010101010",
         &pool_vrf.public_key,
-        &stake_key_file,
+        &owner_key_file,
         0,
         1,
-        &faucet.public_key,
+        &owner_pubkey,
     );
     let stake_pool_signcert = file_utils::read_file(&stake_pool_signcert_file);
 
@@ -116,14 +118,14 @@ pub fn test_genesis_stake_pool_with_utxo_faucet_starts_successfully() {
         .with_consensus_genesis_praos_active_slot_coeff("0.1")
         .with_consensus_leaders_ids(vec![leader.public_key.clone()])
         .with_kes_update_speed(43200)
-        .with_initial_certs(vec![
-            stake_pool_signcert.clone(),
-            stake_delegation_signcert.clone(),
-        ])
         .with_funds(vec![Fund {
             address: faucet.address.clone(),
             value: 100.into(),
         }])
+        .with_initial_certs(vec![
+            stake_pool_signcert.clone(),
+            stake_delegation_signcert.clone(),
+        ])
         .build();
 
     let secret =

--- a/jormungandr-lib/Cargo.toml
+++ b/jormungandr-lib/Cargo.toml
@@ -13,6 +13,7 @@ chain-addr      = { path = "../chain-deps/chain-addr" }
 chain-core      = { path = "../chain-deps/chain-core" }
 chain-crypto    = { path = "../chain-deps/chain-crypto" }
 cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }
+typed-bytes = { path = "../chain-deps/typed-bytes" }
 rand_core = "0.3"
 rand_chacha = "0.1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/jormungandr-lib/src/interfaces/certificate.rs
+++ b/jormungandr-lib/src/interfaces/certificate.rs
@@ -6,6 +6,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, str::FromStr};
 use typed_bytes::ByteBuilder;
 
+pub const SIGNED_CERTIFICATE_HRP: &str = "signedcert";
+pub const CERTIFICATE_HRP: &str = "cert";
+
 #[derive(Debug, Clone)]
 pub struct Certificate(pub certificate::Certificate);
 
@@ -200,13 +203,13 @@ impl Certificate {
     pub fn to_bech32(&self) -> Result<Bech32, CertificateToBech32Error> {
         use chain_core::property::Serialize as _;
         let bytes = self.serialize_as_vec()?;
-        Ok(Bech32::new("cert".to_string(), bytes.to_base32())?)
+        Ok(Bech32::new(CERTIFICATE_HRP.to_string(), bytes.to_base32())?)
     }
 
     pub fn from_bech32(bech32: &Bech32) -> Result<Self, CertificateFromBech32Error> {
-        if bech32.hrp() != "cert" {
+        if bech32.hrp() != CERTIFICATE_HRP {
             return Err(CertificateFromBech32Error::InvalidHRP {
-                expected: "cert".to_owned(),
+                expected: CERTIFICATE_HRP.to_owned(),
                 actual: bech32.hrp().to_owned(),
             });
         }
@@ -220,13 +223,16 @@ impl SignedCertificate {
     pub fn to_bech32(&self) -> Result<Bech32, CertificateToBech32Error> {
         use chain_core::property::Serialize as _;
         let bytes = self.serialize_as_vec()?;
-        Ok(Bech32::new("signedcert".to_string(), bytes.to_base32())?)
+        Ok(Bech32::new(
+            SIGNED_CERTIFICATE_HRP.to_string(),
+            bytes.to_base32(),
+        )?)
     }
 
     pub fn from_bech32(bech32: &Bech32) -> Result<Self, CertificateFromBech32Error> {
-        if bech32.hrp() != "signedcert" {
+        if bech32.hrp() != SIGNED_CERTIFICATE_HRP {
             return Err(CertificateFromBech32Error::InvalidHRP {
-                expected: "signedcert".to_owned(),
+                expected: SIGNED_CERTIFICATE_HRP.to_owned(),
                 actual: bech32.hrp().to_owned(),
             });
         }

--- a/jormungandr-lib/src/interfaces/certificate.rs
+++ b/jormungandr-lib/src/interfaces/certificate.rs
@@ -4,16 +4,42 @@ use chain_core::property;
 use chain_impl_mockchain::certificate;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, str::FromStr};
+use typed_bytes::ByteBuilder;
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct Certificate(pub certificate::Certificate);
 
-impl PartialEq for Certificate {
+#[derive(Debug, Clone)]
+pub struct SignedCertificate(pub certificate::SignedCertificate);
+
+impl PartialEq for SignedCertificate {
     fn eq(&self, other: &Self) -> bool {
         use property::Serialize as _;
         match (self.serialize_as_vec(), other.serialize_as_vec()) {
             (Ok(a), Ok(b)) => a == b,
             _ => false,
+        }
+    }
+}
+
+impl SignedCertificate {
+    pub fn strip_auth(self) -> Certificate {
+        match self.0 {
+            certificate::SignedCertificate::StakeDelegation(c, _) => {
+                Certificate(certificate::Certificate::StakeDelegation(c))
+            }
+            certificate::SignedCertificate::OwnerStakeDelegation(c, _) => {
+                Certificate(certificate::Certificate::OwnerStakeDelegation(c))
+            }
+            certificate::SignedCertificate::PoolRegistration(c, _) => {
+                Certificate(certificate::Certificate::PoolRegistration(c))
+            }
+            certificate::SignedCertificate::PoolRetirement(c, _) => {
+                Certificate(certificate::Certificate::PoolRetirement(c))
+            }
+            certificate::SignedCertificate::PoolUpdate(c, _) => {
+                Certificate(certificate::Certificate::PoolUpdate(c))
+            }
         }
     }
 }
@@ -24,19 +50,23 @@ impl property::Serialize for Certificate {
         match &self.0 {
             certificate::Certificate::StakeDelegation(c) => {
                 writer.write_all(&[1])?;
-                c.serialize(&mut writer)?
+                c.serialize(&mut writer)?;
             }
             certificate::Certificate::OwnerStakeDelegation(c) => {
                 writer.write_all(&[2])?;
-                c.serialize(&mut writer)?
+                c.serialize(&mut writer)?;
             }
             certificate::Certificate::PoolRegistration(c) => {
                 writer.write_all(&[3])?;
-                writer.write_all(c.serialize().as_slice())?
+                writer.write_all(c.serialize().as_slice())?;
             }
-            certificate::Certificate::PoolManagement(c) => {
+            certificate::Certificate::PoolRetirement(c) => {
                 writer.write_all(&[4])?;
-                writer.write_all(c.serialize().as_slice())?
+                writer.write_all(c.serialize().as_slice())?;
+            }
+            certificate::Certificate::PoolUpdate(c) => {
+                writer.write_all(&[5])?;
+                writer.write_all(c.serialize().as_slice())?;
             }
         };
         Ok(())
@@ -46,18 +76,105 @@ impl property::Serialize for Certificate {
 impl Readable for Certificate {
     fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError> {
         match buf.get_u8()? {
-            1 => Ok(Certificate(certificate::Certificate::StakeDelegation(
-                certificate::StakeDelegation::read(buf)?,
-            ))),
-            2 => Ok(Certificate(certificate::Certificate::OwnerStakeDelegation(
-                certificate::OwnerStakeDelegation::read(buf)?,
-            ))),
-            3 => Ok(Certificate(certificate::Certificate::PoolRegistration(
-                certificate::PoolRegistration::read(buf)?,
-            ))),
-            4 => Ok(Certificate(certificate::Certificate::PoolManagement(
-                certificate::PoolManagement::read(buf)?,
-            ))),
+            1 => {
+                let cert = certificate::StakeDelegation::read(buf)?;
+                Ok(Certificate(certificate::Certificate::StakeDelegation(cert)))
+            }
+            2 => {
+                let cert = certificate::OwnerStakeDelegation::read(buf)?;
+                Ok(Certificate(certificate::Certificate::OwnerStakeDelegation(
+                    cert,
+                )))
+            }
+            3 => {
+                let cert = certificate::PoolRegistration::read(buf)?;
+                Ok(Certificate(certificate::Certificate::PoolRegistration(
+                    cert,
+                )))
+            }
+            4 => {
+                let cert = certificate::PoolRetirement::read(buf)?;
+                Ok(Certificate(certificate::Certificate::PoolRetirement(cert)))
+            }
+            5 => {
+                let cert = certificate::PoolUpdate::read(buf)?;
+                Ok(Certificate(certificate::Certificate::PoolUpdate(cert)))
+            }
+            t => Err(ReadError::UnknownTag(t as u32))?,
+        }
+    }
+}
+
+impl property::Serialize for SignedCertificate {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, mut writer: W) -> Result<(), Self::Error> {
+        match &self.0 {
+            certificate::SignedCertificate::StakeDelegation(c, a) => {
+                writer.write_all(&[1])?;
+                c.serialize(&mut writer)?;
+                writer.write_all(a.as_ref())?;
+            }
+            certificate::SignedCertificate::OwnerStakeDelegation(c, ()) => {
+                writer.write_all(&[2])?;
+                c.serialize(&mut writer)?;
+            }
+            certificate::SignedCertificate::PoolRegistration(c, a) => {
+                writer.write_all(&[3])?;
+                writer.write_all(c.serialize().as_slice())?;
+                writer.write_all(a.serialize_in(ByteBuilder::new()).finalize().as_slice())?;
+            }
+            certificate::SignedCertificate::PoolRetirement(c, a) => {
+                writer.write_all(&[4])?;
+                writer.write_all(c.serialize().as_slice())?;
+                writer.write_all(a.serialize_in(ByteBuilder::new()).finalize().as_slice())?;
+            }
+            certificate::SignedCertificate::PoolUpdate(c, a) => {
+                writer.write_all(&[5])?;
+                writer.write_all(c.serialize().as_slice())?;
+                writer.write_all(a.serialize_in(ByteBuilder::new()).finalize().as_slice())?;
+            }
+        };
+        Ok(())
+    }
+}
+
+impl Readable for SignedCertificate {
+    fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError> {
+        match buf.get_u8()? {
+            1 => {
+                let cert = certificate::StakeDelegation::read(buf)?;
+                let auth = Readable::read(buf)?;
+                Ok(SignedCertificate(
+                    certificate::SignedCertificate::StakeDelegation(cert, auth),
+                ))
+            }
+            2 => {
+                let cert = certificate::OwnerStakeDelegation::read(buf)?;
+                Ok(SignedCertificate(
+                    certificate::SignedCertificate::OwnerStakeDelegation(cert, ()),
+                ))
+            }
+            3 => {
+                let cert = certificate::PoolRegistration::read(buf)?;
+                let auth = Readable::read(buf)?;
+                Ok(SignedCertificate(
+                    certificate::SignedCertificate::PoolRegistration(cert, auth),
+                ))
+            }
+            4 => {
+                let cert = certificate::PoolRetirement::read(buf)?;
+                let auth = Readable::read(buf)?;
+                Ok(SignedCertificate(
+                    certificate::SignedCertificate::PoolRetirement(cert, auth),
+                ))
+            }
+            5 => {
+                let cert = certificate::PoolUpdate::read(buf)?;
+                let auth = Readable::read(buf)?;
+                Ok(SignedCertificate(
+                    certificate::SignedCertificate::PoolUpdate(cert, auth),
+                ))
+            }
             t => Err(ReadError::UnknownTag(t as u32))?,
         }
     }
@@ -99,6 +216,26 @@ impl Certificate {
     }
 }
 
+impl SignedCertificate {
+    pub fn to_bech32(&self) -> Result<Bech32, CertificateToBech32Error> {
+        use chain_core::property::Serialize as _;
+        let bytes = self.serialize_as_vec()?;
+        Ok(Bech32::new("signedcert".to_string(), bytes.to_base32())?)
+    }
+
+    pub fn from_bech32(bech32: &Bech32) -> Result<Self, CertificateFromBech32Error> {
+        if bech32.hrp() != "signedcert" {
+            return Err(CertificateFromBech32Error::InvalidHRP {
+                expected: "signedcert".to_owned(),
+                actual: bech32.hrp().to_owned(),
+            });
+        }
+        let bytes: Vec<u8> = Vec::from_base32(bech32.data())?;
+        let mut buf = ReadBuf::from(&bytes);
+        SignedCertificate::read(&mut buf).map_err(CertificateFromBech32Error::from)
+    }
+}
+
 /* ---------------- Display ------------------------------------------------ */
 
 impl fmt::Display for Certificate {
@@ -115,6 +252,20 @@ impl FromStr for Certificate {
     }
 }
 
+impl fmt::Display for SignedCertificate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_bech32().unwrap())
+    }
+}
+
+impl FromStr for SignedCertificate {
+    type Err = CertificateFromStrError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bech32 = Bech32::from_str(s)?;
+        Ok(SignedCertificate::from_bech32(&bech32)?)
+    }
+}
+
 /* ---------------- Conversion --------------------------------------------- */
 
 impl From<certificate::Certificate> for Certificate {
@@ -125,6 +276,18 @@ impl From<certificate::Certificate> for Certificate {
 
 impl From<Certificate> for certificate::Certificate {
     fn from(v: Certificate) -> Self {
+        v.0
+    }
+}
+
+impl From<certificate::SignedCertificate> for SignedCertificate {
+    fn from(v: certificate::SignedCertificate) -> Self {
+        SignedCertificate(v)
+    }
+}
+
+impl From<SignedCertificate> for certificate::SignedCertificate {
+    fn from(v: SignedCertificate) -> Self {
         v.0
     }
 }
@@ -155,5 +318,32 @@ impl<'de> Deserialize<'de> for Certificate {
         let bech32: Bech32 = bech32_str.parse().map_err(D::Error::custom)?;
 
         Certificate::from_bech32(&bech32).map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for SignedCertificate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::Error as _;
+
+        let bech32 = self.to_bech32().map_err(S::Error::custom)?;
+
+        bech32.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SignedCertificate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+
+        let bech32_str = String::deserialize(deserializer)?;
+        let bech32: Bech32 = bech32_str.parse().map_err(D::Error::custom)?;
+
+        SignedCertificate::from_bech32(&bech32).map_err(D::Error::custom)
     }
 }

--- a/jormungandr-lib/src/interfaces/mod.rs
+++ b/jormungandr-lib/src/interfaces/mod.rs
@@ -8,6 +8,7 @@ mod leadership_log;
 mod linear_fee;
 mod old_address;
 mod settings;
+mod transaction_input;
 mod transaction_output;
 mod transaction_witness;
 mod utxo_info;
@@ -19,12 +20,14 @@ pub use self::block0_configuration::*;
 pub use self::blockdate::BlockDate;
 pub use self::certificate::{
     Certificate, CertificateFromBech32Error, CertificateFromStrError, CertificateToBech32Error,
+    SignedCertificate,
 };
 pub use self::fragment_log::{FragmentLog, FragmentOrigin, FragmentStatus};
 pub use self::leadership_log::{EnclaveLeaderId, LeadershipLog, LeadershipLogId};
 pub use self::linear_fee::LinearFeeDef;
 pub use self::old_address::OldAddress;
 pub use self::settings::*;
+pub use self::transaction_input::{TransactionInput, TransactionInputType};
 pub use self::transaction_output::TransactionOutput;
 pub use self::transaction_witness::TransactionWitness;
 pub use self::utxo_info::UTxOInfo;

--- a/jormungandr-lib/src/interfaces/mod.rs
+++ b/jormungandr-lib/src/interfaces/mod.rs
@@ -20,7 +20,7 @@ pub use self::block0_configuration::*;
 pub use self::blockdate::BlockDate;
 pub use self::certificate::{
     Certificate, CertificateFromBech32Error, CertificateFromStrError, CertificateToBech32Error,
-    SignedCertificate,
+    SignedCertificate, CERTIFICATE_HRP, SIGNED_CERTIFICATE_HRP,
 };
 pub use self::fragment_log::{FragmentLog, FragmentOrigin, FragmentStatus};
 pub use self::leadership_log::{EnclaveLeaderId, LeadershipLog, LeadershipLogId};

--- a/jormungandr-lib/src/interfaces/transaction_input.rs
+++ b/jormungandr-lib/src/interfaces/transaction_input.rs
@@ -1,0 +1,52 @@
+use crate::interfaces::Value;
+use chain_impl_mockchain::transaction::{Input, InputEnum, UtxoPointer};
+use serde::{Deserialize, Serialize};
+
+const INPUT_PTR_SIZE: usize = 32;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransactionInput {
+    pub input: TransactionInputType,
+    pub value: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransactionInputType {
+    Account([u8; INPUT_PTR_SIZE]),
+    Utxo([u8; INPUT_PTR_SIZE], u8),
+}
+
+impl From<TransactionInput> for Input {
+    fn from(i: TransactionInput) -> Input {
+        match i.input {
+            TransactionInputType::Account(aid) => {
+                Input::from_enum(InputEnum::AccountInput(aid.into(), i.value.into()))
+            }
+            TransactionInputType::Utxo(txptr, txid) => {
+                Input::from_enum(InputEnum::UtxoInput(UtxoPointer {
+                    output_index: txid,
+                    transaction_id: txptr.into(),
+                    value: i.value.into(),
+                }))
+            }
+        }
+    }
+}
+
+impl From<Input> for TransactionInput {
+    fn from(i: Input) -> TransactionInput {
+        match i.to_enum() {
+            InputEnum::AccountInput(ai, value) => TransactionInput {
+                input: TransactionInputType::Account(ai.into()),
+                value: value.into(),
+            },
+            InputEnum::UtxoInput(utxoptr) => TransactionInput {
+                input: TransactionInputType::Utxo(
+                    utxoptr.transaction_id.into(),
+                    utxoptr.output_index,
+                ),
+                value: utxoptr.value.into(),
+            },
+        }
+    }
+}

--- a/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -7,8 +7,11 @@ use crate::{
 };
 use chain_crypto::{Curve25519_2HashDH, Ed25519, SumEd25519_12};
 use chain_impl_mockchain::{
-    block::ConsensusVersion, fee::LinearFee, rewards::TaxType, transaction::{AccountBindingSignature, TxBuilder},
+    block::ConsensusVersion,
+    fee::LinearFee,
     key::EitherEd25519SecretKey,
+    rewards::TaxType,
+    transaction::{AccountBindingSignature, TxBuilder},
 };
 use chain_time::DurationSeconds;
 use jormungandr_lib::{
@@ -218,7 +221,10 @@ impl Settings {
                             .set_ios(&[], &[])
                             .set_witnesses(&[]);
                         let auth_data = txb.get_auth_data();
-                        let sig0 = AccountBindingSignature::new(&EitherEd25519SecretKey::Normal(owner), &auth_data);
+                        let sig0 = AccountBindingSignature::new(
+                            &EitherEd25519SecretKey::Normal(owner),
+                            &auth_data,
+                        );
                         let owner_signed = PoolOwnersSigned {
                             signatures: vec![(0, sig0)],
                         };

--- a/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -6,7 +6,10 @@ use crate::{
     style, NodeAlias, Wallet, WalletAlias, WalletType,
 };
 use chain_crypto::{Curve25519_2HashDH, Ed25519, SumEd25519_12};
-use chain_impl_mockchain::{block::ConsensusVersion, fee::LinearFee, rewards::TaxType};
+use chain_impl_mockchain::{
+    block::ConsensusVersion, fee::LinearFee, rewards::TaxType, transaction::{AccountBindingSignature, TxBuilder},
+    key::EitherEd25519SecretKey,
+};
 use chain_time::DurationSeconds;
 use jormungandr_lib::{
     crypto::{hash::Hash, key::SigningKey},
@@ -168,7 +171,7 @@ impl Settings {
 
             if let Some(delegation) = wallet_template.delegate() {
                 use chain_impl_mockchain::certificate::{
-                    Certificate, PoolId as StakePoolId, StakeDelegation,
+                    PoolId as StakePoolId, PoolOwnersSigned, SignedCertificate,
                 };
 
                 // 1. retrieve the public data (we may need to create a stake pool
@@ -186,16 +189,14 @@ impl Settings {
                         let serial: u128 = context.rng_mut().sample(Standard);
                         let kes_signing_key = SigningKey::generate(context.rng_mut());
                         let vrf_signing_key = SigningKey::generate(context.rng_mut());
+                        let owner = chain_crypto::SecretKey::<chain_crypto::Ed25519>::generate(
+                            context.rng_mut(),
+                        );
                         let stake_pool_info = PoolRegistration {
                             serial,
                             management_threshold: 1,
                             start_validity: DurationSeconds(0).into(),
-                            owners: vec![
-                                chain_crypto::SecretKey::<chain_crypto::Ed25519>::generate(
-                                    context.rng_mut(),
-                                )
-                                .to_public(),
-                            ],
+                            owners: vec![owner.to_public()],
                             rewards: TaxType::zero(),
                             keys: GenesisPraosLeader {
                                 kes_public_key: kes_signing_key.identifier().into_public_key(),
@@ -212,8 +213,18 @@ impl Settings {
                             },
                         });
 
+                        let txb = TxBuilder::new()
+                            .set_payload(&stake_pool_info)
+                            .set_ios(&[], &[])
+                            .set_witnesses(&[]);
+                        let auth_data = txb.get_auth_data();
+                        let sig0 = AccountBindingSignature::new(&EitherEd25519SecretKey::Normal(owner), &auth_data);
+                        let owner_signed = PoolOwnersSigned {
+                            signatures: vec![(0, sig0)],
+                        };
+
                         let stake_pool_registration_certificate =
-                            Certificate::PoolRegistration(stake_pool_info);
+                            SignedCertificate::PoolRegistration(stake_pool_info, owner_signed);
 
                         self.block0
                             .initial
@@ -228,20 +239,9 @@ impl Settings {
                     unimplemented!("delegating stake to a stake pool that is not a node is not supported (yet)")
                 };
 
-                // 2. retrieve the wallet delegation identifier
-                let stake_key_id = if let Some(stake_key_id) = wallet.stake_key() {
-                    stake_key_id
-                } else {
-                    unimplemented!(
-                        "delegation from a wallet that is not an Account is not supported (yet)"
-                    )
-                };
-
-                // 3. create delegation certificate and add it to the block0.initial array
-                let delegation_certificate = Certificate::StakeDelegation(StakeDelegation {
-                    account_id: stake_key_id, // 2
-                    pool_id: stake_pool_id,   // 1
-                });
+                // 2. create delegation certificate for the wallet stake key
+                // and add it to the block0.initial array
+                let delegation_certificate = wallet.delegation_cert_for_block0(stake_pool_id);
 
                 self.block0
                     .initial

--- a/jormungandr-scenario-tests/src/wallet/account.rs
+++ b/jormungandr-scenario-tests/src/wallet/account.rs
@@ -5,9 +5,8 @@ use chain_impl_mockchain::{
     certificate::{PoolId, SignedCertificate, StakeDelegation},
     fee::{FeeAlgorithm, LinearFee},
     transaction::{
-        AccountBindingSignature, AccountIdentifier, Balance, Input, InputOutputBuilder,
-        Payload, PayloadSlice,
-        TransactionSignDataHash, TxBuilder, Witness,
+        AccountBindingSignature, AccountIdentifier, Balance, Input, InputOutputBuilder, Payload,
+        PayloadSlice, TransactionSignDataHash, TxBuilder, Witness,
     },
 };
 use jormungandr_lib::{

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -445,6 +445,7 @@ impl OwnerStakeDelegation {
     }
 }
 
+// TODO can we use jormungandr-lib Certificate ?
 enum Certificate {
     StakeDelegation(StakeDelegation),
     OwnerStakeDelegation(OwnerStakeDelegation),
@@ -467,7 +468,8 @@ impl TryFrom<chain_impl_mockchain::certificate::Certificate> for Certificate {
             certificate::Certificate::PoolRegistration(c) => {
                 Ok(Certificate::PoolRegistration(PoolRegistration::from(c)))
             }
-            certificate::Certificate::PoolManagement(_) => Err(ErrorKind::Unimplemented.into()),
+            certificate::Certificate::PoolRetirement(_) => Err(ErrorKind::Unimplemented.into()),
+            certificate::Certificate::PoolUpdate(_) => Err(ErrorKind::Unimplemented.into()),
         }
     }
 }

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -136,13 +136,13 @@ pub fn get_stats_counter(context: State<Context>) -> ActixFuture!() {
                     contents
                         .iter()
                         .filter_map(|fragment| match fragment {
-                            Fragment::Transaction(tx) => Some(&tx.transaction),
+                            Fragment::Transaction(tx) => Some(tx),
                             _ => None,
                         })
                         .map(|tx| {
-                            let input_sum = Value::sum(tx.inputs.iter().map(|input| input.value))?;
-                            let output_sum =
-                                Value::sum(tx.outputs.iter().map(|input| input.value))?;
+                            let input_sum = tx.total_input()?;
+                            let output_sum = tx.total_output()?;
+                            //    Value::sum(tx.outputs.iter().map(|input| input.value))?;
                             // Input < output implies minting, so no fee
                             let fee = (input_sum - output_sum).unwrap_or(Value::zero());
                             block_tx_count += 1;

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -170,6 +170,7 @@ POOL_KES_PK=$(echo ${POOL_KES_SK} | $CLI key to-public)
 STAKE_KEY=${FAUCET_SK}
 STAKE_KEY_PUB=${FAUCET_PK}
 
+echo ${LEADER_SK} > ${TMPDIR}/leader.sk
 echo ${STAKE_KEY} > ${TMPDIR}/stake_key.sk
 echo ${FIXED_SK} > ${TMPDIR}/fixed_key.sk
 echo ${POOL_VRF_SK} > ${TMPDIR}/stake_pool.vrf.sk
@@ -183,7 +184,7 @@ $CLI certificate new stake-pool-registration \
     --vrf-key ${POOL_VRF_PK} \
     --serial 1010101010 > ${TMPDIR}/stake_pool.cert
 
-cat ${TMPDIR}/stake_pool.cert | $CLI certificate sign -k ${TMPDIR}/stake_key.sk > ${TMPDIR}/stake_pool.signcert
+cat ${TMPDIR}/stake_pool.cert | $CLI certificate sign -k ${TMPDIR}/leader.sk > ${TMPDIR}/stake_pool.signcert
 
 STAKE_POOL_ID=$(cat ${TMPDIR}/stake_pool.signcert | $CLI certificate get-stake-pool-id)
 STAKE_POOL_CERT=$(cat ${TMPDIR}/stake_pool.signcert)

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -183,7 +183,7 @@ $CLI certificate new stake-pool-registration \
     --vrf-key ${POOL_VRF_PK} \
     --serial 1010101010 > ${TMPDIR}/stake_pool.cert
 
-cat ${TMPDIR}/stake_pool.cert | $CLI certificate sign ${TMPDIR}/stake_key.sk > ${TMPDIR}/stake_pool.signcert
+cat ${TMPDIR}/stake_pool.cert | $CLI certificate sign -k ${TMPDIR}/stake_key.sk > ${TMPDIR}/stake_pool.signcert
 
 STAKE_POOL_ID=$(cat ${TMPDIR}/stake_pool.signcert | $CLI certificate get-stake-pool-id)
 STAKE_POOL_CERT=$(cat ${TMPDIR}/stake_pool.signcert)
@@ -191,13 +191,13 @@ STAKE_POOL_CERT=$(cat ${TMPDIR}/stake_pool.signcert)
 $CLI certificate new stake-delegation \
     ${STAKE_POOL_ID} \
     ${FAUCET_PK} > ${TMPDIR}/stake_delegation1.cert
-cat ${TMPDIR}/stake_delegation1.cert | $CLI certificate sign ${TMPDIR}/stake_key.sk > ${TMPDIR}/stake_delegation1.signcert
+cat ${TMPDIR}/stake_delegation1.cert | $CLI certificate sign -k ${TMPDIR}/stake_key.sk > ${TMPDIR}/stake_delegation1.signcert
 STAKE_DELEGATION_CERT1=$(cat ${TMPDIR}/stake_delegation1.signcert)
 
 $CLI certificate new stake-delegation \
     ${STAKE_POOL_ID} \
     ${FIXED_PK} > ${TMPDIR}/stake_delegation2.cert
-cat ${TMPDIR}/stake_delegation2.cert | $CLI certificate sign ${TMPDIR}/fixed_key.sk > ${TMPDIR}/stake_delegation2.signcert
+cat ${TMPDIR}/stake_delegation2.cert | $CLI certificate sign -k ${TMPDIR}/fixed_key.sk > ${TMPDIR}/stake_delegation2.signcert
 STAKE_DELEGATION_CERT2=$(cat ${TMPDIR}/stake_delegation2.signcert)
 
 

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -213,20 +213,20 @@ if([System.IO.File]::Exists($MYCLI)){
 
 	$STAKEPOOLCERT = & $MYCLI certificate new stake-pool-registration --kes-key $POOL_KES_PK --vrf-key $POOL_VRF_PK --serial 1010101010 --management-threshold 1 --start-validity 0 --owner $LEADER_PK
 	echo $STAKEPOOLCERT | Out-File $WORKDIR"\"$SECRET_PATH\stake_pool.cert -Encoding Oem
-	$STAKEPOOLCERTSIGN = echo $STAKEPOOLCERT | & $MYCLI certificate sign $WORKDIR"\"$SECRET_PATH\stake_key.sk 
+	$STAKEPOOLCERTSIGN = echo $STAKEPOOLCERT | & $MYCLI certificate sign -k $WORKDIR"\"$SECRET_PATH\stake_key.sk 
 	echo $STAKEPOOLCERTSIGN | Out-File $WORKDIR"\"$SECRET_PATH\stake_pool.signcert -Encoding Oem
 	$STAKE_POOL_ID = echo $STAKEPOOLCERTSIGN | & $MYCLI certificate get-stake-pool-id
 	write-host "stake-pool-registration certificate: done" -ForegroundColor DarkGreen
 
 	$STAKEDELEGATION1 = & $MYCLI certificate new stake-delegation $STAKE_POOL_ID $FAUCET_PK 
 	echo $STAKEDELEGATION1 | Out-File $WORKDIR"\"$SECRET_PATH\stake_delegation1.cert -Encoding Oem
-	$STAKEDELEGATIONSIGN1 = $STAKEDELEGATION1 | & $MYCLI certificate sign $WORKDIR"\"$SECRET_PATH\stake_key.sk 
+	$STAKEDELEGATIONSIGN1 = $STAKEDELEGATION1 | & $MYCLI certificate sign -k $WORKDIR"\"$SECRET_PATH\stake_key.sk 
 	echo $STAKEDELEGATIONSIGN1 | Out-File $WORKDIR"\"$SECRET_PATH\stake_delegation1.signcert -Encoding Oem
 	write-host "stake-pool-delegation certificate 1: done" -ForegroundColor DarkGreen
 
 	$STAKEDELEGATION2 = & $MYCLI certificate new stake-delegation $STAKE_POOL_ID $FIXED_PK
 	echo $STAKEDELEGATION2 | Out-File $WORKDIR"\"$SECRET_PATH\stake_delegation2.cert -Encoding Oem
-	$STAKEDELEGATIONSIGN2 = $STAKEDELEGATION2 | & $MYCLI certificate sign $WORKDIR"\"$SECRET_PATH\fixed_key.sk 
+	$STAKEDELEGATIONSIGN2 = $STAKEDELEGATION2 | & $MYCLI certificate sign -k $WORKDIR"\"$SECRET_PATH\fixed_key.sk 
 	echo $STAKEDELEGATIONSIGN2 | Out-File $WORKDIR"\"$SECRET_PATH\stake_delegation2.signcert -Encoding Oem
 	write-host "stake-pool-delegation certificate 2: done" -ForegroundColor DarkGreen
 

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -205,6 +205,7 @@ if([System.IO.File]::Exists($MYCLI)){
 	# note we use the faucet as the owner to this pool
 	$STAKE_KEY=$FAUCET_SK
 	$STAKE_KEY_PUB=$FAUCET_PK
+	echo $LEADER_SK | Out-File $WORKDIR"\"$SECRET_PATH\leader.sk -Encoding Oem
 	echo $STAKE_KEY | Out-File $WORKDIR"\"$SECRET_PATH\stake_key.sk -Encoding Oem
 	echo $FIXED_SK | Out-File $WORKDIR"\"$SECRET_PATH\fixed_key.sk -Encoding Oem
 	echo $POOL_VRF_SK | Out-File $WORKDIR"\"$SECRET_PATH\stake_pool.vrf.sk -Encoding Oem
@@ -213,7 +214,7 @@ if([System.IO.File]::Exists($MYCLI)){
 
 	$STAKEPOOLCERT = & $MYCLI certificate new stake-pool-registration --kes-key $POOL_KES_PK --vrf-key $POOL_VRF_PK --serial 1010101010 --management-threshold 1 --start-validity 0 --owner $LEADER_PK
 	echo $STAKEPOOLCERT | Out-File $WORKDIR"\"$SECRET_PATH\stake_pool.cert -Encoding Oem
-	$STAKEPOOLCERTSIGN = echo $STAKEPOOLCERT | & $MYCLI certificate sign -k $WORKDIR"\"$SECRET_PATH\stake_key.sk 
+	$STAKEPOOLCERTSIGN = echo $STAKEPOOLCERT | & $MYCLI certificate sign -k $WORKDIR"\"$SECRET_PATH\leader.sk
 	echo $STAKEPOOLCERTSIGN | Out-File $WORKDIR"\"$SECRET_PATH\stake_pool.signcert -Encoding Oem
 	$STAKE_POOL_ID = echo $STAKEPOOLCERTSIGN | & $MYCLI certificate get-stake-pool-id
 	write-host "stake-pool-registration certificate: done" -ForegroundColor DarkGreen


### PR DESCRIPTION
### Chain-libs change

* Keep the transaction in binary format and slice it efficiently on demand (**API BREAKING CHANGE**)
* Get rid of AuthenticatedTransaction (now just Transaction) (**API BREAKING CHANGE**)
* Add InputOutputs builder which is not parametrised to the type anymore, but expect it explicitly when calculating fees.
* Redo the transaction builder to be a state machine: 1) set payload 2) set input-outputs 3) set witnesses 4) set payload-auth (**API BREAKING CHANGE**)
* Bind certificate with transaction (**BREAKING CHANGE**)
* simplify tests and add more efficient kitchen sink construct (e.g. TestLedger) to allow less repetition and more state tracking
* Flatten PoolManagement into PoolUpdate/PoolRetirement (**BREAKING CHANGE**)
* Simplify the fees calculation (**API BREAKING CHANGE**)

### jcli usage change

`jcli certificate sign`:

* now take explicit secret keys using the -k/--key flag
* verify that the secret key is matching the associated public key (if possible)
* is now only used for the block0 creation, as for certificate using the transaction system, we know need `transaction auth`.

`jcli transaction auth`:

* new subcommand that need to happens after sealing
* take explicit secret keys using the -k/--key flags
* similar to `jcli certificate sign` but apply to an almost built transaction
* only needed for StakeDelegation, PoolRegistration, PoolRetirement, PoolUpdate. Not for OwnerStakeDelegation