### PR TITLE
Use checkpoints when bootstrapping

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -749,7 +749,7 @@ impl Blockchain {
 
     pub fn get_checkpoints(
         &self,
-        branch: Branch,
+        branch: &Branch,
     ) -> impl Future<Item = Checkpoints, Error = Error> {
         branch.get_ref().map(Checkpoints::new_from)
     }

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -237,6 +237,27 @@ impl PostCheckedHeader {
     }
 }
 
+pub enum AppliedBlock {
+    New(Arc<Ref>),
+    Existing(Arc<Ref>),
+}
+
+impl AppliedBlock {
+    pub fn cached_ref(&self) -> Arc<Ref> {
+        match self {
+            AppliedBlock::New(r) => r.clone(),
+            AppliedBlock::Existing(r) => r.clone(),
+        }
+    }
+
+    pub fn new_ref(&self) -> Option<Arc<Ref>> {
+        match self {
+            AppliedBlock::New(r) => Some(r.clone()),
+            AppliedBlock::Existing(_) => None,
+        }
+    }
+}
+
 impl Blockchain {
     pub fn new(block0: HeaderHash, storage: NodeStorage, ref_cache_ttl: Duration) -> Self {
         Blockchain {
@@ -495,17 +516,15 @@ impl Blockchain {
         &self,
         post_checked_header: PostCheckedHeader,
         block: Block,
-    ) -> impl Future<Item = Option<Arc<Ref>>, Error = Error> {
+    ) -> impl Future<Item = AppliedBlock, Error = Error> {
         let mut storage = self.storage.clone();
         self.apply_block(post_checked_header, &block)
             .and_then(move |block_ref| {
-                storage
-                    .put_block(block)
-                    .map(|()| Some(block_ref))
-                    .or_else(|err| match err {
-                        StorageError::BlockAlreadyPresent => Ok(None),
-                        err => Err(err.into()),
-                    })
+                storage.put_block(block).then(|res| match res {
+                    Ok(()) => Ok(AppliedBlock::New(block_ref)),
+                    Err(StorageError::BlockAlreadyPresent) => Ok(AppliedBlock::Existing(block_ref)),
+                    Err(e) => Err(e.into()),
+                })
             })
     }
 

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -1,5 +1,6 @@
 use super::{
-    candidate, chain,
+    candidate,
+    chain::{self, AppliedBlock},
     chain_selection::{self, ComparisonResult},
     Blockchain, Error, ErrorKind, PreCheckedHeader, Ref, Tip, MAIN_BRANCH_TAG,
 };
@@ -551,7 +552,9 @@ pub fn process_leadership_block(
         })
         .map_err(|err| Error::with_chain(err, "cannot process leadership block"))
         .map(move |applied| {
-            let new_ref = applied.expect("block from leadership must be unique");
+            let new_ref = applied
+                .new_ref()
+                .expect("block from leadership must be unique");
             info!(logger, "block from leader event successfully stored");
             new_ref
         })
@@ -701,8 +704,8 @@ fn check_and_apply_block(
             let fragment_ids = block.fragments().map(|f| f.id()).collect::<Vec<_>>();
             blockchain1
                 .apply_and_store_block(post_checked, block)
-                .and_then(move |maybe_block_ref| {
-                    if let Some(ref block_ref) = maybe_block_ref {
+                .and_then(move |applied_block| {
+                    if let AppliedBlock::New(block_ref) = applied_block {
                         let header = block_ref.header();
                         debug!(
                             logger,
@@ -721,14 +724,15 @@ fn check_and_apply_block(
                                     error!(logger, "cannot add block to explorer: {}", err)
                                 });
                         }
+                        Ok(Some(block_ref))
                     } else {
                         debug!(
                             logger,
                             "block is already present in storage, not applied";
                             "hash" => %block_hash,
                         );
+                        Ok(None)
                     }
-                    Ok(maybe_block_ref)
                 })
         })
 }

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -578,7 +578,7 @@ fn process_block_announcement(
                 let to = header.hash();
                 Either::B(
                     blockchain
-                        .get_checkpoints(blockchain_tip.branch().clone())
+                        .get_checkpoints(blockchain_tip.branch())
                         .map(move |from| {
                             pull_headers_scheduler
                                 .schedule(to, node_id, from)

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -168,7 +168,7 @@ fn handle_block(
                         );
                         blockchain
                             .apply_and_store_block(post_checked, block)
-                            .map(|applied| applied.expect("validated block must be unique"))
+                            .map(|applied| applied.cached_ref())
                             .map_err(|e| Error::ApplyBlockFailed { source: e })
                     });
                 Either::B(future)

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -30,10 +30,14 @@ pub enum Error {
     PullStreamFailed { source: NetworkError },
     #[error("block header check failed")]
     HeaderCheckFailed { source: BlockchainError },
-    #[error("received block {0} is already present")]
-    BlockAlreadyPresent(HeaderHash),
+    #[error(
+        "received block {0} is already present, but does not descend from any of the checkpoints"
+    )]
+    BlockNotOnBranch(HeaderHash),
     #[error("received block {0} is not connected to the block chain")]
     BlockMissingParent(HeaderHash),
+    #[error("failed to fetch checkpoints from storage")]
+    GetCheckpointsFailed { source: BlockchainError },
     #[error("failed to apply block to the blockchain")]
     ApplyBlockFailed { source: BlockchainError },
     #[error("failed to select the new tip")]
@@ -43,9 +47,9 @@ pub enum Error {
 pub fn bootstrap_from_peer(
     peer: Peer,
     blockchain: Blockchain,
-    branch: Tip,
+    tip: Tip,
     logger: Logger,
-) -> Result<Arc<Ref>, Error> {
+) -> Result<(), Error> {
     info!(logger, "connecting to bootstrap peer {}", peer.connection);
 
     let runtime = Runtime::new().map_err(|e| Error::RuntimeInit { source: e })?;
@@ -57,16 +61,20 @@ pub fn bootstrap_from_peer(
                 .ready()
                 .map_err(|e| Error::ClientNotReady { source: e })
         })
-        .join(branch.get_ref())
-        .and_then(move |(mut client, tip)| {
-            let tip_hash = tip.hash();
-            debug!(logger, "pulling blocks starting from {}", tip_hash);
+        .join(
+            blockchain
+                .get_checkpoints(tip.branch())
+                .map_err(|e| Error::GetCheckpointsFailed { source: e }),
+        )
+        .and_then(move |(mut client, checkpoints)| {
+            debug!(
+                logger,
+                "pulling blocks starting from checkpoints: {:?}", checkpoints
+            );
             client
-                .pull_blocks_to_tip(&[tip_hash])
+                .pull_blocks_to_tip(checkpoints.as_slice())
                 .map_err(|e| Error::PullRequestFailed { source: e })
-                .and_then(move |stream| {
-                    bootstrap_from_stream(blockchain, branch, tip, stream, logger)
-                })
+                .and_then(move |stream| bootstrap_from_stream(blockchain, tip, stream, logger))
         });
 
     runtime.block_on_all(bootstrap)
@@ -75,10 +83,9 @@ pub fn bootstrap_from_peer(
 fn bootstrap_from_stream<S>(
     blockchain: Blockchain,
     branch: Tip,
-    tip: Arc<Ref>,
     stream: S,
     logger: Logger,
-) -> impl Future<Item = Arc<Ref>, Error = Error>
+) -> impl Future<Item = (), Error = Error>
 where
     S: Stream<Item = Block, Error = NetworkError>,
     S::Error: Debug,
@@ -91,23 +98,39 @@ where
     stream
         .skip_while(move |block| Ok(block.header.hash() == block0))
         .then(|res| Ok(res))
-        .fold(tip, move |parent_tip, block_or_err| match block_or_err {
-            Ok(block) => Either::A(handle_block(blockchain.clone(), block, logger.clone())),
-            Err(e) => {
-                let fut = blockchain::process_new_ref(
-                    logger.clone(),
-                    blockchain.clone(),
-                    branch.clone(),
-                    parent_tip.clone(),
+        .fold(
+            None,
+            move |parent_tip: Option<Arc<Ref>>, block_or_err| match block_or_err {
+                Ok(block) => {
+                    let fut = handle_block(blockchain.clone(), block, logger.clone()).map(Some);
+                    Either::A(fut)
+                }
+                Err(e) => {
+                    let fut = if let Some(parent_tip) = parent_tip {
+                        Either::A(blockchain::process_new_ref(
+                            logger.clone(),
+                            blockchain.clone(),
+                            branch.clone(),
+                            parent_tip.clone(),
+                        ))
+                    } else {
+                        Either::B(future::ok(()))
+                    }
+                    .then(|_| Err(Error::PullStreamFailed { source: e }));
+                    Either::B(fut)
+                }
+            },
+        )
+        .and_then(move |maybe_new_tip| {
+            if let Some(new_tip) = maybe_new_tip {
+                Either::A(
+                    blockchain::process_new_ref(logger2, blockchain2, branch2, new_tip.clone())
+                        .map_err(|e| Error::ChainSelectionFailed { source: e }),
                 )
-                .then(|_| Err(Error::PullStreamFailed { source: e }));
-                Either::B(fut)
+            } else {
+                info!(logger2, "no new blocks in bootstrap stream");
+                Either::B(future::ok(()))
             }
-        })
-        .and_then(move |new_tip| {
-            blockchain::process_new_ref(logger2, blockchain2, branch2, new_tip.clone())
-                .map_err(|e| Error::ChainSelectionFailed { source: e })
-                .map(|()| new_tip)
         })
 }
 
@@ -117,34 +140,38 @@ fn handle_block(
     logger: Logger,
 ) -> impl Future<Item = Arc<Ref>, Error = Error> {
     let header = block.header();
-    let end_blockchain = blockchain.clone();
     blockchain
         .pre_check_header(header, true)
         .map_err(|e| Error::HeaderCheckFailed { source: e })
-        .and_then(|pre_checked| match pre_checked {
-            PreCheckedHeader::AlreadyPresent { header, .. } => {
-                Err(Error::BlockAlreadyPresent(header.hash()))
-            }
+        .and_then(move |pre_checked| match pre_checked {
+            PreCheckedHeader::AlreadyPresent {
+                cached_reference: Some(block_ref),
+                ..
+            } => Either::A(future::ok(block_ref)),
+            PreCheckedHeader::AlreadyPresent {
+                cached_reference: None,
+                header,
+            } => Either::A(future::err(Error::BlockNotOnBranch(header.hash()))),
             PreCheckedHeader::MissingParent { header, .. } => {
-                Err(Error::BlockMissingParent(header.hash()))
+                Either::A(future::err(Error::BlockMissingParent(header.hash())))
             }
-            PreCheckedHeader::HeaderWithCache { header, parent_ref } => Ok((header, parent_ref)),
-        })
-        .and_then(move |(header, parent_ref)| {
-            blockchain
-                .post_check_header(header, parent_ref)
-                .map_err(|e| Error::HeaderCheckFailed { source: e })
-        })
-        .and_then(move |post_checked| {
-            debug!(
-                logger,
-                "validated block";
-                "hash" => %post_checked.header().hash(),
-                "block_date" => %post_checked.header().block_date(),
-            );
-            end_blockchain
-                .apply_and_store_block(post_checked, block)
-                .map(|applied| applied.expect("validated block must be unique"))
-                .map_err(|e| Error::ApplyBlockFailed { source: e })
+            PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
+                let future = blockchain
+                    .post_check_header(header, parent_ref)
+                    .map_err(|e| Error::HeaderCheckFailed { source: e })
+                    .and_then(move |post_checked| {
+                        debug!(
+                            logger,
+                            "validated block";
+                            "hash" => %post_checked.header().hash(),
+                            "block_date" => %post_checked.header().block_date(),
+                        );
+                        blockchain
+                            .apply_and_store_block(post_checked, block)
+                            .map(|applied| applied.expect("validated block must be unique"))
+                            .map_err(|e| Error::ApplyBlockFailed { source: e })
+                    });
+                Either::B(future)
+            }
         })
 }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -568,7 +568,7 @@ pub fn bootstrap(
             Err(e) => {
                 warn!(logger, "initial bootstrap failed"; "error" => ?e);
             }
-            Ok(_) => {
+            Ok(()) => {
                 info!(logger, "initial bootstrap completed");
                 bootstrapped = true;
                 break;


### PR DESCRIPTION
The stored tip may be on a fork, so send checkpoints to fall back to when pulling the blockchain on bootstrap. Otherwise the serving node falls back all the way to block 0.

Fixes #1677