### PR TITLE
Added common vscode and idea workspace folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 book
 /target
 /vendor
+.idea/
+.vscode/


### PR DESCRIPTION
This commit adds common workspace directories (intellij idea and vs code) to .gitignore.