### PR TITLE
[Tests] sync spending counter with blockchain

### DIFF
--- a/jormungandr-integration-tests/src/common/data/address.rs
+++ b/jormungandr-integration-tests/src/common/data/address.rs
@@ -9,7 +9,7 @@ pub struct Account {
     pub private_key: String,
     pub public_key: String,
     pub address: String,
-    pub spending_key: u64,
+    pub spending_key: u32,
 }
 
 impl Account {
@@ -18,7 +18,7 @@ impl Account {
             private_key: private_key.to_string(),
             public_key: public_key.to_string(),
             address: address.to_string(),
-            spending_key: 0u64,
+            spending_key: 0u32,
         }
     }
 
@@ -39,7 +39,7 @@ pub trait AddressDataProvider {
     fn get_address(&self) -> String;
     fn get_private_key(&self) -> String;
     fn get_address_type(&self) -> String;
-    fn get_spending_key(&self) -> Option<u64>;
+    fn get_spending_key(&self) -> Option<u32>;
 }
 
 impl AddressDataProvider for Utxo {
@@ -56,7 +56,7 @@ impl AddressDataProvider for Utxo {
         address_type
     }
 
-    fn get_spending_key(&self) -> Option<u64> {
+    fn get_spending_key(&self) -> Option<u32> {
         None
     }
 }
@@ -75,7 +75,7 @@ impl AddressDataProvider for Account {
         address_type
     }
 
-    fn get_spending_key(&self) -> Option<u64> {
+    fn get_spending_key(&self) -> Option<u32> {
         Some(self.spending_key)
     }
 }
@@ -94,7 +94,7 @@ impl AddressDataProvider for Delegation {
         address_type
     }
 
-    fn get_spending_key(&self) -> Option<u64> {
+    fn get_spending_key(&self) -> Option<u32> {
         None
     }
 }

--- a/jormungandr-integration-tests/src/common/data/witness.rs
+++ b/jormungandr-integration-tests/src/common/data/witness.rs
@@ -10,7 +10,7 @@ pub struct Witness {
     pub transaction_id: Hash,
     pub addr_type: String,
     pub private_key_path: PathBuf,
-    pub spending_account_counter: Option<u64>,
+    pub spending_account_counter: Option<u32>,
     pub file: PathBuf,
 }
 
@@ -20,7 +20,7 @@ impl Witness {
         transaction_id: &Hash,
         addr_type: &str,
         private_key: &str,
-        spending_account_counter: Option<u64>,
+        spending_account_counter: Option<u32>,
     ) -> Witness {
         let temp_folder_path = file_utils::get_temp_folder();
         Witness {

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/jcli_transaction_commands.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/jcli_transaction_commands.rs
@@ -130,7 +130,7 @@ impl TransactionCommands {
         block0_hash: &str,
         tx_id: &str,
         addr_type: &str,
-        spending_account_counter: Option<u64>,
+        spending_account_counter: Option<u32>,
         witness_file: &PathBuf,
         witness_key: &PathBuf,
     ) -> Command {

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/mod.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/mod.rs
@@ -247,7 +247,7 @@ impl JCLITransactionWrapper {
         &mut self,
         private_key: &str,
         transaction_type: &str,
-        spending_key: Option<u64>,
+        spending_key: Option<u32>,
     ) -> &mut Self {
         let witness = self.create_witness_from_key(&private_key, &transaction_type, spending_key);
         self.assert_make_witness(&witness);
@@ -270,7 +270,7 @@ impl JCLITransactionWrapper {
         &mut self,
         private_key: &str,
         transaction_type: &str,
-        spending_key: Option<u64>,
+        spending_key: Option<u32>,
     ) -> &mut Self {
         let witness = self.create_witness_from_key(&private_key, &transaction_type, spending_key);
         self.seal_with_witness(&witness);
@@ -316,7 +316,7 @@ impl JCLITransactionWrapper {
         &self,
         private_key: &str,
         addr_type: &str,
-        spending_key: Option<u64>,
+        spending_key: Option<u32>,
     ) -> Witness {
         let transaction_id = self.get_transaction_id();
         let witness = Witness::new(
@@ -329,7 +329,7 @@ impl JCLITransactionWrapper {
         witness
     }
 
-    pub fn create_witness_default(&self, addr_type: &str, spending_key: Option<u64>) -> Witness {
+    pub fn create_witness_default(&self, addr_type: &str, spending_key: Option<u32>) -> Witness {
         let private_key = jcli_wrapper::assert_key_generate_default();
         self.create_witness_from_key(&private_key, &addr_type, spending_key)
     }

--- a/jormungandr-integration-tests/src/networking/testnet.rs
+++ b/jormungandr-integration-tests/src/networking/testnet.rs
@@ -98,6 +98,12 @@ pub fn e2e_stake_pool() {
         .start()
         .unwrap();
 
+    let account_state = jcli_wrapper::assert_rest_account_get_stats(
+        &actor_account.address,
+        &jormungandr.rest_address(),
+    );
+    actor_account.spending_key = account_state.counter();
+
     let long_wait = WaitBuilder::new()
         .tries(100)
         .sleep_between_tries(120)


### PR DESCRIPTION
Instead of creating account each time test will rely on already created account (using faucet) and then will do test flow.