### PR TITLE
Logging to multiple outputs

### DIFF
--- a/jormungandr-integration-tests/src/common/configuration/node_config_model.rs
+++ b/jormungandr-integration-tests/src/common/configuration/node_config_model.rs
@@ -8,7 +8,10 @@ use std::{path::PathBuf, time::Duration};
 use jormungandr_lib::interfaces::Mempool;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Log {
+pub struct Log(pub Vec<LogEntry>);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LogEntry {
     pub level: Option<String>,
     pub format: Option<String>,
 }
@@ -65,13 +68,14 @@ impl NodeConfig {
         let public_address_port = super::get_available_port();
         let storage_file = file_utils::get_path_in_temp("storage");
         let public_id = poldercast::Id::generate(&mut rand::rngs::OsRng::new().unwrap());
+        let log = Log(vec![LogEntry {
+            level: Some("info".to_string()),
+            format: Some("json".to_string()),
+        }]);
 
         NodeConfig {
             storage: Some(String::from(storage_file.as_os_str().to_str().unwrap())),
-            log: Some(Log {
-                level: Some("info".to_string()),
-                format: Some("json".to_string()),
-            }),
+            log: Some(log),
             rest: Some(Rest {
                 listen: format!("{}:{}", DEFAULT_HOST, rest_port.to_string()),
             }),

--- a/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    configuration::node_config_model::{Log, TrustedPeer},
+    configuration::node_config_model::{Log, LogEntry, TrustedPeer},
     jormungandr::{ConfigurationBuilder, Starter},
 };
 
@@ -58,13 +58,13 @@ pub fn test_jormungandr_with_no_trusted_peers_starts_succesfully() {
 #[test]
 pub fn test_jormungandr_with_wrong_logger_fails_to_start() {
     let config = ConfigurationBuilder::new()
-        .with_log(Log {
+        .with_log(Log(vec![LogEntry {
             format: Some("xml".to_string()),
             level: None,
-        })
+        }]))
         .build();
     Starter::new().config(config).start_fail(
-        r"Error while parsing the node configuration file: log\.format: unknown variant",
+        r"Error while parsing the node configuration file: log\[0\]\.format: unknown variant",
     );
 }
 

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -404,7 +404,11 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     // The log crate is used by some libraries, e.g. tower-grpc.
     // Set up forwarding from log to slog, but only when trace log level is
     // requested, because the logs are very verbose.
-    if log_settings.level >= slog::FilterLevel::Trace {
+    if log_settings
+        .0
+        .iter()
+        .any(|entry| entry.level >= slog::FilterLevel::Trace)
+    {
         slog_scope::set_global_logger(logger.new(o!(log::KEY_SCOPE => "global"))).cancel_reset();
         slog_stdlog::init().unwrap();
     }

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -34,12 +34,15 @@ pub struct Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct ConfigLogSettings {
+pub struct ConfigLogSettingsEntry {
     #[serde(with = "filter_level_opt_serde")]
     pub level: Option<FilterLevel>,
     pub format: Option<LogFormat>,
     pub output: Option<LogOutput>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfigLogSettings(pub Vec<ConfigLogSettingsEntry>);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
Implement the possibility to log into multiple outputs. Configuration file example:

```yaml
log:
  - output:
      file: example.log
    level: info
    format: json
  - output: stderr
    level: debug
    format: plain
```

In addition a user can specify one additional logger through the command line arguments.

Resolves #392.