### PR TITLE
[Tests] wait for block sync 

### DIFF
--- a/jormungandr-scenario-tests/src/test/comm/leader_leader.rs
+++ b/jormungandr-scenario-tests/src/test/comm/leader_leader.rs
@@ -4,7 +4,7 @@ use crate::{
         utils::{self, SyncWaitParams},
         Result,
     },
-    Context, ScenarioResult
+    Context, ScenarioResult,
 };
 use rand_chacha::ChaChaRng;
 use std::time::Duration;

--- a/jormungandr-scenario-tests/src/test/comm/leader_leader.rs
+++ b/jormungandr-scenario-tests/src/test/comm/leader_leader.rs
@@ -1,8 +1,10 @@
 use crate::{
     node::{LeadershipMode, PersistenceMode},
-    scenario::repository::ScenarioResult,
-    test::{utils, Result},
-    Context,
+    test::{
+        utils::{self, SyncWaitParams},
+        Result,
+    },
+    Context, ScenarioResult
 };
 use rand_chacha::ChaChaRng;
 use std::time::Duration;
@@ -60,6 +62,7 @@ pub fn two_transaction_to_two_leaders(mut context: Context<ChaChaRng>) -> Result
         wallet2.confirm_transaction();
     }
 
+    utils::wait_for_nodes_sync(SyncWaitParams::two_nodes());
     utils::assert_are_in_sync(vec![&leader_1, &leader_2])?;
 
     leader_1.shutdown().unwrap();

--- a/jormungandr-scenario-tests/src/test/comm/passive_leader.rs
+++ b/jormungandr-scenario-tests/src/test/comm/passive_leader.rs
@@ -1,8 +1,8 @@
 use crate::{
     node::{LeadershipMode, PersistenceMode},
-    scenario::repository::ScenarioResult,
-    test::{utils, Result},
-    Context,
+    test::utils::{self, SyncWaitParams},
+    test::Result,
+    Context, ScenarioResult,
 };
 use rand_chacha::ChaChaRng;
 
@@ -50,6 +50,7 @@ pub fn transaction_to_passive(mut context: Context<ChaChaRng>) -> Result<Scenari
         &passive,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams::two_nodes());
     utils::assert_are_in_sync(vec![&passive, &leader])?;
 
     passive.shutdown()?;
@@ -123,6 +124,7 @@ pub fn leader_restart(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
         &passive,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams::two_nodes());
     utils::assert_are_in_sync(vec![&passive, &leader])?;
 
     passive.shutdown()?;
@@ -175,6 +177,7 @@ pub fn passive_node_is_updated(mut context: Context<ChaChaRng>) -> Result<Scenar
         &leader,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams::two_nodes());
     utils::assert_are_in_sync(vec![&passive, &leader])?;
 
     passive.shutdown()?;

--- a/jormungandr-scenario-tests/src/test/mod.rs
+++ b/jormungandr-scenario-tests/src/test/mod.rs
@@ -5,6 +5,8 @@ pub mod utils;
 
 use jormungandr_lib::interfaces::FragmentStatus;
 
+use std::time::Duration;
+
 error_chain! {
     links {
         Node(crate::node::Error, crate::node::ErrorKind);
@@ -13,6 +15,11 @@ error_chain! {
     }
 
     errors {
+        SyncTimeoutOccurred(info: String, timeout: Duration) {
+            description("synchronization for nodes has failed"),
+            display("synchronization for nodes has failed. {}. Timeout was: {} s", info, timeout.as_secs()),
+        }
+
         AssertionFailed(info: String) {
             description("assertion has failed"),
             display("{}", info),
@@ -21,5 +28,7 @@ error_chain! {
             description("transaction not in block"),
             display("transaction should be 'In Block'. status: {:?}, node: {}", status, node),
         }
+
+
     }
 }

--- a/jormungandr-scenario-tests/src/test/network/topology/scenarios.rs
+++ b/jormungandr-scenario-tests/src/test/network/topology/scenarios.rs
@@ -1,7 +1,9 @@
 use crate::{
     node::{LeadershipMode, PersistenceMode},
-    test::utils,
-    test::Result,
+    test::{
+        utils::{self, SyncWaitParams},
+        Result,
+    },
     Context, ScenarioResult,
 };
 use rand_chacha::ChaChaRng;
@@ -69,6 +71,12 @@ pub fn fully_connected(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
         &leader1,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams {
+        no_of_nodes: 4,
+        longest_path_length: 2,
+    });
+    utils::assert_are_in_sync(vec![&leader1, &leader2, &leader3, &leader4])?;
+
     leader4.shutdown()?;
     leader3.shutdown()?;
     leader2.shutdown()?;
@@ -132,6 +140,10 @@ pub fn star(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         &leader1,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams {
+        no_of_nodes: 5,
+        longest_path_length: 3,
+    });
     utils::assert_are_in_sync(vec![&leader1, &leader2, &leader3, &leader4, &leader5])?;
 
     leader5.shutdown()?;
@@ -194,6 +206,10 @@ pub fn ring(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         &leader1,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams {
+        no_of_nodes: 4,
+        longest_path_length: 3,
+    });
     utils::assert_are_in_sync(vec![&leader1, &leader2, &leader3, &leader4])?;
 
     leader4.shutdown()?;
@@ -259,6 +275,10 @@ pub fn mesh(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         &leader1,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams {
+        no_of_nodes: 5,
+        longest_path_length: 3,
+    });
     utils::assert_are_in_sync(vec![&leader1, &leader2, &leader3, &leader4, &leader5])?;
 
     leader5.shutdown()?;
@@ -319,6 +339,10 @@ pub fn point_to_point(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
         &leader1,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams {
+        no_of_nodes: 4,
+        longest_path_length: 4,
+    });
     utils::assert_are_in_sync(vec![&leader1, &leader2, &leader3, &leader4])?;
 
     leader4.shutdown()?;
@@ -392,6 +416,10 @@ pub fn point_to_point_on_file_storage(mut context: Context<ChaChaRng>) -> Result
         &leader1,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams {
+        no_of_nodes: 4,
+        longest_path_length: 4,
+    });
     utils::assert_are_in_sync(vec![&leader1, &leader2, &leader3, &leader4])?;
 
     leader4.shutdown()?;
@@ -465,6 +493,10 @@ pub fn tree(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         &leader1,
     )?;
 
+    utils::wait_for_nodes_sync(SyncWaitParams {
+        no_of_nodes: 7,
+        longest_path_length: 5,
+    });
     utils::assert_are_in_sync(vec![
         &leader1, &leader2, &leader3, &leader4, &leader5, &leader6, &leader7,
     ])?;
@@ -601,6 +633,10 @@ pub fn relay(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         wallet7.confirm_transaction();
     }
 
+    utils::wait_for_nodes_sync(SyncWaitParams {
+        no_of_nodes: 9,
+        longest_path_length: 3,
+    });
     utils::assert_are_in_sync(vec![
         &leader1, &leader2, &leader3, &leader4, &leader5, &leader6, &leader7, &relay1, &relay2,
     ])?;

--- a/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -127,7 +127,6 @@ pub fn assert_are_in_sync(nodes: Vec<&NodeController>) -> Result<()> {
                 first_node.log_content(),
                 node.alias(),
                 node.log_content()),
-
         )?;
         assert_equals(
             &block_height,

--- a/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -6,10 +6,7 @@ use crate::{
     wallet::Wallet,
 };
 use jormungandr_lib::interfaces::FragmentStatus;
-use std::{
-    fmt, thread,
-    time::{Duration, SystemTime},
-};
+use std::{fmt, thread, time::Duration};
 
 #[derive(Clone, Debug)]
 pub struct SyncWaitParams {

--- a/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -6,7 +6,10 @@ use crate::{
     wallet::Wallet,
 };
 use jormungandr_lib::interfaces::FragmentStatus;
-use std::{fmt, thread, time::Duration};
+use std::{
+    fmt, thread,
+    time::{Duration, SystemTime},
+};
 
 #[derive(Clone, Debug)]
 pub struct SyncWaitParams {


### PR DESCRIPTION
Added wait for nodes block synchronization in private networks. It waits till all nodes have the same block height. (This is first attempt for sync wait, right now there wasn't situation in which block heights were different for longer period of time, thus a very simple case is supported at this moment only)