### PR TITLE
[Tests] Private network tests improvements

### DIFF
--- a/jormungandr-scenario-tests/src/node.rs
+++ b/jormungandr-scenario-tests/src/node.rs
@@ -66,9 +66,9 @@ error_chain! {
             display("fragment '{}' not in the mempool of the node '{}'. logs: {}", fragment_id, alias, log),
         }
 
-        FragmentIsPendingForTooLong (fragment_id: FragmentId, duration: Duration, log: String) {
+        FragmentIsPendingForTooLong (fragment_id: FragmentId, duration: Duration, alias: String, log: String) {
             description("fragment is pending for too long"),
-            display("fragment '{}' is pending for too long ({} s). Logs: {}", fragment_id, duration.as_secs(), log),
+            display("fragment '{}' is pending for too long ({} s). Node: {}, Logs: {}", fragment_id, duration.as_secs(), alias, log),
         }
     }
 }
@@ -328,6 +328,7 @@ impl NodeController {
         bail!(ErrorKind::FragmentIsPendingForTooLong(
             check.fragment_id.clone(),
             Duration::from_secs(duration.as_secs() * max_try),
+            self.alias().to_string(),
             self.logger().get_log_content()
         ))
     }

--- a/jormungandr-scenario-tests/src/test/comm/passive_leader.rs
+++ b/jormungandr-scenario-tests/src/test/comm/passive_leader.rs
@@ -84,7 +84,7 @@ pub fn leader_restart(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
     //controller.monitor_nodes();
 
     let leader =
-        controller.spawn_node(LEADER, LeadershipMode::Leader, PersistenceMode::InMemory)?;
+        controller.spawn_node(LEADER, LeadershipMode::Leader, PersistenceMode::Persistent)?;
     leader.wait_for_bootstrap()?;
 
     let passive =
@@ -114,7 +114,7 @@ pub fn leader_restart(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
     )?;
 
     let leader =
-        controller.spawn_node(LEADER, LeadershipMode::Leader, PersistenceMode::InMemory)?;
+        controller.spawn_node(LEADER, LeadershipMode::Leader, PersistenceMode::Persistent)?;
 
     utils::sending_transactions_to_node_sequentially(
         10,

--- a/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
+++ b/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
@@ -34,16 +34,31 @@ pub fn mesh_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
 
     //monitor node disabled due to unsupported operation: restart node
     //controller.monitor_nodes();
-    let mut leader5 =
-        controller.spawn_node(LEADER_5, LeadershipMode::Leader, PersistenceMode::InMemory)?;
-    let leader4 =
-        controller.spawn_node(LEADER_4, LeadershipMode::Leader, PersistenceMode::InMemory)?;
-    let leader3 =
-        controller.spawn_node(LEADER_3, LeadershipMode::Leader, PersistenceMode::InMemory)?;
-    let mut leader2 =
-        controller.spawn_node(LEADER_2, LeadershipMode::Leader, PersistenceMode::InMemory)?;
-    let leader1 =
-        controller.spawn_node(LEADER_1, LeadershipMode::Leader, PersistenceMode::InMemory)?;
+    let mut leader5 = controller.spawn_node(
+        LEADER_5,
+        LeadershipMode::Leader,
+        PersistenceMode::Persistent,
+    )?;
+    let leader4 = controller.spawn_node(
+        LEADER_4,
+        LeadershipMode::Leader,
+        PersistenceMode::Persistent,
+    )?;
+    let leader3 = controller.spawn_node(
+        LEADER_3,
+        LeadershipMode::Leader,
+        PersistenceMode::Persistent,
+    )?;
+    let mut leader2 = controller.spawn_node(
+        LEADER_2,
+        LeadershipMode::Leader,
+        PersistenceMode::Persistent,
+    )?;
+    let leader1 = controller.spawn_node(
+        LEADER_1,
+        LeadershipMode::Leader,
+        PersistenceMode::Persistent,
+    )?;
 
     leader5.wait_for_bootstrap()?;
     leader4.wait_for_bootstrap()?;
@@ -63,7 +78,7 @@ pub fn mesh_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
     )?;
 
     leader2 =
-        controller.restart_node(leader2, LeadershipMode::Leader, PersistenceMode::InMemory)?;
+        controller.restart_node(leader2, LeadershipMode::Leader, PersistenceMode::Persistent)?;
 
     utils::sending_transactions_to_node_sequentially(
         10,
@@ -74,8 +89,7 @@ pub fn mesh_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
     )?;
 
     leader5 =
-        controller.restart_node(leader5, LeadershipMode::Leader, PersistenceMode::InMemory)?;
-
+        controller.restart_node(leader5, LeadershipMode::Leader, PersistenceMode::Persistent)?;
     utils::sending_transactions_to_node_sequentially(
         10,
         &mut controller,

--- a/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -34,7 +34,7 @@ impl SyncWaitParams {
     }
 
     fn calculate_wait_time(&self) -> u64 {
-        self.no_of_nodes + self.longest_path_length * 2
+        (self.no_of_nodes + self.longest_path_length * 2) * 2
     }
 
     pub fn wait_time(&self) -> Duration {


### PR DESCRIPTION
1. Extended timeouts for node synchronization by 2
2. Display more information on FragmentIsPendingFrorTooLong error
3. Changed PersistentMode to persistent for tests which restarts nodes