### PR TITLE
Implement all stake pools graphql query

### DIFF
--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -1217,10 +1217,10 @@ impl Query {
         let mut stake_pools = context.db.get_stake_pools().wait()?;
 
         // Although it's probably not a big performance concern
-        // There are a few alternatives to not have to sort this 
+        // There are a few alternatives to not have to sort this
         // - A separate data structure can be used to track InsertionOrder -> PoolId
         // (or any other order)
-        // - Find some way to rely in the Hamt iterator order (but I think this is probably not a good idea) 
+        // - Find some way to rely in the Hamt iterator order (but I think this is probably not a good idea)
         stake_pools.sort_unstable_by_key(|(id, data)| id.clone());
 
         let boundaries = if stake_pools.len() > 0 {

--- a/jormungandr/src/explorer/graphql/scalars.rs
+++ b/jormungandr/src/explorer/graphql/scalars.rs
@@ -30,6 +30,9 @@ pub struct BlockCount(pub String);
 pub struct TransactionCount(pub String);
 
 #[derive(juniper::GraphQLScalarValue)]
+pub struct PoolCount(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
 pub struct PublicKey(pub String);
 
 #[derive(juniper::GraphQLScalarValue)]
@@ -123,6 +126,12 @@ impl From<chain_time::TimeOffsetSeconds> for TimeOffsetSeconds {
 impl From<u64> for TransactionCount {
     fn from(n: u64) -> TransactionCount {
         TransactionCount(format!("{}", n))
+    }
+}
+
+impl From<u64> for PoolCount {
+    fn from(n: u64) -> PoolCount {
+        PoolCount(format!("{}", n))
     }
 }
 

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -410,6 +410,18 @@ impl ExplorerDB {
         })
     }
 
+    pub fn get_stake_pools(
+        &self,
+    ) -> impl Future<Item = Vec<(PoolId, Arc<StakePoolData>)>, Error = Infallible> {
+        self.with_latest_state(move |state| {
+            state
+                .stake_pool_data
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        })
+    }
+
     /// run given function with the longest branch's state
     fn with_latest_state<T>(
         &self,


### PR DESCRIPTION
# Implement query for all stake pools.

## Considerations
- The order is by pool id.
- The pagination scheme is the same as the other querys.

## For example:

```graphql
{
  allStakePools {
    totalCount
    edges {
      cursor
      node {
        id
        registration {
          startValidity
          owners
          managementThreshold
          operators
          rewards {
            fixed
            ratio {
              numerator,
              denominator
            }
            maxLimit
          }
          rewardAccount {
            id
          }
        }
      }
    }
  }
}
``` 