### PR TITLE
don't add the block0 per-certificate fee if they are all not set (0)

### DIFF
--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
@@ -320,14 +320,19 @@ impl BlockchainConfiguration {
         params.push(ConfigParam::Discrimination(discrimination));
         params.push(ConfigParam::ConsensusVersion(block0_consensus));
         params.push(ConfigParam::LinearFee(linear_fees));
-        params.push(ConfigParam::PerCertificateFees(
-            linear_fees.per_certificate_fees,
-        ));
         params.push(ConfigParam::from(slots_per_epoch));
         params.push(ConfigParam::from(slot_duration));
         params.push(ConfigParam::from(kes_update_speed));
         params.push(ConfigParam::from(consensus_genesis_praos_active_slot_coeff));
         params.push(ConfigParam::from(bft_slots_ratio));
+
+        if !crate::interfaces::linear_fee::per_certificate_fee_is_zero(
+            &linear_fees.per_certificate_fees,
+        ) {
+            params.push(ConfigParam::PerCertificateFees(
+                linear_fees.per_certificate_fees,
+            ));
+        }
 
         if let Some(max_number_of_transactions_per_block) = max_number_of_transactions_per_block {
             params.push(ConfigParam::MaxNumberOfTransactionsPerBlock(

--- a/jormungandr-lib/src/interfaces/linear_fee.rs
+++ b/jormungandr-lib/src/interfaces/linear_fee.rs
@@ -31,7 +31,7 @@ pub struct LinearFeeDef {
     per_certificate_fees: PerCertificateFee,
 }
 
-fn per_certificate_fee_is_zero(fee: &PerCertificateFee) -> bool {
+pub(crate) fn per_certificate_fee_is_zero(fee: &PerCertificateFee) -> bool {
     fee.certificate_stake_delegation.is_none()
         && fee.certificate_owner_stake_delegation.is_none()
         && fee.certificate_pool_registration.is_none()


### PR DESCRIPTION
this will make the block0 a couple of bytes smaller.