### PR TITLE
keep more room for nodes that are actually giving us blocks

### DIFF
--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -74,7 +74,11 @@ rest:
     - `blocks`: notify other peers this node is interested about new Blocs.
     typical settings for a non mining node: `"normal"`. For a stakepool: `"high"`.
 - `max_connections`: the maximum number of P2P connections this node should
-    maintain. If not specified, an internal limit is used by default.
+    maintain. If not specified, an internal limit is used by default `[default: 256]`
+- `max_connections_threshold`: this is the number of available connections to keep
+  reserved for actually active connections. The node will apply this GC operation
+  from time to time if the `max_connections - max_connections_threshold` is reached.
+  `[default: 64]`
 - `policy`: (optional) set the setting for the policy module
     - `quarantine_duration` set the time to leave a node in quarantine before allowing
     it back (or not) into the fold.

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -156,7 +156,11 @@ impl GlobalState {
                 .into(),
         );
 
-        let peers = Peers::new(config.max_connections, logger.clone());
+        let peers = Peers::new(
+            config.max_connections,
+            config.max_connections_threshold,
+            logger.clone(),
+        );
 
         GlobalState {
             block0_hash,
@@ -278,6 +282,28 @@ pub fn start(
                 .for_each(move |_| Ok(tp2p.force_reset_layers())),
         );
     }
+
+    let peers = global_state.peers.clone();
+    let gc_err_logger = global_state.logger.clone();
+    let gc_info_logger = global_state.logger.clone();
+    global_state.spawn(
+        Interval::new_interval(Duration::from_secs(13))
+            .map_err(move |e| {
+                error!(gc_err_logger, "interval timer error: {:?}", e);
+            })
+            .for_each(move |_| {
+                if let Some(number_gced) = peers.gc() {
+                    warn!(
+                        gc_info_logger,
+                        "Peer GCed {number_gced} nodes",
+                        number_gced = number_gced
+                    );
+                } else {
+                    debug!(gc_info_logger, "Peer GCed nothing");
+                }
+                Ok(())
+            }),
+    );
 
     let gossip = Interval::new_interval(global_state.config.gossip_interval.clone())
         .map_err(move |e| {

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -51,7 +51,7 @@ use self::p2p::{
 use crate::blockcfg::{Block, HeaderHash};
 use crate::blockchain::{Blockchain as NewBlockchain, Tip};
 use crate::intercom::{BlockMsg, ClientMsg, NetworkMsg, PropagateMsg, TransactionMsg};
-use crate::settings::start::network::{Configuration, Peer, Protocol};
+use crate::settings::start::network::{Configuration, Peer, Protocol, DEFAULT_PEER_GC_INTERVAL};
 use crate::utils::{
     async_msg::{MessageBox, MessageQueue},
     task::TokioServiceInfo,
@@ -287,7 +287,7 @@ pub fn start(
     let gc_err_logger = global_state.logger.clone();
     let gc_info_logger = global_state.logger.clone();
     global_state.spawn(
-        Interval::new_interval(Duration::from_secs(13))
+        Interval::new_interval(DEFAULT_PEER_GC_INTERVAL)
             .map_err(move |e| {
                 error!(gc_err_logger, "interval timer error: {:?}", e);
             })

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -88,6 +88,30 @@ impl PeerMap {
         }
     }
 
+    /// for clearing the peer map
+    pub fn clear(&mut self) {
+        self.map.clear()
+    }
+
+    pub fn gc(&mut self, at_most: usize) -> usize {
+        let mut len = 0;
+
+        for entry in self.map.entries() {
+            if let Some(_peer) = entry.get().stats.last_block_received() {
+                // TODO: check for more reasons to evict
+            } else {
+                let _peer = entry.remove();
+                len += 1;
+            }
+
+            if len >= at_most {
+                break;
+            }
+        }
+
+        len
+    }
+
     pub fn refresh_peer(&mut self, id: &Id) -> Option<&mut PeerStats> {
         self.map.get_refresh(&id).map(|data| &mut data.stats)
     }
@@ -152,6 +176,14 @@ impl PeerMap {
         if self.map.len() >= self.capacity {
             self.map.pop_front();
         }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
     }
 }
 

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -105,6 +105,15 @@ pub struct P2pConfig {
     /// If not specified, an internal default limit is used.
     pub max_connections: Option<usize>,
 
+    /// capacity threshold delta
+    ///
+    /// this value will be compared to the delta between the number
+    /// of connections and the max_connections. If the threshold
+    /// has been reached (less then max_connections_threshold remaining)
+    /// the connections will be GCed in order to make some space for
+    /// nodes that are actually propagating blocks
+    pub max_connections_threshold: Option<usize>,
+
     /// Whether to allow non-public IP addresses on the network.
     /// The default is to not allow advertising non-public IP addresses.
     #[serde(default)]
@@ -196,6 +205,7 @@ impl Default for P2pConfig {
             trusted_peers: None,
             topics_of_interest: None,
             max_connections: None,
+            max_connections_threshold: None,
             allow_private_addresses: false,
             policy: PolicyConfig::default(),
             max_unreachable_nodes_to_connect_per_event: None,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -257,6 +257,9 @@ fn generate_network(
         max_connections: p2p
             .max_connections
             .unwrap_or(network::DEFAULT_MAX_CONNECTIONS),
+        max_connections_threshold: p2p
+            .max_connections_threshold
+            .unwrap_or(network::DEFAULT_MAX_CONNECTIONS_THRESHOLD),
         timeout: std::time::Duration::from_secs(15),
         allow_private_addresses: p2p.allow_private_addresses,
         max_unreachable_nodes_to_connect_per_event: p2p.max_unreachable_nodes_to_connect_per_event,

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -41,6 +41,9 @@ pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
 /// dedicated to nodes with network improvements capacity
 pub const DEFAULT_MAX_CONNECTIONS_THRESHOLD: usize = DEFAULT_MAX_CONNECTIONS / 4;
 
+/// the interval to run the GC on the peer map connections
+pub const DEFAULT_PEER_GC_INTERVAL: Duration = Duration::from_secs(13);
+
 const DEFAULT_TIMEOUT_MICROSECONDS: u64 = 500_000;
 
 ///

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -37,6 +37,10 @@ pub struct Listen {
 /// used unless the corresponding configuration option is specified.
 pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
 
+/// try to keep at least 25% of the remaining connections
+/// dedicated to nodes with network improvements capacity
+pub const DEFAULT_MAX_CONNECTIONS_THRESHOLD: usize = DEFAULT_MAX_CONNECTIONS / 4;
+
 const DEFAULT_TIMEOUT_MICROSECONDS: u64 = 500_000;
 
 ///
@@ -58,6 +62,15 @@ pub struct Configuration {
 
     /// Maximum allowed number of peer connections.
     pub max_connections: usize,
+
+    /// capacity threshold delta
+    ///
+    /// this value will be compared to the delta between the number
+    /// of connections and the max_connections. If the threshold
+    /// has been reached (less then max_connections_threshold remaining)
+    /// the connections will be GCed in order to make some space for
+    /// nodes that are actually propagating blocks
+    pub max_connections_threshold: usize,
 
     /// the default value for the timeout for inactive connection
     pub timeout: Duration,


### PR DESCRIPTION
add new `p2p.max_connections_threshold` configuration parameter. Default is set to `64`.

this value is meant to reserve more rooms for block propagating connections.

- [x] is dropping the connections enough to close it?
- [ ] shall we be more **aggressive** with the GCing peer?