### PR TITLE
breaking change: add pool permission + operators

### DIFF
--- a/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
@@ -34,7 +34,7 @@ pub struct StakePoolRegistration {
     #[structopt(
         long = "operators",
         name = "OPERATOR_KEY",
-        parse(try_from_str = "parse_pub_key"),
+        parse(try_from_str = "parse_pub_key")
     )]
     pub operators: Vec<PublicKey<Ed25519>>,
     /// Public key of the block signing key
@@ -71,7 +71,8 @@ impl StakePoolRegistration {
             },
         };
 
-        if self.management_threshold == 0 || self.management_threshold as usize > self.owners.len() {
+        if self.management_threshold == 0 || self.management_threshold as usize > self.owners.len()
+        {
             return Err(Error::ManagementThresholdInvalid {
                 got: self.management_threshold as usize,
                 max_expected: self.owners.len(),

--- a/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
@@ -25,7 +25,7 @@ pub struct StakePoolRegistration {
     /// public key of the owner(s)
     #[structopt(
         long = "owner",
-        name = "PUBLIC_KEY",
+        name = "OWNER_KEY",
         parse(try_from_str = "parse_pub_key"),
         required = true
     )]
@@ -33,9 +33,8 @@ pub struct StakePoolRegistration {
     /// public key of the operators(s)
     #[structopt(
         long = "operators",
-        name = "PUBLIC_KEY",
+        name = "OPERATOR_KEY",
         parse(try_from_str = "parse_pub_key"),
-        required = true
     )]
     pub operators: Vec<PublicKey<Ed25519>>,
     /// Public key of the block signing key
@@ -72,7 +71,7 @@ impl StakePoolRegistration {
             },
         };
 
-        if self.management_threshold as usize > self.owners.len() {
+        if self.management_threshold == 0 || self.management_threshold as usize > self.owners.len() {
             return Err(Error::ManagementThresholdInvalid {
                 got: self.management_threshold as usize,
                 max_expected: self.owners.len(),

--- a/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
@@ -32,7 +32,7 @@ pub struct StakePoolRegistration {
     pub owners: Vec<PublicKey<Ed25519>>,
     /// public key of the operators(s)
     #[structopt(
-        long = "operators",
+        long = "operator",
         name = "OPERATOR_KEY",
         parse(try_from_str = "parse_pub_key")
     )]

--- a/jcli/src/jcli_app/certificate/sign.rs
+++ b/jcli/src/jcli_app/certificate/sign.rs
@@ -1,6 +1,6 @@
 use chain_crypto::{Ed25519, PublicKey};
 use chain_impl_mockchain::certificate::{
-    Certificate, PoolOwnersSigned, PoolRegistration, SignedCertificate, StakeDelegation,
+    Certificate, PoolOwnersSigned, PoolSignature, PoolRegistration, SignedCertificate, StakeDelegation,
 };
 use chain_impl_mockchain::key::EitherEd25519SecretKey;
 use chain_impl_mockchain::transaction::{
@@ -54,19 +54,19 @@ impl Sign {
                 let sclone = s.clone();
                 let txbuilder = Transaction::block0_payload_builder(&s);
                 pool_owner_sign(s, Some(&sclone), &keys_str, txbuilder, |c, a| {
-                    SignedCertificate::PoolRegistration(c, a)
+                    SignedCertificate::PoolRegistration(c, PoolSignature::Owners(a))
                 })?
             }
             Certificate::PoolRetirement(s) => {
                 let txbuilder = Transaction::block0_payload_builder(&s);
                 pool_owner_sign(s, None, &keys_str, txbuilder, |c, a| {
-                    SignedCertificate::PoolRetirement(c, a)
+                    SignedCertificate::PoolRetirement(c, PoolSignature::Owners(a))
                 })?
             }
             Certificate::PoolUpdate(s) => {
                 let txbuilder = Transaction::block0_payload_builder(&s);
                 pool_owner_sign(s, None, &keys_str, txbuilder, |c, a| {
-                    SignedCertificate::PoolUpdate(c, a)
+                    SignedCertificate::PoolUpdate(c, PoolSignature::Owners(a))
                 })?
             }
             Certificate::OwnerStakeDelegation(_) => {
@@ -123,12 +123,12 @@ where
         .collect();
     let keys = keys?;
 
-    let keys: Vec<(u16, &EitherEd25519SecretKey)> = match mreg {
+    let keys: Vec<(u8, &EitherEd25519SecretKey)> = match mreg {
         None => {
             // here we don't know the order of things, so just assume sequential index from 0
             keys.iter()
                 .enumerate()
-                .map(|(i, k)| (i as u16, k))
+                .map(|(i, k)| (i as u8, k))
                 .collect()
         }
         Some(reg) => {
@@ -139,7 +139,7 @@ where
                 // look for the owner's index of k
                 match reg.owners.iter().enumerate().find(|(_, p)| *p == &pk) {
                     None => return Err(Error::KeyNotFound { index: isk }),
-                    Some((ipk, _)) => found.push((ipk as u16, k)),
+                    Some((ipk, _)) => found.push((ipk as u8, k)),
                 }
             }
             found

--- a/jcli/src/jcli_app/certificate/sign.rs
+++ b/jcli/src/jcli_app/certificate/sign.rs
@@ -1,6 +1,7 @@
 use chain_crypto::{Ed25519, PublicKey};
 use chain_impl_mockchain::certificate::{
-    Certificate, PoolOwnersSigned, PoolSignature, PoolRegistration, SignedCertificate, StakeDelegation,
+    Certificate, PoolOwnersSigned, PoolRegistration, PoolSignature, SignedCertificate,
+    StakeDelegation,
 };
 use chain_impl_mockchain::key::EitherEd25519SecretKey;
 use chain_impl_mockchain::transaction::{
@@ -126,10 +127,7 @@ where
     let keys: Vec<(u8, &EitherEd25519SecretKey)> = match mreg {
         None => {
             // here we don't know the order of things, so just assume sequential index from 0
-            keys.iter()
-                .enumerate()
-                .map(|(i, k)| (i as u8, k))
-                .collect()
+            keys.iter().enumerate().map(|(i, k)| (i as u8, k)).collect()
         }
         Some(reg) => {
             //let pks = &reg.owners;

--- a/jcli/src/jcli_app/transaction/staging.rs
+++ b/jcli/src/jcli_app/transaction/staging.rs
@@ -1,7 +1,7 @@
 use chain_addr::Address;
 use chain_impl_mockchain::{
     self as chain,
-    certificate::{Certificate, CertificatePayload, SignedCertificate},
+    certificate::{Certificate, CertificatePayload, PoolSignature, SignedCertificate},
     fee::FeeAlgorithm,
     fragment::Fragment,
     transaction::{
@@ -136,7 +136,7 @@ impl Staging {
                     let pool_reg = Some(&sclone);
                     let builder = self.builder_after_witness(TxBuilder::new().set_payload(&s))?;
                     let sc = pool_owner_sign(s, pool_reg, keys, builder, |p, pos| {
-                        SignedCertificate::PoolRegistration(p, pos)
+                        SignedCertificate::PoolRegistration(p, PoolSignature::Owners(pos))
                     })
                     .map_err(|e| Error::CertificateError { error: e })?;
                     self.extra_authed = Some(sc.into())
@@ -145,7 +145,7 @@ impl Staging {
                     let pool_reg = None; // TODO eventually ask for optional extra registration cert to do a better job
                     let builder = self.builder_after_witness(TxBuilder::new().set_payload(&s))?;
                     let sc = pool_owner_sign(s, pool_reg, keys, builder, |p, pos| {
-                        SignedCertificate::PoolRetirement(p, pos)
+                        SignedCertificate::PoolRetirement(p, PoolSignature::Owners(pos))
                     })
                     .map_err(|e| Error::CertificateError { error: e })?;
                     self.extra_authed = Some(sc.into())
@@ -154,7 +154,7 @@ impl Staging {
                     let pool_reg = None; // TODO eventually ask for optional extra registration cert to do a better job
                     let builder = self.builder_after_witness(TxBuilder::new().set_payload(&s))?;
                     let sc = pool_owner_sign(s, pool_reg, keys, builder, |p, pos| {
-                        SignedCertificate::PoolUpdate(p, pos)
+                        SignedCertificate::PoolUpdate(p, PoolSignature::Owners(pos))
                     })
                     .map_err(|e| Error::CertificateError { error: e })?;
                     self.extra_authed = Some(sc.into())

--- a/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -8,6 +8,7 @@ use crate::{
 use chain_crypto::{Curve25519_2HashDH, Ed25519, SumEd25519_12};
 use chain_impl_mockchain::{
     block::ConsensusVersion,
+    certificate::{PoolSignature, PoolPermissions},
     fee::LinearFee,
     key::EitherEd25519SecretKey,
     rewards::TaxType,
@@ -201,9 +202,10 @@ impl Settings {
                         );
                         let stake_pool_info = PoolRegistration {
                             serial,
-                            management_threshold: 1,
+                            permissions: PoolPermissions::new(1),
                             start_validity: DurationSeconds(0).into(),
                             owners: vec![owner.to_public()],
+                            operators: vec![].into(),
                             rewards: TaxType::zero(),
                             keys: GenesisPraosLeader {
                                 kes_public_key: kes_signing_key.identifier().into_public_key(),
@@ -234,7 +236,7 @@ impl Settings {
                         };
 
                         let stake_pool_registration_certificate =
-                            SignedCertificate::PoolRegistration(stake_pool_info, owner_signed);
+                            SignedCertificate::PoolRegistration(stake_pool_info, PoolSignature::Owners(owner_signed));
 
                         self.block0
                             .initial

--- a/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -8,7 +8,7 @@ use crate::{
 use chain_crypto::{Curve25519_2HashDH, Ed25519, SumEd25519_12};
 use chain_impl_mockchain::{
     block::ConsensusVersion,
-    certificate::{PoolSignature, PoolPermissions},
+    certificate::{PoolPermissions, PoolSignature},
     fee::LinearFee,
     key::EitherEd25519SecretKey,
     rewards::TaxType,
@@ -236,7 +236,10 @@ impl Settings {
                         };
 
                         let stake_pool_registration_certificate =
-                            SignedCertificate::PoolRegistration(stake_pool_info, PoolSignature::Owners(owner_signed));
+                            SignedCertificate::PoolRegistration(
+                                stake_pool_info,
+                                PoolSignature::Owners(owner_signed),
+                            );
 
                         self.block0
                             .initial

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -523,7 +523,7 @@ impl PoolRegistration {
     /// Management threshold for owners, this need to be <= #owners and > 0
     pub fn management_threshold(&self) -> i32 {
         // XXX: u16 fits in i32, but maybe some kind of custom scalar is better?
-        self.registration.management_threshold.into()
+        self.registration.management_threshold().into()
     }
 
     /// Owners of this pool


### PR DESCRIPTION
Add pool operators where the owners can delegate administration operations over pool parameters (e.g. updating the pool cryptographic keys).

no permission are defined, so for now the operator cannot do anything.