### PR TITLE
catch the error the drains

### DIFF
--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -105,10 +105,9 @@ impl<D: Drain> Drain for DrainMux<D> {
         record: &slog::Record,
         values: &slog::OwnedKVList,
     ) -> Result<Self::Ok, Self::Err> {
-        self.0.iter().try_for_each(|drain| {
-            drain.log(record, values);
-            Ok(())
-        })
+        self.0
+            .iter()
+            .try_for_each(|drain| drain.log(record, values).map(|_| ()))
     }
 }
 


### PR DESCRIPTION
If an error happened in the sub-drains we may have ignored it completely. Now we can catch it accordingly and report/handle errors.