### PR TITLE
Reverts change in 7e79334da1a46c484e3d6ffe0c52e2518c3c4c44 which remo…

### DIFF
--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -276,6 +276,8 @@ impl Sink for BlockAnnouncementProcessor {
         if polled_ready.is_not_ready() {
             return Ok(AsyncSink::NotReady(header));
         }
+        let block_hash = header.hash();
+        info!(self.logger, "received block announcement"; "hash" => %block_hash);
         let polled = self
             .mbox
             .start_send(BlockMsg::AnnouncedBlock(header, self.node_id))


### PR DESCRIPTION
…ved a block announcement log. This log is temporarily being used to drive the visual on iohk.io. Once we have a more robust solution in place this can be removed again.