### PR TITLE
BlockContent Size: finally set the rifht value for number of fragments

### DIFF
--- a/doc/advanced/01_the_genesis_block.md
+++ b/doc/advanced/01_the_genesis_block.md
@@ -38,7 +38,7 @@ There are multiple _parts_ in the genesis file:
 | `slot_duration` | number | the number of seconds between the creation of 2 blocks |
 | `epoch_stability_depth` | number | allowed size of a fork (in number of block) |
 | `consensus_leader_ids` | array | the list of the BFT leader at the beginning of the blockchain |
-| `max_number_of_transactions_per_block` | number | the maximum number of transactions allowed in a block |
+| `block_content_max_size` | number | the maximum size of the block content, in bytes. |
 | `bft_slots_ratio` | number | placeholder, do not use |
 | `linear_fees` | object | linear fee settings, set the fee for transaction and certificate publishing |
 | `consensus_genesis_praos_active_slot_coeff` | number | genesis praos active slot coefficient.  Determines minimum stake required to try becoming slot leader, must be in range (0,1] |

--- a/doc/advanced/02_starting_bft_blockchain.md
+++ b/doc/advanced/02_starting_bft_blockchain.md
@@ -35,7 +35,6 @@ blockchain_configuration:
     - ed25519e_pk13talprd9grgaqzs42mkm0x2xek5wf9mdf0eefdy8a6dk5grka2gstrp3en
   bft_slots_ratio: 0.220
   consensus_genesis_praos_active_slot_coeff: 0.22
-  max_number_of_transactions_per_block: 255
   linear_fees:
     constant: 2
     coefficient: 1

--- a/jormungandr-lib/src/interfaces/block0_configuration/DOCUMENTED_EXAMPLE.yaml
+++ b/jormungandr-lib/src/interfaces/block0_configuration/DOCUMENTED_EXAMPLE.yaml
@@ -33,6 +33,14 @@ blockchain_configuration:
   # default value is {default_slot_duration}
   slot_duration: {default_slot_duration}
 
+  # set the block content max size
+  #
+  # This is the size, in bytes, of all the contents of the block (excluding the
+  # block header).
+  #
+  # default value is {default_block_content_max_size}
+  block_content_max_size: {default_block_content_max_size}
+
   # A list of Ed25519 PublicKey that represents the
   # BFT leaders encoded as bech32. The order in the list matters.
   consensus_leader_ids:

--- a/jormungandr-lib/src/interfaces/block0_configuration/block_content_max_size.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/block_content_max_size.rs
@@ -1,0 +1,44 @@
+use crate::interfaces::DEFAULT_BLOCK_CONTENT_MAX_SIZE;
+use chain_impl_mockchain::fragment;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// the block content max size
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct BlockContentMaxSize(fragment::BlockContentSize);
+
+impl fmt::Display for BlockContentMaxSize {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Default for BlockContentMaxSize {
+    fn default() -> Self {
+        BlockContentMaxSize(DEFAULT_BLOCK_CONTENT_MAX_SIZE)
+    }
+}
+
+impl From<fragment::BlockContentSize> for BlockContentMaxSize {
+    fn from(v: fragment::BlockContentSize) -> Self {
+        BlockContentMaxSize(v)
+    }
+}
+
+impl From<BlockContentMaxSize> for fragment::BlockContentSize {
+    fn from(v: BlockContentMaxSize) -> Self {
+        v.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for BlockContentMaxSize {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            BlockContentMaxSize(Arbitrary::arbitrary(g))
+        }
+    }
+}

--- a/jormungandr-lib/src/interfaces/block0_configuration/default_values.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/default_values.rs
@@ -29,6 +29,9 @@ pub const MINIMUM_NUMBER_OF_SLOTS_PER_EPOCH: u32 = 1;
 /// maximum number of slots per epoch
 pub const MAXIMUM_NUMBER_OF_SLOTS_PER_EPOCH: u32 = 1_000_000;
 
+/// the default value for block content max size
+pub const DEFAULT_BLOCK_CONTENT_MAX_SIZE: u32 = 102_400;
+
 /// default slot duration in seconds
 pub const DEFAULT_SLOT_DURATION: u8 = 5;
 /// minimum slot duration in seconds

--- a/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
@@ -1,5 +1,6 @@
 mod active_slot_coefficient;
 mod bft_slots_ratio;
+mod block_content_max_size;
 mod default_values;
 mod initial_config;
 mod initial_fragment;
@@ -10,6 +11,7 @@ mod slots_duration;
 
 pub use self::active_slot_coefficient::ActiveSlotCoefficient;
 pub use self::bft_slots_ratio::BFTSlotsRatio;
+pub use self::block_content_max_size::BlockContentMaxSize;
 pub use self::default_values::*;
 pub use self::initial_config::BlockchainConfiguration;
 pub use self::initial_fragment::{Initial, InitialUTxO, LegacyUTxO};
@@ -115,6 +117,7 @@ pub fn block0_configuration_documented_example() -> String {
         default_bft_slots_ratio = BFTSlotsRatio::default(),
         default_consensus_genesis_praos_active_slot_coeff = ActiveSlotCoefficient::default(),
         default_kes_update_speed = KESUpdateSpeed::default(),
+        default_block_content_max_size = BlockContentMaxSize::default(),
         leader_1 = leader_1_pk,
         leader_2 = leader_2_pk,
         initial_funds_address = initial_funds_address

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -461,7 +461,7 @@ impl Blockchain {
 
         future::result(
             ledger
-                .apply_block(&epoch_ledger_parameters, block.contents.iter(), &metadata)
+                .apply_block(&epoch_ledger_parameters, &block.contents, &metadata)
                 .chain_err(|| ErrorKind::CannotApplyBlock),
         )
         .and_then(move |new_ledger| {

--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -663,7 +663,7 @@ fn prepare_block(
 ) -> impl Future<Item = Contents, Error = LeadershipError> {
     use crate::fragment::selection::{FragmentSelectionAlgorithm as _, OldestFirst};
 
-    let selection_algorithm = OldestFirst::new(250 /* TODO!! */);
+    let selection_algorithm = OldestFirst::new();
     fragment_pool
         .select(
             ledger.as_ref().clone(),


### PR DESCRIPTION
fix #86

⚠️ this contains a breaking change. Once applied, previous blockchain won't be compatible anymore.

This PR add the concept of block content max size: the maximum size, in bytes, of the whole block content.

```yaml
blockchain_configuration:
  # set the maximum block content size to 100KBytes.
  block_content_max_size: 102400
```

depends on input-output-hk/chain-libs#204 to be merged in first