### PR TITLE
[Tests] Private network tests - logging fix 

### DIFF
--- a/jormungandr-scenario-tests/src/main.rs
+++ b/jormungandr-scenario-tests/src/main.rs
@@ -47,6 +47,14 @@ struct CommandArgs {
     #[structopt(long = "document")]
     generate_documentation: bool,
 
+    /// in some circumstances progress bar can spoil test logs (e.g. on test build job)
+    /// if this parametrer value is true, then no progress bar is visible,
+    /// but simple log on console enabled
+    ///
+    /// no progress bar, only simple console output
+    #[structopt(long = "disable-progress-bar")]
+    disable_progress_bar: bool,
+
     /// to set if to reproduce an existing test
     #[structopt(long = "seed")]
     seed: Option<Seed>,
@@ -57,6 +65,7 @@ fn main() {
 
     let jormungandr = prepare_command(command_args.jormungandr);
     let jcli = prepare_command(command_args.jcli);
+    let disable_progress_bar = command_args.disable_progress_bar;
     let seed = command_args
         .seed
         .unwrap_or_else(|| Seed::generate(rand::rngs::OsRng));
@@ -69,6 +78,7 @@ fn main() {
         jcli,
         testing_directory,
         generate_documentation,
+        disable_progress_bar,
     );
 
     introduction(&context);

--- a/jormungandr-scenario-tests/src/main.rs
+++ b/jormungandr-scenario-tests/src/main.rs
@@ -55,6 +55,10 @@ struct CommandArgs {
     #[structopt(long = "disable-progress-bar")]
     disable_progress_bar: bool,
 
+    /// set exit code based on test result
+    #[structopt(long = "set-exit-code")]
+    set_exit_code: bool,
+
     /// to set if to reproduce an existing test
     #[structopt(long = "seed")]
     seed: Option<Seed>,
@@ -84,7 +88,14 @@ fn main() {
     introduction(&context);
     let scenarios_repo = ScenariosRepository::new(command_args.scenario, command_args.tag);
     let scenario_suite_result = scenarios_repo.run(&mut context);
-    println!("{}", scenario_suite_result.result_string())
+    println!("{}", scenario_suite_result.result_string());
+
+    if command_args.set_exit_code == true {
+        std::process::exit(match scenario_suite_result.is_failed() {
+            true => 1,
+            false => 0,
+        });
+    }
 }
 
 fn introduction<R: rand_core::RngCore>(context: &Context<R>) {

--- a/jormungandr-scenario-tests/src/node.rs
+++ b/jormungandr-scenario-tests/src/node.rs
@@ -105,6 +105,7 @@ pub enum Status {
 struct ProgressBarController {
     progress_bar: ProgressBar,
     prefix: String,
+    legacy_logging: bool,
 }
 
 /// send query to a running node
@@ -419,6 +420,7 @@ impl Node {
         let progress_bar = ProgressBarController::new(
             progress_bar,
             format!("{}@{}", alias, node_settings.config().rest.listen),
+            context.disable_progress_bar(),
         );
 
         let config_file = dir.join(NODE_CONFIG);
@@ -532,10 +534,11 @@ impl Node {
 use std::fmt::Display;
 
 impl ProgressBarController {
-    fn new(progress_bar: ProgressBar, prefix: String) -> Self {
+    fn new(progress_bar: ProgressBar, prefix: String, legacy_logging: bool) -> Self {
         ProgressBarController {
             progress_bar,
             prefix,
+            legacy_logging,
         }
     }
 
@@ -558,13 +561,20 @@ impl ProgressBarController {
         L: Display,
         M: Display,
     {
-        self.progress_bar.println(format!(
-            "[{}][{}{}]: {}",
-            lvl,
-            *style::icons::jormungandr,
-            style::binary.apply_to(&self.prefix),
-            msg,
-        ))
+        match self.legacy_logging {
+            true => {
+                println!("[{}][{}]: {}", lvl, &self.prefix, msg);
+            }
+            false => {
+                self.progress_bar.println(format!(
+                    "[{}][{}{}]: {}",
+                    lvl,
+                    *style::icons::jormungandr,
+                    style::binary.apply_to(&self.prefix),
+                    msg,
+                ));
+            }
+        }
     }
 }
 

--- a/jormungandr-scenario-tests/src/scenario/context.rs
+++ b/jormungandr-scenario-tests/src/scenario/context.rs
@@ -39,6 +39,7 @@ pub struct Context<RNG: RngCore + Sized> {
 
     testing_directory: TestingDirectory,
     generate_documentation: bool,
+    disable_progress_bar: bool,
 }
 
 impl Seed {
@@ -60,6 +61,7 @@ impl Context<ChaChaRng> {
         jcli: bawawa::Command,
         testing_directory: Option<PathBuf>,
         generate_documentation: bool,
+        disable_progress_bar: bool,
     ) -> Self {
         let rng = ChaChaRng::from_seed(seed.0);
 
@@ -78,6 +80,7 @@ impl Context<ChaChaRng> {
             jcli,
             testing_directory,
             generate_documentation,
+            disable_progress_bar,
         }
     }
 
@@ -96,6 +99,7 @@ impl Context<ChaChaRng> {
             jcli: self.jcli().clone(),
             testing_directory: self.testing_directory.clone(),
             generate_documentation: self.generate_documentation.clone(),
+            disable_progress_bar: self.disable_progress_bar.clone(),
         }
     }
 
@@ -148,6 +152,10 @@ impl<RNG: RngCore> Context<RNG> {
     #[inline]
     pub fn seed(&self) -> &Seed {
         &self.seed
+    }
+
+    pub fn disable_progress_bar(&self) -> bool {
+        self.disable_progress_bar
     }
 }
 

--- a/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -87,6 +87,11 @@ impl ControllerBuilder {
         }
         self.controller_progress.finish_and_clear();
         self.summary();
+
+        if context.disable_progress_bar() {
+            println!("nodes monitoring disabled due to legacy logging setting enabled");
+        }
+
         Controller::new(self.settings.unwrap(), context, working_directory)
     }
 
@@ -197,6 +202,10 @@ impl Controller {
     }
 
     pub fn monitor_nodes(&mut self) {
+        if self.context.disable_progress_bar() {
+            return;
+        }
+
         let pb = Arc::clone(&self.progress_bar);
         self.progress_bar_thread = Some(std::thread::spawn(move || {
             pb.join().unwrap();
@@ -204,7 +213,7 @@ impl Controller {
     }
 
     pub fn finalize(self) {
-        self.runtime.shutdown_on_idle().wait().unwrap(); //.shutdown_now().wait().unwrap();
+        self.runtime.shutdown_now().wait().unwrap();
         if let Some(thread) = self.progress_bar_thread {
             thread.join().unwrap()
         }

--- a/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
+++ b/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
@@ -4,7 +4,7 @@ use crate::{
     Context, ScenarioResult,
 };
 use rand_chacha::ChaChaRng;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 pub fn mesh_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     let scenario_settings = prepare_scenario! {


### PR DESCRIPTION
- enabled simple logging to console (progress bar is not supported in nightly aws runs).
- enabled shutdown now (in some cases in blocked test execution forever)
- clean warning