### PR TITLE
Fixed Deadlocking

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -100,7 +100,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         bootstrapped_node.settings.leadership.log_ttl.into();
 
     let topology = P2pTopology::new(
-        &bootstrapped_node.settings.network,
+        bootstrapped_node.settings.network.profile.clone(),
         bootstrapped_node
             .logger
             .new(o!(log::KEY_TASK => "poldercast")),

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -29,7 +29,7 @@ pub fn connect(
 ) -> (ConnectHandle, ConnectFuture<grpc::ConnectFuture>) {
     let (sender, receiver) = oneshot::channel();
     let addr = state.connection;
-    let node_id = state.global.topology.node_id();
+    let node_id = (*state.global.topology.node().id()).into();
     let builder = Some(ClientBuilder {
         channels,
         logger: state.logger,

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -9,11 +9,10 @@ use crate::{
 use poldercast::{
     custom_layers,
     poldercast::{Cyclon, Rings, Vicinity},
-    NodeProfile, PolicyReport, StrikeReason, Topology,
+    Layer, NodeProfile, PolicyReport, StrikeReason, Topology,
 };
 use slog::Logger;
-use tokio::prelude::future::{self, Future};
-use tokio::sync::lock::{Lock, LockGuard};
+use std::sync::{Arc, RwLock};
 
 // object holding a count of available, unreachable and quarantined nodes.
 #[derive(Clone)]
@@ -45,196 +44,142 @@ impl NodeCount {
     }
 }
 
-pub struct View {
-    pub self_node: NodeProfile,
-    pub peers: Vec<Node>,
-}
-
 /// object holding the P2pTopology of the Node
 #[derive(Clone)]
 pub struct P2pTopology {
-    lock: Lock<Topology>,
-    node_id: Id,
+    lock: Arc<RwLock<Topology>>,
     logger: Logger,
 }
 
-/// Builder object used to initialize the `P2pTopology`
-struct Builder {
-    topology: Topology,
-    logger: Logger,
-}
-
-impl Builder {
-    /// Create a new topology for the given node profile
-    fn new(node: poldercast::NodeProfile, logger: Logger) -> Self {
-        Builder {
-            topology: Topology::new(node),
+impl P2pTopology {
+    /// create a new P2pTopology for the given Address and Id
+    ///
+    /// The address is the public
+    pub fn new(node: poldercast::NodeProfile, logger: Logger) -> Self {
+        P2pTopology {
+            lock: Arc::new(RwLock::new(Topology::new(node))),
             logger,
         }
     }
 
-    fn set_policy(mut self, policy: PolicyConfig) -> Self {
-        self.topology.set_policy(Policy::new(
+    /// set a P2P Topology Module. Each module will work independently from
+    /// each other and will help improve the node connectivity
+    pub fn add_module<M: Layer + Send + Sync + 'static>(&self, module: M) {
+        let mut topology = self.lock.write().unwrap();
+        info!(
+            self.logger,
+            "adding P2P Topology module: {}",
+            module.alias()
+        );
+        topology.add_layer(module)
+    }
+
+    pub fn set_policy(&mut self, policy: PolicyConfig) {
+        let mut topology = self.lock.write().unwrap();
+        topology.set_policy(Policy::new(
             policy,
             self.logger.new(o!(KEY_SUB_TASK => "policy")),
         ));
-        self
     }
 
     /// set all the default poldercast modules (Rings, Vicinity and Cyclon)
-    fn set_poldercast_modules(mut self) -> Self {
-        self.topology.add_layer(Rings::default());
-        self.topology.add_layer(Vicinity::default());
-        self.topology.add_layer(Cyclon::default());
-        self
+    pub fn set_poldercast_modules(&mut self) {
+        let mut topology = self.lock.write().unwrap();
+        topology.add_layer(Rings::default());
+        topology.add_layer(Vicinity::default());
+        topology.add_layer(Cyclon::default());
     }
 
-    fn set_custom_modules(mut self, config: &Configuration) -> Self {
+    pub fn set_custom_modules(&mut self, config: &Configuration) {
+        let mut topology = self.lock.write().unwrap();
         if let Some(size) = config.max_unreachable_nodes_to_connect_per_event {
-            self.topology
-                .add_layer(custom_layers::RandomDirectConnections::with_max_view_length(size));
+            topology.add_layer(custom_layers::RandomDirectConnections::with_max_view_length(size))
         } else {
-            self.topology
-                .add_layer(custom_layers::RandomDirectConnections::default());
+            topology.add_layer(custom_layers::RandomDirectConnections::default());
         }
-        self
-    }
-
-    fn build(self) -> P2pTopology {
-        let node_id = self.topology.profile().id().clone();
-        P2pTopology {
-            lock: Lock::new(self.topology),
-            node_id: node_id.into(),
-            logger: self.logger,
-        }
-    }
-}
-
-impl P2pTopology {
-    pub fn new(config: &Configuration, logger: Logger) -> Self {
-        Builder::new(config.profile.clone(), logger)
-            .set_poldercast_modules()
-            .set_custom_modules(&config)
-            .set_policy(config.policy.clone())
-            .build()
-    }
-
-    // TODO: same as write now, but can be implemented differently
-    // with RwLock in tokio 0.2
-    fn read<E>(&self) -> impl Future<Item = LockGuard<Topology>, Error = E> {
-        self.write()
-    }
-
-    fn write<E>(&self) -> impl Future<Item = LockGuard<Topology>, Error = E> {
-        let mut lock = self.lock.clone();
-        future::poll_fn(move || Ok(lock.poll_lock()))
     }
 
     /// Returns a list of neighbors selected in this turn
     /// to contact for event dissemination.
-    pub fn view<E>(&self, selection: poldercast::Selection) -> impl Future<Item = View, Error = E> {
-        self.write().map(move |mut topology| {
-            let peers = topology
-                .view(None, selection)
-                .into_iter()
-                .map(Node::new)
-                .collect();
-            View {
-                self_node: topology.profile().clone(),
-                peers,
-            }
-        })
+    pub fn view(&self, selection: poldercast::Selection) -> Vec<Node> {
+        let mut topology = self.lock.write().unwrap();
+        topology
+            .view(None, selection)
+            .into_iter()
+            .map(Node::new)
+            .collect()
     }
 
-    pub fn initiate_gossips<E>(&self, with: Id) -> impl Future<Item = Gossips, Error = E> {
-        self.write()
-            .map(move |mut topology| topology.initiate_gossips(with.into()).into())
+    pub fn initiate_gossips(&self, with: Id) -> Gossips {
+        let mut topology = self.lock.write().unwrap();
+        topology.initiate_gossips(with.into()).into()
     }
 
-    pub fn accept_gossips<E>(
-        &self,
-        from: Id,
-        gossips: Gossips,
-    ) -> impl Future<Item = (), Error = E> {
-        self.write()
-            .map(move |mut topology| topology.accept_gossips(from.into(), gossips.into()))
+    pub fn accept_gossips(&self, from: Id, gossips: Gossips) {
+        let mut topology = self.lock.write().unwrap();
+        topology.accept_gossips(from.into(), gossips.into())
     }
 
-    pub fn exchange_gossips<E>(
-        &mut self,
-        with: Id,
-        gossips: Gossips,
-    ) -> impl Future<Item = Gossips, Error = E> {
-        self.write().map(move |mut topology| {
-            topology
-                .exchange_gossips(with.into(), gossips.into())
-                .into()
-        })
+    pub fn exchange_gossips(&mut self, with: Id, gossips: Gossips) -> Gossips {
+        let mut topology = self.lock.write().unwrap();
+        topology
+            .exchange_gossips(with.into(), gossips.into())
+            .into()
     }
 
-    pub fn node_id(&self) -> Id {
-        self.node_id
+    pub fn node(&self) -> NodeProfile {
+        self.lock.read().unwrap().profile().clone()
     }
 
-    pub fn node<E>(&self) -> impl Future<Item = NodeProfile, Error = E> {
-        self.read().map(|topology| topology.profile().clone())
+    pub fn force_reset_layers(&self) {
+        self.lock.write().unwrap().force_reset_layers()
     }
 
-    pub fn force_reset_layers<E>(&self) -> impl Future<Item = (), Error = E> {
-        self.write()
-            .map(|mut topology| topology.force_reset_layers())
+    pub fn list_quarantined(&self) -> Vec<poldercast::Node> {
+        self.lock
+            .read()
+            .unwrap()
+            .nodes()
+            .all_quarantined_nodes()
+            .into_iter()
+            .cloned()
+            .collect()
     }
 
-    pub fn list_quarantined<E>(&self) -> impl Future<Item = Vec<poldercast::Node>, Error = E> {
-        self.read().map(|topology| {
-            topology
-                .nodes()
-                .all_quarantined_nodes()
-                .into_iter()
-                .cloned()
-                .collect()
-        })
+    pub fn list_available(&self) -> Vec<poldercast::Node> {
+        self.lock
+            .read()
+            .unwrap()
+            .nodes()
+            .all_available_nodes()
+            .into_iter()
+            .cloned()
+            .collect()
     }
 
-    pub fn list_available<E>(&self) -> impl Future<Item = Vec<poldercast::Node>, Error = E> {
-        self.read().map(|topology| {
-            topology
-                .nodes()
-                .all_available_nodes()
-                .into_iter()
-                .cloned()
-                .collect()
-        })
+    pub fn list_non_public(&self) -> Vec<poldercast::Node> {
+        self.lock
+            .read()
+            .unwrap()
+            .nodes()
+            .all_unreachable_nodes()
+            .into_iter()
+            .cloned()
+            .collect()
     }
 
-    pub fn list_non_public<E>(&self) -> impl Future<Item = Vec<poldercast::Node>, Error = E> {
-        self.read().map(|topology| {
-            topology
-                .nodes()
-                .all_unreachable_nodes()
-                .into_iter()
-                .cloned()
-                .collect()
-        })
-    }
-
-    pub fn nodes_count<E>(&self) -> impl Future<Item = NodeCount, Error = E> {
-        self.read().map(|topology| NodeCount::new(topology.nodes()))
+    pub fn nodes_count(&self) -> NodeCount {
+        NodeCount::new(self.lock.read().unwrap().nodes())
     }
 
     /// register a strike against the given node id
     ///
     /// the function returns `None` if the node was not even in the
     /// the topology (not even quarantined).
-    pub fn report_node<E>(
-        &self,
-        node: Id,
-        issue: StrikeReason,
-    ) -> impl Future<Item = Option<PolicyReport>, Error = E> {
-        self.write().map(move |mut topology| {
-            topology.update_node(node.into(), |node| {
-                node.record_mut().strike(issue);
-            })
+    pub fn report_node(&self, node: Id, issue: StrikeReason) -> Option<PolicyReport> {
+        let mut topology = self.lock.write().unwrap();
+        topology.update_node(node.into(), |node| {
+            node.record_mut().strike(issue);
         })
     }
 }

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -70,7 +70,7 @@ impl P2pService for NodeService {
     type NodeId = Id;
 
     fn node_id(&self) -> Id {
-        self.global_state.topology.node_id()
+        (*self.global_state.topology.node().id()).into()
     }
 }
 

--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -405,11 +405,9 @@ impl GossipProcessor {
                     Ok(())
                 }),
         );
-        self.global_state.spawn(
-            self.global_state
-                .topology
-                .accept_gossips(self.node_id, nodes.into()),
-        );
+        self.global_state
+            .topology
+            .accept_gossips(self.node_id, nodes.into());
     }
 }
 

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -154,9 +154,9 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
         })
         .collect::<Result<(), ValueError>>()
         .map_err(|e| ErrorInternalServerError(format!("Block value calculation error: {}", e)))?;
-    let nodes_count = &context.p2p.nodes_count::<Error>().compat().await?;
-    let tip_header = tip.header();
     let stats = &context.stats_counter;
+    let tip_header = tip.header();
+    let nodes_count = &context.p2p.nodes_count();
     Ok(json!({
         "txRecvCnt": stats.tx_recv_cnt(),
         "blockRecvCnt": stats.block_recv_cnt(),
@@ -452,31 +452,31 @@ pub async fn get_diagnostic(context: Data<Context>) -> Result<impl Responder, Er
 }
 
 pub async fn get_network_p2p_quarantined(context: Data<Context>) -> Result<impl Responder, Error> {
-    let ctx = context.try_full()?;
-    let list = ctx.p2p.list_quarantined::<Error>().compat().await?;
-    Ok(Json(json!(list)))
+    context
+        .try_full()
+        .map(|ctx| Json(json!(ctx.p2p.list_quarantined())))
 }
 
 pub async fn get_network_p2p_non_public(context: Data<Context>) -> Result<impl Responder, Error> {
-    let ctx = context.try_full()?;
-    let list = ctx.p2p.list_non_public::<Error>().compat().await?;
-    Ok(Json(json!(list)))
+    context
+        .try_full()
+        .map(|ctx| Json(json!(ctx.p2p.list_non_public())))
 }
 
 pub async fn get_network_p2p_available(context: Data<Context>) -> Result<impl Responder, Error> {
-    let ctx = context.try_full()?;
-    let list = ctx.p2p.list_available::<Error>().compat().await?;
-    Ok(Json(json!(list)))
+    context
+        .try_full()
+        .map(|ctx| Json(json!(ctx.p2p.list_available())))
 }
 
 pub async fn get_network_p2p_view(context: Data<Context>) -> Result<impl Responder, Error> {
-    let ctx = context.try_full()?;
-    let view = ctx
+    let node_infos: Vec<poldercast::NodeInfo> = context
+        .try_full()?
         .p2p
-        .view::<Error>(poldercast::Selection::Any)
-        .compat()
-        .await?;
-    let node_infos: Vec<poldercast::NodeInfo> = view.peers.into_iter().map(Into::into).collect();
+        .view(poldercast::Selection::Any)
+        .into_iter()
+        .map(Into::into)
+        .collect();
     Ok(Json(json!(node_infos)))
 }
 
@@ -498,10 +498,15 @@ pub async fn get_network_p2p_view_topic(
             _ => Err(ErrorBadRequest("invalid topic")),
         }
     }
+    dbg!(&topic);
 
     let topic = parse_topic(&topic.into_inner())?;
-    let ctx = context.try_full()?;
-    let view = ctx.p2p.view::<Error>(topic).compat().await?;
-    let node_infos: Vec<poldercast::NodeInfo> = view.peers.into_iter().map(Into::into).collect();
+    let node_infos: Vec<poldercast::NodeInfo> = context
+        .try_full()?
+        .p2p
+        .view(topic)
+        .into_iter()
+        .map(Into::into)
+        .collect();
     Ok(Json(json!(node_infos)))
 }


### PR DESCRIPTION
This reverts commit e6bfb93, reversing changes made to ac36553. A critical bug
was introduced in this commit (deadlock when using P2PTopology) which cannot 
be easily resolved. 

It think it's probably easiest to revert the change for now and revisit an appropriate 
solution? Other option is to try an resolve the issue which I believe to be caused by replacing the P2PTopology R/W lock with a tokio Lock (non read/write). I know this was done for good reason, but at the moment I don't think there is a workable alternative that is likely to manifest before next release date (prove me wrong!).

Fixes: #1637