### PR TITLE
Add pool retirement and pool update certificates graphql types

### DIFF
--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -483,7 +483,7 @@ impl StakeDelegation {
             .map(|addr| Address::from(&ExplorerAddress::New(addr)))
     }
 
-    pub fn pool(&self, context: &Context) -> Vec<Pool> {
+    pub fn pools(&self, context: &Context) -> Vec<Pool> {
         use chain_impl_mockchain::account::DelegationType;
         use std::iter::FromIterator as _;
 
@@ -567,7 +567,7 @@ impl From<certificate::OwnerStakeDelegation> for OwnerStakeDelegation {
     Context = Context,
 )]
 impl OwnerStakeDelegation {
-    fn pool(&self) -> Vec<Pool> {
+    fn pools(&self) -> Vec<Pool> {
         use chain_impl_mockchain::account::DelegationType;
         use std::iter::FromIterator as _;
 


### PR DESCRIPTION
- Add missing `PoolRetirement` and `PoolUpdate`
- Rename (breaking change) `pool` for `pools` in `StakeDelegation` and `OwnerStakeDelegation` certificates, as it returns a list (plural) now.