### PR TITLE
Disgraceful REST shutdown

### DIFF
--- a/jormungandr/src/rest/server/mod.rs
+++ b/jormungandr/src/rest/server/mod.rs
@@ -84,13 +84,6 @@ impl Future for Server {
     }
 }
 
-impl Drop for Server {
-    fn drop(&mut self) {
-        self.stopper.stop();
-        let _ = self.wait();
-    }
-}
-
 impl ServerStopper {
     pub fn stop(&self) {
         self.addr.do_send(StopServer { graceful: false })


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/jormungandr/pull/1173#discussion_r350579386

Removes graceful yet slow and risky shutdown of REST server when its future is dropped. We don't have graceful node shutdown yet and server clean-up during abrupt shutdown is a bad idea.

When graceful shutdown is designed, it'll make sense to make REST server a task with input, so it can listen for the `Shutdown` message. Right now there's nobody to send it, so this change would be pointless.