### PR TITLE
[Tests] Reward test fix

### DIFF
--- a/jormungandr-integration-tests/src/common/startup/mod.rs
+++ b/jormungandr-integration-tests/src/common/startup/mod.rs
@@ -159,15 +159,13 @@ pub fn start_stake_pool(
         .iter()
         .map(|x| Fund {
             address: x.address.clone(),
-            value: 1_000_000.into(),
+            value: 1_000_000_000.into(),
         })
         .collect();
 
     let mut config = config_builder
         .with_block0_consensus("genesis_praos")
-        .with_consensus_genesis_praos_active_slot_coeff("0.1")
         .with_consensus_leaders_ids(leaders)
-        .with_kes_update_speed(43200)
         .with_initial_certs(initial_certs)
         .with_funds(funds)
         .build();

--- a/jormungandr-integration-tests/src/jormungandr/explorer/mod.rs
+++ b/jormungandr-integration-tests/src/jormungandr/explorer/mod.rs
@@ -13,8 +13,9 @@ pub fn explorer_test() {
     let receiver = startup::create_new_account_address();
 
     let mut config = ConfigurationBuilder::new();
-
-    config.with_explorer();
+    config
+        .with_consensus_genesis_praos_active_slot_coeff("0.999")
+        .with_explorer();
 
     let (jormungandr, _) = startup::start_stake_pool(&[faucet.clone()], &mut config).unwrap();
 

--- a/jormungandr-integration-tests/src/jormungandr/genesis/rewards.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/rewards.rs
@@ -5,7 +5,6 @@ use crate::common::{
 use chain_impl_mockchain::value::Value;
 use jormungandr_lib::interfaces::StakePoolStats;
 
-#[ignore]
 #[test]
 pub fn collect_reward() {
     let stake_pool_owners = [


### PR DESCRIPTION
Fix small issue on reward tests which resets coeff parameter to 0.1 (instead using 0.999) which cause that block will be created less likely