### PR TITLE
Expose stake pool parameters

### DIFF
--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -435,9 +435,7 @@ impl Address {
             .db
             .get_transactions_by_address(&self.id)
             .wait()?
-            .ok_or(ErrorKind::InternalError(
-                "Expected address to be indexed".to_owned(),
-            ))?;
+            .unwrap_or(PersistentSequence::<FragmentId>::new());
 
         let boundaries = if transactions.len() > 0 {
             PaginationInterval::Inclusive(InclusivePaginationInterval {

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -7,7 +7,7 @@ use self::connections::{
 };
 use self::error::ErrorKind;
 use super::indexing::{
-    BlockProducer, EpochData, ExplorerAddress, ExplorerBlock, ExplorerTransaction,
+    BlockProducer, EpochData, ExplorerAddress, ExplorerBlock, ExplorerTransaction, StakePoolData,
 };
 use super::persistent_sequence::PersistentSequence;
 use crate::blockcfg::{self, FragmentId, HeaderHash};
@@ -22,7 +22,7 @@ use std::str::FromStr;
 use tokio::prelude::*;
 
 use self::scalars::{
-    BlockCount, ChainLength, EpochNumber, IndexCursor, PoolId, PublicKey, Serial, Slot,
+    BlockCount, ChainLength, EpochNumber, IndexCursor, NonZero, PoolId, PublicKey, Serial, Slot,
     TimeOffsetSeconds, Value,
 };
 
@@ -558,7 +558,7 @@ impl PoolRegistration {
 
     /// Management threshold for owners, this need to be <= #owners and > 0
     pub fn management_threshold(&self) -> i32 {
-        // XXX: u16 fits in i32, but maybe some kind of custom scalar is better?
+        // XXX: u8 fits in i32, but maybe some kind of custom scalar is better?
         self.registration.management_threshold().into()
     }
 
@@ -571,8 +571,64 @@ impl PoolRegistration {
             .collect()
     }
 
-    // TODO: rewards
-    // TODO: keys
+    pub fn operators(&self) -> Vec<PublicKey> {
+        self.registration
+            .operators
+            .iter()
+            .map(PublicKey::from)
+            .collect()
+    }
+
+    pub fn rewards(&self) -> TaxType {
+        TaxType(self.registration.rewards)
+    }
+
+    /// Reward account
+    pub fn reward_account(&self, context: &Context) -> Option<String> {
+        // TODO: What's the best way to show this? As an Address?
+        self.registration
+            .reward_account
+            .clone()
+            .map(|acc_id| format!("{:#?}", &acc_id))
+    }
+
+    // Genesis Praos keys
+    // pub keys: GenesisPraosLeader,
+}
+
+struct TaxType(chain_impl_mockchain::rewards::TaxType);
+
+#[juniper::object(
+    Context = Context,
+)]
+impl TaxType {
+    /// what get subtracted as fixed value
+    pub fn fixed(&self) -> Value {
+        Value(format!("{}", self.0.fixed))
+    }
+    /// Ratio of tax after fixed amout subtracted
+    pub fn ratio(&self) -> Ratio {
+        Ratio(self.0.ratio)
+    }
+
+    /// Max limit of tax
+    pub fn max_limit(&self) -> Option<NonZero> {
+        self.0.max_limit.map(|n| NonZero(format!("{}", n)))
+    }
+}
+
+struct Ratio(chain_impl_mockchain::rewards::Ratio);
+#[juniper::object(
+    Context = Context,
+)]
+impl Ratio {
+    pub fn numerator(&self) -> Value {
+        Value(format!("{}", self.0.numerator))
+    }
+
+    pub fn denominator(&self) -> NonZero {
+        NonZero(format!("{}", self.0.denominator))
+    }
 }
 
 struct OwnerStakeDelegation {
@@ -650,6 +706,7 @@ graphql_union!(Certificate: Context |&self| {
 
 struct Pool {
     id: certificate::PoolId,
+    data: Option<StakePoolData>,
     blocks: Option<PersistentSequence<HeaderHash>>,
 }
 
@@ -661,14 +718,26 @@ impl Pool {
             .wait()
             .unwrap()
             .ok_or(ErrorKind::NotFound("Stake pool not found".to_owned()))?;
+
+        let data = db
+            .get_stake_pool_data(&id)
+            .wait()
+            .unwrap()
+            .ok_or(ErrorKind::NotFound("Stake pool not found".to_owned()))?;
+
         Ok(Pool {
             id,
+            data: Some(data),
             blocks: Some(blocks),
         })
     }
 
     fn from_valid_id(id: certificate::PoolId) -> Pool {
-        Pool { id, blocks: None }
+        Pool {
+            id,
+            blocks: None,
+            data: None,
+        }
     }
 }
 
@@ -726,6 +795,19 @@ impl Pool {
                 .filter_map(|i| blocks.get(i).map(|h| ((*h).clone(), i)))
                 .collect(),
         })
+    }
+
+    pub fn registration(&self, context: &Context) -> FieldResult<PoolRegistration> {
+        match &self.data {
+            Some(data) => Ok(data.registration.clone().into()),
+            None => context
+                .db
+                .get_stake_pool_data(&self.id)
+                .wait()
+                .unwrap()
+                .map(|data| PoolRegistration::from(data.registration.clone()))
+                .ok_or(ErrorKind::NotFound("Stake pool not found".to_owned()).into()),
+        }
     }
 }
 

--- a/jormungandr/src/explorer/graphql/scalars.rs
+++ b/jormungandr/src/explorer/graphql/scalars.rs
@@ -38,6 +38,9 @@ pub struct PublicKey(pub String);
 #[derive(juniper::GraphQLScalarValue)]
 pub struct TimeOffsetSeconds(pub String);
 
+#[derive(juniper::GraphQLScalarValue)]
+pub struct NonZero(pub String);
+
 // u32 should be enough to count blocks and transactions (the only two cases for now)
 #[derive(Clone)]
 pub struct IndexCursor(pub u64);

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -8,7 +8,7 @@ use chain_addr::{Address, Discrimination};
 use chain_core::property::Block as _;
 use chain_core::property::Fragment as _;
 use chain_impl_mockchain::block::Proof;
-use chain_impl_mockchain::certificate::{Certificate, PoolId};
+use chain_impl_mockchain::certificate::{Certificate, PoolId, PoolRegistration};
 use chain_impl_mockchain::leadership::bft;
 use chain_impl_mockchain::transaction::{InputEnum, TransactionSlice, Witness};
 use chain_impl_mockchain::value::Value;
@@ -25,7 +25,14 @@ pub type ChainLengths = Hamt<ChainLength, HeaderHash>;
 pub type Addresses = Hamt<ExplorerAddress, PersistentSequence<FragmentId>>;
 pub type Epochs = Hamt<Epoch, EpochData>;
 
-pub type StakePools = Hamt<PoolId, PersistentSequence<HeaderHash>>;
+pub type StakePoolBlocks = Hamt<PoolId, PersistentSequence<HeaderHash>>;
+pub type StakePool = Hamt<PoolId, StakePoolData>;
+
+#[derive(Clone)]
+pub struct StakePoolData {
+    pub registration: PoolRegistration,
+    // TODO: Track updates and retirement here too?
+}
 
 /// Block with unified inputs the metadata needed in the queries
 #[derive(Clone)]

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -6,8 +6,8 @@ mod persistent_sequence;
 use self::error::{Error, ErrorKind, Result};
 use self::graphql::Context;
 use self::indexing::{
-    Addresses, Blocks, ChainLengths, EpochData, Epochs, ExplorerAddress, ExplorerBlock, StakePools,
-    Transactions,
+    Addresses, Blocks, ChainLengths, EpochData, Epochs, ExplorerAddress, ExplorerBlock, StakePool,
+    StakePoolBlocks, StakePoolData, Transactions,
 };
 use self::persistent_sequence::PersistentSequence;
 
@@ -73,7 +73,8 @@ struct State {
     addresses: Addresses,
     epochs: Epochs,
     chain_lengths: ChainLengths,
-    stake_pools: StakePools,
+    stake_pool_data: StakePool,
+    stake_pool_blocks: StakePoolBlocks,
 }
 
 #[derive(Clone)]
@@ -160,7 +161,8 @@ impl ExplorerDB {
         let chain_lengths = apply_block_to_chain_lengths(ChainLengths::new(), &block)?;
         let transactions = apply_block_to_transactions(Transactions::new(), &block)?;
         let addresses = apply_block_to_addresses(Addresses::new(), &block)?;
-        let stake_pools = apply_block_to_stake_pools(StakePools::new(), &block);
+        let (stake_pool_data, stake_pool_blocks) =
+            apply_block_to_stake_pools(StakePool::new(), StakePoolBlocks::new(), &block);
 
         let initial_state = State {
             blocks,
@@ -168,7 +170,8 @@ impl ExplorerDB {
             chain_lengths,
             transactions,
             addresses,
-            stake_pools,
+            stake_pool_data,
+            stake_pool_blocks,
         };
 
         let multiverse = Multiverse::<State>::new();
@@ -237,7 +240,8 @@ impl ExplorerDB {
                         addresses,
                         epochs,
                         chain_lengths,
-                        stake_pools,
+                        stake_pool_data,
+                        stake_pool_blocks,
                     } = state;
 
                     let explorer_block =
@@ -249,7 +253,11 @@ impl ExplorerDB {
                         apply_block_to_addresses(addresses, &explorer_block)?,
                         apply_block_to_epochs(epochs, &explorer_block),
                         apply_block_to_chain_lengths(chain_lengths, &explorer_block)?,
-                        apply_block_to_stake_pools(stake_pools, &explorer_block),
+                        apply_block_to_stake_pools(
+                            stake_pool_data,
+                            stake_pool_blocks,
+                            &explorer_block,
+                        ),
                     ))
                 }
                 None => Err(Error::from(ErrorKind::AncestorNotFound(format!(
@@ -261,6 +269,7 @@ impl ExplorerDB {
                 move |(transactions, blocks, addresses, epochs, chain_lengths, stake_pools)| {
                     let chain_length = chain_length.clone();
                     let block_id = block_id.clone();
+                    let (stake_pool_data, stake_pool_blocks) = stake_pools;
                     multiverse
                         .insert(
                             chain_length,
@@ -271,7 +280,8 @@ impl ExplorerDB {
                                 addresses,
                                 epochs,
                                 chain_lengths,
-                                stake_pools,
+                                stake_pool_data,
+                                stake_pool_blocks,
                             },
                         )
                         .map_err(|_: Infallible| unreachable!())
@@ -370,7 +380,17 @@ impl ExplorerDB {
         pool: &PoolId,
     ) -> impl Future<Item = Option<PersistentSequence<HeaderHash>>, Error = Infallible> {
         let pool = pool.clone();
-        self.with_latest_state(move |state| state.stake_pools.lookup(&pool).map(|i| i.clone()))
+        self.with_latest_state(move |state| {
+            state.stake_pool_blocks.lookup(&pool).map(|i| i.clone())
+        })
+    }
+
+    pub fn get_stake_pool_data(
+        &self,
+        pool: &PoolId,
+    ) -> impl Future<Item = Option<StakePoolData>, Error = Infallible> {
+        let pool = pool.clone();
+        self.with_latest_state(move |state| state.stake_pool_data.lookup(&pool).map(|i| i.clone()))
     }
 
     /// run given function with the longest branch's state
@@ -486,9 +506,13 @@ fn apply_block_to_chain_lengths(
         })
 }
 
-fn apply_block_to_stake_pools(stake_pools: StakePools, block: &ExplorerBlock) -> StakePools {
-    let mut stake_pools = match &block.producer() {
-        indexing::BlockProducer::StakePool(id) => stake_pools
+fn apply_block_to_stake_pools(
+    data: StakePool,
+    blocks: StakePoolBlocks,
+    block: &ExplorerBlock,
+) -> (StakePool, StakePoolBlocks) {
+    let mut blocks = match &block.producer() {
+        indexing::BlockProducer::StakePool(id) => blocks
             .update(
                 &id,
                 |array: &PersistentSequence<HeaderHash>| -> std::result::Result<_, Infallible> {
@@ -497,21 +521,34 @@ fn apply_block_to_stake_pools(stake_pools: StakePools, block: &ExplorerBlock) ->
             )
             .expect("block to be created by registered stake pool"),
         indexing::BlockProducer::BftLeader(_) => unimplemented!(),
-        indexing::BlockProducer::None => stake_pools,
+        indexing::BlockProducer::None => blocks,
     };
+
+    let mut data = data;
 
     for tx in block.transactions.values() {
         if let Some(cert) = &tx.certificate {
-            stake_pools = match cert {
-                Certificate::PoolRegistration(registration) => stake_pools
+            blocks = match cert {
+                Certificate::PoolRegistration(registration) => blocks
                     .insert(registration.to_id(), PersistentSequence::new())
-                    .expect("same pool registration to happen only once"),
-                _ => stake_pools,
-            }
+                    .expect("pool was registered more than once"),
+                _ => blocks,
+            };
+            data = match cert {
+                Certificate::PoolRegistration(registration) => data
+                    .insert(
+                        registration.to_id(),
+                        StakePoolData {
+                            registration: registration.clone(),
+                        },
+                    )
+                    .expect("pool was registered more than once"),
+                _ => data,
+            };
         }
     }
 
-    stake_pools
+    (data, blocks)
 }
 
 impl BlockchainConfig {


### PR DESCRIPTION
Implement #1158 

Currently all the fields mentioned in that issue are present in the registration certificate, so this adds a way to get the registration certificate from a certain Pool. If those parameters can actually change after the registration, then it may be better to add this fields directly in the pool (but keep them in the certificate)

Like this
```graphql
{
  stakePool(id: "935f26b40001c2c3b716d865df4d92487262414e26c5cabe3bb6b01bdbba088a") {
    registration {
      serial
      startValidity
      managementThreshold
      owners
      operators
      rewards {
        fixed
        ratio {
          numerator
          denominator
        }
        maxLimit
      }
      rewardAccount
    }
  }
}
```