### PR TITLE
Update poldercast library and use performant node count

### DIFF
--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -39,7 +39,7 @@ lazy_static = "1.3"
 linked-hash-map = "0.5"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
-poldercast = "0.11.1"
+poldercast = "0.11.2"
 rand = "0.7"
 rustls = "^0.16.0 "
 serde = "1.0"

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -15,36 +15,6 @@ use slog::Logger;
 use tokio::prelude::future::{self, Future};
 use tokio::sync::lock::{Lock, LockGuard};
 
-// object holding a count of available, unreachable and quarantined nodes.
-#[derive(Clone)]
-pub struct NodeCount {
-    all_available_nodes: usize,
-    all_unreachable_nodes: usize,
-    all_quarantined_nodes: usize,
-}
-
-impl NodeCount {
-    pub fn new(nodes: &poldercast::Nodes) -> Self {
-        NodeCount {
-            all_available_nodes: nodes.all_available_nodes().len(),
-            all_unreachable_nodes: nodes.all_unreachable_nodes().len(),
-            all_quarantined_nodes: nodes.all_quarantined_nodes().len(),
-        }
-    }
-
-    pub fn all_available_nodes_count(&self) -> usize {
-        self.all_available_nodes
-    }
-
-    pub fn all_unreachable_nodes_count(&self) -> usize {
-        self.all_unreachable_nodes
-    }
-
-    pub fn all_quarantined_nodes_count(&self) -> usize {
-        self.all_quarantined_nodes
-    }
-}
-
 pub struct View {
     pub self_node: NodeProfile,
     pub peers: Vec<Node>,
@@ -218,8 +188,8 @@ impl P2pTopology {
         })
     }
 
-    pub fn nodes_count<E>(&self) -> impl Future<Item = NodeCount, Error = E> {
-        self.read().map(|topology| NodeCount::new(topology.nodes()))
+    pub fn nodes_count<E>(&self) -> impl Future<Item = poldercast::Count, Error = E> {
+        self.read().map(|topology| topology.nodes().node_count())
     }
 
     /// register a strike against the given node id

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -172,9 +172,10 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
         "lastBlockContentSize": tip_header.block_content_size(),
         "lastBlockSum": block_input_sum.0,
         "lastBlockFees": block_fee_sum.0,
-        "peerAvailableCnt": nodes_count.all_available_nodes_count(),
-        "peerUnreachableCnt": nodes_count.all_unreachable_nodes_count(),
-        "peerQuarantinedCnt": nodes_count.all_quarantined_nodes_count(),
+        "peerTotalCnt": nodes_count.all_count,
+        "peerAvailableCnt": nodes_count.available_count,
+        "peerUnreachableCnt": nodes_count.not_reachable_count,
+        "peerQuarantinedCnt": nodes_count.quarantined_count,
     }))
 }
 


### PR DESCRIPTION
This commit references a fork of Poldercast v0.11.1 with the addition of changes that allow for efficient querying of the peer count. This should significantly reduce lock contention on the P2PTopology.