### PR TITLE
Implement a custom policy object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,9 +2346,9 @@ checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
 name = "poldercast"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3522a4768c86cabd46f4ba4d4abe06d79ab94babb8228ece627d4f14654bf4"
+checksum = "6b2bea90465325528b27fe4d500f7fa01cf8d1bc5e3e28fddaeefb91d1050cea"
 dependencies = [
  "hex 0.4.0",
  "multiaddr",

--- a/doc/concepts/network.md
+++ b/doc/concepts/network.md
@@ -9,7 +9,7 @@ chapter already: [go to REST documentation](../quickstart/03_rest_api.md)
 # The protocol
 
 The protocol is based on commonly used in the industry tools: HTTP/2 and RPC.
-More precisely, Jörmungandr utilises [`gRPC`](https://www.grpc.io).
+More precisely, Jörmungandr utilises [`gRPC`].
 
 This choice has been made for it is already widely supported across the world,
 it is utilising HTTP/2 which makes it easier for Proxy and Firewall to recognise
@@ -31,26 +31,110 @@ Another type of messages is the `Gossip` message. It allows Nodes to exchange
 information (gossips) about other nodes on the network, allowing the peer
 discovery.
 
-## Peer discovery
+## Peer to peer
 
-Peer discovery is done via [`Poldercast`](https://hal.inria.fr/hal-01555561/document)'s Peer to Peer (P2P) topology
-construction. The idea is to allow the node to participate actively into
-building the decentralized topology of the p2p network.
+The peer 2 peer connections are established utilising multiple components:
 
-This is done through gossiping. This is the process of sharing with others
-topology information: who is on the network, how to reach them and what are
-they interested about.
+* A multilayered topology (e.g. [Poldercast]);
+* Gossiping for node discoverability;
+* Subscription mechanism for event propagation;
+* Security and countermeasures: (such as Topology Policy for scoring and/or
+  blacklisting nodes);
 
-In the poldercast paper there are 3 different modules implementing 3 different
-strategies to select nodes to gossip to and to select the gossiping data:
+### Multilayered topology
 
-1. Cyclon: this module is responsible to add a bit of randomness in the gossiping
-   strategy. It also prevent nodes to be left behind, favouring contacting Nodes
-   we have the least used;
-2. Vicinity: this module helps with building an interest-induced links between
-   the nodes of the topology. Making sure that nodes that have common interests
-   are often in touch.
-3. Rings: this module create an oriented list of nodes. It is an arbitrary way to
-   link the nodes in the network. For each topics, the node will select a set of
-   close nodes.
+Just as described in the [Poldercast] paper we allow for our network topology
+to be built on multiple layers, behaving slightly differently and allowing for
+better granular control. In practice it means the node will have different
+group of nodes it connects to based on different algorithms, each of these
+groups being a subset of the whole known list of nodes.
 
+In short we have:
+
+* The rings layer, which select a predecessor(s) and a successor(s) for each
+  topic (Fragment or Blocks);
+* The Vicinity layer, will select nodes we are close to in terms of interests;
+* The Cyclon layer, will select nodes randomly.
+
+However, we keep the option open to remove some of these layers or to add new
+ones, such as:
+
+* A layer to allow privilege connections between stake pools;
+* A layer for the user's whitelist, a list of nodes the users considered
+  trustworthy and that we could use to check in the current state of the
+  network and verify the user's node is not within a long running fork;
+
+### Gossiping
+
+Gossiping is the process used for peer discovery. It allows two things:
+
+1. For any nodes to advertise themselves as discoverable;
+2. To discover new nodes via exchanging a list of nodes (gossips);
+
+The gossips are selected by the different layers of the multilayered topology.
+For the Poldercast modules, the gossips are selected just as in the paper.
+Additional modules may select new nodes in the gossip list or may decide to
+not add any new information.
+
+### Subscription mechanism
+
+Based on the multilayered topology, the node will open multiplexed and
+bi-directional connections (thanks to industry standard [`gRPC`], this comes for
+free). These bi-directional connections are used to propagate events such as:
+
+* Gossiping events, when 2 nodes exchange gossips for peer discovery;
+* Fragment events, when a node wants to propagate a new fragment to other nodes;
+* Block events, when a node wants to propagate a new block creation event
+
+
+### Security and countermeasures
+
+In order to facilitate the handling of unreachable nodes or of misbehaving ones
+we have built a node policy tooling. This is constructed via 2 mechanisms:
+collecting connectivity statuses and blockchain status for each node. The policy
+can then be tuned over the collected data to apply some parameters when
+connecting to a given node, as well as banning nodes from our topology.
+
+For each node, the following data is collected:
+
+Connection statuses:
+
+* The failed connection attempts and when it happened;
+* Latency
+* Last message used per topic item (last time a fragment has been received from
+  that node, last time a block has been received from that node…)
+
+Blockchain level info:
+
+* Faults (e.g. trying to send an invalid block)
+* Contributions in the network
+* Their blockchain status (e.g. tips)
+
+### Policy
+
+The p2p policy provides some more fine control on how to handle nodes flagged
+as not behaving as expected (see the list of data collected).
+
+It currently works as a 3 levels: possible contact, quarantined, forgotten.
+Each new gossip will create a new entry in the list of possible contact. Then
+the policy, based on the logged data associated to this node, may decide to put
+this node in quarantine for a certain amount of time. At the end of this time
+the node may decide one of the following: keep it quarantined, make it a
+possible contact again or forget about it.
+
+The changes from one level to another is best effort only. Applying the policy
+may be costly so the node applies the policy only on the node it is interested
+about (a gossip update or when reporting an issue against a node). This
+guarantees that the node does not spend too much time policing its database.
+And it also makes sure that only the nodes of interest are up to date. However
+it is possible for the node to choose, at a convenient time, to policy the whole
+p2p database. This is not enforced by the protocol.
+
+| Disposition | Description |
+|:------------|:------------|
+| available   | Node is available for the p2p topology for view selection and gossips. |
+| quarantined | Node is not available for the p2p topology for view selection or gossips. After a certain amount of time, if the node is still being gossiped about, it will be moved to available. |
+| forgotten   | A node forgotten is simply removed from the whole p2p database. However, if the node is still being gossiped about it will be added back as available and the process will start again. |
+
+[Poldercast]: https://hal.inria.fr/hal-01555561/document
+[`gRPC`]: https://www.grpc.io

--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -39,6 +39,10 @@ p2p:
     typical settings for a non mining node: `"normal"`. For a stakepool: `"high"`.
 - `max_connections`: the maximum number of P2P connections this node should
     maintain. If not specified, an internal limit is used by default.
+- `policy`: (optional) set the setting for the policy module
+    - `quarantine_duration` set the time to leave a node in quarantine before allowing
+    it back (or not) into the fold.
+    It is recommended to leave the default value `[default: 30min]`.
 
 ### The trusted peers
 

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -37,7 +37,7 @@ linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = "0.9.3"
+poldercast = "0.9.5"
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -122,6 +122,7 @@ impl GlobalState {
     ) -> Self {
         let mut topology = P2pTopology::new(config.profile.clone(), logger.clone());
         topology.set_poldercast_modules();
+        topology.set_policy(config.policy.clone());
 
         // inject the trusted peers as initial gossips, this will make the node
         // gossip with them at least at the beginning

--- a/jormungandr/src/network/p2p/mod.rs
+++ b/jormungandr/src/network/p2p/mod.rs
@@ -2,11 +2,13 @@ pub mod comm;
 mod gossip;
 mod id;
 mod node;
+mod policy;
 mod topology;
 
 pub use self::gossip::{Gossip, Gossips};
 pub use self::id::Id;
 pub use self::node::Node;
+pub use self::policy::{Policy, PolicyConfig};
 pub use self::topology::P2pTopology;
 
 /**

--- a/jormungandr/src/network/p2p/policy.rs
+++ b/jormungandr/src/network/p2p/policy.rs
@@ -1,0 +1,79 @@
+use jormungandr_lib::time::Duration;
+use poldercast::{Node, PolicyReport};
+use serde::{Deserialize, Serialize};
+use slog::Logger;
+
+/// default quarantine duration is 30min
+const DEFAULT_QUARANTINE_DURATION: std::time::Duration = std::time::Duration::from_secs(1800);
+
+/// This is the P2P policy. Right now it is very similar to the default policy
+/// defined in `poldercast` crate.
+///
+#[derive(Debug, Clone)]
+pub struct Policy {
+    quarantine_duration: std::time::Duration,
+
+    logger: Logger,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct PolicyConfig {
+    quarantine_duration: Duration,
+}
+
+impl Policy {
+    pub fn new(pc: PolicyConfig, logger: Logger) -> Self {
+        Self {
+            quarantine_duration: pc.quarantine_duration.into(),
+            logger,
+        }
+    }
+}
+
+impl Default for PolicyConfig {
+    fn default() -> Self {
+        Self {
+            quarantine_duration: Duration::from(DEFAULT_QUARANTINE_DURATION),
+        }
+    }
+}
+
+impl poldercast::Policy for Policy {
+    fn check(&mut self, node: &mut Node) -> PolicyReport {
+        let id = node.id().to_string();
+        let logger = self.logger.new(o!("id" => id));
+
+        // if the node is already quarantined
+        if let Some(since) = node.logs().quarantined() {
+            let duration = since.elapsed().unwrap();
+
+            if duration < self.quarantine_duration {
+                // the node still need to do some quarantine time
+                PolicyReport::None
+            } else if node.logs().last_update().elapsed().unwrap() < self.quarantine_duration {
+                // the node has been quarantined long enough, check if it has been updated
+                // while being quarantined (i.e. the node is still up and advertising itself
+                // or others are still gossiping about it.)
+
+                // the fact that this `Policy` does clean the records is a policy choice.
+                // one could prefer to keep the record longers for future `check`.
+                node.record_mut().clean_slate();
+                debug!(logger, "lifting quarantine");
+                PolicyReport::LiftQuarantine
+            } else {
+                // it appears the node was quarantine and is no longer active or gossiped
+                // about, so we can forget it
+                debug!(logger, "forgetting about the node");
+                PolicyReport::Forget
+            }
+        } else if node.record().is_clear() {
+            // if the record is clear, do nothing, leave the Node in the available nodes
+            PolicyReport::None
+        } else {
+            // if the record is not `clear` then we quarantine the block for some time
+            debug!(logger, "move node to quarantine");
+            PolicyReport::Quarantine
+        }
+    }
+}

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -1,7 +1,7 @@
 //! module defining the p2p topology management objects
 //!
 
-use crate::network::p2p::{Gossips, Id, Node};
+use crate::network::p2p::{Gossips, Id, Node, Policy, PolicyConfig};
 use poldercast::{
     poldercast::{Cyclon, Rings, Vicinity},
     Layer, NodeProfile, PolicyReport, StrikeReason, Topology,
@@ -36,6 +36,11 @@ impl P2pTopology {
             module.alias()
         );
         topology.add_layer(module)
+    }
+
+    pub fn set_policy(&mut self, policy: PolicyConfig) {
+        let mut topology = self.lock.write().unwrap();
+        topology.set_policy(Policy::new(policy, self.logger.new(o!("task" => "policy"))));
     }
 
     /// set all the default poldercast modules (Rings, Vicinity and Cyclon)

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -1,5 +1,5 @@
 use crate::{
-    network::p2p::{topic, Id},
+    network::p2p::{topic, Id, PolicyConfig},
     settings::logging::{LogFormat, LogOutput},
     settings::LOG_FILTER_LEVEL_POSSIBLE_VALUES,
 };
@@ -97,6 +97,10 @@ pub struct P2pConfig {
     /// The default is to not allow advertising non-public IP addresses.
     #[serde(default)]
     pub allow_private_addresses: bool,
+
+    /// setting for the policy
+    #[serde(default)]
+    pub policy: PolicyConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -156,6 +160,7 @@ impl Default for P2pConfig {
             topics_of_interest: None,
             max_connections: None,
             allow_private_addresses: false,
+            policy: PolicyConfig::default(),
         }
     }
 }

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -226,6 +226,7 @@ fn generate_network(
             .map(Into::into)
             .collect(),
         protocol: Protocol::Grpc,
+        policy: p2p.policy.clone(),
         max_connections: p2p
             .max_connections
             .unwrap_or(network::DEFAULT_MAX_CONNECTIONS),

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -1,4 +1,4 @@
-use crate::network::p2p::Id;
+use crate::network::p2p::{Id, PolicyConfig};
 use poldercast::NodeProfile;
 use std::{net::SocketAddr, str, time::Duration};
 
@@ -61,6 +61,8 @@ pub struct Configuration {
 
     /// the default value for the timeout for inactive connection
     pub timeout: Duration,
+
+    pub policy: PolicyConfig,
 
     /// Whether to allow non-public IP addresses in gossip
     pub allow_private_addresses: bool,


### PR DESCRIPTION
This PR creates a custom policy algorithm in the node. Previously we were utilising the default one provided in the `poldercast` crate.

Also update the documentation and the associated component to explain p2p, gossiping and how the policy is applied on all of this.