### PR TITLE
Index blocks by chain length and block time

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -49,7 +49,7 @@ See Internal documentation for more details: doc/internal_design.md
 [`Branch`]: ./struct.Branch.html
 */
 
-use super::{branch::Branches, reference_cache::RefCache};
+use super::{branch::Branches, index::Error as IndexError, reference_cache::RefCache};
 use crate::{
     blockcfg::{
         Block, Block0Error, BlockDate, ChainLength, Epoch, EpochRewardsInfo, Header, HeaderHash,
@@ -72,6 +72,7 @@ error_chain! {
         Storage(StorageError);
         Ledger(ledger::Error);
         Block0(Block0Error);
+        Index(IndexError);
     }
 
     errors {

--- a/jormungandr/src/blockchain/index.rs
+++ b/jormungandr/src/blockchain/index.rs
@@ -1,0 +1,108 @@
+use crate::blockchain::{
+    chain::MAIN_BRANCH_TAG,
+    storage::{Storage, StorageError},
+};
+use chain_impl_mockchain::header::{Header, HeaderId};
+use std::collections::BTreeMap;
+use thiserror::Error;
+use tokio::{prelude::*, sync::lock::Lock};
+
+type HeaderToKey<K> = fn(Header) -> K;
+
+pub struct Index<K>
+where
+    K: std::cmp::Ord,
+{
+    transform: HeaderToKey<K>,
+    index_lock: Lock<BTreeMap<K, HeaderId>>,
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("no blockchain head found in the database")]
+    NoHeadFound,
+    #[error("storage error")]
+    StorageError(#[from] StorageError),
+}
+
+impl<K> Index<K>
+where
+    K: std::cmp::Ord + Clone,
+{
+    pub fn new(transform: HeaderToKey<K>) -> Self {
+        Self {
+            transform,
+            index_lock: Lock::new(BTreeMap::new()),
+        }
+    }
+
+    pub fn get(&self, key: K) -> impl Future<Item = Option<HeaderId>, Error = ()> {
+        let mut index_lock = self.index_lock.clone();
+        future::poll_fn(move || Ok(index_lock.poll_lock()))
+            .map(move |index| index.get(&key).map(|v| v.to_owned()))
+    }
+
+    pub fn update_from_storage(
+        &mut self,
+        storage: Storage,
+    ) -> impl Future<Item = (), Error = Error> {
+        let mut index_lock = self.index_lock.clone();
+        let mut index_lock_2 = self.index_lock.clone();
+        let transform = self.transform;
+
+        future::poll_fn(move || Ok(index_lock.poll_lock())).and_then(move |mut index| {
+            // stream of values from the storage (HEAD to genesis)
+            let mut storage_stream = storage
+                .get_tag(MAIN_BRANCH_TAG.to_owned())
+                .map_err(Error::StorageError)
+                .map(|r| r.ok_or(Error::NoHeadFound))
+                .flatten()
+                .and_then(move |hash| {
+                    storage
+                        .stream_from_to_reversed(hash, None)
+                        .map_err(Error::StorageError)
+                })
+                .map(|stream| stream.map_err(Error::StorageError))
+                .into_stream()
+                .flatten();
+
+            // interrupt the stream of blocks once we met an existing block
+            stream::poll_fn(move || match storage_stream.poll()? {
+                Async::Ready(Some(block)) => {
+                    let id = block.header.id().clone();
+                    let key = (transform)(block.header);
+                    if let Some(stored_id) = index.get(&key) {
+                        if stored_id == &id {
+                            return Ok(Async::Ready(None));
+                        }
+                    }
+                    Ok(Async::Ready(Some((key, id))))
+                }
+                Async::Ready(None) => Ok(Async::Ready(None)),
+                Async::NotReady => Ok(Async::NotReady),
+            })
+            // fuse will ensure that the stream is stopped after the first None
+            .fuse()
+            .collect()
+            .and_then(move |new_keys| {
+                future::poll_fn(move || Ok(index_lock_2.poll_lock())).map(move |mut index| {
+                    use std::ops::Bound;
+                    if new_keys.is_empty() {
+                        return;
+                    }
+                    let to_remove: Vec<_> = index
+                        .range((Bound::Excluded(&new_keys[0].0), Bound::Unbounded))
+                        .map(|(key, _)| key)
+                        .cloned()
+                        .collect();
+                    to_remove.into_iter().for_each(|key| {
+                        index.remove(&key);
+                    });
+                    new_keys.into_iter().for_each(|(key, id)| {
+                        index.insert(key, id);
+                    });
+                })
+            })
+        })
+    }
+}

--- a/jormungandr/src/blockchain/index.rs
+++ b/jormungandr/src/blockchain/index.rs
@@ -2,19 +2,20 @@ use crate::blockchain::{
     chain::MAIN_BRANCH_TAG,
     storage::{Storage, StorageError},
 };
-use chain_impl_mockchain::header::{Header, HeaderId};
+use chain_impl_mockchain::header::{BlockDate, ChainLength, Header, HeaderId};
 use std::collections::BTreeMap;
 use thiserror::Error;
 use tokio::{prelude::*, sync::lock::Lock};
 
-type HeaderToKey<K> = fn(Header) -> K;
+#[derive(Clone)]
+pub struct Index {
+    inner: Lock<IndexInternal>,
+}
 
-pub struct Index<K>
-where
-    K: std::cmp::Ord,
-{
-    transform: HeaderToKey<K>,
-    index_lock: Lock<BTreeMap<K, HeaderId>>,
+#[derive(Default)]
+struct IndexInternal {
+    chain_length_index: BTreeMap<ChainLength, HeaderId>,
+    block_date_index: BTreeMap<BlockDate, HeaderId>,
 }
 
 #[derive(Debug, Error)]
@@ -25,32 +26,37 @@ pub enum Error {
     StorageError(#[from] StorageError),
 }
 
-impl<K> Index<K>
-where
-    K: std::cmp::Ord + Clone,
-{
-    pub fn new(transform: HeaderToKey<K>) -> Self {
+pub enum IndexRequest {
+    ChainLength(ChainLength),
+    BlockDate(BlockDate),
+}
+
+impl Index {
+    pub fn new() -> Self {
         Self {
-            transform,
-            index_lock: Lock::new(BTreeMap::new()),
+            inner: Lock::new(Default::default()),
         }
     }
 
-    pub fn get(&self, key: K) -> impl Future<Item = Option<HeaderId>, Error = ()> {
-        let mut index_lock = self.index_lock.clone();
-        future::poll_fn(move || Ok(index_lock.poll_lock()))
-            .map(move |index| index.get(&key).map(|v| v.to_owned()))
+    pub fn get(&self, key: IndexRequest) -> impl Future<Item = Option<HeaderId>, Error = ()> {
+        let mut inner = self.inner.clone();
+        future::poll_fn(move || Ok(inner.poll_lock())).map(move |index| {
+            match key {
+                IndexRequest::ChainLength(key) => index.chain_length_index.get(&key),
+                IndexRequest::BlockDate(key) => index.block_date_index.get(&key),
+            }
+            .map(|v| v.to_owned())
+        })
     }
 
     pub fn update_from_storage(
         &mut self,
         storage: Storage,
     ) -> impl Future<Item = (), Error = Error> {
-        let mut index_lock = self.index_lock.clone();
-        let mut index_lock_2 = self.index_lock.clone();
-        let transform = self.transform;
+        let mut inner = self.inner.clone();
+        let mut inner_2 = self.inner.clone();
 
-        future::poll_fn(move || Ok(index_lock.poll_lock())).and_then(move |mut index| {
+        future::poll_fn(move || Ok(inner.poll_lock())).and_then(move |index| {
             // stream of values from the storage (HEAD to genesis)
             let mut storage_stream = storage
                 .get_tag(MAIN_BRANCH_TAG.to_owned())
@@ -70,13 +76,16 @@ where
             stream::poll_fn(move || match storage_stream.poll()? {
                 Async::Ready(Some(block)) => {
                     let id = block.header.id().clone();
-                    let key = (transform)(block.header);
-                    if let Some(stored_id) = index.get(&key) {
+                    let by_chain_length = header_to_chain_length(&block.header);
+                    let by_block_date = header_to_block_date(&block.header);
+                    // we only check one of arguments assuming that indexes are
+                    // under the same lock and thus are always consistent
+                    if let Some(stored_id) = index.chain_length_index.get(&by_chain_length) {
                         if stored_id == &id {
                             return Ok(Async::Ready(None));
                         }
                     }
-                    Ok(Async::Ready(Some((key, id))))
+                    Ok(Async::Ready(Some((by_chain_length, by_block_date, id))))
                 }
                 Async::Ready(None) => Ok(Async::Ready(None)),
                 Async::NotReady => Ok(Async::NotReady),
@@ -85,24 +94,47 @@ where
             .fuse()
             .collect()
             .and_then(move |new_keys| {
-                future::poll_fn(move || Ok(index_lock_2.poll_lock())).map(move |mut index| {
-                    use std::ops::Bound;
+                future::poll_fn(move || Ok(inner_2.poll_lock())).map(move |mut index| {
                     if new_keys.is_empty() {
                         return;
                     }
-                    let to_remove: Vec<_> = index
-                        .range((Bound::Excluded(&new_keys[0].0), Bound::Unbounded))
-                        .map(|(key, _)| key)
-                        .cloned()
-                        .collect();
-                    to_remove.into_iter().for_each(|key| {
-                        index.remove(&key);
-                    });
-                    new_keys.into_iter().for_each(|(key, id)| {
-                        index.insert(key, id);
-                    });
+
+                    clean_index(&mut index.chain_length_index, &new_keys[0].0);
+                    clean_index(&mut index.block_date_index, &new_keys[0].1);
+
+                    new_keys
+                        .into_iter()
+                        .for_each(|(chain_length, block_date, id)| {
+                            index.chain_length_index.insert(chain_length, id.clone());
+                            index.block_date_index.insert(block_date, id);
+                        });
                 })
             })
         })
     }
+}
+
+fn header_to_chain_length(h: &Header) -> ChainLength {
+    h.chain_length()
+}
+
+fn header_to_block_date(h: &Header) -> BlockDate {
+    h.block_date()
+}
+
+fn clean_index<T>(index: &mut BTreeMap<T, HeaderId>, key: &T)
+where
+    T: Clone + Ord,
+{
+    use std::ops::Bound;
+
+    let to_remove: Vec<_> = index
+        .range((Bound::Excluded(key), Bound::Unbounded))
+        .map(|(key, _)| key)
+        .cloned()
+        .collect();
+
+    to_remove.into_iter().for_each(|key| {
+        index.remove(&key);
+    });
 }

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -3,6 +3,7 @@ mod candidate;
 mod chain;
 mod chain_selection;
 mod checkpoints;
+mod index;
 mod multiverse;
 mod process;
 mod reference;

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -3,7 +3,7 @@ mod candidate;
 mod chain;
 mod chain_selection;
 mod checkpoints;
-mod index;
+pub mod index;
 mod multiverse;
 mod process;
 mod reference;

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -296,6 +296,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
             stats_counter,
             blockchain,
             blockchain_tip: blockchain_tip.clone(),
+            blockchain_index: bootstrapped_node.index.clone(),
             network_task: network_msgbox,
             transaction_task: fragment_msgbox,
             logs: pool_logs,

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -1,6 +1,8 @@
 use super::{grpc, BlockConfig};
 use crate::blockcfg::{Block, HeaderHash};
-use crate::blockchain::{self, Blockchain, Error as BlockchainError, PreCheckedHeader, Ref, Tip};
+use crate::blockchain::{
+    self, index::Index, Blockchain, Error as BlockchainError, PreCheckedHeader, Ref, Tip,
+};
 use crate::settings::start::network::Peer;
 use chain_core::property::HasHeader;
 use network_core::client::{BlockService, Client as _};
@@ -43,6 +45,7 @@ pub fn bootstrap_from_peer(
     peer: Peer,
     blockchain: Blockchain,
     branch: Tip,
+    index: Index,
     logger: Logger,
 ) -> Result<Arc<Ref>, Error> {
     info!(logger, "connecting to bootstrap peer {}", peer.connection);
@@ -69,7 +72,7 @@ pub fn bootstrap_from_peer(
                 .and_then(move |stream| bootstrap_from_stream(blockchain, tip, stream, logger))
         })
         .and_then(move |tip| {
-            blockchain::process_new_ref(logger2, blockchain2, branch, tip.clone())
+            blockchain::process_new_ref(logger2, blockchain2, branch, index, tip.clone())
                 .map_err(|e| Error::ChainSelectionFailed { source: e })
                 .map(|()| tip)
         });

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -49,7 +49,7 @@ use self::p2p::{
     P2pTopology,
 };
 use crate::blockcfg::{Block, HeaderHash};
-use crate::blockchain::{Blockchain as NewBlockchain, Tip};
+use crate::blockchain::{index::Index, Blockchain as NewBlockchain, Tip};
 use crate::intercom::{BlockMsg, ClientMsg, NetworkMsg, PropagateMsg, TransactionMsg};
 use crate::settings::start::network::{Configuration, Peer, Protocol};
 use crate::utils::{
@@ -478,6 +478,7 @@ pub fn bootstrap(
     config: &Configuration,
     blockchain: NewBlockchain,
     branch: Tip,
+    index: Index,
     logger: &Logger,
 ) -> Result<bool, bootstrap::Error> {
     if config.protocol != Protocol::Grpc {
@@ -497,6 +498,7 @@ pub fn bootstrap(
             peer,
             blockchain.clone(),
             branch.clone(),
+            index.clone(),
             logger.clone(),
         );
 

--- a/jormungandr/src/rest/mod.rs
+++ b/jormungandr/src/rest/mod.rs
@@ -16,7 +16,7 @@ use futures::{Future, IntoFuture};
 use slog::Logger;
 use std::sync::{Arc, RwLock};
 
-use crate::blockchain::{Blockchain, Tip};
+use crate::blockchain::{index::Index, Blockchain, Tip};
 use crate::fragment::Logs;
 use crate::leadership::Logs as LeadershipLogs;
 use crate::network::p2p::P2pTopology;
@@ -110,6 +110,7 @@ pub struct FullContext {
     pub stats_counter: StatsCounter,
     pub blockchain: Blockchain,
     pub blockchain_tip: Tip,
+    pub blockchain_index: Index,
     pub network_task: MessageBox<NetworkMsg>,
     pub transaction_task: MessageBox<TransactionMsg>,
     pub logs: Logs,

--- a/jormungandr/src/rest/v0/mod.rs
+++ b/jormungandr/src/rest/v0/mod.rs
@@ -16,6 +16,12 @@ pub fn resources() -> Vec<(
         ("/block/{block_id}/next_id", &|r| {
             r.get().with_async(handlers::get_block_next_id)
         }),
+        ("/block/by_chain_length/{chain_length}", &|r| {
+            r.get().with_async(handlers::get_block_id_by_chain_length)
+        }),
+        ("/block/by_block_date/{block_date}", &|r| {
+            r.get().with_async(handlers::get_block_id_by_block_date)
+        }),
         ("/fragment/logs", &|r| {
             r.get().with_async(handlers::get_message_logs)
         }),


### PR DESCRIPTION
Implements indexing blocks by chain length and block time which are mapped into block ids.

Index is updated every time the tip is updated and can handle switching between branches when necessary.