### PR TITLE
Update tip after network blocks

### DIFF
--- a/jormungandr/src/blockchain/candidate.rs
+++ b/jormungandr/src/blockchain/candidate.rs
@@ -279,7 +279,7 @@ impl ChainAdvance {
                 }
             }
             // TODO: bail out when block data are needed due to new epoch.
-            if self.new_hashes.len() >= chunk_sizes::BLOCKS {
+            if self.new_hashes.len() as u64 >= chunk_sizes::BLOCKS {
                 return Ok(Outcome::Incomplete.into());
             }
         }

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -14,10 +14,12 @@ mod tip;
 
 mod chunk_sizes {
     // The maximum number of blocks to request per each GetBlocks request
-    // when pulling missing blocks.
+    // or a Solicit event when pulling missing blocks.
     //
     // This may need to be made into a configuration parameter.
-    pub const BLOCKS: usize = 32;
+    // The number used here aims for this number of block IDs to fit within
+    // a reasonable network path MTU, leaving room for gRPC and TCP/IP framing.
+    pub const BLOCKS: u64 = 32;
 }
 
 // Re-exports

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -2,7 +2,7 @@ use super::{
     candidate::{self, CandidateForest},
     chain,
     chain_selection::{self, ComparisonResult},
-    Blockchain, Error, ErrorKind, PreCheckedHeader, Ref, Tip, MAIN_BRANCH_TAG,
+    chunk_sizes, Blockchain, Error, ErrorKind, PreCheckedHeader, Ref, Tip, MAIN_BRANCH_TAG,
 };
 use crate::{
     blockcfg::{Block, FragmentId, Header},
@@ -147,6 +147,7 @@ pub fn run_handle_input(
             let blockchain_fold = blockchain.clone();
             let (stream, reply) = handle.into_stream_and_reply();
             let future = stream
+                .take(chunk_sizes::BLOCKS)
                 .map_err(|()| Error::from("Error while processing block input stream"))
                 .fold(
                     (reply, stats_counter, None),

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -99,24 +99,16 @@ pub fn run_handle_input(
             });
 
             let process_new_ref = update_mempool.and_then(move |new_block_ref| {
-                process_new_ref(
-                    logger.clone(),
-                    blockchain.clone(),
-                    blockchain_tip.clone(),
+                process_and_propagate_new_ref(
+                    logger,
+                    blockchain,
+                    blockchain_tip,
                     Arc::clone(&new_block_ref),
+                    network_msg_box,
                 )
-                .map(|()| new_block_ref)
             });
 
-            let propagate_new_block = process_new_ref.and_then(|new_block_ref| {
-                let header = new_block_ref.header().clone();
-                network_msg_box
-                    .send(NetworkMsg::Propagate(PropagateMsg::Block(header)))
-                    .map_err(|_| "Cannot propagate block to network".into())
-                    .map(|_| new_block_ref)
-            });
-
-            let notify_explorer = propagate_new_block.and_then(move |_new_block_ref| {
+            let notify_explorer = process_new_ref.and_then(move |()| {
                 if let Some(msg_box) = explorer_msg_box {
                     Either::A(
                         msg_box
@@ -151,7 +143,8 @@ pub fn run_handle_input(
         }
         BlockMsg::NetworkBlocks(handle) => {
             let logger = info.logger().clone();
-            let tx_msg_box = tx_msg_box.clone();
+            let logger_fold = logger.clone();
+            let blockchain_fold = blockchain.clone();
             let (stream, reply) = handle.into_stream_and_reply();
             let future = stream
                 .map_err(|()| Error::from("Error while processing block input stream"))
@@ -159,12 +152,12 @@ pub fn run_handle_input(
                     (reply, stats_counter, None),
                     move |(reply, stats_counter, _), block| {
                         process_network_block(
-                            blockchain.clone(),
+                            blockchain_fold.clone(),
                             candidate_forest.clone(),
                             block,
                             tx_msg_box.clone(),
                             explorer_msg_box.clone(),
-                            logger.clone(),
+                            logger_fold.clone(),
                         )
                         .then(move |res| match res {
                             Ok(maybe_updated) => {
@@ -180,13 +173,15 @@ pub fn run_handle_input(
                 )
                 .and_then(move |(reply, _, maybe_updated)| {
                     if let Some(new_block_ref) = maybe_updated {
-                        let header = new_block_ref.header().clone();
-                        Either::A(
-                            network_msg_box
-                                .send(NetworkMsg::Propagate(PropagateMsg::Block(header)))
-                                .map_err(|_| Error::from("cannot propagate block to network"))
-                                .map(|_| reply),
+                        let future = process_and_propagate_new_ref(
+                            logger,
+                            blockchain,
+                            blockchain_tip,
+                            Arc::clone(&new_block_ref),
+                            network_msg_box,
                         )
+                        .map(|()| reply);
+                        Either::A(future)
                     } else {
                         Either::B(future::ok(reply))
                     }
@@ -236,8 +231,6 @@ fn try_request_fragment_removal(
 
 /// process a new candidate block on top of the blockchain, this function may:
 ///
-/// * remove the candidate from the CandidateForest (chain pulls pending
-///   validation);
 /// * update the current tip if the candidate's parent is the current tip;
 /// * update a branch if the candidate parent is that branch's tip;
 /// * create a new branch if none of the above;
@@ -289,6 +282,24 @@ pub fn process_new_ref(
                 B(future::ok(()))
             }
         })
+}
+
+fn process_and_propagate_new_ref(
+    logger: Logger,
+    blockchain: Blockchain,
+    tip: Tip,
+    new_block_ref: Arc<Ref>,
+    network_msg_box: MessageBox<NetworkMsg>,
+) -> impl Future<Item = (), Error = Error> {
+    let process_new_ref = process_new_ref(logger, blockchain, tip, new_block_ref.clone());
+
+    process_new_ref.and_then(move |()| {
+        let header = new_block_ref.header().clone();
+        network_msg_box
+            .send(NetworkMsg::Propagate(PropagateMsg::Block(header)))
+            .map_err(|_| "Cannot propagate block to network".into())
+            .map(|_| ())
+    })
 }
 
 pub fn process_leadership_block(

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -154,9 +154,8 @@ pub fn run_handle_input(
             let logger_fold = logger.clone();
             let blockchain_fold = blockchain.clone();
             let (stream, reply) = handle.into_stream_and_reply();
-            let stream = stream
-                .take(chunk_sizes::BLOCKS)
-                .map_err(|()| Error::from("Error while processing block input stream"));
+            let stream =
+                stream.map_err(|()| Error::from("Error while processing block input stream"));
             let state = State {
                 stream,
                 reply,


### PR DESCRIPTION
After-fixes to #1121 plus improvements:

- ~The number of blocks processed from incoming stream is capped to the maximum number we solicit, to prevent DoS with an outsized (but somehow valid throughout?) divergent chain of blocks.~
- A partially validated incoming stream of blocks would result in a tip update, even if another block fails validation.