### PR TITLE
Add input output to block and initial fees

### DIFF
--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -154,6 +154,16 @@ impl Block {
                 BlockProducer::None => None,
             })
     }
+
+    pub fn total_input(&self, context: &Context) -> FieldResult<Value> {
+        self.get_explorer_block(&context.db)
+            .map(|block| Value(format!("{}", block.total_input)))
+    }
+
+    pub fn total_output(&self, context: &Context) -> FieldResult<Value> {
+        self.get_explorer_block(&context.db)
+            .map(|block| Value(format!("{}", block.total_output)))
+    }
 }
 
 struct BftLeader {

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -908,9 +908,18 @@ impl Status {
             .map(|b| Block::from(&b))
     }
 
-    pub fn fee_settings(&self) -> FieldResult<FeeSettings> {
-        // TODO: Where can I get this?
-        Err(ErrorKind::Unimplemented.into())
+    pub fn fee_settings(&self, context: &Context) -> FeeSettings {
+        let chain_impl_mockchain::fee::LinearFee {
+            constant,
+            coefficient,
+            certificate,
+        } = context.db.blockchain_config.fees;
+
+        FeeSettings {
+            constant: Value(format!("{}", constant)),
+            coefficient: Value(format!("{}", coefficient)),
+            certificate: Value(format!("{}", certificate)),
+        }
     }
 }
 

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -22,6 +22,7 @@ use crate::utils::task::{Input, TokioServiceInfo};
 use chain_addr::Discrimination;
 use chain_core::property::Block as _;
 use chain_impl_mockchain::certificate::{Certificate, PoolId};
+use chain_impl_mockchain::fee::LinearFee;
 use chain_impl_mockchain::multiverse::GCRoot;
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -61,6 +62,7 @@ pub struct BlockchainConfig {
     /// inputs
     discrimination: Discrimination,
     consensus_version: ConsensusVersion,
+    fees: LinearFee,
 }
 
 /// Inmutable data structure used to represent the explorer's state at a given Block
@@ -571,9 +573,19 @@ impl BlockchainConfig {
             .next()
             .expect("consensus version to be present");
 
+        let fees = params
+            .iter()
+            .filter_map(|param| match param {
+                ConfigParam::LinearFee(fee) => Some(fee.clone()),
+                _ => None,
+            })
+            .next()
+            .expect("fee is not in config params");
+
         BlockchainConfig {
             discrimination,
             consensus_version,
+            fees,
         }
     }
 }


### PR DESCRIPTION
- Add total input and output aggregations to blocks. To avoid the need of iterating though all the transactions as mentioned in #1125 , although I'm not sure how much worth it is
- Implement fee getter. This are only the initial fees and doesn't track updates.