### PR TITLE
poldercast crate update and automatic topology reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,7 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
- "poldercast 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1533,7 +1533,7 @@ dependencies = [
  "jormungandr-lib 0.7.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1594,7 +1594,7 @@ dependencies = [
  "jormungandr-lib 0.7.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2171,7 +2171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "poldercast"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4181,7 +4181,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum platforms 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
-"checksum poldercast 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2e427bda43436ad9b16e8cef283d13149aa9e48270003642abd2f4c570d91ca7"
+"checksum poldercast 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b70c2608abbc0b55553be895661c7d790305be66b9ceb041ccf358a332ec741d"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,7 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
- "poldercast 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1533,7 +1533,7 @@ dependencies = [
  "jormungandr-lib 0.7.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1594,7 +1594,7 @@ dependencies = [
  "jormungandr-lib 0.7.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2171,7 +2171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "poldercast"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4181,7 +4181,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum platforms 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
-"checksum poldercast 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c3551900c513e7c2d98758f28cb22cb533a4adbcedd5f21e21215f0a3d917db4"
+"checksum poldercast 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2e427bda43436ad9b16e8cef283d13149aa9e48270003642abd2f4c570d91ca7"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -48,7 +48,13 @@ p2p:
   Every time a new propagation event is triggered, the node will select
   randomly a certain amount of unreachable nodes to connect to in addition
   to the one selected by other p2p topology layer `[default: 20]`
-
+- `gossip_interval`: (optional) interval to start gossiping with new nodes,
+  changing the value will affect the bandwidth. The more often the node will
+  gossip the more bandwidth the node will need. The less often the node gossips
+  the less good the resilience to node churn. `[default: 10]`
+- `topology_force_reset_interval`: (optional) If this value is set, it will
+  trigger a force reset of the topology layers. The default is to not do
+  force the reset. It is recommended to let the protocol handle it.
 
 ### The trusted peers
 

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -39,7 +39,7 @@ linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = "0.9.8"
+poldercast = "0.9.9"
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -39,7 +39,7 @@ linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = "0.9.7"
+poldercast = "0.9.8"
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -258,16 +258,17 @@ pub fn start(
     let reset_err_logger = global_state.logger.clone();
     let tp2p = global_state.topology.clone();
 
-    global_state.spawn(
-        Interval::new_interval(Duration::from_secs(20))
-            .map_err(move |e| {
-                error!(reset_err_logger, "interval timer error: {:?}", e);
-            })
-            .for_each(move |_| Ok(tp2p.force_reset_layers())),
-    );
+    if let Some(interval) = global_state.config.topology_force_reset_interval.clone() {
+        global_state.spawn(
+            Interval::new_interval(interval)
+                .map_err(move |e| {
+                    error!(reset_err_logger, "interval timer error: {:?}", e);
+                })
+                .for_each(move |_| Ok(tp2p.force_reset_layers())),
+        );
+    }
 
-    // TODO: get gossip propagation interval from configuration
-    let gossip = Interval::new_interval(Duration::from_secs(10))
+    let gossip = Interval::new_interval(global_state.config.gossip_interval.clone())
         .map_err(move |e| {
             error!(gossip_err_logger, "interval timer error: {:?}", e);
         })

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -255,6 +255,17 @@ pub fn start(
     let handle_cmds = handle_network_input(input, global_state.clone(), channels.clone());
 
     let gossip_err_logger = global_state.logger.clone();
+    let reset_err_logger = global_state.logger.clone();
+    let tp2p = global_state.topology.clone();
+
+    global_state.spawn(
+        Interval::new_interval(Duration::from_secs(20))
+            .map_err(move |e| {
+                error!(reset_err_logger, "interval timer error: {:?}", e);
+            })
+            .for_each(move |_| Ok(tp2p.force_reset_layers())),
+    );
+
     // TODO: get gossip propagation interval from configuration
     let gossip = Interval::new_interval(Duration::from_secs(10))
         .map_err(move |e| {

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -14,6 +14,7 @@ use slog::Logger;
 use std::sync::{Arc, RwLock};
 
 /// object holding the P2pTopology of the Node
+#[derive(Clone)]
 pub struct P2pTopology {
     lock: Arc<RwLock<Topology>>,
     logger: Logger,
@@ -94,6 +95,10 @@ impl P2pTopology {
 
     pub fn node(&self) -> NodeProfile {
         self.lock.read().unwrap().profile().clone()
+    }
+
+    pub fn force_reset_layers(&self) {
+        self.lock.write().unwrap().force_reset_layers()
     }
 
     /// register a strike against the given node id

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -108,6 +108,22 @@ pub struct P2pConfig {
     /// to the one selected by other p2p topology layer.
     #[serde(default)]
     pub max_unreachable_nodes_to_connect_per_event: Option<usize>,
+
+    /// interval to start gossiping with new nodes, changing the value will
+    /// affect the bandwidth. The more often the node will gossip the more
+    /// bandwidth the node will need. The less often the node gossips the less
+    /// good the resilience to node churn.
+    ///
+    /// The default value is 10seconds.
+    #[serde(default)]
+    pub gossip_interval: Option<Duration>,
+
+    /// If this value is set, it will trigger a force reset of the topology
+    /// layers. The default is to not do force the reset. It is recommended
+    /// to let the protocol handle it.
+    ///
+    #[serde(default)]
+    pub topology_force_reset_interval: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -169,6 +185,8 @@ impl Default for P2pConfig {
             allow_private_addresses: false,
             policy: PolicyConfig::default(),
             max_unreachable_nodes_to_connect_per_event: None,
+            gossip_interval: None,
+            topology_force_reset_interval: None,
         }
     }
 }

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -243,6 +243,11 @@ fn generate_network(
         timeout: std::time::Duration::from_secs(15),
         allow_private_addresses: p2p.allow_private_addresses,
         max_unreachable_nodes_to_connect_per_event: p2p.max_unreachable_nodes_to_connect_per_event,
+        gossip_interval: p2p
+            .gossip_interval
+            .map(|d| d.into())
+            .unwrap_or(std::time::Duration::from_secs(10)),
+        topology_force_reset_interval: p2p.topology_force_reset_interval.map(|d| d.into()),
     };
 
     Ok(network)

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -68,6 +68,10 @@ pub struct Configuration {
     pub allow_private_addresses: bool,
 
     pub max_unreachable_nodes_to_connect_per_event: Option<usize>,
+
+    pub gossip_interval: Duration,
+
+    pub topology_force_reset_interval: Option<Duration>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This PR update the dependency on `poldercast` library and also exposes 2 new parameters for the interval for gossips and the optional resetting the topology reset.

The latest one is a new feature for the long running publicly reachable nodes. They may want to force the policy to re-apply on the topology more often. This will allow removing lose ends more often.