### PR TITLE
Resolve the ancestor once for chain streaming

### DIFF
--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -468,7 +468,6 @@ pub enum ClientMsg {
     GetHeaders(Vec<HeaderHash>, ReplyStreamHandle<Header>),
     GetHeadersRange(Vec<HeaderHash>, HeaderHash, ReplyStreamHandle<Header>),
     GetBlocks(Vec<HeaderHash>, ReplyStreamHandle<Block>),
-    GetBlocksRange(HeaderHash, HeaderHash, ReplyStreamHandle<Block>),
     PullBlocksToTip(Vec<HeaderHash>, ReplyStreamHandle<Block>),
 }
 
@@ -491,14 +490,8 @@ impl Debug for ClientMsg {
                 .field(&format_args!("_"))
                 .finish(),
             ClientMsg::GetBlocks(ids, _) => f
-                .debug_tuple("GetBlocksRange")
+                .debug_tuple("GetBlocks")
                 .field(ids)
-                .field(&format_args!("_"))
-                .finish(),
-            ClientMsg::GetBlocksRange(from, to, _) => f
-                .debug_tuple("GetBlocksRange")
-                .field(from)
-                .field(to)
                 .field(&format_args!("_"))
                 .finish(),
             ClientMsg::PullBlocksToTip(from, _) => f

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -207,7 +207,6 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
     let client_task = {
         let mut task_data = client::TaskData {
             storage: blockchain.storage().clone(),
-            block0_hash: bootstrapped_node.block0_hash,
             blockchain_tip: blockchain_tip.clone(),
         };
 


### PR DESCRIPTION
The return value for `Storage::find_closest_ancestor` also returns the distance, which is used by the streaming function `Storage::send_branch`, renamed from `send_from_to`, to avold looking up the ancestor one more time.

The `GetBlocksRange` request is removed as it is not used in the current protocol.