### PR TITLE
Rest node stats REST cert fees

### DIFF
--- a/doc/jcli/rest.md
+++ b/doc/jcli/rest.md
@@ -267,7 +267,13 @@ fees:                                           # transaction fee configuration
   certificate: 4                                # fee per certificate
   coefficient: 1                                # fee per every input and output
   constant: 2                                   # fee per transaction
+  per_certificate_fees:                         # Fee per certificate operations, all zero if this object absent (optional)
+    certificate_pool_registration: 5            # Fee per pool registration, zero if absent (optional)
+    certificate_stake_delegation: 15            # Fee per stake delegation, zero if absent (optional)
+    certificate_owner_stake_delegation: 2       # Fee per pool owner stake delegation, zero if absent (optional)
 maxTxsPerBlock: 100                             # maximum number of transactions in block
+slotDuration: 5                                 # slot duration in seconds
+slotsPerEpoch: 720                              # number of slots per epoch
 ```
 
 ## Node shutdown

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -612,21 +612,22 @@ paths:
                         type: integer
                         minimum: 0
                       per_certificate_fees:
+                        description: Fee per certificate operations, all zero if this object absent
                         type: object
-                        required: [certificate_pool_registration, certificate_stake_delegation, certificate_owner_stake_delegation]
+                        required: []
                         properties:
                           certificate_pool_registration:
-                            description: Fee per pool registration
+                            description: Fee per pool registration, zero if absent
                             type: integer
-                            minimum: 0
+                            minimum: 1
                           certificate_stake_delegation:
-                            description: Fee per stake delegation
+                            description: Fee per stake delegation, zero if absent
                             type: integer
-                            minimum: 0
+                            minimum: 1
                           certificate_owner_stake_delegation:
-                            description: Fee per pool owner stake delegation
+                            description: Fee per pool owner stake delegation, zero if absent
                             type: integer
-                            minimum: 0
+                            minimum: 1
                       coefficient:
                         description: Fee per every input and output of transaction
                         type: integer

--- a/jormungandr-lib/src/interfaces/linear_fee.rs
+++ b/jormungandr-lib/src/interfaces/linear_fee.rs
@@ -9,11 +9,11 @@ use std::num::NonZeroU64;
     remote = "PerCertificateFee"
 )]
 pub struct PerCertificateFeeDef {
-    #[serde(default, skip_serializing_if = "is_none_or_zero")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub certificate_pool_registration: Option<NonZeroU64>,
-    #[serde(default, skip_serializing_if = "is_none_or_zero")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub certificate_stake_delegation: Option<NonZeroU64>,
-    #[serde(default, skip_serializing_if = "is_none_or_zero")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub certificate_owner_stake_delegation: Option<NonZeroU64>,
 }
 
@@ -35,8 +35,4 @@ pub(crate) fn per_certificate_fee_is_zero(fee: &PerCertificateFee) -> bool {
     fee.certificate_stake_delegation.is_none()
         && fee.certificate_owner_stake_delegation.is_none()
         && fee.certificate_pool_registration.is_none()
-}
-
-fn is_none_or_zero(opt_nz: &Option<NonZeroU64>) -> bool {
-    !opt_nz.map(|_| true).unwrap_or(false)
 }

--- a/jormungandr-lib/src/interfaces/settings.rs
+++ b/jormungandr-lib/src/interfaces/settings.rs
@@ -12,8 +12,8 @@ pub struct SettingsDto {
     #[serde(with = "LinearFeeDef")]
     pub fees: LinearFee,
     pub max_txs_per_block: u32,
-    pub slot_duration: Option<u64>,
-    pub slots_per_epoch: Option<u32>,
+    pub slot_duration: u64,
+    pub slots_per_epoch: u32,
 }
 
 impl PartialEq<SettingsDto> for SettingsDto {

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -295,7 +295,6 @@ pub fn get_settings(context: State<Context>) -> ActixFuture!() {
             let consensus_version = ledger.consensus_version();
             let current_params = blockchain_tip.epoch_ledger_parameters();
             let fees = current_params.fees;
-            let slot_duration = blockchain_tip.time_frame().slot_duration();
             let slots_per_epoch = blockchain_tip
                 .epoch_leadership_schedule()
                 .era()
@@ -311,8 +310,8 @@ pub fn get_settings(context: State<Context>) -> ActixFuture!() {
                 consensus_version: consensus_version.to_string(),
                 fees: fees,
                 max_txs_per_block: 255, // TODO?
-                slot_duration: Some(slot_duration),
-                slots_per_epoch: Some(slots_per_epoch),
+                slot_duration: blockchain_tip.time_frame().slot_duration(),
+                slots_per_epoch,
             };
 
             Json(json!(settings))


### PR DESCRIPTION
Kind of part of https://github.com/input-output-hk/jormungandr/issues/1248

It turned out that the first point was already done and per-cert fees are returned, but only if they are non-zero. It wasn't documented very precisely, which is being fixed here, as well as little clean-up of that functionality.