### PR TITLE
Debug block operation in jcli

### DIFF
--- a/jcli/src/jcli_app/debug/block.rs
+++ b/jcli/src/jcli_app/debug/block.rs
@@ -1,0 +1,33 @@
+use crate::jcli_app::debug::Error;
+use crate::jcli_app::utils::{error::CustomErrorFiller, io};
+use chain_core::property::Deserialize as _;
+use chain_impl_mockchain::block::Block as BlockMock;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+pub struct Block {
+    /// file containing hex-encoded message. If not provided, it will be read from stdin.
+    #[structopt(short, long)]
+    input: Option<PathBuf>,
+}
+
+impl Block {
+    pub fn exec(self) -> Result<(), Error> {
+        let reader = io::open_file_read(&self.input).map_err(|source| Error::InputInvalid {
+            source,
+            path: self.input.unwrap_or_default(),
+        })?;
+        let mut hex_str = String::new();
+        BufReader::new(reader).read_line(&mut hex_str)?;
+        let bytes = hex::decode(hex_str.trim())?;
+        let message =
+            BlockMock::deserialize(bytes.as_ref()).map_err(|source| Error::MessageMalformed {
+                source,
+                filler: CustomErrorFiller,
+            })?;
+        println!("{:#?}", message);
+        Ok(())
+    }
+}

--- a/jcli/src/jcli_app/debug/mod.rs
+++ b/jcli/src/jcli_app/debug/mod.rs
@@ -1,5 +1,5 @@
+mod block;
 mod message;
-
 use crate::jcli_app::utils::error::CustomErrorFiller;
 use hex::FromHexError;
 use std::path::PathBuf;
@@ -8,8 +8,10 @@ use structopt::StructOpt;
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub enum Debug {
-    /// Decode hex-encoded message an display its content
+    /// Decode hex-encoded message and display its content
     Message(message::Message),
+    /// Decode hex-encoded block and display its content
+    Block(block::Block),
 }
 
 custom_error! {pub Error
@@ -24,6 +26,7 @@ impl Debug {
     pub fn exec(self) -> Result<(), Error> {
         match self {
             Debug::Message(message) => message.exec(),
+            Debug::Block(block) => block.exec(),
         }
     }
 }


### PR DESCRIPTION
Fixes #1336 

Example:

`jcli rest v0 block 11f4e215e95cd279f11e68e23c4397d8265482ba60160f6b15258c07d3ae2eb6 get --host "http://127.0.0.1:9001/api" | jcli debug block`

 