### PR TITLE
Pull from block 0 if no checkpoints intersect

### DIFF
--- a/jormungandr/src/client.rs
+++ b/jormungandr/src/client.rs
@@ -83,7 +83,7 @@ pub fn handle_input(
             TaskAction::GetHeaders(handle.async_reply(get_headers(task_data.storage.clone(), ids)))
         }
         ClientMsg::GetHeadersRange(checkpoints, to, handle) => TaskAction::GetHeadersRange(
-            handle_get_headers_range(task_data.storage.clone(), checkpoints, to, handle),
+            handle_get_headers_range(task_data, checkpoints, to, handle),
         ),
         ClientMsg::GetBlocks(ids, handle) => {
             TaskAction::GetBlocks(handle.async_reply(get_blocks(task_data.storage.clone(), ids)))
@@ -92,12 +92,7 @@ pub fn handle_input(
             handle_get_blocks_range(&task_data.storage, from, to, handle),
         ),
         ClientMsg::PullBlocksToTip(from, handle) => {
-            TaskAction::PullBlocksToTip(handle_pull_blocks_to_tip(
-                task_data.storage.clone(),
-                task_data.blockchain_tip.clone(),
-                from,
-                handle,
-            ))
+            TaskAction::PullBlocksToTip(handle_pull_blocks_to_tip(task_data, from, handle))
         }
     }
 }
@@ -109,15 +104,18 @@ fn get_block_tip(blockchain_tip: &Tip) -> impl Future<Item = Header, Error = Err
 }
 
 fn handle_get_headers_range(
-    storage: Storage,
+    task_data: &TaskData,
     checkpoints: Vec<HeaderHash>,
     to: HeaderHash,
     handle: ReplyStreamHandle<Header>,
 ) -> impl Future<Item = (), Error = ()> {
+    let storage = task_data.storage.clone();
+    let block0_hash = task_data.block0_hash;
     storage
         .find_closest_ancestor(checkpoints, to)
         .then(move |res| match res {
-            Ok(Some(from)) => {
+            Ok(maybe_ancestor) => {
+                let from = maybe_ancestor.unwrap_or(block0_hash);
                 let fut = storage
                     .send_from_to(
                         from,
@@ -127,10 +125,6 @@ fn handle_get_headers_range(
                     .map_err(|_: ReplySendError| ());
                 Either::A(fut)
             }
-            Ok(None) => Either::B(handle.async_error(Error::not_found(
-                "none of the checkpoints found in the local storage \
-                 are ancestors of the requested end block",
-            ))),
             Err(e) => Either::B(handle.async_error(e.into())),
         })
 }
@@ -178,27 +172,27 @@ fn get_headers(
 }
 
 fn handle_pull_blocks_to_tip(
-    storage: Storage,
-    blockchain_tip: Tip,
+    task_data: &TaskData,
     checkpoints: Vec<HeaderHash>,
     handle: ReplyStreamHandle<Block>,
 ) -> impl Future<Item = (), Error = ()> {
-    blockchain_tip
+    let storage = task_data.storage.clone();
+    let block0_hash = task_data.block0_hash;
+    task_data
+        .blockchain_tip
         .get_ref()
         .and_then(move |tip| {
             let tip_hash = tip.hash();
             storage
                 .find_closest_ancestor(checkpoints, tip_hash)
-                .map(move |maybe_ancestor| (storage, maybe_ancestor, tip_hash))
+                .map(move |maybe_ancestor| {
+                    (storage, maybe_ancestor.unwrap_or(block0_hash), tip_hash)
+                })
         })
         .then(move |res| match res {
-            Ok((storage, Some(from), to)) => {
+            Ok((storage, from, to)) => {
                 Either::A(storage.send_from_to(from, to, handle).map_err(|_| ()))
             }
-            Ok((_, None, _)) => Either::B(handle.async_error(Error::not_found(
-                "none of the checkpoints found in the local storage \
-                 are ancestors of the current tip",
-            ))),
             Err(e) => Either::B(handle.async_error(e.into())),
         })
 }


### PR DESCRIPTION
In the client task, fall back to block 0 as the starting point for pulling headers or blocks from, if no checkpoints sent by the requesting node are found to be ancestors of the end block and present in the local storage.