### PR TITLE
[Tests] Removed duplicated Funds struct from jormungandr-integration-tests

### DIFF
--- a/jormungandr-integration-tests/src/common/configuration/genesis_model.rs
+++ b/jormungandr-integration-tests/src/common/configuration/genesis_model.rs
@@ -5,15 +5,16 @@ extern crate chain_crypto;
 extern crate rand;
 extern crate rand_chacha;
 extern crate serde_derive;
-use self::chain_addr::{Address, Discrimination};
-use self::chain_addr::{AddressReadable, Kind};
+use self::chain_addr::{Address as ChainAddress, Discrimination, Kind};
 use self::chain_crypto::bech32::Bech32;
 use self::chain_crypto::{Ed25519, Ed25519Extended, KeyPair, PublicKey, SecretKey};
 use self::rand::SeedableRng;
 use self::rand_chacha::ChaChaRng;
 use self::serde_derive::{Deserialize, Serialize};
 use super::file_utils;
-use jormungandr_lib::interfaces::{Ratio, RewardParams, TaxType, Value};
+use jormungandr_lib::interfaces::{
+    Address, Initial, InitialUTxO, LegacyUTxO, Ratio, RewardParams, TaxType, Value,
+};
 use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::vec::Vec;
@@ -66,20 +67,6 @@ impl From<chain_impl_mockchain::fee::LinearFee> for LinearFees {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Fund {
-    pub value: Value,
-    pub address: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Initial {
-    Fund(Vec<Fund>),
-    Cert(String),
-    LegacyFund(Vec<Fund>),
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GenesisYaml {
     pub blockchain_configuration: BlockchainConfig,
     pub initial: Vec<Initial>,
@@ -93,42 +80,41 @@ impl GenesisYaml {
     }
 
     pub fn new() -> GenesisYaml {
+        let prefix = "ca".to_owned();
         let sk1: SecretKey<Ed25519Extended> =
             SecretKey::generate(&mut ChaChaRng::from_seed([1; 32]));
         let pk1: PublicKey<Ed25519> = sk1.to_public();
-        let initial_funds_address1 = Address(Discrimination::Test, Kind::Single(pk1));
-        let initial_funds_address1 =
-            AddressReadable::from_address("ca", &initial_funds_address1).to_string();
+        let initial_funds_address1 = ChainAddress(Discrimination::Test, Kind::Single(pk1));
 
         let sk2: SecretKey<Ed25519Extended> =
             SecretKey::generate(&mut ChaChaRng::from_seed([2; 32]));
         let pk2: PublicKey<Ed25519> = sk2.to_public();
-        let initial_funds_address2 = Address(Discrimination::Test, Kind::Single(pk2));
-        let initial_funds_address2 =
-            AddressReadable::from_address("ca", &initial_funds_address2).to_string();
-
+        let initial_funds_address2 = ChainAddress(Discrimination::Test, Kind::Single(pk2));
         let initial_funds = vec![
-            Fund {
-                address: String::from(initial_funds_address1),
+            InitialUTxO {
+                address: Address(prefix.clone(), initial_funds_address1),
                 value: 100.into(),
             },
-            Fund {
-                address: String::from(initial_funds_address2),
+            InitialUTxO {
+                address: Address(prefix.clone(), initial_funds_address2),
                 value: 100.into(),
             },
         ];
         GenesisYaml::new_with_funds(&initial_funds)
     }
 
-    pub fn new_with_funds(initial_funds: &[Fund]) -> GenesisYaml {
+    pub fn new_with_funds(initial_funds: &[InitialUTxO]) -> GenesisYaml {
         GenesisYaml::new_with_funds_and_legacy(initial_funds, &[])
     }
 
-    pub fn new_with_legacy_funds(legacy_funds: &[Fund]) -> GenesisYaml {
+    pub fn new_with_legacy_funds(legacy_funds: &[LegacyUTxO]) -> GenesisYaml {
         GenesisYaml::new_with_funds_and_legacy(&[], legacy_funds)
     }
 
-    pub fn new_with_funds_and_legacy(initial_funds: &[Fund], legacy_funds: &[Fund]) -> GenesisYaml {
+    pub fn new_with_funds_and_legacy(
+        initial_funds: &[InitialUTxO],
+        legacy_funds: &[LegacyUTxO],
+    ) -> GenesisYaml {
         let leader_1: KeyPair<Ed25519Extended> =
             KeyPair::generate(&mut ChaChaRng::from_seed([1; 32]));
         let leader_2: KeyPair<Ed25519Extended> =

--- a/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/mod.rs
+++ b/jormungandr-integration-tests/src/common/jcli_wrapper/jcli_transaction_wrapper/mod.rs
@@ -3,7 +3,7 @@
 pub mod jcli_transaction_commands;
 
 use self::jcli_transaction_commands::TransactionCommands;
-use crate::common::configuration::genesis_model::{Fund, LinearFees};
+use crate::common::configuration::genesis_model::LinearFees;
 use crate::common::data::address::AddressDataProvider;
 use crate::common::data::witness::Witness;
 use crate::common::file_utils;
@@ -15,7 +15,7 @@ use chain_core::property::Deserialize;
 use chain_impl_mockchain::fragment::Fragment;
 use jormungandr_lib::{
     crypto::hash::Hash,
-    interfaces::{UTxOInfo, Value},
+    interfaces::{LegacyUTxO, UTxOInfo, Value},
 };
 use std::path::PathBuf;
 
@@ -179,8 +179,8 @@ impl JCLITransactionWrapper {
         );
     }
 
-    pub fn assert_add_account_from_legacy(&mut self, fund: &Fund) -> &mut Self {
-        self.assert_add_account(&fund.address, &fund.value)
+    pub fn assert_add_account_from_legacy(&mut self, fund: &LegacyUTxO) -> &mut Self {
+        self.assert_add_account(&fund.address.to_string(), &fund.value)
     }
 
     pub fn assert_add_output(&mut self, addr: &str, amount: &Value) -> &mut Self {

--- a/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -1,6 +1,6 @@
 use crate::common::{
     configuration::{
-        genesis_model::{Fund, GenesisYaml, Initial, LinearFees},
+        genesis_model::{GenesisYaml, LinearFees},
         jormungandr_config::JormungandrConfig,
         node_config_model::{Log, LogEntry, NodeConfig, TrustedPeer},
         secret_model::SecretModel,
@@ -9,10 +9,11 @@ use crate::common::{
     startup::build_genesis_block,
 };
 
-use jormungandr_lib::interfaces::Mempool;
+use jormungandr_lib::interfaces::{Initial, InitialUTxO, Mempool, SignedCertificate};
 
 pub struct ConfigurationBuilder {
-    funds: Vec<Fund>,
+    funds: Vec<InitialUTxO>,
+    certs: Vec<SignedCertificate>,
     trusted_peers: Option<Vec<TrustedPeer>>,
     public_address: Option<String>,
     listen_address: Option<String>,
@@ -25,7 +26,6 @@ pub struct ConfigurationBuilder {
     epoch_stability_depth: Option<u32>,
     kes_update_speed: u32,
     linear_fees: LinearFees,
-    certs: Vec<String>,
     consensus_leader_ids: Vec<String>,
     mempool: Option<Mempool>,
     enable_explorer: bool,
@@ -92,7 +92,7 @@ impl ConfigurationBuilder {
     }
 
     pub fn with_initial_certs(&mut self, certs: Vec<String>) -> &mut Self {
-        self.certs = certs;
+        self.certs = certs.iter().map(|cert| cert.parse().unwrap()).collect();
         self
     }
 
@@ -114,7 +114,7 @@ impl ConfigurationBuilder {
         self
     }
 
-    pub fn with_funds(&mut self, funds: Vec<Fund>) -> &mut Self {
+    pub fn with_funds(&mut self, funds: Vec<InitialUTxO>) -> &mut Self {
         self.funds = funds.clone();
         self
     }

--- a/jormungandr-integration-tests/src/common/startup/mod.rs
+++ b/jormungandr-integration-tests/src/common/startup/mod.rs
@@ -1,8 +1,5 @@
 use crate::common::{
-    configuration::{
-        genesis_model::{Fund, GenesisYaml},
-        secret_model::SecretModel,
-    },
+    configuration::{genesis_model::GenesisYaml, secret_model::SecretModel},
     data::address::{Account, Delegation, Utxo},
     file_utils,
     jcli_wrapper::{self, certificate::wrapper::JCLICertificateWrapper},
@@ -12,7 +9,7 @@ use chain_addr::Discrimination;
 use chain_crypto::{AsymmetricKey, Curve25519_2HashDH, Ed25519, SumEd25519_12};
 use jormungandr_lib::{
     crypto::key::KeyPair,
-    interfaces::{Ratio, TaxType},
+    interfaces::{InitialUTxO, Ratio, TaxType},
 };
 use std::path::PathBuf;
 
@@ -155,10 +152,10 @@ pub fn start_stake_pool(
         .map(|x| x.leader.identifier().to_bech32_str())
         .collect();
 
-    let funds: Vec<Fund> = owners
+    let funds: Vec<InitialUTxO> = owners
         .iter()
-        .map(|x| Fund {
-            address: x.address.clone(),
+        .map(|x| InitialUTxO {
+            address: x.address.parse().unwrap(),
             value: 1_000_000_000.into(),
         })
         .collect();

--- a/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -1,11 +1,9 @@
 use crate::common::{
-    configuration::{
-        genesis_model::{Fund, GenesisYaml, Initial},
-        jormungandr_config::JormungandrConfig,
-    },
+    configuration::{genesis_model::GenesisYaml, jormungandr_config::JormungandrConfig},
     file_utils, jcli_wrapper, startup,
 };
 use chain_addr::Discrimination;
+use jormungandr_lib::interfaces::{Initial, InitialUTxO, LegacyUTxO};
 
 #[test]
 pub fn test_genesis_block_is_built_from_correct_yaml() {
@@ -42,9 +40,9 @@ pub fn test_genesis_for_prod_with_initial_funds_for_testing_address_fail_to_buil
     let test_address = jcli_wrapper::assert_address_single(&public_key, Discrimination::Test);
 
     let mut config = JormungandrConfig::new();
-    config.genesis_yaml.initial = vec![Initial::Fund(vec![Fund {
+    config.genesis_yaml.initial = vec![Initial::Fund(vec![InitialUTxO {
         value: 100.into(),
-        address: test_address.clone(),
+        address: test_address.parse().unwrap(),
     }])];
     config.genesis_yaml.blockchain_configuration.discrimination = Some("production".to_string());
     jcli_wrapper::assert_genesis_encode_fails(&config.genesis_yaml, "Invalid discrimination");
@@ -75,13 +73,13 @@ pub fn test_genesis_with_many_initial_funds_is_built_successfully() {
     let address_1 = startup::create_new_account_address();
     let address_2 = startup::create_new_account_address();
     let initial_funds = Initial::Fund(vec![
-        Fund {
+        InitialUTxO {
             value: 100.into(),
-            address: address_1.address,
+            address: address_1.address.parse().unwrap(),
         },
-        Fund {
+        InitialUTxO {
             value: 100.into(),
-            address: address_2.address,
+            address: address_2.address.parse().unwrap(),
         },
     ]);
     config.genesis_yaml.initial.push(initial_funds);
@@ -95,9 +93,9 @@ pub fn test_genesis_with_legacy_funds_is_built_successfully() {
     let mut config = JormungandrConfig::new();
     let legacy_funds = Initial::LegacyFund(
             vec![
-                Fund{
+                LegacyUTxO{
                     value: 100.into(),
-                    address: "DdzFFzCqrht5TM5GznWhJ3GTpKawtJuA295F8igwXQXyt2ih1TL1XKnZqRBQBoLpyYVKfNKgCXPBUYruUneC83KjGK6QNAoBSqRJovbG".to_string()
+                    address: "DdzFFzCqrht5TM5GznWhJ3GTpKawtJuA295F8igwXQXyt2ih1TL1XKnZqRBQBoLpyYVKfNKgCXPBUYruUneC83KjGK6QNAoBSqRJovbG".parse().unwrap()
                 },
             ]
         );

--- a/jormungandr-integration-tests/src/jcli/rest/utxo.rs
+++ b/jormungandr-integration-tests/src/jcli/rest/utxo.rs
@@ -1,10 +1,10 @@
 use crate::common::{
-    configuration::genesis_model::Fund,
     data::address::Utxo,
     jcli_wrapper,
     jormungandr::{starter::Starter, ConfigurationBuilder},
 };
 use chain_addr::Discrimination;
+use jormungandr_lib::interfaces::InitialUTxO;
 
 #[test]
 pub fn test_correct_utxos_are_read_from_node() {
@@ -41,12 +41,12 @@ pub fn test_correct_utxos_are_read_from_node() {
     };
 
     let funds = vec![
-        Fund {
-            address: receiver_address.clone(),
+        InitialUTxO {
+            address: receiver_address.parse().unwrap(),
             value: 100.into(),
         },
-        Fund {
-            address: sender_address.clone(),
+        InitialUTxO {
+            address: sender_address.parse().unwrap(),
             value: 100.into(),
         },
     ];

--- a/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
+++ b/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
@@ -1,10 +1,13 @@
 use crate::common::{
-    configuration::genesis_model::{Fund, LinearFees},
+    configuration::genesis_model::LinearFees,
     jcli_wrapper::{self, jcli_transaction_wrapper::JCLITransactionWrapper},
     jormungandr::{ConfigurationBuilder, Starter},
     startup,
 };
-use jormungandr_lib::{crypto::hash::Hash, interfaces::UTxOInfo};
+use jormungandr_lib::{
+    crypto::hash::Hash,
+    interfaces::{InitialUTxO, UTxOInfo},
+};
 
 lazy_static! {
     static ref FAKE_INPUT_TRANSACTION_ID: Hash = {
@@ -19,8 +22,8 @@ pub fn test_utxo_transaction_with_more_than_one_witness_per_input_is_rejected() 
     let sender = startup::create_new_utxo_address();
     let receiver = startup::create_new_utxo_address();
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();
@@ -55,8 +58,8 @@ pub fn test_two_correct_utxo_to_utxo_transactions_are_accepted_by_node() {
     let receiver = startup::create_new_utxo_address();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();
@@ -95,8 +98,8 @@ pub fn test_correct_utxo_transaction_is_accepted_by_node() {
     let receiver = startup::create_new_utxo_address();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();
@@ -122,8 +125,8 @@ pub fn test_correct_utxo_transaction_replaces_old_utxo_by_node() {
     let receiver = startup::create_new_utxo_address();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: TX_VALUE.into(),
         }])
         .build();
@@ -162,8 +165,8 @@ pub fn test_account_is_created_if_transaction_out_is_account() {
     let transfer_amount = 100.into();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: transfer_amount,
         }])
         .build();
@@ -207,8 +210,8 @@ pub fn test_transaction_from_delegation_to_delegation_is_accepted_by_node() {
     let transfer_amount = 100.into();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: transfer_amount,
         }])
         .build();
@@ -233,8 +236,8 @@ pub fn test_transaction_from_delegation_to_account_is_accepted_by_node() {
     let transfer_amount = 100.into();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: transfer_amount,
         }])
         .build();
@@ -259,8 +262,8 @@ pub fn test_transaction_from_delegation_to_utxo_is_accepted_by_node() {
     let transfer_amount = 100.into();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: transfer_amount,
         }])
         .build();
@@ -284,8 +287,8 @@ pub fn test_transaction_from_utxo_to_account_is_accepted_by_node() {
     let receiver = startup::create_new_account_address();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();
@@ -310,8 +313,8 @@ pub fn test_transaction_from_account_to_account_is_accepted_by_node() {
     let transfer_amount = 100.into();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: transfer_amount,
         }])
         .build();
@@ -335,8 +338,8 @@ pub fn test_transaction_from_account_to_delegation_is_accepted_by_node() {
     let transfer_amount = 100.into();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: transfer_amount,
         }])
         .build();
@@ -359,8 +362,8 @@ pub fn test_transaction_from_utxo_to_delegation_is_accepted_by_node() {
     let transfer_amount = 100.into();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: transfer_amount,
         }])
         .build();
@@ -383,8 +386,8 @@ pub fn test_input_with_smaller_value_than_initial_utxo_is_rejected_by_node() {
     let sender = startup::create_new_utxo_address();
     let receiver = startup::create_new_utxo_address();
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();
@@ -412,8 +415,8 @@ pub fn test_transaction_with_non_existing_id_should_be_rejected_by_node() {
     let sender = startup::create_new_utxo_address();
     let receiver = startup::create_new_utxo_address();
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();
@@ -439,8 +442,8 @@ pub fn test_transaction_with_non_existing_id_should_be_rejected_by_node() {
 pub fn test_transaction_with_input_address_equal_to_output_is_accepted_by_node() {
     let sender = startup::create_new_utxo_address();
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();
@@ -464,8 +467,8 @@ pub fn test_input_with_no_spending_utxo_is_rejected_by_node() {
     let sender = startup::create_new_utxo_address();
     let receiver = startup::create_new_utxo_address();
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();
@@ -493,8 +496,8 @@ pub fn test_transaction_with_non_zero_linear_fees() {
     let sender = startup::create_new_utxo_address();
     let receiver = startup::create_new_utxo_address();
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .with_linear_fees(LinearFees {

--- a/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    configuration::genesis_model::{Fund, LinearFees},
+    configuration::genesis_model::LinearFees,
     data::address::Account,
     file_utils,
     jcli_wrapper::{
@@ -15,7 +15,7 @@ use chain_addr::Discrimination;
 use chain_crypto::{Curve25519_2HashDH, SumEd25519_12};
 use jormungandr_lib::{
     crypto::hash::Hash,
-    interfaces::{Ratio, TaxType, Value},
+    interfaces::{InitialUTxO, Ratio, TaxType, Value},
 };
 use std::str::FromStr;
 
@@ -36,32 +36,31 @@ pub fn create_delegate_retire_stake_pool() {
             coefficient: 100,
             certificate: 200,
         })
-        .with_funds(vec![Fund {
+        .with_funds(vec![InitialUTxO {
             value: 1000000.into(),
-            address: actor_account.address.clone(),
+            address: actor_account.address.parse().unwrap(),
         }])
         .build();
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
-    let block0_hash = config.genesis_block_hash;
 
     let stake_pool_id = create_new_stake_pool(
         &mut actor_account,
-        &block0_hash,
+        &config.genesis_block_hash,
         &jormungandr.rest_address(),
         &Default::default(),
     );
     delegate_stake(
         &mut actor_account,
         &stake_pool_id,
-        &block0_hash,
+        &config.genesis_block_hash,
         &jormungandr.rest_address(),
         &Default::default(),
     );
     retire_stake_pool(
         &stake_pool_id,
         &mut actor_account,
-        &block0_hash,
+        &config.genesis_block_hash,
         &jormungandr.rest_address(),
         &Default::default(),
     );

--- a/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
@@ -1,11 +1,12 @@
 use crate::common::{
-    configuration::{genesis_model::Fund, secret_model::SecretModel},
+    configuration::secret_model::SecretModel,
     file_utils,
     jcli_wrapper::certificate::wrapper::JCLICertificateWrapper,
     jormungandr::{ConfigurationBuilder, Starter},
     startup,
 };
 use chain_crypto::{Curve25519_2HashDH, Ed25519, Ed25519Extended, SumEd25519_12};
+use jormungandr_lib::interfaces::InitialUTxO;
 
 #[test]
 pub fn test_genesis_stake_pool_with_account_faucet_starts_successfully() {
@@ -64,8 +65,8 @@ pub fn test_genesis_stake_pool_with_utxo_faucet_starts_successfully() {
         .with_consensus_genesis_praos_active_slot_coeff("0.1")
         .with_consensus_leaders_ids(vec![leader.identifier().to_bech32_str()])
         .with_kes_update_speed(43200)
-        .with_funds(vec![Fund {
-            address: faucet.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: faucet.address.parse().unwrap(),
             value: 100.into(),
         }])
         .with_initial_certs(vec![

--- a/jormungandr-integration-tests/src/jormungandr/mempool/mod.rs
+++ b/jormungandr-integration-tests/src/jormungandr/mempool/mod.rs
@@ -1,11 +1,10 @@
 use crate::common::{
-    configuration::genesis_model::Fund,
     jcli_wrapper::{self, JCLITransactionWrapper},
     jormungandr::{ConfigurationBuilder, Starter},
     process_utils, startup,
 };
 
-use jormungandr_lib::interfaces::Mempool;
+use jormungandr_lib::interfaces::{InitialUTxO, Mempool};
 use std::time::Duration;
 
 #[test]
@@ -18,9 +17,9 @@ pub fn test_log_ttl() {
     let timeout_grace_period = garbage_collection_interval * 2;
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
+        .with_funds(vec![InitialUTxO {
             value: 1000000.into(),
-            address: sender.address.clone(),
+            address: sender.address.parse().unwrap(),
         }])
         .with_mempool(Mempool {
             pool_max_entries: 10_000usize.into(),

--- a/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -1,5 +1,4 @@
 use crate::common::{
-    configuration::genesis_model::Fund,
     data::address::{Account, AddressDataProvider, Utxo},
     jcli_wrapper,
     jcli_wrapper::jcli_transaction_wrapper::JCLITransactionWrapper,
@@ -9,7 +8,7 @@ use crate::common::{
     startup,
 };
 
-use jormungandr_lib::interfaces::{AccountState, SettingsDto, UTxOInfo};
+use jormungandr_lib::interfaces::{AccountState, InitialUTxO, SettingsDto, UTxOInfo};
 
 #[derive(Clone, Debug, PartialEq)]
 struct LedgerSnapshot {
@@ -79,8 +78,8 @@ pub fn test_node_recovers_from_node_restart() {
     let utxo_receiver = startup::create_new_utxo_address();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();
@@ -113,8 +112,8 @@ pub fn test_node_recovers_kill_signal() {
     let utxo_receiver = startup::create_new_utxo_address();
 
     let config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();

--- a/jormungandr-integration-tests/src/networking/communication.rs
+++ b/jormungandr-integration-tests/src/networking/communication.rs
@@ -1,9 +1,11 @@
 use crate::common::{
-    configuration::{genesis_model::Fund, node_config_model::TrustedPeer},
+    configuration::node_config_model::TrustedPeer,
     jcli_wrapper::{self, jcli_transaction_wrapper::JCLITransactionWrapper},
     jormungandr::{ConfigurationBuilder, Starter},
     startup,
 };
+
+use jormungandr_lib::interfaces::InitialUTxO;
 
 #[test]
 #[ignore]
@@ -12,8 +14,8 @@ pub fn two_nodes_communication() {
     let reciever = startup::create_new_utxo_address();
 
     let leader_config = ConfigurationBuilder::new()
-        .with_funds(vec![Fund {
-            address: sender.address.clone(),
+        .with_funds(vec![InitialUTxO {
+            address: sender.address.parse().unwrap(),
             value: 100.into(),
         }])
         .build();

--- a/jormungandr-lib/src/interfaces/address.rs
+++ b/jormungandr-lib/src/interfaces/address.rs
@@ -5,7 +5,7 @@ use std::{fmt, str::FromStr};
 /// Display/FromStr interfaces.
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Address(pub(crate) String, pub(crate) chain_addr::Address);
+pub struct Address(pub String, pub chain_addr::Address);
 
 /* ---------------- Display ------------------------------------------------ */
 


### PR DESCRIPTION
Removed `Funds` and `Initial` structs and use existing one from jormungandr-lib. 
Updated usages.

Part of epic: #1526 
