### PR TITLE
Display the cause of ListenError

### DIFF
--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -86,7 +86,11 @@ pub struct ListenError {
 
 impl fmt::Display for ListenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "failed to listen for connections on {}", self.sockaddr)
+        write!(
+            f,
+            "failed to listen for connections on {}: {}",
+            self.sockaddr, self.cause
+        )
     }
 }
 


### PR DESCRIPTION
Improves logging for failure to listen on a socket.