### PR TITLE
Add old utxo and old address to explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ dependencies = [
  "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cardano-legacy-address 0.1.1",
  "chain-addr 0.1.0",
  "chain-core 0.1.0",
  "chain-crypto 0.1.0",

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -24,6 +24,7 @@ chain-storage   = { path = "../chain-deps/chain-storage" }
 chain-storage-sqlite = { path = "../chain-deps/chain-storage-sqlite" }
 chain-time      = { path = "../chain-deps/chain-time" }
 chain-addr = { path = "../chain-deps/chain-addr" }
+cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }
 imhamt = { path = "../chain-deps/imhamt" }
 custom_error = "1.7"
 error-chain = "0.12"

--- a/jormungandr/src/explorer/graphql/error.rs
+++ b/jormungandr/src/explorer/graphql/error.rs
@@ -20,5 +20,9 @@ error_chain! {
             description("invalid cursor in pagination query"),
             display("invalid cursor in pagination query: {}", msg)
         }
+        InvalidAddress(address: String) {
+            description("failed to parse address"),
+            display("invalid address: {}", address)
+        }
     }
 }

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -6,7 +6,9 @@ use self::connections::{
     TransactionConnection,
 };
 use self::error::ErrorKind;
-use super::indexing::{BlockProducer, EpochData, ExplorerBlock, ExplorerTransaction};
+use super::indexing::{
+    BlockProducer, EpochData, ExplorerAddress, ExplorerBlock, ExplorerTransaction,
+};
 use super::persistent_sequence::PersistentSequence;
 use crate::blockcfg::{self, FragmentId, HeaderHash};
 use chain_impl_mockchain::certificate;
@@ -360,19 +362,21 @@ impl TransactionOutput {
 }
 
 struct Address {
-    id: chain_addr::Address,
+    id: ExplorerAddress,
 }
 
 impl Address {
     fn from_bech32(bech32: &String) -> FieldResult<Address> {
-        Ok(Address {
-            id: chain_addr::AddressReadable::from_string_anyprefix(bech32)?.to_address(),
-        })
+        // TODO: Try to parse legacy address too
+        let addr = ExplorerAddress::New(
+            chain_addr::AddressReadable::from_string_anyprefix(bech32)?.to_address(),
+        );
+        Ok(Address { id: addr })
     }
 }
 
-impl From<&chain_addr::Address> for Address {
-    fn from(addr: &chain_addr::Address) -> Address {
+impl From<&ExplorerAddress> for Address {
+    fn from(addr: &ExplorerAddress) -> Address {
         Address { id: addr.clone() }
     }
 }
@@ -383,8 +387,15 @@ impl From<&chain_addr::Address> for Address {
 impl Address {
     /// The base32 representation of an address
     fn id(&self, context: &Context) -> String {
-        chain_addr::AddressReadable::from_address(&context.settings.address_bech32_prefix, &self.id)
-            .to_string()
+        match &self.id {
+            ExplorerAddress::New(addr) => chain_addr::AddressReadable::from_address(
+                &context.settings.address_bech32_prefix,
+                addr,
+            )
+            .to_string(),
+            // XXX: bech32 here?
+            ExplorerAddress::Old(addr) => format!("{}", addr),
+        }
     }
 
     fn delegation() -> FieldResult<Pool> {
@@ -468,7 +479,7 @@ impl StakeDelegation {
             .map(|single| {
                 chain_addr::Address(discrimination, chain_addr::Kind::Account(single.into()))
             })
-            .map(|addr| Address::from(&addr))
+            .map(|addr| Address::from(&ExplorerAddress::New(addr)))
     }
 
     pub fn pool(&self, context: &Context) -> Vec<Pool> {

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -393,7 +393,6 @@ impl Address {
                 addr,
             )
             .to_string(),
-            // XXX: bech32 here?
             ExplorerAddress::Old(addr) => format!("{}", addr),
         }
     }

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -294,9 +294,13 @@ impl ExplorerTransaction {
                     let tx = utxo_pointer.transaction_id;
                     let index = utxo_pointer.output_index;
 
-                    let block_id = transactions.lookup(&tx).expect("transaction not found for utxo input");
+                    let block_id = transactions
+                        .lookup(&tx)
+                        .expect("transaction not found for utxo input");
 
-                    let block = blocks.lookup(&block_id).expect("transaction not found for utxo input");
+                    let block = blocks
+                        .lookup(&block_id)
+                        .expect("transaction not found for utxo input");
 
                     let output = &block.transactions[&tx].outputs[index as usize];
 

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -294,9 +294,9 @@ impl ExplorerTransaction {
                     let tx = utxo_pointer.transaction_id;
                     let index = utxo_pointer.output_index;
 
-                    let block_id = transactions.lookup(&tx).expect("the input to be validated");
+                    let block_id = transactions.lookup(&tx).expect("transaction not found for utxo input");
 
-                    let block = blocks.lookup(&block_id).expect("the input to be validated");
+                    let block = blocks.lookup(&block_id).expect("transaction not found for utxo input");
 
                     let output = &block.transactions[&tx].outputs[index as usize];
 

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -6,7 +6,8 @@ mod persistent_sequence;
 use self::error::{Error, ErrorKind, Result};
 use self::graphql::Context;
 use self::indexing::{
-    Addresses, Blocks, ChainLengths, EpochData, Epochs, ExplorerBlock, StakePools, Transactions,
+    Addresses, Blocks, ChainLengths, EpochData, Epochs, ExplorerAddress, ExplorerBlock, StakePools,
+    Transactions,
 };
 use self::persistent_sequence::PersistentSequence;
 
@@ -18,7 +19,7 @@ use crate::blockcfg::{
 use crate::blockchain::{Blockchain, Multiverse, MAIN_BRANCH_TAG};
 use crate::intercom::ExplorerMsg;
 use crate::utils::task::{Input, TokioServiceInfo};
-use chain_addr::{Address, Discrimination};
+use chain_addr::Discrimination;
 use chain_core::property::Block as _;
 use chain_impl_mockchain::certificate::{Certificate, PoolId};
 use chain_impl_mockchain::multiverse::GCRoot;
@@ -335,7 +336,7 @@ impl ExplorerDB {
 
     pub fn get_transactions_by_address(
         &self,
-        address: &Address,
+        address: &ExplorerAddress,
     ) -> impl Future<Item = Option<PersistentSequence<FragmentId>>, Error = Infallible> {
         let address = address.clone();
         self.with_latest_state(move |state| state.addresses.lookup(&address).map(|set| set.clone()))

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -4,6 +4,7 @@ extern crate actix_web;
 extern crate bech32;
 extern crate bincode;
 extern crate bytes;
+extern crate cardano_legacy_address;
 extern crate chain_addr;
 extern crate chain_core;
 extern crate chain_crypto;


### PR DESCRIPTION
It's still a bit hacky (the `Hash` implementation), but fixes #1103  

Basically the explorer was not processing `OldUtxoDeclaration` fragments, so it crashed when some transaction tried to use when of those utxos.

With this, every `OldUtxoDeclaration` is mapped to a transaction with no inputs, and one output for every address and the declaration. This also adds support for legacy addresses, which are represented as the same `Address` type in the *graphql* interface.

Open to feedback on whether adding the legacy address crate is the right way.