### PR TITLE
Small network fixes, improve logging

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -228,6 +228,12 @@ pub struct PostCheckedHeader {
     previous_epoch_state: Option<Arc<Ref>>,
 }
 
+impl PostCheckedHeader {
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+}
+
 impl Blockchain {
     pub fn new(storage: NodeStorage, ref_cache_ttl: Duration) -> Self {
         Blockchain {

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -125,6 +125,12 @@ fn handle_block(
                 .map_err(|e| Error::HeaderCheckFailed { source: e })
         })
         .and_then(move |post_checked| {
+            debug!(
+                logger,
+                "validated block";
+                "hash" => %post_checked.header().hash(),
+                "block_date" => %post_checked.header().block_date(),
+            );
             end_blockchain
                 .apply_and_store_block(post_checked, block)
                 .map_err(|e| Error::ApplyBlockFailed { source: e })

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -538,7 +538,7 @@ pub fn fetch_block(
                 warn!(logger, "failed to download block"; "error" => ?e);
             }
             Ok(b) => {
-                info!(logger, "initial bootstrap completed");
+                info!(logger, "genesis block fetched");
                 block = Some(b);
                 break;
             }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -24,7 +24,7 @@ mod buffer_sizes {
         // (GetBlocks response or an UploadBlocks request)
         // while waiting for the block task to become ready to process
         // the next block.
-        pub const BLOCKS: usize = 2;
+        pub const BLOCKS: usize = 8;
 
         // The maximum number of fragments to buffer from an incoming subscription
         // while waiting for the fragment task to become ready to process them.
@@ -37,7 +37,7 @@ mod buffer_sizes {
         // The maximum number of blocks to buffer for an outbound stream
         // (GetBlocks response or an UploadBlocks request)
         // before the client request task producing them gets preempted.
-        pub const BLOCKS: usize = 2;
+        pub const BLOCKS: usize = 8;
     }
 }
 


### PR DESCRIPTION
Small fixes, more logging, and band-aids in trying to troubleshoot the network slowness observed with bootstrapping nodes.