### PR TITLE
use a global runtime instead of a local one and new future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "c2-chacha"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,12 +1053,40 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-task"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1498,6 +1531,7 @@ dependencies = [
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-compat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionisator 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2192,6 +2226,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pkg-config"
@@ -3298,6 +3342,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-buf"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,6 +3374,22 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-compat"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4066,6 +4141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bytecount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b92204551573580e078dc80017f36a213eb77a0450e4ddd8cfa0f3f2d1f0178f"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cargo_metadata 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1b4d380e1bab994591a24c2bdd1b054f64b60bef483a8c598c7c345bc3bbe"
 "checksum cbor_event 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2b6cda8a789815488ee290d106bc97dba47785dae73d63576fc42c126912a451"
@@ -4135,7 +4211,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+"checksum futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
+"checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
+"checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 "checksum galvanic-test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e6ec93b2f388dcd1102437036da399ae305e9c6cdd4e213260f5ddb6005907a"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
@@ -4234,6 +4314,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
+"checksum pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422"
+"checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum platforms 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 "checksum poldercast 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca6a852c0810f500bb90c32ae4c525b4165f8869291cd0443c9c205ef6ca05a3"
@@ -4355,8 +4437,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tls-api 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "049c03787a0595182357fbd487577947f4351b78ce20c3668f6d49f17feb13d1"
 "checksum tls-api-stub 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c9a0cc8c149724db9de7d73a0e1bc80b1a74f5394f08c6f301e11f9c35fa061e"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
+"checksum tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ffa2fdcfa937b20cb3c822a635ceecd5fc1a27a6a474527e5516aa24b8c8820a"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
+"checksum tokio-compat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d4000e3c984d0e58ace4926f1eae4d830a90a76c386dccf5b82aeca4cbee6df"
 "checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 "checksum tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -56,6 +56,7 @@ structopt = "^0.2"
 thiserror = "1.0"
 tokio      = "^0.1.16"
 tokio-threadpool = "0.1"
+tokio-compat = "^0.1.4"
 bech32 = "0.7"
 
 [build-dependencies]

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -57,10 +57,10 @@ pub mod utils;
 
 use stats_counter::StatsCounter;
 
-fn start() -> Result<(), start_up::Error> {
-    let initialized_node = initialize_node()?;
+async fn start() -> Result<(), start_up::Error> {
+    let initialized_node = initialize_node().await?;
 
-    let bootstrapped_node = bootstrap(initialized_node)?;
+    let bootstrapped_node = bootstrap(initialized_node).await?;
 
     start_services(bootstrapped_node)
 }
@@ -317,7 +317,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
 /// * network / peer discoveries (?)
 ///
 ///
-fn bootstrap(initialized_node: InitializedNode) -> Result<BootstrappedNode, start_up::Error> {
+async fn bootstrap(initialized_node: InitializedNode) -> Result<BootstrappedNode, start_up::Error> {
     let InitializedNode {
         settings,
         block0,
@@ -348,7 +348,8 @@ fn bootstrap(initialized_node: InitializedNode) -> Result<BootstrappedNode, star
         blockchain.clone(),
         blockchain_tip.clone(),
         &bootstrap_logger,
-    )?;
+    )
+    .await?;
 
     let explorer_db = if settings.explorer {
         Some(explorer::ExplorerDB::bootstrap(
@@ -389,7 +390,7 @@ pub struct InitializedNode {
     pub diagnostic: Diagnostic,
 }
 
-fn initialize_node() -> Result<InitializedNode, start_up::Error> {
+async fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let command_line = CommandLine::load();
 
     if command_line.full_version {
@@ -455,7 +456,8 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
         &settings,
         &storage,
         &init_logger, /* add network to fetch block0 */
-    )?;
+    )
+    .await?;
 
     Ok(InitializedNode {
         settings,
@@ -471,19 +473,21 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
 fn main() {
     use std::error::Error;
 
-    if let Err(error) = start() {
-        eprintln!("{}", error);
-        let mut source = error.source();
-        while let Some(err) = source {
-            eprintln!(" |-> {}", err);
-            source = err.source();
-        }
+    tokio_compat::run_std(async {
+        if let Err(error) = start().await {
+            eprintln!("{}", error);
+            let mut source = error.source();
+            while let Some(err) = source {
+                eprintln!(" |-> {}", err);
+                source = err.source();
+            }
 
-        // TODO: https://github.com/rust-lang/rust/issues/43301
-        //
-        // as soon as #43301 is stabilized it would be nice to no use
-        // `exit` but the more appropriate:
-        // https://doc.rust-lang.org/stable/std/process/trait.Termination.html
-        std::process::exit(error.code());
-    }
+            // TODO: https://github.com/rust-lang/rust/issues/43301
+            //
+            // as soon as #43301 is stabilized it would be nice to no use
+            // `exit` but the more appropriate:
+            // https://doc.rust-lang.org/stable/std/process/trait.Termination.html
+            std::process::exit(error.code());
+        }
+    })
 }

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -9,7 +9,7 @@ use network_grpc::client::Connection;
 use slog::Logger;
 use thiserror::Error;
 use tokio::prelude::*;
-use tokio::runtime::Runtime;
+use tokio_compat::prelude::*;
 
 use std::fmt::Debug;
 use std::io;
@@ -39,7 +39,7 @@ pub enum Error {
     ChainSelectionFailed { source: BlockchainError },
 }
 
-pub fn bootstrap_from_peer(
+pub async fn bootstrap_from_peer(
     peer: Peer,
     blockchain: Blockchain,
     branch: Tip,
@@ -47,12 +47,10 @@ pub fn bootstrap_from_peer(
 ) -> Result<Arc<Ref>, Error> {
     info!(logger, "connecting to bootstrap peer {}", peer.connection);
 
-    let runtime = Runtime::new().map_err(|e| Error::RuntimeInit { source: e })?;
-
     let blockchain2 = blockchain.clone();
     let logger2 = logger.clone();
 
-    let bootstrap = grpc::connect(peer.address(), None, runtime.executor())
+    let bootstrap = grpc::connect(peer.address(), None)
         .map_err(|e| Error::Connect { source: e })
         .and_then(|client: Connection<BlockConfig>| {
             client
@@ -74,7 +72,7 @@ pub fn bootstrap_from_peer(
                 .map(|()| tip)
         });
 
-    runtime.block_on_all(bootstrap)
+    bootstrap.compat().await
 }
 
 fn bootstrap_from_stream<S>(

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -34,7 +34,7 @@ pub fn connect(
         channels,
         logger: state.logger,
     });
-    let cf = grpc::connect(addr, Some(node_id), state.global.executor.clone());
+    let cf = grpc::connect(addr, Some(node_id));
     let handle = ConnectHandle { receiver };
     let future = ConnectFuture {
         sender: Some(sender),

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -42,7 +42,7 @@ pub fn prepare_storage(setting: &Settings, logger: &Logger) -> Result<NodeStorag
 /// 2. we have the block_0 hash only:
 ///     1. check the storage if we don't have it already there;
 ///     2. check the network nodes we know about
-pub fn prepare_block_0(
+pub async fn prepare_block_0(
     settings: &Settings,
     storage: &NodeStorage,
     logger: &Logger,
@@ -75,7 +75,9 @@ pub fn prepare_block_0(
                     logger,
                     "retrieving block0 from network with hash {}", block0_id
                 );
-                network::fetch_block(&settings.network, *block0_id, logger).map_err(|e| e.into())
+                network::fetch_block(&settings.network, *block0_id, logger)
+                    .await
+                    .map_err(|e| e.into())
             }
         }
     }


### PR DESCRIPTION
Reverts input-output-hk/jormungandr#1570

Re-instate the change for the `tokio-compat` and unified `Runtime`. We need to find the issues on the travis-ci and see how it can be addressed.