### PR TITLE
Transform REST server into Tokio service

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -415,12 +415,12 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let rest_context = match settings.rest.clone() {
         Some(rest) => {
             let context = rest::Context::new();
+            let service_context = context.clone();
             let explorer = settings.explorer;
-            let server_context = context.clone();
-            services.spawn("rest", move |info| {
-                server_context.set_logger(info.into_logger());
-                rest::run_rest_server(rest, explorer, server_context)
-                    .expect("REST server critical failure")
+            let server_handler = rest::start_rest_server(rest, explorer, &context)?;
+            services.spawn_future("rest", move |info| {
+                service_context.set_logger(info.into_logger());
+                server_handler
             });
             Some(context)
         }

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -314,7 +314,7 @@ pub fn get_shutdown(context: State<Context>) -> Result<impl Responder, Error> {
     // Server finishes ongoing tasks before stopping, so user will get response to this request
     // Node should be shutdown automatically when server stopping is finished
     context.try_full()?;
-    context.server()?.stop();
+    context.server_stopper()?.stop();
     Ok(HttpResponse::Ok().finish())
 }
 


### PR DESCRIPTION
Closes https://github.com/input-output-hk/jormungandr/issues/913. Actix-web is monolithic, the only way to run it is in custom thread. This PR wraps it in a future making it controllable as a regular Tokio task:

- finish future when server stops (causing stopping the whole node)
- stop server when future is dropped (because other task has finished or crashed and whole node is being stopped)