### PR TITLE
Trace spawned futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,19 +871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,15 +906,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1760,7 +1738,6 @@ dependencies = [
  "slog-journald 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-stdlog 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-syslog 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3287,17 +3264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slog-stdlog"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "slog-syslog"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4494,12 +4460,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
-"checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
-"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
@@ -4736,7 +4700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum slog-journald 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6f3f1e08a03b2c913e975da940c6adcc26377b2d2bf31cf4904a5d57a4deba7"
 "checksum slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 "checksum slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
-"checksum slog-stdlog 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be4d87903baf655da2d82bc3ac3f7ef43868c58bf712b3a661fda72009304c23"
 "checksum slog-syslog 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9aa4bcc86188ea50a6ae3be357c72a87d96d8bce713abd819ca55f15589609dd"
 "checksum slog-term 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54b50e85b73c2bd42ceb97b6ded235576d405bd1e974242ccfe634fa269f6da7"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -52,7 +52,6 @@ slog-gelf = { version = "0.1.0", optional = true }
 slog-journald = { version = "2.0.0", optional = true }
 slog-json = "2.3.0"
 slog-scope = "4.1"
-slog-stdlog = "4.0"
 slog-term = "2.4.0"
 structopt = "^0.2"
 thiserror = "1.0"

--- a/jormungandr/src/client.rs
+++ b/jormungandr/src/client.rs
@@ -36,6 +36,7 @@ pub fn handle_input(
             let fut = handle.async_reply(get_block_tip(&task_data.blockchain_tip));
             let logger = info.logger().new(o!("request" => "GetBlockTip"));
             info.spawn(
+                "get block tip",
                 Timeout::new(fut, Duration::from_secs(PROCESS_TIMEOUT_GET_BLOCK_TIP)).map_err(
                     move |e| {
                         error!(
@@ -51,6 +52,7 @@ pub fn handle_input(
             let fut = handle.async_reply(get_headers(task_data.storage.clone(), ids));
             let logger = info.logger().new(o!("request" => "GetHeaders"));
             info.spawn(
+                "GetHeaders",
                 Timeout::new(fut, Duration::from_secs(PROCESS_TIMEOUT_GET_HEADERS)).map_err(
                     move |e| {
                         warn!(
@@ -66,6 +68,7 @@ pub fn handle_input(
             let fut = handle_get_headers_range(task_data, checkpoints, to, handle);
             let logger = info.logger().new(o!("request" => "GetHeadersRange"));
             info.spawn(
+                "GetHeadersRange",
                 Timeout::new(fut, Duration::from_secs(PROCESS_TIMEOUT_GET_HEADERS_RANGE)).map_err(
                     move |e| {
                         warn!(
@@ -81,6 +84,7 @@ pub fn handle_input(
             let fut = handle.async_reply(get_blocks(task_data.storage.clone(), ids));
             let logger = info.logger().new(o!("request" => "GetBlocks"));
             info.spawn(
+                "get blocks",
                 Timeout::new(fut, Duration::from_secs(PROCESS_TIMEOUT_GET_BLOCKS)).map_err(
                     move |e| {
                         warn!(
@@ -96,6 +100,7 @@ pub fn handle_input(
             let fut = handle_pull_blocks_to_tip(task_data, from, handle);
             let logger = info.logger().new(o!("request" => "PullBlocksToTip"));
             info.spawn(
+                "PullBlocksToTip",
                 Timeout::new(fut, Duration::from_secs(PROCESS_TIMEOUT_PULL_BLOCKS_TO_TIP)).map_err(
                     move |e| {
                         warn!(

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -123,13 +123,16 @@ impl Explorer {
         let mut explorer_db = self.db.clone();
         let logger = info.logger().clone();
         match bquery {
-            ExplorerMsg::NewBlock(block) => info.spawn(explorer_db.apply_block(block).then(
-                move |result| match result {
-                    // XXX: There is no garbage collection now, so the GCRoot is not used
-                    Ok(_gc_root) => Ok(()),
-                    Err(err) => Err(error!(logger, "Explorer error: {}", err)),
-                },
-            )),
+            ExplorerMsg::NewBlock(block) => info.spawn(
+                "apply block",
+                explorer_db
+                    .apply_block(block)
+                    .then(move |result| match result {
+                        // XXX: There is no garbage collection now, so the GCRoot is not used
+                        Ok(_gc_root) => Ok(()),
+                        Err(err) => Err(error!(logger, "Explorer error: {}", err)),
+                    }),
+            ),
         }
         future::ok::<(), ()>(())
     }

--- a/jormungandr/src/fragment/process.rs
+++ b/jormungandr/src/fragment/process.rs
@@ -53,7 +53,10 @@ impl Process {
         stats_counter: StatsCounter,
         input: MessageQueue<TransactionMsg>,
     ) -> impl Future<Item = (), Error = ()> {
-        service_info.spawn(self.start_pool_garbage_collector(service_info.logger().clone()));
+        service_info.spawn(
+            "pool garbage collector",
+            self.start_pool_garbage_collector(service_info.logger().clone()),
+        );
         input.for_each(move |input| {
             match input {
                 TransactionMsg::SendTransaction(origin, txs) => {

--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -106,7 +106,7 @@ impl Module {
                     error!(error_logger, "Cannot run the garbage collection" ; "reason" => error.to_string());
                 });
 
-        service_info.spawn(purge_logs);
+        service_info.spawn("purge logs", purge_logs);
 
         tip.get_ref().map(move |tip_ref| Self {
             schedule: Schedule::default(),

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -405,18 +405,6 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let log_settings = raw_settings.log_settings();
     let logger = log_settings.to_logger()?;
 
-    // The log crate is used by some libraries, e.g. tower-grpc.
-    // Set up forwarding from log to slog, but only when trace log level is
-    // requested, because the logs are very verbose.
-    if log_settings
-        .0
-        .iter()
-        .any(|entry| entry.level >= slog::FilterLevel::Trace)
-    {
-        slog_scope::set_global_logger(logger.new(o!(log::KEY_SCOPE => "global"))).cancel_reset();
-        slog_stdlog::init().unwrap();
-    }
-
     let init_logger = logger.new(o!(log::KEY_TASK => "init"));
     info!(init_logger, "Starting {}", env!("FULL_VERSION"),);
 

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -117,11 +117,6 @@ fn handle_block(
     logger: Logger,
 ) -> impl Future<Item = Arc<Ref>, Error = Error> {
     let header = block.header();
-    trace!(
-        logger,
-        "received block from the bootstrap node: {:#?}",
-        header
-    );
     let end_blockchain = blockchain.clone();
     blockchain
         .pre_check_header(header, true)

--- a/jormungandr/src/network/client/mod.rs
+++ b/jormungandr/src/network/client/mod.rs
@@ -210,13 +210,6 @@ where
                 return Ok(Disconnect.into());
             }
         };
-        trace!(
-            self.logger,
-            "received block event";
-            "stream" => "block_events",
-            "direction" => "in",
-            "item" => ?event,
-        );
         match event {
             BlockEvent::Announce(header) => {
                 debug_assert!(self.incoming_block_announcement.is_none());
@@ -440,13 +433,6 @@ where
         }));
         match maybe_fragment {
             Some(fragment) => {
-                trace!(
-                    self.logger,
-                    "received fragment";
-                    "stream" => "fragments",
-                    "direction" => "in",
-                    "item" => ?fragment,
-                );
                 debug_assert!(self.incoming_fragment.is_none());
                 self.incoming_fragment = Some(fragment);
                 Ok(Continue.into())
@@ -477,13 +463,6 @@ where
         }));
         match maybe_gossip {
             Some(gossip) => {
-                trace!(
-                    self.logger,
-                    "received gossip";
-                    "stream" => "gossip",
-                    "direction" => "in",
-                    "item" => ?gossip,
-                );
                 self.gossip_processor.process_item(gossip);
                 Ok(Continue.into())
             }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -321,7 +321,6 @@ fn handle_propagation_msg(
     state: GlobalStateR,
     channels: Channels,
 ) -> impl Future<Item = (), Error = ()> {
-    trace!(state.logger(), "to propagate: {:?}", &msg);
     let prop_state = state.clone();
     let send_to_peers = match msg {
         PropagateMsg::Block(ref header) => {

--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -147,15 +147,7 @@ where
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         match self.outbound.poll() {
             Ok(Async::NotReady) => Ok(Async::NotReady),
-            Ok(Async::Ready(Some(item))) => {
-                trace!(
-                    self.logger,
-                    "sending";
-                    "item" => ?item,
-                    "direction" => "out",
-                );
-                Ok(Some(item).into())
-            }
+            Ok(Async::Ready(Some(item))) => Ok(Some(item).into()),
             Ok(Async::Ready(None)) => {
                 debug!(
                     self.logger,
@@ -471,11 +463,6 @@ impl Sink for FragmentProcessor {
         if self.buffered_fragments.len() >= buffer_sizes::inbound::FRAGMENTS {
             return Ok(AsyncSink::NotReady(fragment));
         }
-        trace!(
-            self.logger,
-            "received";
-            "item" => ?fragment,
-        );
         self.buffered_fragments.push(fragment);
         let async_send = self.try_send_fragments()?;
         Ok(async_send.map(|()| self.buffered_fragments.pop().unwrap()))
@@ -550,11 +537,6 @@ impl Sink for GossipProcessor {
         &mut self,
         gossip: Gossip<NodeData>,
     ) -> StartSend<Self::SinkItem, core_error::Error> {
-        trace!(
-            self.logger,
-            "received";
-            "item" => ?gossip,
-        );
         self.process_item(gossip);
         Ok(AsyncSink::Ready)
     }

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -181,11 +181,19 @@ impl TokioServiceInfo {
     }
 
     /// spawn a future within the service's tokio executor
-    pub fn spawn<F>(&self, future: F)
+    pub fn spawn<F>(&self, name: &'static str, future: F)
     where
         F: Future<Item = (), Error = ()> + Send + 'static,
     {
-        self.executor.spawn(future)
+        let logger = self.logger.clone();
+        trace!(logger, "spawning {}", name);
+        self.executor.spawn(future.then(move |res| {
+            match res {
+                Ok(()) => trace!(logger, "{} finished successfully", name),
+                Err(()) => trace!(logger, "{} finished with error", name),
+            }
+            res
+        }));
     }
 }
 


### PR DESCRIPTION
In order to help debug task pileups and lockups, add tracing to each task spawned through the utility layer.

Remove older trace statements, which are almost never useful.