### PR TITLE
change to old sqlite connection impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "chain-storage-sqlite"
+name = "chain-storage-sqlite-old"
 version = "0.1.0"
 dependencies = [
  "chain-core 0.1.0",
@@ -1467,7 +1467,7 @@ dependencies = [
  "chain-crypto 0.1.0",
  "chain-impl-mockchain 0.1.0",
  "chain-storage 0.1.0",
- "chain-storage-sqlite 0.1.0",
+ "chain-storage-sqlite-old 0.1.0",
  "chain-time 0.1.0",
  "custom_error 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1520,7 +1520,7 @@ dependencies = [
  "chain-crypto 0.1.0",
  "chain-impl-mockchain 0.1.0",
  "chain-storage 0.1.0",
- "chain-storage-sqlite 0.1.0",
+ "chain-storage-sqlite-old 0.1.0",
  "chain-time 0.1.0",
  "custom_error 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-bip32 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/jormungandr-integration-tests/Cargo.toml
+++ b/jormungandr-integration-tests/Cargo.toml
@@ -17,7 +17,7 @@ chain-core      = { path = "../chain-deps/chain-core" }
 chain-crypto    = { path = "../chain-deps/chain-crypto" }
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 chain-storage   = { path = "../chain-deps/chain-storage" }
-chain-storage-sqlite = { path = "../chain-deps/chain-storage-sqlite" }
+chain-storage-sqlite-old = { path = "../chain-deps/chain-storage-sqlite-old" }
 chain-time      = { path = "../chain-deps/chain-time" }
 jormungandr-lib = { path = "../jormungandr-lib" }
 rand = "0.6"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -22,7 +22,7 @@ chain-core      = { path = "../chain-deps/chain-core" }
 chain-crypto    = { path = "../chain-deps/chain-crypto" }
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 chain-storage   = { path = "../chain-deps/chain-storage" }
-chain-storage-sqlite = { path = "../chain-deps/chain-storage-sqlite" }
+chain-storage-sqlite-old = { path = "../chain-deps/chain-storage-sqlite-old" }
 chain-time      = { path = "../chain-deps/chain-time" }
 chain-addr = { path = "../chain-deps/chain-addr" }
 cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -14,7 +14,7 @@ extern crate chain_core;
 extern crate chain_crypto;
 extern crate chain_impl_mockchain;
 extern crate chain_storage;
-extern crate chain_storage_sqlite;
+extern crate chain_storage_sqlite_old;
 extern crate chain_time;
 extern crate imhamt;
 #[macro_use]

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     settings::start::Settings,
 };
 use chain_storage::{memory::MemoryBlockStore, store::BlockStore};
-use chain_storage_sqlite::SQLiteBlockStore;
+use chain_storage_sqlite_old::SQLiteBlockStore;
 use slog::Logger;
 use std::time::Duration;
 


### PR DESCRIPTION
SQLite connection with in-memory index was implemented in input-output-hk/chain-libs#205 but we want to keep the original implementation for the next release for stability reasons.