### PR TITLE
add reward constraints parameter

### DIFF
--- a/jormungandr-lib/src/interfaces/block0_configuration/DOCUMENTED_EXAMPLE.yaml
+++ b/jormungandr-lib/src/interfaces/block0_configuration/DOCUMENTED_EXAMPLE.yaml
@@ -160,16 +160,33 @@ blockchain_configuration:
 
   # set some reward constraints and limits
   #
-  # this value is optional, the default is no constraints at all
-  reward_constraints:
-    # limit the epoch total reward drawing limit to a portion of the total
-    # active stake of the system.
-    #
-    # for example, if set to 10%, the reward drawn will be bounded by the
-    # 10% of the total active stake.
-    #
-    # this value is optional, the default is no reward drawing limit
-    reward_drawing_limit_max: "10/100"
+  # this value is optional, the default is no constraints at all. The settings
+  # are commented below:
+  #
+  #reward_constraints:
+  #  # limit the epoch total reward drawing limit to a portion of the total
+  #  # active stake of the system.
+  #  #
+  #  # for example, if set to 10%, the reward drawn will be bounded by the
+  #  # 10% of the total active stake.
+  #  #
+  #  # this value is optional, the default is no reward drawing limit
+  #  reward_drawing_limit_max: "10/100"
+  #
+  #  # settings to incentivize the numbers of stake pool to be registered
+  #  # on the blockchain.
+  #  #
+  #  # These settings does not prevent more stake pool to be added. For example
+  #  # if there is already 1000 stake pools, someone can still register a new
+  #  # stake pool and affect the rewards of everyone else too.
+  #  #
+  #  # if the threshold is reached, the pool doesn't really have incentive to
+  #  # create more blocks than 1 / set-value-of-pools % of stake.
+  #  #
+  #  # this value is optional, the default is no pool participation capping
+  #  pool_participation_capping:
+  #    min: 300
+  #    max: 1000
 
 # Initial state of the ledger. Each item is applied in order of this list
 initial:

--- a/jormungandr-lib/src/interfaces/block0_configuration/DOCUMENTED_EXAMPLE.yaml
+++ b/jormungandr-lib/src/interfaces/block0_configuration/DOCUMENTED_EXAMPLE.yaml
@@ -158,6 +158,19 @@ blockchain_configuration:
       # the rate at which the contribution is tweaked related to epoch.
       epoch_rate: 3
 
+  # set some reward constraints and limits
+  #
+  # this value is optional, the default is no constraints at all
+  reward_constraints:
+    # limit the epoch total reward drawing limit to a portion of the total
+    # active stake of the system.
+    #
+    # for example, if set to 10%, the reward drawn will be bounded by the
+    # 10% of the total active stake.
+    #
+    # this value is optional, the default is no reward drawing limit
+    reward_drawing_limit_max: "10/100"
+
 # Initial state of the ledger. Each item is applied in order of this list
 initial:
   # Initial deposits present in the blockchain

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
@@ -1,8 +1,8 @@
 use crate::{
     interfaces::{
         ActiveSlotCoefficient, BlockContentMaxSize, ConsensusLeaderId, EpochStabilityDepth,
-        FeesGoTo, KESUpdateSpeed, LinearFeeDef, NumberOfSlotsPerEpoch, RewardConstraints,
-        RewardParams, SlotDuration, TaxType, Value,
+        FeesGoTo, KESUpdateSpeed, LinearFeeDef, NumberOfSlotsPerEpoch, PoolParticipationCapping,
+        RewardConstraints, RewardParams, SlotDuration, TaxType, Value,
     },
     time::SecondsSinceUnixEpoch,
 };
@@ -267,6 +267,10 @@ impl BlockchainConfiguration {
                     .reward_drawing_limit_max
                     .replace(ratio.into())
                     .map(|_| "reward_constraints.reward_drawing_limit_max"),
+                ConfigParam::PoolRewardParticipationCapping((min, max)) => reward_constraints
+                    .pool_participation_capping
+                    .replace(PoolParticipationCapping { min, max })
+                    .map(|_| "reward_constraints.pool_participation_capping"),
                 ConfigParam::PerCertificateFees(param) => per_certificate_fees
                     .replace(param)
                     .map(|_| "per_certificate_fees"),
@@ -377,6 +381,13 @@ impl BlockchainConfiguration {
             params.push(ConfigParam::RewardLimitByAbsoluteStake(
                 reward_drawing_limit_max.into(),
             ));
+        }
+
+        if let Some(pool_participation_capping) = reward_constraints.pool_participation_capping {
+            params.push(ConfigParam::PoolRewardParticipationCapping((
+                pool_participation_capping.min,
+                pool_participation_capping.max,
+            )));
         }
 
         consensus_leader_ids

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_config.rs
@@ -1,8 +1,8 @@
 use crate::{
     interfaces::{
         ActiveSlotCoefficient, BlockContentMaxSize, ConsensusLeaderId, EpochStabilityDepth,
-        FeesGoTo, KESUpdateSpeed, LinearFeeDef, NumberOfSlotsPerEpoch, RewardParams, SlotDuration,
-        TaxType, Value,
+        FeesGoTo, KESUpdateSpeed, LinearFeeDef, NumberOfSlotsPerEpoch, RewardConstraints,
+        RewardParams, SlotDuration, TaxType, Value,
     },
     time::SecondsSinceUnixEpoch,
 };
@@ -121,6 +121,10 @@ pub struct BlockchainConfiguration {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reward_parameters: Option<RewardParams>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "RewardConstraints::is_none")]
+    pub reward_constraints: RewardConstraints,
 }
 
 impl From<BlockchainConfiguration> for ConfigParams {
@@ -172,6 +176,7 @@ impl BlockchainConfiguration {
             treasury_parameters: None,
             total_reward_supply: None,
             reward_parameters: None,
+            reward_constraints: RewardConstraints::default(),
         }
     }
 
@@ -197,6 +202,7 @@ impl BlockchainConfiguration {
         let mut reward_parameters = None;
         let mut per_certificate_fees = None;
         let mut fees_go_to = None;
+        let mut reward_constraints = RewardConstraints::default();
 
         for param in params.iter().cloned() {
             match param {
@@ -254,6 +260,13 @@ impl BlockchainConfiguration {
                 ConfigParam::RewardParams(param) => reward_parameters
                     .replace(param.into())
                     .map(|_| "reward_parameters"),
+                ConfigParam::RewardLimitNone => {
+                    panic!("ConfigParam::RewardLimitNone should not be in the block0")
+                }
+                ConfigParam::RewardLimitByAbsoluteStake(ratio) => reward_constraints
+                    .reward_drawing_limit_max
+                    .replace(ratio.into())
+                    .map(|_| "reward_constraints.reward_drawing_limit_max"),
                 ConfigParam::PerCertificateFees(param) => per_certificate_fees
                     .replace(param)
                     .map(|_| "per_certificate_fees"),
@@ -290,6 +303,7 @@ impl BlockchainConfiguration {
             treasury_parameters,
             total_reward_supply,
             reward_parameters,
+            reward_constraints: reward_constraints,
         })
     }
 
@@ -311,6 +325,7 @@ impl BlockchainConfiguration {
             treasury_parameters,
             total_reward_supply,
             reward_parameters,
+            reward_constraints,
         } = self;
 
         let mut params = ConfigParams::new();
@@ -356,6 +371,12 @@ impl BlockchainConfiguration {
 
         if let Some(reward_parameters) = reward_parameters {
             params.push(ConfigParam::RewardParams(reward_parameters.into()));
+        }
+
+        if let Some(reward_drawing_limit_max) = reward_constraints.reward_drawing_limit_max {
+            params.push(ConfigParam::RewardLimitByAbsoluteStake(
+                reward_drawing_limit_max.into(),
+            ));
         }
 
         consensus_leader_ids
@@ -424,6 +445,7 @@ mod test {
                 treasury_parameters: Arbitrary::arbitrary(g),
                 total_reward_supply: Arbitrary::arbitrary(g),
                 reward_parameters: Arbitrary::arbitrary(g),
+                reward_constraints: Arbitrary::arbitrary(g),
             }
         }
     }

--- a/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
@@ -21,7 +21,7 @@ pub use self::initial_fragment::{Initial, InitialUTxO, LegacyUTxO};
 pub use self::kes_update_speed::KESUpdateSpeed;
 pub use self::leader_id::ConsensusLeaderId;
 pub use self::number_of_slots_per_epoch::NumberOfSlotsPerEpoch;
-pub use self::reward_constraint::RewardConstraints;
+pub use self::reward_constraint::{PoolParticipationCapping, RewardConstraints};
 pub use self::slots_duration::SlotDuration;
 use chain_impl_mockchain::{
     block::{self, Block},

--- a/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
@@ -8,6 +8,7 @@ mod initial_fragment;
 mod kes_update_speed;
 mod leader_id;
 mod number_of_slots_per_epoch;
+mod reward_constraint;
 mod slots_duration;
 
 pub use self::active_slot_coefficient::ActiveSlotCoefficient;
@@ -20,6 +21,7 @@ pub use self::initial_fragment::{Initial, InitialUTxO, LegacyUTxO};
 pub use self::kes_update_speed::KESUpdateSpeed;
 pub use self::leader_id::ConsensusLeaderId;
 pub use self::number_of_slots_per_epoch::NumberOfSlotsPerEpoch;
+pub use self::reward_constraint::RewardConstraints;
 pub use self::slots_duration::SlotDuration;
 use chain_impl_mockchain::{
     block::{self, Block},

--- a/jormungandr-lib/src/interfaces/block0_configuration/reward_constraint.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/reward_constraint.rs
@@ -1,20 +1,37 @@
 use crate::interfaces::Ratio;
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU32;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PoolParticipationCapping {
+    pub min: NonZeroU32,
+    pub max: NonZeroU32,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct RewardConstraints {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reward_drawing_limit_max: Option<Ratio>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pool_participation_capping: Option<PoolParticipationCapping>,
 }
 
 impl RewardConstraints {
     pub fn is_none(&self) -> bool {
-        self.reward_drawing_limit_max.is_none()
+        self.reward_drawing_limit_max.is_none() && self.pool_participation_capping.is_none()
     }
 
     pub fn set_reward_drawing_limit_max(&mut self, limit: Option<Ratio>) {
         self.reward_drawing_limit_max = limit
+    }
+
+    pub fn set_pool_participation_capping(&mut self, setting: Option<(NonZeroU32, NonZeroU32)>) {
+        let setting = setting.map(|(min, max)| PoolParticipationCapping { min, max });
+
+        self.pool_participation_capping = setting;
     }
 }
 
@@ -23,10 +40,22 @@ mod test {
     use super::*;
     use quickcheck::{Arbitrary, Gen};
 
+    impl Arbitrary for PoolParticipationCapping {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Self {
+                min: NonZeroU32::new(Arbitrary::arbitrary(g))
+                    .unwrap_or(unsafe { NonZeroU32::new_unchecked(1) }),
+                max: NonZeroU32::new(Arbitrary::arbitrary(g))
+                    .unwrap_or(unsafe { NonZeroU32::new_unchecked(1) }),
+            }
+        }
+    }
+
     impl Arbitrary for RewardConstraints {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
             Self {
                 reward_drawing_limit_max: Arbitrary::arbitrary(g),
+                pool_participation_capping: Arbitrary::arbitrary(g),
             }
         }
     }

--- a/jormungandr-lib/src/interfaces/block0_configuration/reward_constraint.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/reward_constraint.rs
@@ -1,0 +1,33 @@
+use crate::interfaces::Ratio;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RewardConstraints {
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reward_drawing_limit_max: Option<Ratio>,
+}
+
+impl RewardConstraints {
+    pub fn is_none(&self) -> bool {
+        self.reward_drawing_limit_max.is_none()
+    }
+
+    pub fn set_reward_drawing_limit_max(&mut self, limit: Option<Ratio>) {
+        self.reward_drawing_limit_max = limit
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for RewardConstraints {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Self {
+                reward_drawing_limit_max: Arbitrary::arbitrary(g),
+            }
+        }
+    }
+}

--- a/jormungandr-lib/src/interfaces/settings.rs
+++ b/jormungandr-lib/src/interfaces/settings.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use chain_impl_mockchain::block::Epoch;
 use chain_impl_mockchain::fee::LinearFee;
-use chain_impl_mockchain::rewards::{CompoundingType, Parameters, Ratio, TaxType};
+use chain_impl_mockchain::rewards::{CompoundingType, Limit, Parameters, Ratio, TaxType};
 use chain_impl_mockchain::value::Value;
 use serde::{Deserialize, Serialize};
 use std::num::{NonZeroU32, NonZeroU64};
@@ -46,6 +46,13 @@ pub struct TaxTypeDef {
 pub struct TaxTypeSerde(#[serde(with = "TaxTypeDef")] pub TaxType);
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(remote = "Limit")]
+pub enum LimitDef {
+    None,
+    ByStakeAbsolute(#[serde(with = "RatioDef")] Ratio),
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(remote = "Ratio")]
 pub struct RatioDef {
     pub numerator: u64,
@@ -62,6 +69,8 @@ pub struct ParametersDef {
     pub compounding_type: CompoundingType,
     pub epoch_rate: NonZeroU32,
     pub epoch_start: Epoch,
+    #[serde(with = "LimitDef")]
+    pub reward_drawing_limit_max: Limit,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/jormungandr-lib/src/interfaces/settings.rs
+++ b/jormungandr-lib/src/interfaces/settings.rs
@@ -71,6 +71,7 @@ pub struct ParametersDef {
     pub epoch_start: Epoch,
     #[serde(with = "LimitDef")]
     pub reward_drawing_limit_max: Limit,
+    pub pool_participation_capping: Option<(NonZeroU32, NonZeroU32)>,
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
the initial setting is the `reward_drawing_limit_max` and `pool_participation_capping`.

continue the work from input-output-hk/chain-libs#219. This PR is somehow also a clean rewrite of #1281 
(and so closes #1281) to make sure the new parameters are optionals and don't duplicate other works and efforts.

New parameters are:

```yaml
blockchain_configuration
  # set some reward constraints and limits
  #
  # this value is optional, the default is no constraints at all
  reward_constraints:
    # limit the epoch total reward drawing limit to a portion of the total
    # active stake of the system.
    #
    # for example, if set to 10%, the reward drawn will be bounded by the
    # 10% of the total active stake.
    #
    # this value is optional, the default is no reward drawing limit
    reward_drawing_limit_max: "10/100"

    # settings to incentivize the numbers of stake pool to be registered
    # on the blockchain.
    #
    # These settings does not prevent more stake pool to be added. For example
    # if there is already 1000 stake pools, someone can still register a new
    # stake pool and affect the rewards of everyone else too.
    #
    # if the threshold is reached, the pool doesn't really have incentive to
    # create more blocks than 1 / set-value-of-pools % of stake.
    #
    # this value is optional, the default is no pool participation capping
    pool_participation_capping:
      min: 300
      max: 1000
```