### PR TITLE
Async-friendly lock on P2P topology

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -100,7 +100,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         bootstrapped_node.settings.leadership.log_ttl.into();
 
     let topology = P2pTopology::new(
-        bootstrapped_node.settings.network.profile.clone(),
+        &bootstrapped_node.settings.network,
         bootstrapped_node
             .logger
             .new(o!(log::KEY_TASK => "poldercast")),

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -29,7 +29,7 @@ pub fn connect(
 ) -> (ConnectHandle, ConnectFuture<grpc::ConnectFuture>) {
     let (sender, receiver) = oneshot::channel();
     let addr = state.connection;
-    let node_id = (*state.global.topology.node().id()).into();
+    let node_id = state.global.topology.node_id();
     let builder = Some(ClientBuilder {
         channels,
         logger: state.logger,

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -59,6 +59,7 @@ use crate::utils::{
 use futures::future;
 use futures::future::Either::{A, B};
 use futures::prelude::*;
+use futures::stream;
 use network_core::gossip::{Gossip, Node};
 use poldercast::StrikeReason;
 use rand::seq::SliceRandom;
@@ -133,30 +134,6 @@ impl GlobalState {
         topology: P2pTopology,
         logger: Logger,
     ) -> Self {
-        let mut topology = topology;
-        topology.set_poldercast_modules();
-        topology.set_custom_modules(&config);
-        topology.set_policy(config.policy.clone());
-
-        // inject the trusted peers as initial gossips, this will make the node
-        // gossip with them at least at the beginning
-        topology.accept_gossips(
-            (*config.profile.id()).into(),
-            config
-                .trusted_peers
-                .clone()
-                .into_iter()
-                .map(|tp| {
-                    let mut builder = poldercast::NodeProfileBuilder::new();
-                    builder.id(tp.id.into());
-                    builder.address(tp.address.into());
-                    builder.build()
-                })
-                .map(p2p::Gossip::from)
-                .collect::<Vec<p2p::Gossip>>()
-                .into(),
-        );
-
         let peers = Peers::new(
             config.max_connections,
             config.max_connections_threshold,
@@ -259,15 +236,7 @@ pub fn start(
         Either::B(future::ok(()))
     };
 
-    let initial_nodes = global_state.topology.view(poldercast::Selection::Any);
-    let self_node = global_state.topology.node();
-    for node in initial_nodes {
-        let self_node_copy = self_node.clone();
-        connect_and_propagate_with(node, global_state.clone(), channels.clone(), move |comms| {
-            let gossip = Gossip::from_nodes(iter::once(self_node_copy.into()));
-            comms.set_pending_gossip(gossip);
-        });
-    }
+    global_state.spawn(start_gossiping(global_state.clone(), channels.clone()));
 
     let handle_cmds = handle_network_input(input, global_state.clone(), channels.clone());
 
@@ -281,7 +250,7 @@ pub fn start(
                 .map_err(move |e| {
                     error!(reset_err_logger, "interval timer error: {:?}", e);
                 })
-                .for_each(move |_| Ok(tp2p.force_reset_layers())),
+                .for_each(move |_| tp2p.force_reset_layers()),
         );
     }
 
@@ -348,18 +317,27 @@ fn handle_propagation_msg(
     channels: Channels,
 ) -> impl Future<Item = (), Error = ()> {
     trace!(state.logger(), "to propagate: {:?}", &msg);
+    let prop_state = state.clone();
     let send_to_peers = match msg {
         PropagateMsg::Block(ref header) => {
-            let nodes = state.topology.view(poldercast::Selection::Topic {
-                topic: p2p::topic::BLOCKS,
-            });
-            A(state.peers.propagate_block(nodes, header.clone()))
+            let header = header.clone();
+            let future = state
+                .topology
+                .view(poldercast::Selection::Topic {
+                    topic: p2p::topic::BLOCKS,
+                })
+                .and_then(move |view| prop_state.peers.propagate_block(view.peers, header));
+            A(future)
         }
         PropagateMsg::Fragment(ref fragment) => {
-            let nodes = state.topology.view(poldercast::Selection::Topic {
-                topic: p2p::topic::MESSAGES,
-            });
-            B(state.peers.propagate_fragment(nodes, fragment.clone()))
+            let fragment = fragment.clone();
+            let future = state
+                .topology
+                .view(poldercast::Selection::Topic {
+                    topic: p2p::topic::MESSAGES,
+                })
+                .and_then(move |view| prop_state.peers.propagate_fragment(view.peers, fragment));
+            B(future)
         }
     };
     // If any nodes selected for propagation are not in the
@@ -384,23 +362,73 @@ fn handle_propagation_msg(
     })
 }
 
-fn send_gossip(state: GlobalStateR, channels: Channels) -> impl Future<Item = (), Error = ()> {
-    let nodes = state.topology.view(poldercast::Selection::Any);
-
-    tokio::prelude::stream::iter_ok(nodes).for_each(move |node| {
-        let gossip = Gossip::from(state.topology.initiate_gossips(node.id()));
-        let send_to_peer = state.peers.propagate_gossip_to(node.id(), gossip);
-        let state_err = state.clone();
-        let channels_err = channels.clone();
-        send_to_peer.then(move |res| {
-            if let Err(gossip) = res {
-                connect_and_propagate_with(node, state_err, channels_err, |comms| {
-                    comms.set_pending_gossip(gossip)
+fn start_gossiping(state: GlobalStateR, channels: Channels) -> impl Future<Item = (), Error = ()> {
+    let config = &state.config;
+    let topology = state.topology.clone();
+    let conn_state = state.clone();
+    // inject the trusted peers as initial gossips, this will make the node
+    // gossip with them at least at the beginning
+    topology
+        .accept_gossips(
+            (*config.profile.id()).into(),
+            config
+                .trusted_peers
+                .iter()
+                .map(|tp| {
+                    let mut builder = poldercast::NodeProfileBuilder::new();
+                    builder.id(tp.id.clone().into());
+                    builder.address(tp.address.clone().into());
+                    builder.build()
                 })
+                .map(p2p::Gossip::from)
+                .collect::<Vec<p2p::Gossip>>()
+                .into(),
+        )
+        .and_then(move |()| topology.view(poldercast::Selection::Any))
+        .and_then(move |view| {
+            for node in view.peers {
+                let self_node = view.self_node.clone();
+                let gossip = Gossip::from_nodes(iter::once(self_node.into()));
+                connect_and_propagate_with(
+                    node,
+                    conn_state.clone(),
+                    channels.clone(),
+                    move |comms| {
+                        comms.set_pending_gossip(gossip);
+                    },
+                );
             }
             Ok(())
         })
-    })
+}
+
+fn send_gossip(state: GlobalStateR, channels: Channels) -> impl Future<Item = (), Error = ()> {
+    let topology = state.topology.clone();
+    topology
+        .view(poldercast::Selection::Any)
+        .and_then(move |view| {
+            stream::iter_ok(view.peers).for_each(move |node| {
+                let peer_id = node.id();
+                let state_prop = state.clone();
+                let state_err = state.clone();
+                let channels_err = channels.clone();
+                topology
+                    .initiate_gossips(peer_id)
+                    .and_then(move |gossips| {
+                        state_prop
+                            .peers
+                            .propagate_gossip_to(peer_id, Gossip::from(gossips))
+                    })
+                    .then(move |res| {
+                        if let Err(gossip) = res {
+                            connect_and_propagate_with(node, state_err, channels_err, |comms| {
+                                comms.set_pending_gossip(gossip)
+                            })
+                        }
+                        Ok(())
+                    })
+            })
+        })
 }
 
 fn connect_and_propagate_with<F>(
@@ -425,7 +453,7 @@ fn connect_and_propagate_with<F>(
     let node_id = node.id();
     assert_ne!(
         node_id,
-        (*state.topology.node().id()).into(),
+        state.topology.node_id(),
         "topology tells the node to connect to itself"
     );
     let peer = Peer::new(addr, Protocol::Grpc);
@@ -461,8 +489,12 @@ fn connect_and_propagate_with<F>(
                 }
             };
             if !benign {
-                conn_err_state.topology.report_node(node_id, StrikeReason::CannotConnect);
-                A(conn_err_state.peers.remove_peer(node_id).and_then(|_| future::err(())))
+                let future = conn_err_state
+                    .topology
+                    .report_node(node_id, StrikeReason::CannotConnect)
+                    .join(conn_err_state.peers.remove_peer(node_id))
+                    .and_then(|_| future::err(()));
+                A(future)
             } else {
                 B(future::err(()))
             }
@@ -474,8 +506,12 @@ fn connect_and_propagate_with<F>(
                     client.logger(),
                     "peer node ID differs from the expected {}", node_id
                 );
-                state.topology.report_node(node_id, StrikeReason::InvalidPublicId);
-                A(state.peers.remove_peer(node_id).and_then(|_| future::err(())))
+                let future = state
+                    .topology
+                    .report_node(node_id, StrikeReason::InvalidPublicId)
+                    .join(state.peers.remove_peer(node_id))
+                    .and_then(|_| future::err(()));
+                A(future)
             } else {
                 B(future::ok(client))
             }

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -9,10 +9,11 @@ use crate::{
 use poldercast::{
     custom_layers,
     poldercast::{Cyclon, Rings, Vicinity},
-    Layer, NodeProfile, PolicyReport, StrikeReason, Topology,
+    NodeProfile, PolicyReport, StrikeReason, Topology,
 };
 use slog::Logger;
-use std::sync::{Arc, RwLock};
+use tokio::prelude::future::{self, Future};
+use tokio::sync::lock::{Lock, LockGuard};
 
 // object holding a count of available, unreachable and quarantined nodes.
 #[derive(Clone)]
@@ -44,142 +45,196 @@ impl NodeCount {
     }
 }
 
+pub struct View {
+    pub self_node: NodeProfile,
+    pub peers: Vec<Node>,
+}
+
 /// object holding the P2pTopology of the Node
 #[derive(Clone)]
 pub struct P2pTopology {
-    lock: Arc<RwLock<Topology>>,
+    lock: Lock<Topology>,
+    node_id: Id,
     logger: Logger,
 }
 
-impl P2pTopology {
-    /// create a new P2pTopology for the given Address and Id
-    ///
-    /// The address is the public
-    pub fn new(node: poldercast::NodeProfile, logger: Logger) -> Self {
-        P2pTopology {
-            lock: Arc::new(RwLock::new(Topology::new(node))),
+/// Builder object used to initialize the `P2pTopology`
+struct Builder {
+    topology: Topology,
+    logger: Logger,
+}
+
+impl Builder {
+    /// Create a new topology for the given node profile
+    fn new(node: poldercast::NodeProfile, logger: Logger) -> Self {
+        Builder {
+            topology: Topology::new(node),
             logger,
         }
     }
 
-    /// set a P2P Topology Module. Each module will work independently from
-    /// each other and will help improve the node connectivity
-    pub fn add_module<M: Layer + Send + Sync + 'static>(&self, module: M) {
-        let mut topology = self.lock.write().unwrap();
-        info!(
-            self.logger,
-            "adding P2P Topology module: {}",
-            module.alias()
-        );
-        topology.add_layer(module)
-    }
-
-    pub fn set_policy(&mut self, policy: PolicyConfig) {
-        let mut topology = self.lock.write().unwrap();
-        topology.set_policy(Policy::new(
+    fn set_policy(mut self, policy: PolicyConfig) -> Self {
+        self.topology.set_policy(Policy::new(
             policy,
             self.logger.new(o!(KEY_SUB_TASK => "policy")),
         ));
+        self
     }
 
     /// set all the default poldercast modules (Rings, Vicinity and Cyclon)
-    pub fn set_poldercast_modules(&mut self) {
-        let mut topology = self.lock.write().unwrap();
-        topology.add_layer(Rings::default());
-        topology.add_layer(Vicinity::default());
-        topology.add_layer(Cyclon::default());
+    fn set_poldercast_modules(mut self) -> Self {
+        self.topology.add_layer(Rings::default());
+        self.topology.add_layer(Vicinity::default());
+        self.topology.add_layer(Cyclon::default());
+        self
     }
 
-    pub fn set_custom_modules(&mut self, config: &Configuration) {
-        let mut topology = self.lock.write().unwrap();
+    fn set_custom_modules(mut self, config: &Configuration) -> Self {
         if let Some(size) = config.max_unreachable_nodes_to_connect_per_event {
-            topology.add_layer(custom_layers::RandomDirectConnections::with_max_view_length(size))
+            self.topology
+                .add_layer(custom_layers::RandomDirectConnections::with_max_view_length(size));
         } else {
-            topology.add_layer(custom_layers::RandomDirectConnections::default());
+            self.topology
+                .add_layer(custom_layers::RandomDirectConnections::default());
         }
+        self
+    }
+
+    fn build(self) -> P2pTopology {
+        let node_id = self.topology.profile().id().clone();
+        P2pTopology {
+            lock: Lock::new(self.topology),
+            node_id: node_id.into(),
+            logger: self.logger,
+        }
+    }
+}
+
+impl P2pTopology {
+    pub fn new(config: &Configuration, logger: Logger) -> Self {
+        Builder::new(config.profile.clone(), logger)
+            .set_poldercast_modules()
+            .set_custom_modules(&config)
+            .set_policy(config.policy.clone())
+            .build()
+    }
+
+    // TODO: same as write now, but can be implemented differently
+    // with RwLock in tokio 0.2
+    fn read<E>(&self) -> impl Future<Item = LockGuard<Topology>, Error = E> {
+        self.write()
+    }
+
+    fn write<E>(&self) -> impl Future<Item = LockGuard<Topology>, Error = E> {
+        let mut lock = self.lock.clone();
+        future::poll_fn(move || Ok(lock.poll_lock()))
     }
 
     /// Returns a list of neighbors selected in this turn
     /// to contact for event dissemination.
-    pub fn view(&self, selection: poldercast::Selection) -> Vec<Node> {
-        let mut topology = self.lock.write().unwrap();
-        topology
-            .view(None, selection)
-            .into_iter()
-            .map(Node::new)
-            .collect()
+    pub fn view<E>(&self, selection: poldercast::Selection) -> impl Future<Item = View, Error = E> {
+        self.write().map(move |mut topology| {
+            let peers = topology
+                .view(None, selection)
+                .into_iter()
+                .map(Node::new)
+                .collect();
+            View {
+                self_node: topology.profile().clone(),
+                peers,
+            }
+        })
     }
 
-    pub fn initiate_gossips(&self, with: Id) -> Gossips {
-        let mut topology = self.lock.write().unwrap();
-        topology.initiate_gossips(with.into()).into()
+    pub fn initiate_gossips<E>(&self, with: Id) -> impl Future<Item = Gossips, Error = E> {
+        self.write()
+            .map(move |mut topology| topology.initiate_gossips(with.into()).into())
     }
 
-    pub fn accept_gossips(&self, from: Id, gossips: Gossips) {
-        let mut topology = self.lock.write().unwrap();
-        topology.accept_gossips(from.into(), gossips.into())
+    pub fn accept_gossips<E>(
+        &self,
+        from: Id,
+        gossips: Gossips,
+    ) -> impl Future<Item = (), Error = E> {
+        self.write()
+            .map(move |mut topology| topology.accept_gossips(from.into(), gossips.into()))
     }
 
-    pub fn exchange_gossips(&mut self, with: Id, gossips: Gossips) -> Gossips {
-        let mut topology = self.lock.write().unwrap();
-        topology
-            .exchange_gossips(with.into(), gossips.into())
-            .into()
+    pub fn exchange_gossips<E>(
+        &mut self,
+        with: Id,
+        gossips: Gossips,
+    ) -> impl Future<Item = Gossips, Error = E> {
+        self.write().map(move |mut topology| {
+            topology
+                .exchange_gossips(with.into(), gossips.into())
+                .into()
+        })
     }
 
-    pub fn node(&self) -> NodeProfile {
-        self.lock.read().unwrap().profile().clone()
+    pub fn node_id(&self) -> Id {
+        self.node_id
     }
 
-    pub fn force_reset_layers(&self) {
-        self.lock.write().unwrap().force_reset_layers()
+    pub fn node<E>(&self) -> impl Future<Item = NodeProfile, Error = E> {
+        self.read().map(|topology| topology.profile().clone())
     }
 
-    pub fn list_quarantined(&self) -> Vec<poldercast::Node> {
-        self.lock
-            .read()
-            .unwrap()
-            .nodes()
-            .all_quarantined_nodes()
-            .into_iter()
-            .cloned()
-            .collect()
+    pub fn force_reset_layers<E>(&self) -> impl Future<Item = (), Error = E> {
+        self.write()
+            .map(|mut topology| topology.force_reset_layers())
     }
 
-    pub fn list_available(&self) -> Vec<poldercast::Node> {
-        self.lock
-            .read()
-            .unwrap()
-            .nodes()
-            .all_available_nodes()
-            .into_iter()
-            .cloned()
-            .collect()
+    pub fn list_quarantined<E>(&self) -> impl Future<Item = Vec<poldercast::Node>, Error = E> {
+        self.read().map(|topology| {
+            topology
+                .nodes()
+                .all_quarantined_nodes()
+                .into_iter()
+                .cloned()
+                .collect()
+        })
     }
 
-    pub fn list_non_public(&self) -> Vec<poldercast::Node> {
-        self.lock
-            .read()
-            .unwrap()
-            .nodes()
-            .all_unreachable_nodes()
-            .into_iter()
-            .cloned()
-            .collect()
+    pub fn list_available<E>(&self) -> impl Future<Item = Vec<poldercast::Node>, Error = E> {
+        self.read().map(|topology| {
+            topology
+                .nodes()
+                .all_available_nodes()
+                .into_iter()
+                .cloned()
+                .collect()
+        })
     }
 
-    pub fn nodes_count(&self) -> NodeCount {
-        NodeCount::new(self.lock.read().unwrap().nodes())
+    pub fn list_non_public<E>(&self) -> impl Future<Item = Vec<poldercast::Node>, Error = E> {
+        self.read().map(|topology| {
+            topology
+                .nodes()
+                .all_unreachable_nodes()
+                .into_iter()
+                .cloned()
+                .collect()
+        })
+    }
+
+    pub fn nodes_count<E>(&self) -> impl Future<Item = NodeCount, Error = E> {
+        self.read().map(|topology| NodeCount::new(topology.nodes()))
     }
 
     /// register a strike against the given node id
     ///
     /// the function returns `None` if the node was not even in the
     /// the topology (not even quarantined).
-    pub fn report_node(&self, node: Id, issue: StrikeReason) -> Option<PolicyReport> {
-        let mut topology = self.lock.write().unwrap();
-        topology.update_node(node.into(), |node| {
-            node.record_mut().strike(issue);
+    pub fn report_node<E>(
+        &self,
+        node: Id,
+        issue: StrikeReason,
+    ) -> impl Future<Item = Option<PolicyReport>, Error = E> {
+        self.write().map(move |mut topology| {
+            topology.update_node(node.into(), |node| {
+                node.record_mut().strike(issue);
+            })
         })
     }
 }

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -70,7 +70,7 @@ impl P2pService for NodeService {
     type NodeId = Id;
 
     fn node_id(&self) -> Id {
-        (*self.global_state.topology.node().id()).into()
+        self.global_state.topology.node_id()
     }
 }
 

--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -405,9 +405,11 @@ impl GossipProcessor {
                     Ok(())
                 }),
         );
-        self.global_state
-            .topology
-            .accept_gossips(self.node_id, nodes.into());
+        self.global_state.spawn(
+            self.global_state
+                .topology
+                .accept_gossips(self.node_id, nodes.into()),
+        );
     }
 }
 


### PR DESCRIPTION
Remove use of the synchronous lock in `P2pTopology` to avoid the locking messing with the async task thread pool.