### PR TITLE
jcli: transaction (id -> data-for-witness) and new id

### DIFF
--- a/jcli/src/jcli_app/transaction/info.rs
+++ b/jcli/src/jcli_app/transaction/info.rs
@@ -26,12 +26,12 @@ pub struct Info {
     /// formatting for the output to displays
     /// user "{name}" to display the variable with the named `name'.
     ///
-    /// available variables: id, num_inputs, num_outputs, num_witnesses, fee
-    /// balance, input, output and status
+    /// available variables: sign-data-hash, num_inputs, num_outputs, num_witnesses
+    // id, fee, balance, input, output and status
     ///
     #[structopt(
         long = "format",
-        default_value = "Transaction `{id}' ({status})\n  Input:   {input}\n  Output:  {output}\n  Fees:    {fee}\n  Balance: {balance}\n"
+        default_value = "Transaction `{sign-data-hash}' ({status})\n" //  Input:   {input}\n  Output:  {output}\n  Fees:    {fee}\n  Balance: {balance}\n"
     )]
     pub format: String,
 

--- a/jcli/src/jcli_app/transaction/mod.rs
+++ b/jcli/src/jcli_app/transaction/mod.rs
@@ -44,9 +44,11 @@ pub enum Transaction {
     Finalize(finalize::Finalize),
     /// Finalize the transaction
     Seal(seal::Seal),
-    /// get the Transaction ID from the given transaction
-    /// (if the transaction is edited, the returned value will change)
+    /// get the Transaction ID from the given sealed transaction
     Id(common::CommonTransaction),
+    /// get the data to sign from the given transaction
+    /// (if the transaction is edited, the returned value will change)
+    DataForWitness(common::CommonTransaction),
     /// display the info regarding a given transaction
     Info(info::Info),
     /// create witnesses
@@ -149,6 +151,7 @@ impl Transaction {
             Transaction::Finalize(finalize) => finalize.exec(),
             Transaction::Seal(seal) => seal.exec(),
             Transaction::Id(common) => display_id(common),
+            Transaction::DataForWitness(common) => display_data_for_witness(common),
             Transaction::Info(info) => info.exec(),
             Transaction::MakeWitness(mk_witness) => mk_witness.exec(),
             Transaction::Auth(auth) => auth.exec(),
@@ -158,8 +161,14 @@ impl Transaction {
 }
 
 fn display_id(common: common::CommonTransaction) -> Result<(), Error> {
-    let id = common.load()?.transaction_sign_data_hash();
+    let id = common.load()?.fragment()?.hash();
     println!("{}", id);
+    Ok(())
+}
+
+fn display_data_for_witness(common: common::CommonTransaction) -> Result<(), Error> {
+    let old_id = common.load()?.transaction_sign_data_hash();
+    println!("{}", old_id);
     Ok(())
 }
 


### PR DESCRIPTION
1. temporary disable some unavaliable variables from `info` format
2. replace variable `id` -> `sign-data-hash` on `info` format variables list.
3. `transaction id` -> `transaction data-for-witness` (TODO: documentation)
4. new _limited_ `transaction id` (fragment id), 
   works only on `sealed` tx, hence not included on `info`.

partial attempt on https://github.com/input-output-hk/jormungandr/issues/674
