### PR TITLE
Don't panic on network task error

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -236,8 +236,6 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 channels,
             };
             network::start(info, params)
-                // FIXME: more graceful error reporting
-                .map_err(|e| panic!(e))
         });
     }
 


### PR DESCRIPTION
Now that all task errors are gracefully handled, no need to panic on network task errors.