### PR TITLE
add default custom modules to handle unreachable nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
- "poldercast 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1509,7 +1509,7 @@ dependencies = [
  "jormungandr-lib 0.7.0-rc5",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1570,7 +1570,7 @@ dependencies = [
  "jormungandr-lib 0.7.0-rc5",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2152,7 +2152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "poldercast"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4165,7 +4165,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum platforms 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
-"checksum poldercast 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6b2bea90465325528b27fe4d500f7fa01cf8d1bc5e3e28fddaeefb91d1050cea"
+"checksum poldercast 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c3551900c513e7c2d98758f28cb22cb533a4adbcedd5f21e21215f0a3d917db4"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -37,7 +37,7 @@ linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = "0.9.5"
+poldercast = "0.9.6"
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -37,7 +37,7 @@ linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = "0.9.6"
+poldercast = "0.9.7"
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -117,6 +117,7 @@ impl GlobalState {
     ) -> Self {
         let mut topology = P2pTopology::new(config.profile.clone(), logger.clone());
         topology.set_poldercast_modules();
+        topology.set_custom_modules();
         topology.set_policy(config.policy.clone());
 
         // inject the trusted peers as initial gossips, this will make the node

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -3,6 +3,7 @@
 
 use crate::network::p2p::{Gossips, Id, Node, Policy, PolicyConfig};
 use poldercast::{
+    custom_layers,
     poldercast::{Cyclon, Rings, Vicinity},
     Layer, NodeProfile, PolicyReport, StrikeReason, Topology,
 };
@@ -49,6 +50,11 @@ impl P2pTopology {
         topology.add_layer(Rings::default());
         topology.add_layer(Vicinity::default());
         topology.add_layer(Cyclon::default());
+    }
+
+    pub fn set_custom_modules(&mut self) {
+        let mut topology = self.lock.write().unwrap();
+        topology.add_layer(custom_layers::RandomDirectConnections::default());
     }
 
     /// Returns a list of neighbors selected in this turn


### PR DESCRIPTION
this update latest version of `poldercast` to handle unreachable nodes in a slightly different way. Poldercast allow for connecting to reachable nodes. But unreachable nodes connected to the node are still handle separately to allow for better propagation of events