### PR TITLE
remote syslog via UDP

### DIFF
--- a/doc/quickstart/02_passive_node.md
+++ b/doc/quickstart/02_passive_node.md
@@ -49,6 +49,9 @@ Description of the fields:
       - `stdout`: standard output
       - `stderr`: standard error
       - `syslog`: syslog (only available on Unix systems)
+      - `syslogudp`: remote syslog  (only available on Unix systems)
+        - `host`: address and port of a syslog server
+        - `hostname`: hostname to attach to syslog messages
       - `journald`: journald service (only available on Linux with systemd,
         (if jormungandr is built with the `systemd` feature)
       - `gelf`: Configuration fields for GELF (Graylog) network logging protocol


### PR DESCRIPTION
Resolves #525 

An example configuration:

```yaml
log:
  - output:
      syslogudp:
        host: 127.0.0.1:514
        hostname: jormungandr
    level: info
    format: plain
  - output: stderr
    level: debug
    format: plain
```