### PR TITLE
add travis-ci build number on every releases

### DIFF
--- a/ci/before_deploy.ps1
+++ b/ci/before_deploy.ps1
@@ -8,7 +8,7 @@ Set-Location $ENV:Temp
 New-Item -Type Directory -Name $STAGE
 Set-Location $STAGE
 
-$ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
+$ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)+$($Env:TRAVIS_BUILD_NUMBER)-$($Env:TARGET).zip"
 
 Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\jormungandr.exe" '.\'
 Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\jcli.exe" '.\'

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -25,7 +25,7 @@ main() {
     cp target/$TARGET/release/jcli $stage/
 
     cd $stage
-    tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *
+    tar czf $src/$CRATE_NAME-$TRAVIS_TAG+$TRAVIS_BUILD_NUMBER-$TARGET.tar.gz *
     cd $src
 
     rm -rf $stage


### PR DESCRIPTION
As per [SemVer](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions) specs, we can (and should) add the build number on our release target.

This will allow to detect when a rebuild has been trigger for a given asset or to at least quickly retrieve the build associated to an asset. Allowing better auditing of what is being shipped to the users.