### PR TITLE
remove KV pairs with duplicate keys from logs

### DIFF
--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -116,13 +116,147 @@ impl<D: Drain> Drain for DrainMux<D> {
     }
 }
 
+/// slog serializers do not care about duplicates in KV fields that can occur
+/// under certain circumstances. This serializer serves as a wrapper on top of
+/// the actual serializer that takes care of duplicates. First it checks if the
+/// same key was already. If so, this key is skipped during the serialization.
+/// Otherwise the KV pair is passed to the inner serializer.
+struct DedupSerializer<'a> {
+    inner: &'a mut dyn slog::Serializer,
+    seen_keys: std::collections::HashSet<slog::Key>,
+}
+
+impl<'a> DedupSerializer<'a> {
+    fn new(inner: &'a mut dyn slog::Serializer) -> Self {
+        Self {
+            inner,
+            seen_keys: Default::default(),
+        }
+    }
+}
+
+macro_rules! dedup_serializer_method_impl {
+    ($(#[$m:meta])* $t:ty => $f:ident) => {
+        $(#[$m])*
+        fn $f(&mut self, key : slog::Key, val : $t)
+            -> slog::Result {
+                if self.seen_keys.contains(&key) {
+                    return Ok(())
+                }
+                self.seen_keys.insert(key.clone());
+                self.inner.$f(key, val)
+            }
+    };
+}
+
+impl<'a> slog::Serializer for DedupSerializer<'a> {
+    dedup_serializer_method_impl! {
+        &fmt::Arguments => emit_arguments
+    }
+    dedup_serializer_method_impl! {
+        usize => emit_usize
+    }
+    dedup_serializer_method_impl! {
+        isize => emit_isize
+    }
+    dedup_serializer_method_impl! {
+        bool => emit_bool
+    }
+    dedup_serializer_method_impl! {
+        char => emit_char
+    }
+    dedup_serializer_method_impl! {
+        u8 => emit_u8
+    }
+    dedup_serializer_method_impl! {
+        i8 => emit_i8
+    }
+    dedup_serializer_method_impl! {
+        u16 => emit_u16
+    }
+    dedup_serializer_method_impl! {
+        i16 => emit_i16
+    }
+    dedup_serializer_method_impl! {
+        u32 => emit_u32
+    }
+    dedup_serializer_method_impl! {
+        i32 => emit_i32
+    }
+    dedup_serializer_method_impl! {
+        u64 => emit_u64
+    }
+    dedup_serializer_method_impl! {
+        i64 => emit_i64
+    }
+    dedup_serializer_method_impl! {
+        #[cfg(integer128)]
+        u128 => emit_u128
+    }
+    dedup_serializer_method_impl! {
+        #[cfg(integer128)]
+        i128 => emit_i128
+    }
+    dedup_serializer_method_impl! {
+        &str => emit_str
+    }
+
+    fn emit_unit(&mut self, key: slog::Key) -> slog::Result {
+        if self.seen_keys.contains(&key) {
+            return Ok(());
+        }
+        self.seen_keys.insert(key.clone());
+        self.inner.emit_unit(key)
+    }
+
+    fn emit_none(&mut self, key: slog::Key) -> slog::Result {
+        if self.seen_keys.contains(&key) {
+            return Ok(());
+        }
+        self.seen_keys.insert(key.clone());
+        self.inner.emit_none(key)
+    }
+}
+
+/// The wrapper on top of an arbitrary KV object that utilize DedupSerializer.
+struct DedupKV<T>(T);
+
+impl<T: slog::KV> slog::KV for DedupKV<T> {
+    fn serialize(
+        &self,
+        record: &slog::Record,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        let mut serializer = DedupSerializer::new(serializer);
+        self.0.serialize(&record, &mut serializer)
+    }
+}
+
+/// slog drain that uses DedupKV to remove duplicate keys from KV lists
+struct DedupDrain<D>(D);
+
+impl<D: Drain> Drain for DedupDrain<D> {
+    type Ok = D::Ok;
+    type Err = D::Err;
+
+    fn log(
+        &self,
+        record: &slog::Record,
+        values: &slog::OwnedKVList,
+    ) -> Result<Self::Ok, Self::Err> {
+        // clone is ok here because the underlying data is Arc
+        let values = slog::OwnedKV(DedupKV(values.clone()));
+        self.0.log(record, &values.into())
+    }
+}
+
 impl LogSettings {
     pub fn to_logger(&self) -> Result<Logger, Error> {
         let mut drains = Vec::new();
         for config in self.0.iter() {
             drains.push(config.to_logger()?);
         }
-        let common_drain = DrainMux::new(drains).fuse();
+        let common_drain = DedupDrain(DrainMux::new(drains)).fuse();
         Ok(slog::Logger::root(common_drain, o!()))
     }
 }


### PR DESCRIPTION
`slog` do not take care of duplicate keys in KV list which leads to errors
in log parsing, `DedupDrain` deals with such keys.

Fix #1499