### PR TITLE
Exclude block 0 from sent branches

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -181,6 +181,8 @@ pub struct Blockchain {
     ledgers: Multiverse<Arc<Ledger>>,
 
     storage: Storage,
+
+    block0: HeaderHash,
 }
 
 pub enum PreCheckedHeader {
@@ -235,13 +237,18 @@ impl PostCheckedHeader {
 }
 
 impl Blockchain {
-    pub fn new(storage: NodeStorage, ref_cache_ttl: Duration) -> Self {
+    pub fn new(block0: HeaderHash, storage: NodeStorage, ref_cache_ttl: Duration) -> Self {
         Blockchain {
             branches: Branches::new(),
             ref_cache: RefCache::new(ref_cache_ttl),
             ledgers: Multiverse::new(),
             storage: Storage::new(storage),
+            block0,
         }
+    }
+
+    pub fn block0(&self) -> &HeaderHash {
+        &self.block0
     }
 
     pub fn storage(&self) -> &Storage {

--- a/jormungandr/src/blockchain/storage.rs
+++ b/jormungandr/src/blockchain/storage.rs
@@ -159,7 +159,8 @@ impl Storage {
     }
 
     /// Stream a branch ending at `to` and starting from the ancestor
-    /// at `depth` or at the genesis block if `depth` is given as `None`.
+    /// at `depth` or at the first ancestor since genesis block
+    /// if `depth` is given as `None`.
     ///
     /// This function uses buffering in the sink to reduce lock contention.
     pub fn send_branch<S, E>(
@@ -178,7 +179,7 @@ impl Storage {
         future::poll_fn(move || Ok(inner.poll_lock()))
             .and_then(move |store| {
                 store.get_block_info(&to).map(|to_info| {
-                    let depth = depth.unwrap_or(to_info.depth);
+                    let depth = depth.unwrap_or(to_info.depth - 1);
                     BlockIterState::new(to_info, depth)
                 })
             })

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -88,7 +88,7 @@ pub fn load_blockchain(
 ) -> Result<(Blockchain, Tip), Error> {
     use tokio::prelude::*;
 
-    let mut blockchain = Blockchain::new(storage, block_cache_ttl);
+    let blockchain = Blockchain::new(block0.header.hash(), storage, block_cache_ttl);
 
     let main_branch: Branch = match blockchain.load_from_block0(block0.clone()).wait() {
         Err(error) => match error.kind() {


### PR DESCRIPTION
When pulling a branch that has no intersecting checkpoints, exclude block 0.
The recipient node must already be bootstrapped with block 0 and the validating code is not expected, nor is it necessary, to deal with it.

fix #1326 