### PR TITLE
prevent invalid addr to be set in the poldercast entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ dependencies = [
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1535,7 +1535,7 @@ dependencies = [
  "jormungandr-lib 0.8.0-rc9+1",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1597,7 +1597,7 @@ dependencies = [
  "jormungandr-lib 0.8.0-rc9+1",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2209,13 +2209,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "poldercast"
-version = "0.9.9"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multiaddr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4236,7 +4237,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum platforms 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
-"checksum poldercast 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b70c2608abbc0b55553be895661c7d790305be66b9ceb041ccf358a332ec741d"
+"checksum poldercast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b88e4a1974f44e4ecb6559ead0afb6e297f86618dec8f1f8dddf37a0537e692d"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum predicates 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a9bfe52247e5cc9b2f943682a85a5549fb9662245caf094504e69a2f03fe64d4"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/jormungandr-integration-tests/Cargo.toml
+++ b/jormungandr-integration-tests/Cargo.toml
@@ -38,7 +38,7 @@ custom_error = "1.7"
 error-chain = "0.12"
 jormungandr = { path = "../jormungandr" }
 jcli = { path = "../jcli" }
-poldercast = "0.9"
+poldercast = "0.10"
 
 [dev-dependencies]
 chain-core           = { path = "../chain-deps/chain-core", features=["property-test-api"]}

--- a/jormungandr-scenario-tests/Cargo.toml
+++ b/jormungandr-scenario-tests/Cargo.toml
@@ -21,7 +21,7 @@ chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain", features =
 chain-time           = { path = "../chain-deps/chain-time"}
 jormungandr-integration-tests = { path = "../jormungandr-integration-tests"}
 jormungandr-lib = { path = "../jormungandr-lib" }
-poldercast = "0.9"
+poldercast = "0.10"
 rand = "0.6"
 rand_core = "0.3"
 rand_chacha = "0.1"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -39,7 +39,7 @@ linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = "0.9.9"
+poldercast = "0.10.0"
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
This will allow better handling of

```
DEBG nodes dropped from gossip: [Gossip(NodeProfile { info: NodeInfo { id: Id("5336868879c2ceecc4947ef6dcb2cdf653a1e6212f6bf574"), address: Some(Address("/dns4/node.poolunder.com/tcp/3200")) }, subscriptions: Subscriptions({Subscription { topic: Topic(0), interest: Low }, Subscription { topic: Topic(1), interest: Normal }}) })], direction: in, stream: gossip, node_id: 3a7d919bafc14d2acde2afacc27e02de7900b3fb79e627b7, peer_addr: 89.47.167.155:3000, task: network
```