### PR TITLE
Fixes bootstrapping from trusted peers falling through when node is n…

### DIFF
--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -546,11 +546,12 @@ pub fn bootstrap(
         unimplemented!()
     }
 
+    let mut bootstrapped = false;
+
     if config.trusted_peers.is_empty() {
         warn!(logger, "No trusted peers joinable to bootstrap the network");
+        bootstrapped = true;
     }
-
-    let mut bootstrapped = false;
 
     for address in trusted_peers_shuffled(&config) {
         let logger = logger.new(o!("peer_addr" => address.to_string()));

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -147,6 +147,17 @@ pub struct P2pConfig {
     ///
     #[serde(default)]
     pub topology_force_reset_interval: Option<Duration>,
+
+    /// The number of times to retry bootstrapping from trusted peers. The default
+    /// value of None will result in the bootstrap process retrying indefinitely. A
+    /// value of zero will skip bootstrap all together -- even if trusted peers are
+    /// defined. If the node fails to bootstrap from any of the trusted peers and the
+    /// number of bootstrap retry attempts is exceeded, then the node will continue to
+    /// run without completing the bootstrap process. This will allow the node to act
+    /// as the first node in the p2p network (i.e. genesis node), or immediately begin
+    /// gossip with the trusted peers if any are defined.
+    #[serde(default)]
+    pub max_bootstrap_attempts: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -211,6 +222,7 @@ impl Default for P2pConfig {
             max_unreachable_nodes_to_connect_per_event: None,
             gossip_interval: None,
             topology_force_reset_interval: None,
+            max_bootstrap_attempts: None,
         }
     }
 }

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -268,6 +268,7 @@ fn generate_network(
             .map(|d| d.into())
             .unwrap_or(std::time::Duration::from_secs(10)),
         topology_force_reset_interval: p2p.topology_force_reset_interval.map(|d| d.into()),
+        max_bootstrap_attempts: p2p.max_bootstrap_attempts,
     };
 
     Ok(network)

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -88,6 +88,8 @@ pub struct Configuration {
     pub gossip_interval: Duration,
 
     pub topology_force_reset_interval: Option<Duration>,
+
+    pub max_bootstrap_attempts: Option<usize>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Currently, if Jormungandr fails to bootstrap from any of the trusted peers, it simply falls-through and assumes it should be a "genesis node" (i.e. the first node in a new network). This has been very confusing for pool operators as it seems as though their node is stuck.

This change implements a few things. Firstly, a new configuration setting ```genesis_node```. Which by default is set to ```false```. Setting this value to ```true``` essentially makes Jormungandr behave as is currently does. Setting it to ```false```, or accepting the default of ```false``` ensures that if the node fails to bootstrap from any of the trusted peers, it will just try again until it succeeds or the process is terminated.

Setting ```genesis_node``` to ```true``` will still allow the node to bootstrap from trusted peers (if it is possible). However, if it is not possible (e.g there are none defined or none accept a connection), then it will fall-through and attempt to establish itself as the first node in a new p2p network.

This should also fix the ITN Daedalus version from hanging on startup in some circumstances.