### PR TITLE
regenerate grpc port after unsuccessful jormungandr bootstrap

### DIFF
--- a/jormungandr-integration-tests/src/common/configuration/node_config_model.rs
+++ b/jormungandr-integration-tests/src/common/configuration/node_config_model.rs
@@ -72,6 +72,11 @@ impl NodeConfig {
             level: Some("info".to_string()),
             format: Some("json".to_string()),
         }]);
+        let grpc_address = format!(
+            "/ip4/{}/tcp/{}",
+            DEFAULT_HOST,
+            public_address_port.to_string()
+        );
 
         NodeConfig {
             storage: Some(String::from(storage_file.as_os_str().to_str().unwrap())),
@@ -81,17 +86,9 @@ impl NodeConfig {
             }),
             p2p: Peer2Peer {
                 trusted_peers: None,
-                public_address: format!(
-                    "/ip4/{}/tcp/{}",
-                    DEFAULT_HOST,
-                    public_address_port.to_string()
-                ),
+                public_address: grpc_address.clone(),
                 public_id: public_id.to_string(),
-                listen_address: format!(
-                    "/ip4/{}/tcp/{}",
-                    DEFAULT_HOST,
-                    public_address_port.to_string()
-                ),
+                listen_address: grpc_address.clone(),
                 topics_of_interest: TopicsOfInterest {
                     messages: String::from("high"),
                     blocks: String::from("high"),
@@ -120,6 +117,7 @@ impl NodeConfig {
             "/ip4/127.0.0.1/tcp/{}",
             super::get_available_port().to_string()
         );
+        self.p2p.listen_address = self.p2p.public_address.clone();
     }
 
     pub fn get_node_address(&self) -> String {

--- a/jormungandr-integration-tests/src/common/jormungandr/logger.rs
+++ b/jormungandr-integration-tests/src/common/jormungandr/logger.rs
@@ -87,6 +87,15 @@ impl JormungandrLogger {
         println!("{}", self.get_log_content());
     }
 
+    pub fn contains_any_of_messages(&self, messages: &[&str]) -> Result<bool, LoggerError> {
+        for message in messages {
+            if self.contains_message(message)? == true {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     pub fn contains_message(&self, message: &str) -> Result<bool, LoggerError> {
         self.verify_file_exists()?;
         Ok(self.get_log_entries().any(|x| x.msg.contains(message)))

--- a/jormungandr-integration-tests/src/common/jormungandr/logger.rs
+++ b/jormungandr-integration-tests/src/common/jormungandr/logger.rs
@@ -87,9 +87,9 @@ impl JormungandrLogger {
         println!("{}", self.get_log_content());
     }
 
-    pub fn contains_any_of_messages(&self, messages: &[&str]) -> Result<bool, LoggerError> {
+    pub fn raw_log_contains_any_of(&self, messages: &[&str]) -> Result<bool, LoggerError> {
         for message in messages {
-            if self.contains_message(message)? == true {
+            if self.get_log_content().contains(message) {
                 return Ok(true);
             }
         }

--- a/jormungandr-integration-tests/src/common/jormungandr/starter.rs
+++ b/jormungandr-integration-tests/src/common/jormungandr/starter.rs
@@ -234,9 +234,9 @@ impl Starter {
 
     fn custom_errors_found(&self) -> Result<(), StartupError> {
         let logger = JormungandrLogger::new(self.config.log_file_path.clone());
-        //Can not resume socket accept process: The parameter is incorrect. (os error 87)
+        let port_occupied_msgs = ["error 87", "thread 'network0' panicked at 'Box<Any>'"];
         match logger
-            .contains_message("error 87")
+            .contains_any_of_messages(&port_occupied_msgs)
             .unwrap_or_else(|_| false)
         {
             true => Err(StartupError::PortAlreadyInUse),

--- a/jormungandr-integration-tests/src/common/jormungandr/starter.rs
+++ b/jormungandr-integration-tests/src/common/jormungandr/starter.rs
@@ -234,9 +234,9 @@ impl Starter {
 
     fn custom_errors_found(&self) -> Result<(), StartupError> {
         let logger = JormungandrLogger::new(self.config.log_file_path.clone());
-        let port_occupied_msgs = ["error 87", "thread 'network0' panicked at 'Box<Any>'"];
+        let port_occupied_msgs = ["error 87", "panicked at 'Box<Any>'"];
         match logger
-            .contains_any_of_messages(&port_occupied_msgs)
+            .raw_log_contains_any_of(&port_occupied_msgs)
             .unwrap_or_else(|_| false)
         {
             true => Err(StartupError::PortAlreadyInUse),


### PR DESCRIPTION
After brief search of the jormungandr logs, looks like in some test grpc listen port was reused across tests. I've added its regeneration after first unsuccessful bootstrap