### PR TITLE
Remove some dead code

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -2,58 +2,24 @@
 // monomorphized structured with long signatures. This value is enough for current project.
 #![type_length_limit = "10000000"]
 
-extern crate actix_net;
-extern crate actix_threadpool;
-extern crate actix_web;
-extern crate bech32;
-extern crate bincode;
-extern crate bytes;
-extern crate cardano_legacy_address;
-extern crate chain_addr;
-extern crate chain_core;
-extern crate chain_crypto;
-extern crate chain_impl_mockchain;
-extern crate chain_storage;
-extern crate chain_storage_sqlite_old;
-extern crate chain_time;
-extern crate imhamt;
 #[macro_use]
 extern crate error_chain;
 #[macro_use(try_ready)]
 extern crate futures;
-extern crate http;
-extern crate humantime;
-extern crate hyper;
-extern crate jormungandr_lib;
 #[macro_use]
 extern crate lazy_static;
-extern crate linked_hash_map;
-extern crate native_tls;
-extern crate network_core;
-extern crate network_grpc;
-extern crate poldercast;
-extern crate rand;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
-extern crate serde_yaml;
 #[macro_use]
 extern crate slog;
-extern crate juniper;
-extern crate slog_async;
 #[cfg(feature = "gelf")]
 extern crate slog_gelf;
 #[cfg(feature = "systemd")]
 extern crate slog_journald;
-extern crate slog_json;
 #[cfg(unix)]
 extern crate slog_syslog;
-extern crate slog_term;
-extern crate structopt;
-extern crate thiserror;
-extern crate tokio;
 
 use crate::{
     blockcfg::{HeaderHash, Leader},

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -18,10 +18,10 @@ use chain_impl_mockchain::value::{Value, ValueError};
 use chain_storage::error::Error as StorageError;
 
 use crate::blockchain::Ref;
-use crate::chain_crypto::bech32::Bech32;
 use crate::intercom::{self, NetworkMsg, TransactionMsg};
 use crate::secure::NodeSecret;
 use bytes::{Bytes, IntoBuf};
+use chain_crypto::bech32::Bech32;
 use futures::{
     future::{
         self,

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -45,15 +45,6 @@ pub struct Service {
     runtime: Option<Runtime>,
 }
 
-/// the current thread service information
-///
-/// retrieve the name, the up time, the logger
-pub struct ThreadServiceInfo {
-    name: &'static str,
-    up_time: Instant,
-    logger: Logger,
-}
-
 /// the current future service information
 ///
 /// retrieve the name, the up time, the logger and the executor
@@ -164,32 +155,6 @@ impl Services {
     /// select on all the started services. this function will block until first services returns
     pub fn wait_any_finished(&self) -> Result<bool, RecvError> {
         self.finish_listener.wait_any_finished()
-    }
-}
-
-impl ThreadServiceInfo {
-    /// get the time this service has been running since
-    #[inline]
-    pub fn up_time(&self) -> Duration {
-        Instant::now().duration_since(self.up_time)
-    }
-
-    /// get the name of this Service
-    #[inline]
-    pub fn name(&self) -> &'static str {
-        self.name
-    }
-
-    /// access the service's logger
-    #[inline]
-    pub fn logger(&self) -> &Logger {
-        &self.logger
-    }
-
-    /// extract the service's logger
-    #[inline]
-    pub fn into_logger(self) -> Logger {
-        self.logger
     }
 }
 

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -268,14 +268,6 @@ impl ServiceFinishListener {
     pub fn wait_any_finished(&self) -> Result<bool, RecvError> {
         self.receiver.recv()
     }
-
-    #[allow(dead_code)]
-    pub fn wait_all_finished(self) {
-        std::mem::drop(self.sender);
-        while let Ok(_) = self.receiver.recv() {
-            continue;
-        }
-    }
 }
 
 impl Drop for ServiceFinishNotifier {


### PR DESCRIPTION
Remove lines that are unnecessary.

- [x] `extern crate` is a pre-2018 edition;
- [x] `ThreadInfoService` is no longer in used;
- [x] `wait_all_finished` is never used.