### PR TITLE
[Tests] Refresh grpc mock tests

### DIFF
--- a/jormungandr-integration-tests/src/mock/mod.rs
+++ b/jormungandr-integration-tests/src/mock/mod.rs
@@ -10,6 +10,8 @@ pub mod client;
 pub mod convert;
 pub mod proto;
 pub mod server;
+#[cfg(test)]
+pub mod testing;
 
 pub use client::JormungandrClient;
 pub use convert::*;

--- a/jormungandr-integration-tests/src/mock/testing/client_tests.rs
+++ b/jormungandr-integration-tests/src/mock/testing/client_tests.rs
@@ -1,20 +1,26 @@
-
 use crate::mock::{
+    client, read_into,
     testing::{setup::bootstrap_node, setup::Config},
-    read_into
 };
 
 use crate::common::{
-    configuration::genesis_model::Fund, jcli_wrapper, jcli_wrapper::JCLITransactionWrapper,
-    jormungandr::{logger::Level, Starter,ConfigurationBuilder},startup
+    configuration::genesis_model::Fund,
+    jcli_wrapper,
+    jcli_wrapper::JCLITransactionWrapper,
+    jormungandr::{logger::Level, ConfigurationBuilder, Starter},
+    startup,
 };
 use chain_core::property::FromStr;
 use chain_impl_mockchain::{
-    block::{Header,Block},
+    block::{Block, Header},
     key::Hash,
     testing::builders::{GenesisPraosBlockBuilder, StakePoolBuilder},
 };
 use chain_time::{Epoch, TimeEra};
+
+fn fake_hash() -> Hash {
+    Hash::from_str("efe2d4e5c4ad84b8e67e7b5676fff41cad5902a60b8cb6f072f42d7c7d26c944").unwrap()
+}
 
 // L1001 Handshake sanity
 #[test]
@@ -51,9 +57,7 @@ pub fn get_headers_correct_hash() {
 
     let block_hashes = server.logger.get_created_blocks_hashes();
     let headers: Vec<Header> = response_to_vec!(client.get_headers(&block_hashes));
-    let headers_hashes: Vec<Hash> = headers.iter()
-                            .map(|x| x.hash())
-                            .collect();
+    let headers_hashes: Vec<Hash> = headers.iter().map(|x| x.hash()).collect();
     assert_eq!(block_hashes, headers_hashes);
 }
 
@@ -62,9 +66,13 @@ pub fn get_headers_correct_hash() {
 pub fn get_headers_incorrect_hash() {
     let (_server, config) = bootstrap_node();
     let client = Config::attach_to_local_node(config.node_config.get_p2p_port()).client();
-    let hash = Hash::from_str("efe2d4e5c4ad84b8e67e7b5676fff41cad5902a60b8cb6f072f42d7c7d26c944").unwrap();
-    let headers_response: Vec<Header> = response_to_vec!(client.get_headers(&vec![hash]));
-    assert!(headers_response.is_empty());
+    let err = response_to_err!(client.get_headers(&vec![fake_hash()]));
+    match err {
+        grpc::Error::GrpcMessage(grpc_error_message) => {
+            assert_eq!(grpc_error_message.grpc_message, "not%20found");
+        }
+        _ => panic!("Wrong error"),
+    }
 }
 
 // L1011 GetBlocks correct hash
@@ -75,20 +83,21 @@ pub fn get_blocks_correct_hash() {
 
     let tip = client.get_tip();
     let blocks: Vec<Block> = response_to_vec!(client.get_blocks(&vec![tip.hash()]));
-    println!("{:?}", blocks);
+    assert!(!blocks.is_empty());
 }
 // L1012 GetBlocks incorrect hash
 #[test]
 pub fn get_blocks_incorrect_hash() {
     let (_server, config) = bootstrap_node();
     let client = Config::attach_to_local_node(config.node_config.get_p2p_port()).client();
+    let err = response_to_err!(client.get_blocks(&vec![fake_hash()]));
 
-    let blocks: Vec<Block> = response_to_vec!(client.get_blocks(&vec![Hash::from_str(
-        "efe2d4e5c4ad84b8e67e7b5676fff41cad5902a60b8cb6f072f42d7c7d26c944",
-    )
-    .unwrap()]));
-
-    assert!(blocks.is_empty());
+    match err {
+        grpc::Error::GrpcMessage(grpc_error_message) => {
+            assert_eq!(grpc_error_message.grpc_message, "not%20found");
+        }
+        _ => panic!("Wrong error"),
+    }
 }
 
 // L1013 PullBlocksToTip correct hash
@@ -96,11 +105,10 @@ pub fn get_blocks_incorrect_hash() {
 pub fn pull_blocks_to_tip_correct_hash() {
     let (server, config) = bootstrap_node();
     let client = Config::attach_to_local_node(config.node_config.get_p2p_port()).client();
-    let blocks_headers: Vec<Block> = response_to_vec!(client
-        .pull_blocks_to_tip(Hash::from_str(&config.genesis_block_hash).unwrap()));
-    let blocks_hashes: Vec<Hash> = blocks_headers.iter()
-        .map(|x| x.header.hash())
-        .collect();
+    let blocks_headers: Vec<Block> = response_to_vec!(
+        client.pull_blocks_to_tip(Hash::from_str(&config.genesis_block_hash).unwrap())
+    );
+    let blocks_hashes: Vec<Hash> = blocks_headers.iter().map(|x| x.header.hash()).collect();
 
     let block_hashes_from_logs = server.logger.get_created_blocks_hashes();
     assert_eq!(block_hashes_from_logs, blocks_hashes);
@@ -133,9 +141,7 @@ pub fn pull_headers_correct_hash() {
     let client = Config::attach_to_local_node(config.node_config.get_p2p_port()).client();
     let tip_header = client.get_tip();
     let headers: Vec<Header> = response_to_vec!(client.pull_headers(None, Some(tip_header.hash())));
-    let hashes: Vec<Hash> = headers.iter()
-                                .map(|x| x.hash())
-                                .collect();
+    let hashes: Vec<Hash> = headers.iter().map(|x| x.hash()).collect();
 
     let hashes_from_logs = server.logger.get_created_blocks_hashes();
     assert_eq!(hashes, hashes_from_logs);
@@ -197,11 +203,10 @@ pub fn push_headers() {
         .with_parent(&tip_header)
         .build(&stake_pool, &time_era);
 
-    client.push_header(block.header);
-    assert!(server
-        .logger
-        .get_lines_from_log()
-        .any(|line| line.contains("not yet implemented")));
+    client
+        .push_header(block.header)
+        .expect("unexpected failure while pushing headers");
+    server.logger.print_raw_log();
 }
 
 // L1020 Push headers incorrect header
@@ -228,20 +233,23 @@ pub fn upload_block_incompatible_protocol() {
         .build(&stake_pool, &time_era);
 
     match client.upload_blocks(block).err().unwrap() {
-        grpc::Error::GrpcMessage(grpc_error_message) => {
-            assert_eq!(grpc_error_message.grpc_message, "invalid%20request%20data");
+        client::Error(client::ErrorKind::InvalidRequest(grpc_error), _) => {
+            assert_eq!(
+                grpc_error.to_string(),
+                "grpc message error: invalid%20request%20data"
+            );
         }
         _ => panic!("Wrong error"),
     }
 
+    server.logger.print_raw_log();
+
     assert!(server
         .logger
         .get_log_entries()
-        .any(|entry| entry.level == Level::WARN
-            && entry.task == Some("network".to_owned())
-            && entry
-                .msg
-                .contains("block Version is incompatible with LeaderSelection")));
+        .any(|entry| entry.task == Some("network".to_owned())
+            && entry.msg.contains("error processing request")
+            && entry.reason_contains("block Version is incompatible with LeaderSelection")));
 }
 
 // L1020 Push headers incorrect header
@@ -251,7 +259,7 @@ pub fn upload_block_nonexisting_stake_pool() {
         .with_slot_duration(4)
         .with_block0_consensus("genesis_praos")
         .build();
-    let server = Starter::new().config(config.clone()).start().unwrap();
+    let _server = Starter::new().config(config.clone()).start().unwrap();
     let client = Config::attach_to_local_node(config.node_config.get_p2p_port()).client();
     let tip_header = client.get_tip();
     let stake_pool = StakePoolBuilder::new().build();
@@ -271,18 +279,14 @@ pub fn upload_block_nonexisting_stake_pool() {
         .build(&stake_pool, &time_era);
 
     match client.upload_blocks(block).err().unwrap() {
-        grpc::Error::GrpcMessage(grpc_error_message) => {
-            assert_eq!(grpc_error_message.grpc_message, "invalid%20request%20data");
+        client::Error(client::ErrorKind::InvalidRequest(grpc_error), _) => {
+            assert_eq!(
+                grpc_error.to_string(),
+                "grpc message error: invalid%20request%20data"
+            );
         }
         _ => panic!("Wrong error"),
     }
-
-    assert!(server
-        .logger
-        .get_log_entries()
-        .any(|entry| entry.level == Level::WARN
-            && entry.task == Some("network".to_owned())
-            && entry.msg.contains("Invalid block message")));
 }
 
 // L1020 Get fragments
@@ -312,14 +316,11 @@ pub fn get_fragments() {
         jcli_wrapper::assert_transaction_in_block(&transaction, &server.rest_address());
     let client = Config::attach_to_local_node(config.node_config.get_p2p_port()).client();
     match response_to_err!(client.get_fragments(vec![fragment_id.into_hash()])) {
-        grpc::Error::Http(_) => (),
+        grpc::Error::GrpcMessage(grpc_error_message) => {
+            assert_eq!(grpc_error_message.grpc_message, "not%20implemented");
+        }
         _ => panic!("Wrong error"),
     };
-    assert!(server
-        .logger
-        .get_lines_from_log()
-        .any(|line| line.contains("not yet implemented")));
-
     /*assert_eq!(fragments.len(), 1);
     match fragments.iter().next().unwrap() {
         ChainFragment::Transaction(_tx) => (),

--- a/jormungandr-integration-tests/src/mock/testing/client_tests.rs
+++ b/jormungandr-integration-tests/src/mock/testing/client_tests.rs
@@ -7,7 +7,7 @@ use crate::common::{
     configuration::genesis_model::Fund,
     jcli_wrapper,
     jcli_wrapper::JCLITransactionWrapper,
-    jormungandr::{logger::Level, ConfigurationBuilder, Starter},
+    jormungandr::{ConfigurationBuilder, Starter},
     startup,
 };
 use chain_core::property::FromStr;

--- a/jormungandr-integration-tests/src/mock/testing/server_tests.rs
+++ b/jormungandr-integration-tests/src/mock/testing/server_tests.rs
@@ -83,13 +83,7 @@ pub fn wrong_protocol() {
         |logger: &MockLogger| logger.executed_at_least_once(MethodType::Handshake),
     );
 
-    let server = Starter::new()
-        .passive()
-        .config(config)
-        .verify_by(StartupVerificationMode::Log)
-        .start()
-        .unwrap();
-
+    let (server, _) = bootstrap_node_with_peer(mock_port);
     assert_eq!(
         mock_thread.join().expect("mock thread error"),
         MockExitCode::Success,

--- a/jormungandr-integration-tests/src/mock/testing/server_tests.rs
+++ b/jormungandr-integration-tests/src/mock/testing/server_tests.rs
@@ -1,7 +1,8 @@
 use crate::{
     common::{
-        configuration, file_utils, jormungandr::logger::Level,
-        jormungandr::starter::{Starter,StartupVerificationMode},
+        configuration, file_utils,
+        jormungandr::logger::Level,
+        jormungandr::starter::{Starter, StartupVerificationMode},
     },
     mock::{
         server::{self, MethodType, MockLogger, ProtocolVersion},
@@ -21,7 +22,7 @@ pub enum MockExitCode {
     Success,
 }
 
-pub fn start_mock<F: 'static>(
+pub fn start_mock<F: 'static + std::marker::Send>(
     mock_port: u16,
     genesis_hash: Hash,
     tip_hash: Hash,
@@ -30,10 +31,11 @@ pub fn start_mock<F: 'static>(
 ) -> JoinHandle<MockExitCode>
 where
     F: Fn(&MockLogger) -> bool,
-    F: std::marker::Send,
 {
     let log_file = file_utils::get_path_in_temp("mock.log");
     let logger = MockLogger::new(log_file.clone());
+
+    println!("mock will log into location: {:?}", log_file);
 
     thread::spawn(move || {
         let _server = server::start(
@@ -59,10 +61,8 @@ where
     })
 }
 
-const FAKE_HASH: &str = "efe2d4e5c4ad84b8e67e7b5676fff41cad5902a60b8cb6f072f42d7c7d26c944";
-
 pub fn fake_hash() -> Hash {
-    Hash::from_str(FAKE_HASH).unwrap()
+    Hash::from_str("efe2d4e5c4ad84b8e67e7b5676fff41cad5902a60b8cb6f072f42d7c7d26c944").unwrap()
 }
 
 pub fn peer_addr(port: u16) -> Option<String> {
@@ -84,11 +84,11 @@ pub fn wrong_protocol() {
     );
 
     let server = Starter::new()
-                    .passive()
-                    .config(config)
-                    .verify_by(StartupVerificationMode::Log)
-                    .start()
-                    .unwrap();
+        .passive()
+        .config(config)
+        .verify_by(StartupVerificationMode::Log)
+        .start()
+        .unwrap();
 
     assert_eq!(
         mock_thread.join().expect("mock thread error"),
@@ -99,7 +99,7 @@ pub fn wrong_protocol() {
     server.shutdown();
     assert!(
         server.logger.get_log_entries().any(|x| {
-            x.msg == "failed to connect to peer"
+            x.msg == "connection to peer failed"
                 && x.reason_contains("protocol handshake failed: unsupported protocol version 0")
                 && x.peer_addr == peer_addr(mock_port)
                 && x.level == Level::INFO
@@ -129,7 +129,7 @@ pub fn wrong_genesis_hash() {
     server.shutdown();
     assert!(
         server.logger.get_log_entries().any(|x| {
-            x.msg == "failed to connect to peer"
+            x.msg == "connection to peer failed"
                 && x.reason_contains("genesis block hash")
                 && x.peer_addr == peer_addr(mock_port)
                 && x.level == Level::INFO
@@ -150,35 +150,6 @@ pub fn handshake_ok() {
         fake_hash(),
         ProtocolVersion::GenesisPraos,
         |logger: &MockLogger| logger.executed_at_least_once(MethodType::Handshake),
-    );
-
-    let server = Starter::new().config(config.clone()).start().unwrap();
-    assert_eq!(
-        mock_thread.join().expect("mock thread error"),
-        MockExitCode::Success
-    );
-
-    server.shutdown();
-    server.logger.print_error_or_warn_lines();
-    assert!(!server
-        .logger
-        .get_log_entries()
-        .any(|x| { x.peer_addr == peer_addr(mock_port) && x.level == Level::WARN }));
-}
-
-//L1008 Tip request hash discrepancy
-#[ignore] // ignored until issues with missing header will be resolved
-#[test]
-pub fn tip_request_malformed_discrepancy() {
-    let mock_port = configuration::get_available_port();
-    let config = build_configuration(mock_port);
-
-    let mock_thread = start_mock(
-        mock_port,
-        Hash::from_str(&config.genesis_block_hash).unwrap(),
-        fake_hash(),
-        ProtocolVersion::GenesisPraos,
-        |logger: &MockLogger| logger.executed_at_least_once(MethodType::Tip),
     );
 
     let server = Starter::new().config(config.clone()).start().unwrap();

--- a/jormungandr-integration-tests/src/mock/testing/setup.rs
+++ b/jormungandr-integration-tests/src/mock/testing/setup.rs
@@ -1,6 +1,6 @@
 use crate::common::{
     configuration::{jormungandr_config::JormungandrConfig, node_config_model::TrustedPeer},
-    jormungandr::{JormungandrProcess,Starter,ConfigurationBuilder},
+    jormungandr::{ConfigurationBuilder, JormungandrProcess, Starter},
 };
 use crate::mock::client::JormungandrClient;
 use std::{thread, time::Duration};
@@ -35,7 +35,7 @@ pub fn bootstrap_node() -> (JormungandrProcess, JormungandrConfig) {
 pub fn build_configuration(mock_port: u16) -> JormungandrConfig {
     let trusted_peer = TrustedPeer {
         address: format!("/ip4/{}/tcp/{}", LOCALHOST, mock_port),
-        id: "ed25519_pk1hdhe4mnus0uxaf25gxeryskvwtytlzeuvan8glp3n63ztvv0v78qczpm32".to_owned(),
+        id: "fe3332044877b2034c8632a08f08ee47f3fbea6c64165b3b".to_owned(),
     };
 
     ConfigurationBuilder::new()

--- a/jormungandr-integration-tests/src/mock/testing/setup.rs
+++ b/jormungandr-integration-tests/src/mock/testing/setup.rs
@@ -40,6 +40,7 @@ pub fn build_configuration(mock_port: u16) -> JormungandrConfig {
 
     ConfigurationBuilder::new()
         .with_slot_duration(4)
+        .with_block0_consensus("genesis_praos")
         .with_trusted_peers(vec![trusted_peer])
         .build()
 }


### PR DESCRIPTION
Tests were forgotten for some time due to issues with grpc interoperability. Issue is now fixed, thus bringing tests back to life. 

Basically tests are testing basic grpc layer comands like:
- get_tip,
- get_blocks,

Also they can establish grpc mock which can interact with node for some negative scenario (wrong genesis hash etc.)