### PR TITLE
Rest tax and reward settings

### DIFF
--- a/doc/jcli/rest.md
+++ b/doc/jcli/rest.md
@@ -272,8 +272,10 @@ fees:                                           # transaction fee configuration
     certificate_stake_delegation: 15            # Fee per stake delegation, zero if absent (optional)
     certificate_owner_stake_delegation: 2       # Fee per pool owner stake delegation, zero if absent (optional)
 maxTxsPerBlock: 100                             # maximum number of transactions in block
+reward: 250                                     # contribution reward for next slot
 slotDuration: 5                                 # slot duration in seconds
 slotsPerEpoch: 720                              # number of slots per epoch
+treasuryTax: 8                                  # treasury pot reward for next slot
 ```
 
 ## Node shutdown

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -584,7 +584,7 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [block0Hash, block0Time, consensusVersion, fees, maxTxsPerBlock, slotDuration, slotsPerEpoch]
+                required: [block0Hash, block0Time, consensusVersion, fees, maxTxsPerBlock, reward, slotDuration, slotsPerEpoch, treasuryTax]
                 properties:
                   block0Hash:
                     description: Hex-encoded hash of block0
@@ -640,12 +640,20 @@ paths:
                     description: Maximum number of transactions in block
                     type: integer
                     minimum: 0
+                  reward:
+                    description: Contribution reward for next slot
+                    type: integer
+                    minimum: 0
                   slotDuration:
                     description: Slot duration in seconds
                     type: integer
                     minimum: 0
                   slotsPerEpoch:
                     description: Number of slots per epoch
+                    type: integer
+                    minimum: 0
+                  treasuryTax:
+                    description: Treasury pot reward for next slot
                     type: integer
                     minimum: 0
               example: |
@@ -665,8 +673,10 @@ paths:
                     "constant": 2
                   },
                   "maxTxsPerBlock": 100,
+                  "reward": 250,
                   "slotDuration": 10,
-                  "slotsPerEpoch": 60
+                  "slotsPerEpoch": 60,
+                  "treasuryTax": 8
                 }
   /api/v0/shutdown:
     get:

--- a/jormungandr-lib/src/interfaces/certificate.rs
+++ b/jormungandr-lib/src/interfaces/certificate.rs
@@ -53,11 +53,11 @@ impl property::Serialize for Certificate {
         match &self.0 {
             certificate::Certificate::StakeDelegation(c) => {
                 writer.write_all(&[1])?;
-                c.serialize(&mut writer)?;
+                property::Serialize::serialize(&c, &mut writer)?;
             }
             certificate::Certificate::OwnerStakeDelegation(c) => {
                 writer.write_all(&[2])?;
-                c.serialize(&mut writer)?;
+                property::Serialize::serialize(&c, &mut writer)?;
             }
             certificate::Certificate::PoolRegistration(c) => {
                 writer.write_all(&[3])?;
@@ -114,12 +114,12 @@ impl property::Serialize for SignedCertificate {
         match &self.0 {
             certificate::SignedCertificate::StakeDelegation(c, a) => {
                 writer.write_all(&[1])?;
-                c.serialize(&mut writer)?;
+                property::Serialize::serialize(&c, &mut writer)?;
                 writer.write_all(a.serialize_in(ByteBuilder::new()).finalize().as_slice())?;
             }
             certificate::SignedCertificate::OwnerStakeDelegation(c, ()) => {
                 writer.write_all(&[2])?;
-                c.serialize(&mut writer)?;
+                property::Serialize::serialize(&c, &mut writer)?;
             }
             certificate::SignedCertificate::PoolRegistration(c, a) => {
                 writer.write_all(&[3])?;

--- a/jormungandr-lib/src/interfaces/settings.rs
+++ b/jormungandr-lib/src/interfaces/settings.rs
@@ -1,4 +1,7 @@
-use crate::{interfaces::LinearFeeDef, time::SystemTime};
+use crate::{
+    interfaces::{LinearFeeDef, Value},
+    time::SystemTime,
+};
 use chain_impl_mockchain::fee::LinearFee;
 use serde::{Deserialize, Serialize};
 
@@ -14,6 +17,8 @@ pub struct SettingsDto {
     pub max_txs_per_block: u32,
     pub slot_duration: u64,
     pub slots_per_epoch: u32,
+    pub treasury_tax: Value,
+    pub reward: Value,
 }
 
 impl PartialEq<SettingsDto> for SettingsDto {
@@ -25,5 +30,7 @@ impl PartialEq<SettingsDto> for SettingsDto {
             && self.max_txs_per_block == other.max_txs_per_block
             && self.slot_duration == other.slot_duration
             && self.slots_per_epoch == other.slots_per_epoch
+            && self.treasury_tax == other.treasury_tax
+            && self.reward == other.reward
     }
 }


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/jormungandr/issues/1248

Adds treasury tax and reward calculated for the next epoch. I've figured out, that the front end and the users are interested in concrete value and if we provided actual settings, they would have to mirror the non-trivial calculation logic on their side.

If all the little knobs are interesting for users, I can add them as well, abandoned half-finished work with this approach is on another branch, I can rebase and finish it.