### PR TITLE
enable shared cache for in-memory databases

### DIFF
--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -20,7 +20,7 @@ pub fn prepare_storage(setting: &Settings, logger: &Logger) -> Result<NodeStorag
     match &setting.storage {
         None => {
             info!(logger, "storing blockchain in memory");
-            Ok(SQLiteBlockStore::new(":memory:"))
+            Ok(SQLiteBlockStore::new("file::memory:?cache=shared"))
         }
         Some(dir) => {
             std::fs::create_dir_all(dir).map_err(|err| Error::IO {


### PR DESCRIPTION
Using an in-memory sqlite database without shared cache makes the sqlite
to create a unique database for each new connection. Once the connection
pool returns a connection different from the one used for initialization
the node accesses an empty database without an initialized schema and
panics.

Fix #1485

Additional info: https://www.sqlite.org/inmemorydb.html