### PR TITLE
Ground work for header chain validation

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -182,7 +182,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         let stats_counter = stats_counter.clone();
         services.spawn_future_with_inputs("block", move |info, input| {
             let candidate_repo = CandidateForest::new(
-                blockchain.storage().clone(),
+                blockchain.clone(),
                 block_cache_ttl,
                 info.logger().new(o!(log::KEY_SUB_TASK => "chain_pull")),
             );


### PR DESCRIPTION
Use the full `Blockchain` in `CandidateForest` to validate headers.
Currently this is only useful for skipping through existing blocks, as its header pre-validation API expects parent blocks of a header to be present in storage.