### PR TITLE
change how to set the reward account in the jcli command line parameter

### DIFF
--- a/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_pool_registration.rs
@@ -113,6 +113,7 @@ pub struct StakePoolRegistration {
     ///
     /// If this value is set, instead of distributing the rewards to the owners
     /// the rewards will be distributed to this account.
+    #[structopt(long = "reward-account", name = "REWARD_ACCOUNT")]
     pub reward_account: Option<AccountIdentifier>,
 
     /// print the output signed certificate in the given file, if no file given


### PR DESCRIPTION
set the reward account as a command line parameter, not a positional parameter. This will prevent issues when setting the output file if needed. and makes the CLI more verbose/easy to check