### PR TITLE
Rise type_length_limit

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -1,3 +1,7 @@
+// Rustc default type_length_limit is too low for complex futures, which generate deeply nested
+// monomorphized structured with long signatures. This value is enough for current project.
+#![type_length_limit = "10000000"]
+
 extern crate actix_net;
 extern crate actix_threadpool;
 extern crate actix_web;


### PR DESCRIPTION
Complex futures seem to exhaust default rustc limit. Fixes https://github.com/input-output-hk/jormungandr/pull/1141#issuecomment-555946899 and an existing workaround.