### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/jormungandr/src/diagnostic.rs
+++ b/jormungandr/src/diagnostic.rs
@@ -63,6 +63,7 @@ enum RlimitResource {
 #[cfg(unix)]
 fn getrlimit(resource: RlimitResource) -> Result<u64, DiagnosticError> {
     use libc::rlimit;
+    use std::convert::TryInto;
 
     let mut limits = rlimit {
         rlim_cur: 0,
@@ -77,5 +78,8 @@ fn getrlimit(resource: RlimitResource) -> Result<u64, DiagnosticError> {
     let retcode = unsafe { libc::getrlimit(resource, &mut limits as *mut rlimit) };
     nix::errno::Errno::result(retcode).map_err(DiagnosticError::UnixError)?;
 
-    Ok(limits.rlim_cur.into())
+    Ok(limits
+        .rlim_cur
+        .try_into()
+        .expect("rlim always converts to a u64"))
 }


### PR DESCRIPTION
This fixes the following error when compiling on FreeBSD:
```
error[E0277]: the trait bound `u64: std::convert::From<i64>` is not satisfied
  --> jormungandr/src/diagnostic.rs:80:24
   |
80 |     Ok(limits.rlim_cur.into())
   |                        ^^^^ the trait `std::convert::From<i64>` is not implemented for `u64`
   |
   = help: the following implementations were found:
             <u64 as std::convert::From<bool>>
             <u64 as std::convert::From<chain_impl_mockchain::stake::Stake>>
             <u64 as std::convert::From<chain_time::DurationSeconds>>
             <u64 as std::convert::From<chain_time::Slot>>
           and 9 others
   = note: required because of the requirements on the impl of `std::convert::Into<u64>` for `i64`
```
On FreeBSD rlims are i64 (for legacy reasons) which doesn't have an `Into` for u64.  The values are never negative anyway, so we can just convert and unwrap.
