### PR TITLE
update chain-deps to have support for ratio delegation

### DIFF
--- a/jcli/src/jcli_app/certificate/new_stake_delegation.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_delegation.rs
@@ -1,4 +1,5 @@
 use chain_crypto::{Ed25519, PublicKey};
+use chain_impl_mockchain::account::DelegationType;
 use chain_impl_mockchain::certificate::{Certificate, StakeDelegation as Delegation};
 use chain_impl_mockchain::transaction::AccountIdentifier;
 use jcli_app::certificate::{write_cert, Error};
@@ -25,7 +26,7 @@ impl StakeDelegation {
     pub fn exec(self) -> Result<(), Error> {
         let content = Delegation {
             account_id: AccountIdentifier::from_single_account(self.stake_id.into()),
-            pool_id: self.pool_id.into(),
+            delegation: DelegationType::Full(self.pool_id.into()),
         };
         let cert = Certificate::StakeDelegation(content);
         write_cert(

--- a/jormungandr-lib/src/interfaces/account_state.rs
+++ b/jormungandr-lib/src/interfaces/account_state.rs
@@ -23,7 +23,7 @@ impl From<account::DelegationType> for DelegationType {
             },
             account::DelegationType::Ratio(v) => DelegationType {
                 pools: v
-                    .pools
+                    .pools()
                     .iter()
                     .map(|(h, pp)| (h.clone().into(), *pp))
                     .collect(),
@@ -43,14 +43,14 @@ impl From<DelegationType> for account::DelegationType {
             match v.try_into() {
                 Err(_) => panic!("delegation type pool overflow"),
                 Ok(parts) => {
-                    let ratio = account::DelegationRatio {
+                    let ratio = account::DelegationRatio::new(
                         parts,
-                        pools: dt
-                            .pools
+                        dt.pools()
                             .iter()
                             .map(|(h, pp)| (h.into_digest_of(), *pp))
                             .collect(),
-                    };
+                    )
+                    .expect("Assume this is always correct for a delegation type");
                     account::DelegationType::Ratio(ratio)
                 }
             }

--- a/jormungandr-scenario-tests/src/wallet/account.rs
+++ b/jormungandr-scenario-tests/src/wallet/account.rs
@@ -78,7 +78,7 @@ impl Wallet {
     pub fn delegation_cert_for_block0(&self, pool_id: PoolId) -> SignedCertificate {
         let stake_delegation = StakeDelegation {
             account_id: self.stake_key(), // 2
-            pool_id,                      // 1
+            delegation: chain_impl_mockchain::account::DelegationType::Full(pool_id), // 1
         };
         let txb = TxBuilder::new()
             .set_payload(&stake_delegation)

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -471,8 +471,21 @@ impl StakeDelegation {
             .map(|addr| Address::from(&addr))
     }
 
-    pub fn pool(&self, context: &Context) -> Pool {
-        Pool::from_valid_id(self.delegation.pool_id.clone())
+    pub fn pool(&self, context: &Context) -> Vec<Pool> {
+        use chain_impl_mockchain::account::DelegationType;
+        use std::iter::FromIterator as _;
+
+        match self.delegation.get_delegation_type() {
+            DelegationType::NonDelegated => vec![],
+            DelegationType::Full(id) => vec![Pool::from_valid_id(id.clone())],
+            DelegationType::Ratio(delegation_ratio) => Vec::from_iter(
+                delegation_ratio
+                    .pools()
+                    .iter()
+                    .cloned()
+                    .map(|(p, _)| Pool::from_valid_id(p)),
+            ),
+        }
     }
 }
 
@@ -542,8 +555,21 @@ impl From<certificate::OwnerStakeDelegation> for OwnerStakeDelegation {
     Context = Context,
 )]
 impl OwnerStakeDelegation {
-    fn pool(&self) -> Pool {
-        Pool::from_valid_id(self.owner_stake_delegation.pool_id.clone())
+    fn pool(&self) -> Vec<Pool> {
+        use chain_impl_mockchain::account::DelegationType;
+        use std::iter::FromIterator as _;
+
+        match self.owner_stake_delegation.get_delegation_type() {
+            DelegationType::NonDelegated => vec![],
+            DelegationType::Full(id) => vec![Pool::from_valid_id(id.clone())],
+            DelegationType::Ratio(delegation_ratio) => Vec::from_iter(
+                delegation_ratio
+                    .pools()
+                    .iter()
+                    .cloned()
+                    .map(|(p, _)| Pool::from_valid_id(p)),
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
Breaking change in the explorer GraphQL API as we now expose a list of pool id instead of only one pool id for the delegation. Empty if no delegation