### PR TITLE
blockchain: Rework task state

### DIFF
--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
     chain_selection::{compare_against, ComparisonResult},
     checkpoints::Checkpoints,
     multiverse::Multiverse,
-    process::{handle_input, process_new_ref},
+    process::{process_new_ref, Process},
     reference::Ref,
     storage::Storage,
     tip::Tip,


### PR DESCRIPTION
Remodel `blockchain` task state after `fragment::Process`.
No more independent instances of `CandidateForest` mistakenly created anew for each input message.