### PR TITLE
Fix blocks in epoch first cursor not being 0

### DIFF
--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -783,7 +783,7 @@ impl Epoch {
             .wait()?;
 
         let boundaries = PaginationInterval::Inclusive(InclusivePaginationInterval {
-            lower_bound: epoch_lower_bound,
+            lower_bound: 0,
             upper_bound: epoch_upper_bound
                 .checked_sub(epoch_lower_bound)
                 .expect("pagination upper_bound to be greater or equal than lower_bound"),


### PR DESCRIPTION
*May* be the cause of #1093. It could be a different thing, but I could "reproduce" in this query (blocks in epoch).