### PR TITLE
jcli transaction - add data-for-witness (alias id) and fragment-id

### DIFF
--- a/doc/jcli/transaction.md
+++ b/doc/jcli/transaction.md
@@ -26,9 +26,12 @@ There are also functions to help decode and display the
 content information of a transaction:
 
 * `info`
-* `id` to get the **Transaction ID** of the transaction
+* `data-for-witness` get the data to sign from a given transaction
+* `fragment-id` get the **Fragment ID** from a transaction in *sealed* state
 * `to-message` to get the hexadecimal encoded message, ready to send with `cli rest message`
 
+**DEPRECATED**:
+* `id` get the data to sign from a given transaction (use `data-for-witness` instead)
 
 # Examples
 
@@ -41,9 +44,9 @@ Let's use the following utxo as input and transfer 50 lovelaces to the destinati
 
 | Field                     | Value        |
 | ------------------------- |:------------:|
-| UTXO's transaction ID     | 55762218e5737603e6d27d36c8aacf8fcd16406e820361a8ac65c7dc663f6d1c| 
-| UTXO's output index       | 0     | 
-| associated address        |  ca1q09u0nxmnfg7af8ycuygx57p5xgzmnmgtaeer9xun7hly6mlgt3pjyknplu    | 
+| UTXO's transaction ID     | 55762218e5737603e6d27d36c8aacf8fcd16406e820361a8ac65c7dc663f6d1c|
+| UTXO's output index       | 0     |
+| associated address        |  ca1q09u0nxmnfg7af8ycuygx57p5xgzmnmgtaeer9xun7hly6mlgt3pjyknplu    |
 | associated value          | 100             |
 
 ## Destination address
@@ -118,7 +121,7 @@ For signing the transaction, you need the private key associated with the input 
 
 The genesis' hash is needed for ensuring that the transaction cannot be re-used in another blockchain and for security concerns on offline transaction signing, as we are signing the transaction for the specific blockchain started by this block0 hash.
 
-The following command takes the private key in the *key.prv* file and creates a witness in a file named *witness* in the current directory. 
+The following command takes the private key in the *key.prv* file and creates a witness in a file named *witness* in the current directory.
 
 ```sh
 jcli transaction make-witness --genesis-block-hash abcdef987654321... --type utxo txid witness key.prv
@@ -159,7 +162,7 @@ jcli rest v0 message post -f txmsg --host http://127.0.0.1:8443/api
 
 ## Checking if the transaction was accepted
 
-You can check if the transaction was accepted by checking the node logs, for example, if the transaction is accepted 
+You can check if the transaction was accepted by checking the node logs, for example, if the transaction is accepted
 
 `jcli rest v0 message logs -h http://127.0.0.1:8443/api`
 
@@ -178,10 +181,10 @@ You can check if the transaction was accepted by checking the node logs, for exa
 Where the InABlock status means that the transaction was accepted in the block with date "4.707"
 and for block `d9040ca57e513a36ecd3bb54207dfcd10682200929cad6ada46b521417964174`.
 
-The status here could also be: 
+The status here could also be:
 
 Pending: if the transaction is received and is pending being added in the blockchain (or rejected).
 
 or
 
-Rejected: with an attached message of the reason the transaction was rejected. 
+Rejected: with an attached message of the reason the transaction was rejected.

--- a/jcli/src/jcli_app/transaction/info.rs
+++ b/jcli/src/jcli_app/transaction/info.rs
@@ -26,7 +26,7 @@ pub struct Info {
     /// formatting for the output to displays
     /// user "{name}" to display the variable with the named `name'.
     ///
-    /// available variables: id, num_inputs, num_outputs, num_witnesses, fee
+    /// available variables: sign-data-hash, num_inputs, num_outputs, num_witnesses, fee
     /// balance, input, output and status
     ///
     #[structopt(

--- a/jcli/src/jcli_app/transaction/mod.rs
+++ b/jcli/src/jcli_app/transaction/mod.rs
@@ -44,9 +44,13 @@ pub enum Transaction {
     Finalize(finalize::Finalize),
     /// Finalize the transaction
     Seal(seal::Seal),
-    /// get the Transaction ID from the given transaction
-    /// (if the transaction is edited, the returned value will change)
+    /// get the Fragment ID from the given 'sealed' transaction
+    FragmentId(common::CommonTransaction),
+    /// DEPRECATED: use 'data-for-witness' instead
     Id(common::CommonTransaction),
+    /// get the data to sign from the given transaction
+    /// (if the transaction is edited, the returned value will change)
+    DataForWitness(common::CommonTransaction),
     /// display the info regarding a given transaction
     Info(info::Info),
     /// create witnesses
@@ -148,7 +152,9 @@ impl Transaction {
             Transaction::AddCertificate(add_certificate) => add_certificate.exec(),
             Transaction::Finalize(finalize) => finalize.exec(),
             Transaction::Seal(seal) => seal.exec(),
+            Transaction::FragmentId(common) => display_fragment_id(common),
             Transaction::Id(common) => display_id(common),
+            Transaction::DataForWitness(common) => display_data_for_witness(common),
             Transaction::Info(info) => info.exec(),
             Transaction::MakeWitness(mk_witness) => mk_witness.exec(),
             Transaction::Auth(auth) => auth.exec(),
@@ -158,7 +164,18 @@ impl Transaction {
 }
 
 fn display_id(common: common::CommonTransaction) -> Result<(), Error> {
+    eprintln!("DEPRECATED: use 'data-for-witness' instead");
+    display_data_for_witness(common)
+}
+
+fn display_data_for_witness(common: common::CommonTransaction) -> Result<(), Error> {
     let id = common.load()?.transaction_sign_data_hash();
+    println!("{}", id);
+    Ok(())
+}
+
+fn display_fragment_id(common: common::CommonTransaction) -> Result<(), Error> {
+    let id = common.load()?.fragment()?.hash();
     println!("{}", id);
     Ok(())
 }

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/jcli_transaction_commands.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/jcli_transaction_commands.rs
@@ -207,7 +207,7 @@ impl TransactionCommands {
         let mut command = Command::new(configuration::get_jcli_app().as_os_str());
         command
             .arg("transaction")
-            .arg("id")
+            .arg("data-for-witness")
             .arg("--staging")
             .arg(staging_file.as_os_str());
         command


### PR DESCRIPTION
- [x]  add `data-for-witness` providing same functionality as `id`
- [x] `id` is now an **alias** of `data-for-witness` with a deprecation message on:
 - _help_
 - _usage_ (_stderr_)
- [x] add `fragment-id` from a given **sealed** transaction.
- [x] change `id` to `data-for-witness` on tests cmd args.
- [x] update docs mentioning also `id` deprecation
- [ ] update tests to reflect `data-for-witness` name change from `id` (is it worth it?)
