### PR TITLE
Clean up JCLI TX info command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,6 @@ dependencies = [
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "strfmt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "valico 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionisator 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2993,11 +2992,6 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "strfmt"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,7 +4270,6 @@ dependencies = [
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum strfmt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b278b244ef7aa5852b277f52dd0c6cac3a109919e1f6d699adde63251227a30f"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"

--- a/doc/jcli/transaction.md
+++ b/doc/jcli/transaction.md
@@ -25,13 +25,61 @@ There is a couple of commands that can be used to:
 There are also functions to help decode and display the
 content information of a transaction:
 
-* `info`
+* `info` displays summary of transaction being constructed
 * `data-for-witness` get the data to sign from a given transaction
 * `fragment-id` get the **Fragment ID** from a transaction in *sealed* state
 * `to-message` to get the hexadecimal encoded message, ready to send with `cli rest message`
 
 **DEPRECATED**:
 * `id` get the data to sign from a given transaction (use `data-for-witness` instead)
+
+## Transaction info
+
+On every stage of building a transaction user can display its summary
+
+```sh
+jcli transaction info <options>
+```
+
+The options are
+
+--prefix <address-prefix>       - set the address prefix to use when displaying the addresses (default: ca)
+--fee-certificate <certificate> - fee per certificate (default: 0)
+--fee-coefficient <coefficient> - fee per every input and output (default: 0)
+--fee-constant <constant>       - fee per transaction (default: 0)
+--output-format <format>        - Format of output data. Possible values: json, yaml. Any other value is treated as a custom format using values from output data structure. Syntax is Go text template: https://golang.org/pkg/text/template/. (default: yaml)
+--output <output>               - write the info in the given file or print it to the standard output
+--staging <staging-file>        - place where the transaction is going to be save during its staging phase If a file is given, the transaction will be read from this file and modification will be written into this same file. If no file is given, the transaction will be read from the standard input and will be rendered in the standard output
+
+YAML printed on success
+
+```yaml
+---
+balance: 40         # transaction balance or how much input is not spent
+fee: 60             # total fee for transaction
+input: 200          # total input of transaction
+inputs:             # list of transaction inputs, each can be of either "utxo" or "account" kind
+  - index: 4        # index of transaction output
+    kind: utxo      # constant value, signals that UTxO is used
+                    # hex-encoded ID of transaction
+    txid: 543326b2739356ab6d14624a536ca696f1020498b36456b7fdfe8344c084bfcf
+    value: 130      # value of transaction output
+  -                 # hex-encoded account address
+    account: 3fd45a64ae5a3b9c35e37114baa099b8b01285f7d74b371597af22d5ff393d9f
+    kind: account   # constant value, signals that account is used
+    value: 70       # value taken from account
+num_inputs: 1       # total number of inputs of transaction
+num_outputs: 1      # total number of outputs of transaction
+num_witnesses: 1    # total number of witnesses of transaction
+output: 100         # total output of transaction
+outputs:            # list of transaction outputs
+  -                 # bech32-encoded address
+    address: ca1swedukl830v26m8hl7e5dzrjp77yctuz79a68r8jl2l79qnpu3uwz0kg8az
+    value: 100      # value sent to address
+                    # hex-encoded transaction hash, when transaction is complete, it's also its ID
+sign_data_hash: 26be0b8bd7e34efffb769864f00d7c4aab968760f663a7e0b3ce213c4b21651b
+status: sealed      # transaction status, can be "balancing", "finalizing", "sealed" or "authed"
+```
 
 # Examples
 
@@ -102,15 +150,27 @@ jcli transaction info --fee-constant 5 --fee-coefficient 2 --staging tx
 
 You should see something like this
 
-```plaintext
-Transaction `0df39a87d3f18a188b40ba8c203f85f37af665df229fb4821e477f6998864273' (finalizing)
-  Input:   100
-  Output:  89
-  Fees:    11
-  Balance: 0
- - 55762218e5737603e6d27d36c8aacf8fcd16406e820361a8ac65c7dc663f6d1c:0 100
- + ca1qvnr5pvt9e5p009strshxndrsx5etcentslp2rwj6csm8sfk24a2wlqtdj6 50
- + ca1q09u0nxmnfg7af8ycuygx57p5xgzmnmgtaeer9xun7hly6mlgt3pjyknplu 39
+```yaml
+---
+balance: 0
+fee: 11
+input: 100
+inputs:
+  - index: 0
+    kind: utxo
+    txid: 55762218e5737603e6d27d36c8aacf8fcd16406e820361a8ac65c7dc663f6d1c
+    value: 100
+num_inputs: 1
+num_outputs: 2
+num_witnesses: 0
+output: 89
+outputs:
+  - address: ca1qvnr5pvt9e5p009strshxndrsx5etcentslp2rwj6csm8sfk24a2wlqtdj6
+    value: 50
+  - address: ca1q09u0nxmnfg7af8ycuygx57p5xgzmnmgtaeer9xun7hly6mlgt3pjyknplu
+    value: 39
+sign_data_hash: 0df39a87d3f18a188b40ba8c203f85f37af665df229fb4821e477f6998864273
+status: finalizing
 ```
 
 ## Sign the transaction

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -32,7 +32,6 @@ chain-time    = { path = "../chain-deps/chain-time" }
 reqwest = "0.9.11"
 custom_error = "1.7"
 jormungandr-lib = { path = "../jormungandr-lib" }
-strfmt = "0.1"
 gtmpl = "0.5.6"
 openapiv3 = "0.3.0"
 valico = "3.1.0"

--- a/jcli/src/jcli_app/transaction/common.rs
+++ b/jcli/src/jcli_app/transaction/common.rs
@@ -6,10 +6,13 @@ use structopt::StructOpt;
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub struct CommonFees {
+    /// fee per transaction
     #[structopt(long = "fee-constant", default_value = "0")]
     pub constant: u64,
+    /// fee per every input and output
     #[structopt(long = "fee-coefficient", default_value = "0")]
     pub coefficient: u64,
+    /// fee per certificate
     #[structopt(long = "fee-certificate", default_value = "0")]
     pub certificate: u64,
 }

--- a/jcli/src/jcli_app/transaction/info.rs
+++ b/jcli/src/jcli_app/transaction/info.rs
@@ -1,84 +1,30 @@
 use crate::jcli_app::{
-    transaction::{common, staging::Staging, Error},
-    utils::io,
+    transaction::{common, Error},
+    utils::{io, OutputFormat},
 };
-use chain_addr::{Address, AddressReadable};
-use chain_impl_mockchain::transaction::{Balance, Output, UnspecifiedAccountIdentifier};
+use chain_addr::AddressReadable;
+use chain_impl_mockchain::transaction::{Balance, UnspecifiedAccountIdentifier};
 use jormungandr_lib::crypto::hash::Hash;
-use jormungandr_lib::interfaces::{TransactionInput, TransactionInputType, TransactionOutput};
-use std::{collections::HashMap, io::Write, path::PathBuf};
-use strfmt::strfmt;
+use jormungandr_lib::interfaces::TransactionInputType;
+use serde_json::json;
+use std::{io::Write, path::PathBuf};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub struct Info {
     #[structopt(flatten)]
-    pub common: common::CommonTransaction,
+    common: common::CommonTransaction,
 
     #[structopt(flatten)]
-    pub fee: common::CommonFees,
+    fee: common::CommonFees,
 
     /// write the info in the given file or print it to the standard output
     #[structopt(long = "output")]
-    pub output: Option<PathBuf>,
+    output: Option<PathBuf>,
 
-    /// formatting for the output to displays
-    /// user "{name}" to display the variable with the named `name'.
-    ///
-    /// available variables: sign-data-hash, num_inputs, num_outputs, num_witnesses, fee
-    /// balance, input, output and status
-    ///
-    #[structopt(
-        long = "format",
-        default_value = "Transaction {sign-data-hash} ({status})\n  Input:   {input}\n  Output:  {output}\n  Fees:    {fee}\n  Balance: {balance}\n"
-    )]
-    pub format: String,
-
-    /// display only the inputs of type UTxO
-    #[structopt(long = "only-utxos")]
-    pub only_utxos: bool,
-    /// display only the inputs of type Account
-    #[structopt(long = "only-accounts")]
-    pub only_accounts: bool,
-    /// display only the outputs
-    #[structopt(long = "only-outputs")]
-    pub only_outputs: bool,
-
-    /// formatting for the UTxO inputs of the transaction. This format
-    /// will be applied to every inputs of type UTxO.
-    ///
-    /// available variables: txid, index and value.
-    ///
-    #[structopt(
-        long = "format-utxo-input",
-        alias = "utxo",
-        default_value = " - {txid}:{index} {value}\n"
-    )]
-    pub format_utxo_input: String,
-
-    /// formatting for the Account inputs of the transaction. This format
-    /// will be applied to every inputs of type account.
-    ///
-    /// available variables: account and value.
-    ///
-    #[structopt(
-        long = "format-account-input",
-        alias = "account",
-        default_value = " - {account} {value}\n"
-    )]
-    pub format_account_input: String,
-
-    /// Display the outputs of the transaction, this function will be called
-    /// for every outputs of the transaction
-    ///
-    /// available variables: address and value.
-    #[structopt(
-        long = "format-output",
-        alias = "output",
-        default_value = " + {address} {value}\n"
-    )]
-    pub format_output: String,
+    #[structopt(flatten)]
+    output_format: OutputFormat,
 
     /// set the address prefix to use when displaying the addresses
     #[structopt(long = "prefix", default_value = "ca")]
@@ -87,143 +33,69 @@ pub struct Info {
 
 impl Info {
     pub fn exec(self) -> Result<(), Error> {
-        let transaction = self.common.load()?;
+        let staging = self.common.load()?;
+
+        let inputs = staging
+            .inputs()
+            .iter()
+            .map(|input| match input.input {
+                TransactionInputType::Utxo(utxo_ptr, index) => Ok(json!({
+                    "kind": "utxo",
+                    "value": input.value,
+                    "txid": Hash::from(utxo_ptr),
+                    "index": index,
+                })),
+                TransactionInputType::Account(account) => {
+                    let account_id = UnspecifiedAccountIdentifier::from(account)
+                        .to_single_account()
+                        .ok_or(Error::InfoExpectedSingleAccount)?;
+                    Ok(json!({
+                        "kind": "account",
+                        "value": input.value,
+                        "account": account_id.to_string(),
+                    }))
+                }
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        let outputs = staging.outputs().iter().map(|output| {
+            json!({
+                "address": AddressReadable::from_address(&self.address_prefix, output.address().as_ref()).to_string(),
+                "value":  output.value(),
+            })
+        }).collect::<Vec<_>>();
+
+        let fee_algo = self.fee.linear_fee();
+        let balance = match staging.balance(&fee_algo)? {
+            Balance::Negative(value) | Balance::Positive(value) => value.0,
+            Balance::Zero => 0,
+        };
+        let info = json!({
+            "status": staging.staging_kind_name(),
+            "sign_data_hash": staging.transaction_sign_data_hash().to_string(),
+            "num_inputs": staging.inputs().len(),
+            "num_outputs": staging.outputs().len(),
+            "num_witnesses": staging.witness_count(),
+            "input": staging.total_input()?.0,
+            "output": staging.total_output()?.0,
+            "fee": staging.fees(&fee_algo).0,
+            "balance": balance,
+            "inputs": inputs,
+            "outputs": outputs,
+        });
 
         let mut output =
             io::open_file_write(&self.output).map_err(|source| Error::InfoFileWriteFailed {
                 source,
                 path: self.output.clone().unwrap_or_default(),
             })?;
-
-        self.display_info(&mut output, &transaction)?;
-        self.display_inputs(&mut output, &transaction.inputs())?;
-
-        if !self.only_accounts || !self.only_utxos {
-            self.display_outputs(&mut output, transaction.outputs())?;
-        }
-        Ok(())
-    }
-
-    fn display_outputs(
-        &self,
-        mut writer: impl Write,
-        outputs: &[TransactionOutput],
-    ) -> Result<(), Error> {
-        for output in outputs {
-            self.display_output(&mut writer, output)?;
-        }
-        Ok(())
-    }
-
-    fn display_inputs(
-        &self,
-        mut writer: impl Write,
-        inputs: &[TransactionInput],
-    ) -> Result<(), Error> {
-        for input in inputs {
-            match input.input {
-                TransactionInputType::Account(_) => {
-                    if self.only_outputs || self.only_utxos {
-                        continue;
-                    }
-                    self.display_input(&mut writer, input)?;
-                }
-                TransactionInputType::Utxo(..) => {
-                    if self.only_outputs || self.only_accounts {
-                        continue;
-                    }
-                    self.display_input(&mut writer, input)?;
-                }
+        writeln!(output, "{}", self.output_format.format_json(info)?).map_err(|source| {
+            Error::InfoFileWriteFailed {
+                source,
+                path: self.output.clone().unwrap_or_default(),
             }
-        }
-        Ok(())
-    }
-
-    fn display_output(&self, writer: impl Write, output: &TransactionOutput) -> Result<(), Error> {
-        let mut vars = HashMap::new();
-
-        let output: Output<Address> = output.clone().into();
-
-        vars.insert(
-            "address".to_owned(),
-            AddressReadable::from_address(&self.address_prefix, &output.address).to_string(),
-        );
-        vars.insert("value".to_owned(), output.value.0.to_string());
-        self.write_info(writer, &self.format_output, vars)
-    }
-
-    fn display_input(&self, writer: impl Write, input: &TransactionInput) -> Result<(), Error> {
-        let mut vars = HashMap::new();
-        match input.input {
-            TransactionInputType::Utxo(utxo_ptr, index) => {
-                vars.insert("txid".to_owned(), Hash::from(utxo_ptr).to_string());
-                vars.insert("index".to_owned(), index.to_string());
-                vars.insert("value".to_owned(), input.value.to_string());
-                self.write_info(writer, &self.format_utxo_input, vars)
-            }
-            TransactionInputType::Account(account_id) => {
-                let account_id: UnspecifiedAccountIdentifier = account_id.into();
-                let account: chain_crypto::PublicKey<_> = account_id
-                    .to_single_account()
-                    .ok_or(Error::InfoExpectedSingleAccount)?
-                    .into();
-                vars.insert("account".to_owned(), account.to_string());
-                vars.insert("value".to_owned(), input.value.to_string());
-                self.write_info(writer, &self.format_account_input, vars)
-            }
-        }
-    }
-
-    fn display_info(&self, writer: impl Write, transaction: &Staging) -> Result<(), Error> {
-        let mut vars = HashMap::new();
-        vars.insert("status".to_owned(), transaction.staging_kind_name());
-        vars.insert(
-            "sign-data-hash".to_owned(),
-            transaction.transaction_sign_data_hash().to_string(),
-        );
-        vars.insert(
-            "num_inputs".to_owned(),
-            transaction.inputs().len().to_string(),
-        );
-        vars.insert(
-            "num_outputs".to_owned(),
-            transaction.outputs().len().to_string(),
-        );
-        vars.insert(
-            "num_witnesses".to_owned(),
-            transaction.witness_count().to_string(),
-        );
-        vars.insert("input".to_owned(), transaction.total_input()?.0.to_string());
-        vars.insert(
-            "output".to_owned(),
-            transaction.total_output()?.0.to_string(),
-        );
-        let fee_algo = self.fee.linear_fee();
-        vars.insert("fee".to_owned(), transaction.fees(&fee_algo).0.to_string());
-        vars.insert(
-            "balance".to_owned(),
-            match transaction.balance(&fee_algo)? {
-                Balance::Negative(value) => format!("-{}", value.0),
-                Balance::Positive(value) => format!("+{}", value.0),
-                Balance::Zero => "0".to_string(),
-            },
-        );
-        self.write_info(writer, &self.format, vars)
-    }
-
-    fn write_info(
-        &self,
-        mut writer: impl Write,
-        format: &str,
-        info: HashMap<String, String>,
-    ) -> Result<(), Error> {
-        let formatted = strfmt(format, &info).map_err(|source| Error::InfoOutputFormatInvalid {
-            source,
-            format: format.to_string(),
         })?;
-        write!(writer, "{}", formatted).map_err(|source| Error::InfoFileWriteFailed {
-            source,
-            path: self.output.clone().unwrap_or_default(),
-        })
+
+        Ok(())
     }
 }

--- a/jcli/src/jcli_app/transaction/mod.rs
+++ b/jcli/src/jcli_app/transaction/mod.rs
@@ -15,7 +15,7 @@ mod staging;
 use self::staging::StagingKind;
 use crate::jcli_app::certificate;
 use crate::jcli_app::utils::error::CustomErrorFiller;
-use crate::jcli_app::utils::key_parser;
+use crate::jcli_app::utils::{key_parser, output_format};
 use chain_core::property::Serialize as _;
 use chain_impl_mockchain as chain;
 use std::path::PathBuf;
@@ -94,6 +94,7 @@ custom_error! { pub Error
         = "could not serialize witness data",
     InfoFileWriteFailed { source: std::io::Error, path: PathBuf }
         = @{{ let _ = source; format_args!("could not write info file '{}'", path.display()) }},
+    OutputFormatFailed { source: output_format::Error } = "formatting output failed",
 
     TxKindToAddExtraInvalid { kind: StagingKind } = "adding certificate to {kind} transaction is not valid",
     TxKindToAddInputInvalid { kind: StagingKind } = "adding input to {kind} transaction is not valid",
@@ -119,7 +120,6 @@ custom_error! { pub Error
     GeneratedTxTypeUnexpected = "unexpected generated transaction type",
     MessageSerializationFailed { source: std::io::Error, filler: CustomErrorFiller }
         = "serialization of message to bytes failed",
-    InfoOutputFormatInvalid { source: strfmt::FmtError, format: String } = "invalid info output format '{format}'",
     InfoCalculationFailed { source: chain::value::ValueError } = "calculation of info failed",
     FeeCalculationFailed = "fee calculation failed",
     InfoExpectedSingleAccount = "expected a single account, multisig is not supported yet",

--- a/jcli/src/lib.rs
+++ b/jcli/src/lib.rs
@@ -21,7 +21,6 @@ extern crate serde_yaml;
 extern crate structopt;
 #[macro_use(custom_error)]
 extern crate custom_error;
-extern crate strfmt;
 extern crate valico;
 
 pub mod jcli_app;

--- a/jcli/src/main.rs
+++ b/jcli/src/main.rs
@@ -21,7 +21,6 @@ extern crate serde_yaml;
 extern crate structopt;
 #[macro_use(custom_error)]
 extern crate custom_error;
-extern crate strfmt;
 extern crate valico;
 
 mod jcli_app;


### PR DESCRIPTION
Makes its output formatted like the rest of JCLI: YAML by default, possibly translated to JSON, support for Go's custom formatting for picky ones.