### PR TITLE
[Tests] Use KeyPair from jormungandr-libs

### DIFF
--- a/jormungandr-integration-tests/src/common/data/keys.rs
+++ b/jormungandr-integration-tests/src/common/data/keys.rs
@@ -1,5 +1,0 @@
-#[derive(Debug)]
-pub struct KeyPair {
-    pub private_key: String,
-    pub public_key: String,
-}

--- a/jormungandr-integration-tests/src/common/data/mod.rs
+++ b/jormungandr-integration-tests/src/common/data/mod.rs
@@ -1,3 +1,2 @@
 pub mod address;
-pub mod keys;
 pub mod witness;

--- a/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -6,7 +6,7 @@ use crate::common::{
         secret_model::SecretModel,
     },
     file_utils, jcli_wrapper,
-    startup::build_genesis_block,
+    startup::{build_genesis_block, create_new_key_pair},
 };
 
 pub struct ConfigurationBuilder {

--- a/jormungandr-integration-tests/src/common/startup/mod.rs
+++ b/jormungandr-integration-tests/src/common/startup/mod.rs
@@ -1,14 +1,11 @@
 use crate::common::{
     configuration::genesis_model::GenesisYaml,
-    data::{
-        address::{Account, AddressDataProvider, Delegation, Utxo},
-        keys::KeyPair,
-    },
+    data::address::{Account, AddressDataProvider, Delegation, Utxo},
     file_utils, jcli_wrapper,
 };
-
 use chain_addr::Discrimination;
-use jormungandr_lib::interfaces::UTxOInfo;
+use chain_crypto::AsymmetricKey;
+use jormungandr_lib::{crypto::key::KeyPair, interfaces::UTxOInfo};
 use std::path::PathBuf;
 
 pub fn get_genesis_block_hash(genesis_yaml: &GenesisYaml) -> String {
@@ -72,13 +69,8 @@ pub fn create_new_delegation_address_for(delegation_public_key: &str) -> Delegat
     utxo_with_delegation
 }
 
-pub fn create_new_key_pair(key_type: &str) -> KeyPair {
-    let private_key = jcli_wrapper::assert_key_generate(&key_type);
-    let public_key = jcli_wrapper::assert_key_to_public_default(&private_key);
-    KeyPair {
-        private_key,
-        public_key,
-    }
+pub fn create_new_key_pair<K: AsymmetricKey>() -> KeyPair<K> {
+    KeyPair::generate(&mut rand::rngs::OsRng::new().unwrap())
 }
 
 pub fn get_utxo_for_address<T: AddressDataProvider>(

--- a/jormungandr-integration-tests/src/jcli/certificate/e2e.rs
+++ b/jormungandr-integration-tests/src/jcli/certificate/e2e.rs
@@ -1,41 +1,38 @@
-use crate::common::file_assert;
-use crate::common::file_utils;
-use crate::common::jcli_wrapper;
-use crate::common::jcli_wrapper::certificate::wrapper::JCLICertificateWrapper;
+use crate::common::{
+    file_assert, file_utils, jcli_wrapper::certificate::wrapper::JCLICertificateWrapper,
+    startup::create_new_key_pair,
+};
+
+use chain_crypto::{Curve25519_2HashDH, Ed25519, SumEd25519_12};
 
 #[test]
 pub fn test_create_and_sign_new_stake_delegation() {
-    let owner_private_key = jcli_wrapper::assert_key_generate_default();
-    let owner_public_key = jcli_wrapper::assert_key_to_public_default(&owner_private_key);
-
-    let kes_private_key = jcli_wrapper::assert_key_generate("SumEd25519_12");
-    let kes_public_key = jcli_wrapper::assert_key_to_public_default(&kes_private_key);
-
-    let vrf_private_key = jcli_wrapper::assert_key_generate("Curve25519_2HashDH");
-    let vrf_public_key = jcli_wrapper::assert_key_to_public_default(&vrf_private_key);
+    let owner = create_new_key_pair::<Ed25519>();
+    let kes = create_new_key_pair::<SumEd25519_12>();
+    let vrf = create_new_key_pair::<Curve25519_2HashDH>();
 
     let serial_id = "13919597664319319060838570079442950054";
 
     let certificate_wrapper = JCLICertificateWrapper::new();
     let certificate = certificate_wrapper.assert_new_stake_pool_registration(
-        &kes_public_key,
+        &kes.identifier().to_bech32_str(),
         &serial_id,
-        &vrf_public_key,
+        &vrf.identifier().to_bech32_str(),
         0,
         1,
-        &owner_public_key,
+        &owner.identifier().to_bech32_str(),
     );
 
     let input_file = file_utils::create_file_in_temp("certificate", &certificate);
     let stake_pool_id = certificate_wrapper.assert_get_stake_pool_id(&input_file);
-    let certificate =
-        certificate_wrapper.assert_new_stake_delegation(&stake_pool_id, &owner_public_key);
+    let certificate = certificate_wrapper
+        .assert_new_stake_delegation(&stake_pool_id, &owner.identifier().to_bech32_str());
 
     assert_ne!(certificate, "", "delegation cert is empty");
 
     let signed_cert = file_utils::get_path_in_temp("signed_cert");
     let owner_private_key_file =
-        file_utils::create_file_in_temp("owner.private", &owner_private_key);
+        file_utils::create_file_in_temp("owner.private", &owner.signing_key().to_bech32_str());
 
     certificate_wrapper.assert_sign(&owner_private_key_file, &input_file, &signed_cert);
 

--- a/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
@@ -11,6 +11,7 @@ use crate::common::{
 };
 
 use chain_addr::Discrimination;
+use chain_crypto::{Curve25519_2HashDH, SumEd25519_12};
 use jormungandr_lib::{crypto::hash::Hash, interfaces::Value};
 use std::str::FromStr;
 
@@ -65,10 +66,8 @@ pub fn create_new_stake_pool(
     genesis_block_hash: &str,
     jormungandr_rest_address: &str,
 ) -> String {
-    let kes_secret_key = jcli_wrapper::assert_key_generate("Curve25519_2HashDH");
-    let kes_public_key = jcli_wrapper::assert_key_to_public_default(&kes_secret_key);
-    let vrf_secret_key = jcli_wrapper::assert_key_generate("SumEd25519_12");
-    let vrf_public_key = jcli_wrapper::assert_key_to_public_default(&vrf_secret_key);
+    let kes = startup::create_new_key_pair::<Curve25519_2HashDH>();
+    let vrf = startup::create_new_key_pair::<SumEd25519_12>();
 
     let owner_stake_key =
         file_utils::create_file_in_temp("stake_key.private_key", &account.private_key);
@@ -80,9 +79,9 @@ pub fn create_new_stake_pool(
     let certificate_wrapper = JCLICertificateWrapper::new();
 
     let stake_pool_certificate = certificate_wrapper.assert_new_stake_pool_registration(
-        &vrf_public_key,
+        &vrf.identifier().to_bech32_str(),
         node_id,
-        &kes_public_key,
+        &kes.identifier().to_bech32_str(),
         0u32,
         1u32,
         &account.public_key,


### PR DESCRIPTION
Remove duplicated KeyPair from `jormungandr-integration-tests` project and use KeyPair from `jormungandr-scenario-tests`. This will simplify code and can have positive impact on test speed (since private/public key generation is time consuming operation). Key and Address generation tests are not affected since there are meant to test jcli