### PR TITLE
breaking change: add discriminant account signature and reward account

### DIFF
--- a/jcli/src/jcli_app/certificate/new_stake_delegation.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_delegation.rs
@@ -4,7 +4,7 @@ use chain_crypto::{Blake2b256, Ed25519, PublicKey};
 use chain_impl_mockchain::account::{DelegationRatio, DelegationType};
 use chain_impl_mockchain::accounting::account::DELEGATION_RATIO_MAX_DECLS;
 use chain_impl_mockchain::certificate::{Certificate, StakeDelegation as Delegation};
-use chain_impl_mockchain::transaction::AccountIdentifier;
+use chain_impl_mockchain::transaction::UnspecifiedAccountIdentifier;
 use jormungandr_lib::interfaces::Certificate as CertificateType;
 use std::convert::TryFrom;
 use std::error::Error as StdError;
@@ -53,7 +53,7 @@ impl StakeDelegation {
             _ => DelegationType::Ratio(delegation_ratio(&self.pool_ids)?),
         };
         let content = Delegation {
-            account_id: AccountIdentifier::from_single_account(self.stake_id.into()),
+            account_id: UnspecifiedAccountIdentifier::from_single_account(self.stake_id.into()),
             delegation,
         };
         let cert = Certificate::StakeDelegation(content);

--- a/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
@@ -65,6 +65,7 @@ impl StakePoolRegistration {
             permissions: PoolPermissions::new(self.management_threshold),
             start_validity: DurationSeconds::from(self.start_validity).into(),
             rewards: rewards::TaxType::zero(),
+            reward_account: None,
             keys: GenesisPraosLeader {
                 kes_public_key: self.kes_key,
                 vrf_public_key: self.vrf_key,

--- a/jcli/src/jcli_app/certificate/sign.rs
+++ b/jcli/src/jcli_app/certificate/sign.rs
@@ -7,7 +7,8 @@ use chain_impl_mockchain::certificate::{
 };
 use chain_impl_mockchain::key::EitherEd25519SecretKey;
 use chain_impl_mockchain::transaction::{
-    AccountBindingSignature, Payload, SetAuthData, Transaction, TxBuilderState, SingleAccountBindingSignature,
+    AccountBindingSignature, Payload, SetAuthData, SingleAccountBindingSignature, Transaction,
+    TxBuilderState,
 };
 use jormungandr_lib::interfaces;
 use std::ops::Deref;

--- a/jcli/src/jcli_app/certificate/sign.rs
+++ b/jcli/src/jcli_app/certificate/sign.rs
@@ -7,7 +7,7 @@ use chain_impl_mockchain::certificate::{
 };
 use chain_impl_mockchain::key::EitherEd25519SecretKey;
 use chain_impl_mockchain::transaction::{
-    AccountBindingSignature, Payload, SetAuthData, Transaction, TxBuilderState,
+    AccountBindingSignature, Payload, SetAuthData, Transaction, TxBuilderState, SingleAccountBindingSignature,
 };
 use jormungandr_lib::interfaces;
 use std::ops::Deref;
@@ -103,7 +103,7 @@ pub(crate) fn stake_delegation_account_binding_sign(
         }
     }
 
-    let sig = AccountBindingSignature::new(&private_key, &builder.get_auth_data());
+    let sig = AccountBindingSignature::new_single(&private_key, &builder.get_auth_data());
 
     Ok(SignedCertificate::StakeDelegation(delegation, sig))
 }
@@ -149,7 +149,7 @@ where
 
     let mut sigs = Vec::new();
     for (i, key) in keys.iter() {
-        let sig = AccountBindingSignature::new(key, &auth_data);
+        let sig = SingleAccountBindingSignature::new(key, &auth_data);
         sigs.push((*i, sig))
     }
     let sig = PoolOwnersSigned { signatures: sigs };

--- a/jcli/src/jcli_app/transaction/add_account.rs
+++ b/jcli/src/jcli_app/transaction/add_account.rs
@@ -24,8 +24,12 @@ impl AddAccount {
         let mut transaction = self.common.load()?;
 
         let account_id = match Address::from(self.account).kind() {
-            Kind::Account(key) => UnspecifiedAccountIdentifier::from_single_account(key.clone().into()),
-            Kind::Multisig(key) => UnspecifiedAccountIdentifier::from_multi_account(key.clone().into()),
+            Kind::Account(key) => {
+                UnspecifiedAccountIdentifier::from_single_account(key.clone().into())
+            }
+            Kind::Multisig(key) => {
+                UnspecifiedAccountIdentifier::from_multi_account(key.clone().into())
+            }
             Kind::Single(_) => return Err(Error::AccountAddressSingle),
             Kind::Group(_, _) => return Err(Error::AccountAddressGroup),
         };

--- a/jcli/src/jcli_app/transaction/add_account.rs
+++ b/jcli/src/jcli_app/transaction/add_account.rs
@@ -1,6 +1,6 @@
 use crate::jcli_app::transaction::{common, Error};
 use chain_addr::{Address, Kind};
-use chain_impl_mockchain::transaction::AccountIdentifier;
+use chain_impl_mockchain::transaction::UnspecifiedAccountIdentifier;
 use jormungandr_lib::interfaces;
 use structopt::StructOpt;
 
@@ -24,10 +24,10 @@ impl AddAccount {
         let mut transaction = self.common.load()?;
 
         let account_id = match Address::from(self.account).kind() {
-            Kind::Account(key) => AccountIdentifier::from_single_account(key.clone().into()),
+            Kind::Account(key) => UnspecifiedAccountIdentifier::from_single_account(key.clone().into()),
+            Kind::Multisig(key) => UnspecifiedAccountIdentifier::from_multi_account(key.clone().into()),
             Kind::Single(_) => return Err(Error::AccountAddressSingle),
             Kind::Group(_, _) => return Err(Error::AccountAddressGroup),
-            Kind::Multisig(_) => return Err(Error::AccountAddressMultisig),
         };
 
         transaction.add_input(interfaces::TransactionInput {

--- a/jcli/src/jcli_app/transaction/info.rs
+++ b/jcli/src/jcli_app/transaction/info.rs
@@ -3,7 +3,7 @@ use crate::jcli_app::{
     utils::io,
 };
 use chain_addr::{Address, AddressReadable};
-use chain_impl_mockchain::transaction::{AccountIdentifier, Balance, Output};
+use chain_impl_mockchain::transaction::{Balance, Output, UnspecifiedAccountIdentifier};
 use jormungandr_lib::crypto::hash::Hash;
 use jormungandr_lib::interfaces::{TransactionInput, TransactionInputType, TransactionOutput};
 use std::{collections::HashMap, io::Write, path::PathBuf};
@@ -162,7 +162,7 @@ impl Info {
                 self.write_info(writer, &self.format_utxo_input, vars)
             }
             TransactionInputType::Account(account_id) => {
-                let account_id: AccountIdentifier = account_id.into();
+                let account_id: UnspecifiedAccountIdentifier = account_id.into();
                 let account: chain_crypto::PublicKey<_> = account_id
                     .to_single_account()
                     .ok_or(Error::InfoExpectedSingleAccount)?

--- a/jormungandr-lib/src/interfaces/certificate.rs
+++ b/jormungandr-lib/src/interfaces/certificate.rs
@@ -115,7 +115,7 @@ impl property::Serialize for SignedCertificate {
             certificate::SignedCertificate::StakeDelegation(c, a) => {
                 writer.write_all(&[1])?;
                 c.serialize(&mut writer)?;
-                writer.write_all(a.as_ref())?;
+                writer.write_all(a.serialize_in(ByteBuilder::new()).finalize().as_slice())?;
             }
             certificate::SignedCertificate::OwnerStakeDelegation(c, ()) => {
                 writer.write_all(&[2])?;

--- a/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -12,7 +12,7 @@ use chain_impl_mockchain::{
     fee::LinearFee,
     key::EitherEd25519SecretKey,
     rewards::TaxType,
-    transaction::{AccountBindingSignature, TxBuilder},
+    transaction::{SingleAccountBindingSignature, TxBuilder},
 };
 use chain_time::DurationSeconds;
 use jormungandr_lib::{
@@ -207,6 +207,7 @@ impl Settings {
                             owners: vec![owner.to_public()],
                             operators: vec![].into(),
                             rewards: TaxType::zero(),
+                            reward_account: None,
                             keys: GenesisPraosLeader {
                                 kes_public_key: kes_signing_key.identifier().into_public_key(),
                                 vrf_public_key: vrf_signing_key.identifier().into_public_key(),
@@ -227,7 +228,7 @@ impl Settings {
                             .set_ios(&[], &[])
                             .set_witnesses(&[]);
                         let auth_data = txb.get_auth_data();
-                        let sig0 = AccountBindingSignature::new(
+                        let sig0 = SingleAccountBindingSignature::new(
                             &EitherEd25519SecretKey::Normal(owner),
                             &auth_data,
                         );

--- a/jormungandr-scenario-tests/src/wallet/account.rs
+++ b/jormungandr-scenario-tests/src/wallet/account.rs
@@ -5,8 +5,8 @@ use chain_impl_mockchain::{
     certificate::{PoolId, SignedCertificate, StakeDelegation},
     fee::{FeeAlgorithm, LinearFee},
     transaction::{
-        AccountBindingSignature, Balance, Input, InputOutputBuilder, Payload,
-        PayloadSlice, TransactionSignDataHash, TxBuilder, UnspecifiedAccountIdentifier, Witness,
+        AccountBindingSignature, Balance, Input, InputOutputBuilder, Payload, PayloadSlice,
+        TransactionSignDataHash, TxBuilder, UnspecifiedAccountIdentifier, Witness,
     },
 };
 use jormungandr_lib::{

--- a/jormungandr-scenario-tests/src/wallet/account.rs
+++ b/jormungandr-scenario-tests/src/wallet/account.rs
@@ -5,8 +5,8 @@ use chain_impl_mockchain::{
     certificate::{PoolId, SignedCertificate, StakeDelegation},
     fee::{FeeAlgorithm, LinearFee},
     transaction::{
-        AccountBindingSignature, AccountIdentifier, Balance, Input, InputOutputBuilder, Payload,
-        PayloadSlice, TransactionSignDataHash, TxBuilder, Witness,
+        AccountBindingSignature, Balance, Input, InputOutputBuilder, Payload,
+        PayloadSlice, TransactionSignDataHash, TxBuilder, UnspecifiedAccountIdentifier, Witness,
     },
 };
 use jormungandr_lib::{
@@ -63,8 +63,8 @@ impl Wallet {
         &self.internal_counter
     }
 
-    pub fn stake_key(&self) -> AccountIdentifier {
-        AccountIdentifier::from_single_account(self.identifier().clone().to_inner())
+    pub fn stake_key(&self) -> UnspecifiedAccountIdentifier {
+        UnspecifiedAccountIdentifier::from_single_account(self.identifier().clone().to_inner())
     }
 
     pub fn identifier(&self) -> &Identifier {
@@ -86,7 +86,7 @@ impl Wallet {
             .set_witnesses(&[]);
         let auth_data = txb.get_auth_data();
 
-        let sig = AccountBindingSignature::new(self.signing_key.as_ref(), &auth_data);
+        let sig = AccountBindingSignature::new_single(self.signing_key.as_ref(), &auth_data);
         SignedCertificate::StakeDelegation(stake_delegation, sig)
     }
 

--- a/jormungandr-scenario-tests/src/wallet/mod.rs
+++ b/jormungandr-scenario-tests/src/wallet/mod.rs
@@ -7,7 +7,7 @@ use chain_impl_mockchain::{
     certificate::{PoolId, SignedCertificate},
     fee::LinearFee,
     fragment::Fragment,
-    transaction::AccountIdentifier,
+    transaction::UnspecifiedAccountIdentifier,
 };
 use jormungandr_lib::{
     crypto::hash::Hash,
@@ -105,7 +105,7 @@ impl Wallet {
         }
     }
 
-    pub fn stake_key(&self) -> Option<AccountIdentifier> {
+    pub fn stake_key(&self) -> Option<UnspecifiedAccountIdentifier> {
         match &self.inner {
             Inner::Account(account) => Some(account.stake_key()),
             Inner::UTxO(_utxo) => unimplemented!(),


### PR DESCRIPTION
* Add support for discriminant account signature that allow differentiation between single and multi accounts
* Add rewards account in pool registration
* Simplify pool registration format