### PR TITLE
Simplify Storage::stream_from_to

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -686,13 +686,6 @@ impl Blockchain {
                     .storage
                     .stream_from_to(block0_id_2, head_hash)
                     .map_err(|e| Error::with_chain(e, "Cannot iterate blocks from block0 to HEAD"))
-                    .and_then(|block_stream| {
-                        if let Some(block_stream) = block_stream {
-                            future::ok(block_stream)
-                        } else {
-                            future::err("Cannot iterate between block0 and HEAD".into())
-                        }
-                    })
                     .and_then(move |block_stream| {
                         block_stream
                             .map_err(|e| {

--- a/jormungandr/src/client.rs
+++ b/jormungandr/src/client.rs
@@ -68,8 +68,7 @@ fn handle_get_headers_range(
                  of the requested end block",
             ))),
         })
-        .and_then(move |maybe_stream| {
-            let stream = maybe_stream.unwrap();
+        .and_then(move |stream| {
             // Send headers up to the maximum
             stream
                 .map_err(|e| e.into())
@@ -162,8 +161,7 @@ fn handle_pull_blocks_to_tip(
                  are ancestors of the current tip",
             ))),
         })
-        .and_then(move |maybe_stream| {
-            let stream = maybe_stream.unwrap();
+        .and_then(move |stream| {
             // Send headers up to the maximum
             stream
                 .map_err(|e| e.into())

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -202,12 +202,6 @@ impl ExplorerDB {
                         .map_err(|err| Error::from(err)),
                 ),
             })
-            .and_then(move |stream_option| match stream_option {
-                None => Either::A(future::err(Error::from(ErrorKind::BootstrapError(
-                    "Couldn't iterate from Block0 to HEAD".to_owned(),
-                )))),
-                Some(stream) => Either::B(future::ok(stream)),
-            })
             .and_then(move |stream| {
                 stream
                     .map_err(|err| Error::from(err))


### PR DESCRIPTION
No need for an `Option` in the resolved value if every use treats the not-ancestor case as an error.
Just reuse `StorageError::CannotIterate`.