### PR TITLE
Expose Poldercast and Node Quarantine status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ dependencies = [
  "network-core 0.1.0-dev",
  "network-grpc 0.1.0-dev",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1535,7 +1535,7 @@ dependencies = [
  "jormungandr-lib 0.8.0-rc10",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1597,7 +1597,7 @@ dependencies = [
  "jormungandr-lib 0.8.0-rc10",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "poldercast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poldercast 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2209,7 +2209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "poldercast"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4237,7 +4237,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum platforms 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
-"checksum poldercast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b88e4a1974f44e4ecb6559ead0afb6e297f86618dec8f1f8dddf37a0537e692d"
+"checksum poldercast 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "18b912a71224c9eb6b11d2331536eb568182230ba431f5fb469a40f2c673adad"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum predicates 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a9bfe52247e5cc9b2f943682a85a5549fb9662245caf094504e69a2f03fe64d4"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -994,3 +994,495 @@ paths:
                 }
         404:
           description: Fragment with given ID or its output with given index was not found in the UTxO
+  /api/v0/network/p2p/non_public:
+    get:
+      description: list all the nodes that are connected to ours but that are not publicly reachable
+      responses:
+        200:
+          description: array of nodes that are not publicly reachable
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  description: a node and its associated logged data and records
+                  type: object
+                  required: [profile]
+                  properties:
+                    profile:
+                      type: object
+                      required: [info, subscriptions]
+                      description: the node public profile
+                      properties:
+                        info:
+                          type: object
+                          required: [id]
+                          description: the node public info
+                          properties:
+                            address:
+                              type: string
+                              description: the multi-address of the node
+                            id:
+                              type: string
+                              description: the node public id
+                        subscriptions:
+                          type: array
+                          description: the subscriptions of this node
+                          items:
+                            description: a subscription
+                            type: object
+                            required: [interest, topic]
+                            properties:
+                              interest:
+                                type: string
+                                description: the level of interest on the associate subscription
+                                enum: [High, Normal, Low]
+                              topic:
+                                type: integer
+                                description: 0 for fragment topic and 1 for a block topic
+                                enum: [0, 1]
+                    records:
+                      type: object
+                      description: all the recorded error with this node
+                      required: [strikes]
+                      properties:
+                        strikes:
+                          description: the strikes recorded on this node
+                          type: array
+                          items:
+                            description: the type of strike recorded against a node
+                            type: object
+                            required: [reason, when]
+                            properties:
+                              reason:
+                                type: string
+                                description: a short message describing the cause of the strike
+                              when:
+                                description: when the strike was recorded
+                                type: object
+                                required: [seconds_since_epoch, nanos_since_epoch]
+                                properties:
+                                  seconds_since_epoch:
+                                    type: integer
+                                    description: seconds since unix epoch
+                                    minimum: 0
+                                  nanos_since_epoch:
+                                    type: integer
+                                    description: elapsed nanoseconds since unix epoch
+                                    minimum: 0
+
+                    logs:
+                      type: object
+                      description: the different logged events associated to this node
+                      required: [creation_time]
+                      properties:
+                        creation_time:
+                          description: when the node was known of our node
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        last_gossip:
+                          description: the last time we gossiped with the node
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        last_update:
+                          description: the last time we received an update of the node (via gossiping with another node)
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        quarantined:
+                          description: the time at which the node was quarantined (if not there then the node is not quarantined)
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        last_use_of:
+                          description: the last time this node has been part of a view for event propagation
+                          type: object
+                          properties:
+                            0:
+                              description: the last time the node was selected for fragment propagation
+                              type: object
+                              required: [seconds_since_epoch, nanos_since_epoch]
+                              properties:
+                                seconds_since_epoch:
+                                  type: integer
+                                  description: seconds since unix epoch
+                                  minimum: 0
+                                nanos_since_epoch:
+                                  type: integer
+                                  description: elapsed nanoseconds since unix epoch
+                                  minimum: 0
+                            1:
+                              description: the last time the node was selected for block propagation
+                              type: object
+                              required: [seconds_since_epoch, nanos_since_epoch]
+                              properties:
+                                seconds_since_epoch:
+                                  type: integer
+                                  description: seconds since unix epoch
+                                  minimum: 0
+                                nanos_since_epoch:
+                                  type: integer
+                                  description: elapsed nanoseconds since unix epoch
+                                  minimum: 0
+  /api/v0/network/p2p/available:
+    get:
+      description: list all the nodes that are available for p2p discovery and events propagation
+      responses:
+        200:
+          description: array of nodes info
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  description: a node and its associated logged data and records
+                  type: object
+                  required: [profile]
+                  properties:
+                    profile:
+                      type: object
+                      required: [info, subscriptions]
+                      description: the node public profile
+                      properties:
+                        info:
+                          type: object
+                          required: [id, address]
+                          description: the node public info
+                          properties:
+                            address:
+                              type: string
+                              description: the multi-address of the node
+                            id:
+                              type: string
+                              description: the node public id
+                        subscriptions:
+                          type: array
+                          description: the subscriptions of this node
+                          items:
+                            description: a subscription
+                            type: object
+                            required: [interest, topic]
+                            properties:
+                              interest:
+                                type: string
+                                description: the level of interest on the associate subscription
+                                enum: [High, Normal, Low]
+                              topic:
+                                type: integer
+                                description: 0 for fragment topic and 1 for a block topic
+                                enum: [0, 1]
+                    records:
+                      type: object
+                      description: all the recorded error with this node
+                      required: [strikes]
+                      properties:
+                        strikes:
+                          description: the strikes recorded on this node
+                          type: array
+                          items:
+                            description: the type of strike recorded against a node
+                            type: object
+                            required: [reason, when]
+                            properties:
+                              reason:
+                                type: string
+                                description: a short message describing the cause of the strike
+                              when:
+                                description: when the strike was recorded
+                                type: object
+                                required: [seconds_since_epoch, nanos_since_epoch]
+                                properties:
+                                  seconds_since_epoch:
+                                    type: integer
+                                    description: seconds since unix epoch
+                                    minimum: 0
+                                  nanos_since_epoch:
+                                    type: integer
+                                    description: elapsed nanoseconds since unix epoch
+                                    minimum: 0
+
+                    logs:
+                      type: object
+                      description: the different logged events associated to this node
+                      required: [creation_time]
+                      properties:
+                        creation_time:
+                          description: when the node was known of our node
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        last_gossip:
+                          description: the last time we gossiped with the node
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        last_update:
+                          description: the last time we received an update of the node (via gossiping with another node)
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        quarantined:
+                          description: the time at which the node was quarantined (if not there then the node is not quarantined)
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        last_use_of:
+                          description: the last time this node has been part of a view for event propagation
+                          type: object
+                          properties:
+                            0:
+                              description: the last time the node was selected for fragment propagation
+                              type: object
+                              required: [seconds_since_epoch, nanos_since_epoch]
+                              properties:
+                                seconds_since_epoch:
+                                  type: integer
+                                  description: seconds since unix epoch
+                                  minimum: 0
+                                nanos_since_epoch:
+                                  type: integer
+                                  description: elapsed nanoseconds since unix epoch
+                                  minimum: 0
+                            1:
+                              description: the last time the node was selected for block propagation
+                              type: object
+                              required: [seconds_since_epoch, nanos_since_epoch]
+                              properties:
+                                seconds_since_epoch:
+                                  type: integer
+                                  description: seconds since unix epoch
+                                  minimum: 0
+                                nanos_since_epoch:
+                                  type: integer
+                                  description: elapsed nanoseconds since unix epoch
+                                  minimum: 0
+  /api/v0/network/p2p/quarantined:
+    get:
+      description: list all the nodes that have been quarantined
+      responses:
+        200:
+          description: array of nodes info
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  description: a node and its associated logged data and records
+                  type: object
+                  required: [profile]
+                  properties:
+                    profile:
+                      type: object
+                      required: [info, subscriptions]
+                      description: the node public profile
+                      properties:
+                        info:
+                          type: object
+                          required: [id, address]
+                          description: the node public info
+                          properties:
+                            address:
+                              type: string
+                              description: the multi-address of the node
+                            id:
+                              type: string
+                              description: the node public id
+                        subscriptions:
+                          type: array
+                          description: the subscriptions of this node
+                          items:
+                            description: a subscription
+                            type: object
+                            required: [interest, topic]
+                            properties:
+                              interest:
+                                type: string
+                                description: the level of interest on the associate subscription
+                                enum: [High, Normal, Low]
+                              topic:
+                                type: integer
+                                description: 0 for fragment topic and 1 for a block topic
+                                enum: [0, 1]
+                    records:
+                      type: object
+                      description: all the recorded error with this node
+                      required: [strikes]
+                      properties:
+                        strikes:
+                          description: the strikes recorded on this node
+                          type: array
+                          items:
+                            description: the type of strike recorded against a node
+                            type: object
+                            required: [reason, when]
+                            properties:
+                              reason:
+                                type: string
+                                description: a short message describing the cause of the strike
+                              when:
+                                description: when the strike was recorded
+                                type: object
+                                required: [seconds_since_epoch, nanos_since_epoch]
+                                properties:
+                                  seconds_since_epoch:
+                                    type: integer
+                                    description: seconds since unix epoch
+                                    minimum: 0
+                                  nanos_since_epoch:
+                                    type: integer
+                                    description: elapsed nanoseconds since unix epoch
+                                    minimum: 0
+
+                    logs:
+                      type: object
+                      description: the different logged events associated to this node
+                      required: [creation_time, quarantined]
+                      properties:
+                        creation_time:
+                          description: when the node was known of our node
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        last_gossip:
+                          description: the last time we gossiped with the node
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        last_update:
+                          description: the last time we received an update of the node (via gossiping with another node)
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        quarantined:
+                          description: the time at which the node was quarantined (if not there then the node is not quarantined)
+                          type: object
+                          required: [seconds_since_epoch, nanos_since_epoch]
+                          properties:
+                            seconds_since_epoch:
+                              type: integer
+                              description: seconds since unix epoch
+                              minimum: 0
+                            nanos_since_epoch:
+                              type: integer
+                              description: elapsed nanoseconds since unix epoch
+                              minimum: 0
+                        last_use_of:
+                          description: the last time this node has been part of a view for event propagation
+                          type: object
+                          properties:
+                            0:
+                              description: the last time the node was selected for fragment propagation
+                              type: object
+                              required: [seconds_since_epoch, nanos_since_epoch]
+                              properties:
+                                seconds_since_epoch:
+                                  type: integer
+                                  description: seconds since unix epoch
+                                  minimum: 0
+                                nanos_since_epoch:
+                                  type: integer
+                                  description: elapsed nanoseconds since unix epoch
+                                  minimum: 0
+                            1:
+                              description: the last time the node was selected for block propagation
+                              type: object
+                              required: [seconds_since_epoch, nanos_since_epoch]
+                              properties:
+                                seconds_since_epoch:
+                                  type: integer
+                                  description: seconds since unix epoch
+                                  minimum: 0
+                                nanos_since_epoch:
+                                  type: integer
+                                  description: elapsed nanoseconds since unix epoch
+                                  minimum: 0

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -1132,7 +1132,7 @@ paths:
                           description: the last time this node has been part of a view for event propagation
                           type: object
                           properties:
-                            0:
+                            "0":
                               description: the last time the node was selected for fragment propagation
                               type: object
                               required: [seconds_since_epoch, nanos_since_epoch]
@@ -1145,7 +1145,7 @@ paths:
                                   type: integer
                                   description: elapsed nanoseconds since unix epoch
                                   minimum: 0
-                            1:
+                            "1":
                               description: the last time the node was selected for block propagation
                               type: object
                               required: [seconds_since_epoch, nanos_since_epoch]
@@ -1296,7 +1296,7 @@ paths:
                           description: the last time this node has been part of a view for event propagation
                           type: object
                           properties:
-                            0:
+                            "0":
                               description: the last time the node was selected for fragment propagation
                               type: object
                               required: [seconds_since_epoch, nanos_since_epoch]
@@ -1309,7 +1309,7 @@ paths:
                                   type: integer
                                   description: elapsed nanoseconds since unix epoch
                                   minimum: 0
-                            1:
+                            "1":
                               description: the last time the node was selected for block propagation
                               type: object
                               required: [seconds_since_epoch, nanos_since_epoch]
@@ -1460,7 +1460,7 @@ paths:
                           description: the last time this node has been part of a view for event propagation
                           type: object
                           properties:
-                            0:
+                            "0":
                               description: the last time the node was selected for fragment propagation
                               type: object
                               required: [seconds_since_epoch, nanos_since_epoch]
@@ -1473,7 +1473,7 @@ paths:
                                   type: integer
                                   description: elapsed nanoseconds since unix epoch
                                   minimum: 0
-                            1:
+                            "1":
                               description: the last time the node was selected for block propagation
                               type: object
                               required: [seconds_since_epoch, nanos_since_epoch]
@@ -1486,3 +1486,53 @@ paths:
                                   type: integer
                                   description: elapsed nanoseconds since unix epoch
                                   minimum: 0
+  /api/v0/network/p2p/view:
+    get:
+      description: list all the nodes that are selected for gossiping/peer discovery
+      responses:
+        200:
+          description: array of nodes info
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  description: a node id and addresses
+                  type: object
+                  required: [id, address]
+                  properties:
+                    address:
+                      type: string
+                      description: the multi-address of the node
+                    id:
+                      type: string
+                      description: the node public id
+  /api/v0/network/p2p/view/{topic}:
+    get:
+      parameters:
+        - in: path
+          name: topic
+          required: true
+          description: the topic name
+          schema:
+            type: string
+            enum: [blocks, fragments]
+      description: list all the nodes that are selected for the given topic
+      responses:
+        200:
+          description: array of nodes info
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  description: a node id and addresses
+                  type: object
+                  required: [id, address]
+                  properties:
+                    address:
+                      type: string
+                      description: the multi-address of the node
+                    id:
+                      type: string
+                      description: the node public id

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -39,7 +39,7 @@ linked-hash-map = "0.5"
 native-tls = "0.2.2"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = "0.10.0"
+poldercast = "0.10.1"
 rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -138,7 +138,9 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
 
     let topology = P2pTopology::new(
         bootstrapped_node.settings.network.profile.clone(),
-        bootstrapped_node.logger.clone(),
+        bootstrapped_node
+            .logger
+            .new(o!(log::KEY_TASK => "poldercast")),
     );
 
     let stats_counter = StatsCounter::default();

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -62,6 +62,7 @@ use crate::{
     blockcfg::{HeaderHash, Leader},
     blockchain::{Blockchain, CandidateForest},
     diagnostic::Diagnostic,
+    network::p2p::P2pTopology,
     secure::enclave::Enclave,
     settings::start::Settings,
     utils::{async_msg, task::Services},
@@ -134,6 +135,11 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         leadership::Logs::new(bootstrapped_node.settings.leadership.log_ttl.into());
     let leadership_garbage_collection_interval =
         bootstrapped_node.settings.leadership.log_ttl.into();
+
+    let topology = P2pTopology::new(
+        bootstrapped_node.settings.network.profile.clone(),
+        bootstrapped_node.logger.clone(),
+    );
 
     let stats_counter = StatsCounter::default();
 
@@ -233,6 +239,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
             transaction_box: fragment_msgbox,
             block_box: block_msgbox,
         };
+        let topology = topology.clone();
 
         services.spawn_future("network", move |info| {
             let params = network::TaskParams {
@@ -241,7 +248,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 input: network_queue,
                 channels,
             };
-            network::start(info, params)
+            network::start(info, params, topology)
         });
     }
 

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -301,6 +301,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
             logs: pool_logs,
             leadership_logs,
             enclave,
+            p2p: topology,
             explorer: explorer.as_ref().map(|(_msg_box, context)| context.clone()),
             diagnostic: bootstrapped_node.diagnostic,
         };

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -129,10 +129,11 @@ impl GlobalState {
     pub fn new(
         block0_hash: HeaderHash,
         config: Configuration,
+        topology: P2pTopology,
         executor: TaskExecutor,
         logger: Logger,
     ) -> Self {
-        let mut topology = P2pTopology::new(config.profile.clone(), logger.clone());
+        let mut topology = topology;
         topology.set_poldercast_modules();
         topology.set_custom_modules(&config);
         topology.set_policy(config.policy.clone());
@@ -218,6 +219,7 @@ pub struct TaskParams {
 pub fn start(
     service_info: TokioServiceInfo,
     params: TaskParams,
+    topology: P2pTopology,
 ) -> impl Future<Item = (), Error = ()> {
     // TODO: the node needs to be saved/loaded
     //
@@ -227,6 +229,7 @@ pub fn start(
     let global_state = Arc::new(GlobalState::new(
         params.block0_hash,
         params.config,
+        topology,
         service_info.executor().clone(),
         service_info.logger().clone(),
     ));

--- a/jormungandr/src/network/p2p/node.rs
+++ b/jormungandr/src/network/p2p/node.rs
@@ -32,6 +32,12 @@ impl gossip::Node for Node {
     }
 }
 
+impl From<Node> for poldercast::NodeInfo {
+    fn from(node: Node) -> Self {
+        node.info
+    }
+}
+
 #[deprecated]
 impl property::Serialize for Node {
     type Error = bincode::Error;

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -67,10 +67,10 @@ impl P2pTopology {
 
     /// Returns a list of neighbors selected in this turn
     /// to contact for event dissemination.
-    pub fn view(&self) -> Vec<Node> {
+    pub fn view(&self, selection: poldercast::Selection) -> Vec<Node> {
         let mut topology = self.lock.write().unwrap();
         topology
-            .view(None, poldercast::Selection::Any)
+            .view(None, selection)
             .into_iter()
             .map(Node::new)
             .collect()
@@ -99,6 +99,39 @@ impl P2pTopology {
 
     pub fn force_reset_layers(&self) {
         self.lock.write().unwrap().force_reset_layers()
+    }
+
+    pub fn list_quarantined(&self) -> Vec<poldercast::Node> {
+        self.lock
+            .read()
+            .unwrap()
+            .nodes()
+            .all_quarantined_nodes()
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    pub fn list_available(&self) -> Vec<poldercast::Node> {
+        self.lock
+            .read()
+            .unwrap()
+            .nodes()
+            .all_available_nodes()
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    pub fn list_non_public(&self) -> Vec<poldercast::Node> {
+        self.lock
+            .read()
+            .unwrap()
+            .nodes()
+            .all_unreachable_nodes()
+            .into_iter()
+            .cloned()
+            .collect()
     }
 
     /// register a strike against the given node id

--- a/jormungandr/src/rest/mod.rs
+++ b/jormungandr/src/rest/mod.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, RwLock};
 use crate::blockchain::{Blockchain, Tip};
 use crate::fragment::Logs;
 use crate::leadership::Logs as LeadershipLogs;
+use crate::network::p2p::P2pTopology;
 use crate::secure::enclave::Enclave;
 use crate::settings::start::{Cors as CorsConfig, Error as ConfigError, Rest};
 use crate::stats_counter::StatsCounter;
@@ -114,6 +115,7 @@ pub struct FullContext {
     pub logs: Logs,
     pub leadership_logs: LeadershipLogs,
     pub enclave: Enclave,
+    pub p2p: P2pTopology,
     pub explorer: Option<crate::explorer::Explorer>,
     pub diagnostic: crate::diagnostic::Diagnostic,
 }

--- a/jormungandr/src/rest/v0/mod.rs
+++ b/jormungandr/src/rest/v0/mod.rs
@@ -32,6 +32,21 @@ pub fn resources() -> Vec<(
         ("/network/stats", &|r| {
             r.get().with_async(handlers::get_network_stats)
         }),
+        ("/network/p2p/quarantined", &|r| {
+            r.get().with_async(handlers::get_network_p2p_quarantined)
+        }),
+        ("/network/p2p/non_public", &|r| {
+            r.get().with_async(handlers::get_network_p2p_non_public)
+        }),
+        ("/network/p2p/available", &|r| {
+            r.get().with_async(handlers::get_network_p2p_available)
+        }),
+        ("/network/p2p/view", &|r| {
+            r.get().with_async(handlers::get_network_p2p_view)
+        }),
+        ("/network/p2p/view/{topic}", &|r| {
+            r.get().with_async(handlers::get_network_p2p_view_topic)
+        }),
         ("/settings", &|r| r.get().with_async(handlers::get_settings)),
         ("/stake", &|r| {
             r.get().with_async(handlers::get_stake_distribution)


### PR DESCRIPTION
Exposes the different statuses of the P2P Topology built by `poldercast`.

This allows to list:

* `/api/v0/network/p2p/quarantined`: list all the nodes that are quarantined
  ```json
  [
    {
      "logs": {
        "creation_time": {
          "nanos_since_epoch": 337337000,
          "secs_since_epoch": 1575997197
        },
        "last_gossip": {
          "nanos_since_epoch": 474483000,
          "secs_since_epoch": 1575997200
        },
        "last_update": {
          "nanos_since_epoch": 385793000,
          "secs_since_epoch": 1575997207
        },
        "last_use_of": {},
        "quarantined": {
          "nanos_since_epoch": 565809000,
          "secs_since_epoch": 1575997200
        }
      },
      "profile": {
        "info": {
          "address": "/ip4/138.201.181.94/tcp/6663",
          "id": "67b2379edf5ce4a752cdbc82f23437850ef20ff14cf37341"
        },
        "subscriptions": [
          {
            "interest": "High",
            "topic": 0
          },
          {
            "interest": "High",
            "topic": 1
          }
        ]
      },
      "record": {
        "strikes": [
          {
            "reason": "CannotConnect",
            "when": {
              "nanos_since_epoch": 565756000,
              "secs_since_epoch": 1575997200
            }
          }
        ]
      }
    }
  ]
  ```
* `/api/v0/network/p2p/available` will show the list of nodes that are known by our node.
* `/api/v0/network/p2p/non_public` will show the list of nodes that are directly connected to our node and that are not publicly reachable;
* `/api/v0/network/p2p/view` and `/api/v0/network/p2p/view/blocks` and `/api/v0/network/p2p/view/fragments` will show the list of node info our node will connect to for (respectivly) p2p discovery, block propagation and fragment propagation:
  ```json
  [
    {
      "address": "/ip4/139.99.221.149/tcp/4006",
      "id": "e869d9bf130315f6c1ee630d850aea45158688ce635deb3e"
    },
    {
      "address": "/ip4/51.15.64.122/tcp/10299",
      "id": "bee07da9369c9e734e9fb24f15cd7588edc7c8811cfb7499"
    },
    {
      "address": "/ip4/203.221.42.151/tcp/3200",
      "id": "b730119a5bbbd239bbcd45b2ff7a3256ee48d8e096147726"
    }
  ]
  ```

see the [openapi documentation](https://editor.swagger.io/?url=https://raw.githubusercontent.com/input-output-hk/jormungandr/master/doc/openapi.yaml) for the schemas