### PR TITLE
Update ledger ed25519 signing to the new signing closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,7 @@ version = "0.1.1"
 dependencies = [
  "cbor_event 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-bip32 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-bip32 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -648,7 +648,7 @@ dependencies = [
  "cryptoxide 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-bip32 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-bip32 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -670,7 +670,7 @@ dependencies = [
  "chain-crypto 0.1.0",
  "chain-storage 0.1.0",
  "chain-time 0.1.0",
- "ed25519-bip32 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-bip32 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "imhamt 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1016,7 +1016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ed25519-bip32"
-version = "0.1.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cryptoxide 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1679,7 +1679,7 @@ dependencies = [
  "chain-impl-mockchain 0.1.0",
  "chain-time 0.1.0",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-bip32 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-bip32 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtmpl 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jormungandr-lib 0.8.9",
@@ -1771,7 +1771,7 @@ dependencies = [
  "chain-storage 0.1.0",
  "chain-storage-sqlite-old 0.1.0",
  "chain-time 0.1.0",
- "ed25519-bip32 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-bip32 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1815,7 +1815,7 @@ dependencies = [
  "chain-crypto 0.1.0",
  "chain-impl-mockchain 0.1.0",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-bip32 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-bip32 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "poldercast 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4509,7 +4509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
-"checksum ed25519-bip32 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9dc90e26f8ad41b7d3d3ce540bf465df20d54fb3b809427d9a046babf16f5a3d"
+"checksum ed25519-bip32 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b5178f6ae9d2fb18d96705e1bfe37edcd7d455f2887ad4b675f971cf3a6e6ef"
 "checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -34,7 +34,7 @@ jormungandr-lib = { path = "../jormungandr-lib" }
 gtmpl = "0.5.6"
 openapiv3 = "0.3.0"
 valico = "3.1.0"
-ed25519-bip32 = "0.1"
+ed25519-bip32 = "0.3"
 thiserror = "1.0"
 
 [dependencies.clap]

--- a/jcli/src/jcli_app/certificate/sign.rs
+++ b/jcli/src/jcli_app/certificate/sign.rs
@@ -104,7 +104,9 @@ pub(crate) fn stake_delegation_account_binding_sign(
         }
     }
 
-    let sig = AccountBindingSignature::new_single(&private_key, &builder.get_auth_data());
+    let sig = AccountBindingSignature::new_single(&builder.get_auth_data(), |d| {
+        private_key.sign_slice(&d.0)
+    });
 
     Ok(SignedCertificate::StakeDelegation(delegation, sig))
 }
@@ -150,7 +152,7 @@ where
 
     let mut sigs = Vec::new();
     for (i, key) in keys.iter() {
-        let sig = SingleAccountBindingSignature::new(key, &auth_data);
+        let sig = SingleAccountBindingSignature::new(&auth_data, |d| key.sign_slice(&d.0));
         sigs.push((*i, sig))
     }
     let sig = PoolOwnersSigned { signatures: sigs };

--- a/jcli/src/jcli_app/key.rs
+++ b/jcli/src/jcli_app/key.rs
@@ -7,7 +7,7 @@ use chain_crypto::{
 };
 use ed25519_bip32::{DerivationError, DerivationScheme};
 use hex::FromHexError;
-use rand::{rngs::EntropyRng, SeedableRng};
+use rand::{rngs::OsRng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::{
     io::{Read, Write},
@@ -426,7 +426,7 @@ fn gen_priv_key<K: AsymmetricKey>(seed: Option<Seed>) -> Result<Bech32, Error> {
     let rng = if let Some(seed) = seed {
         ChaChaRng::from_seed(seed.0)
     } else {
-        ChaChaRng::from_rng(EntropyRng::new())?
+        ChaChaRng::from_rng(OsRng)?
     };
     let secret = K::generate(rng);
     let hrp = K::SECRET_BECH32_HRP.to_string();

--- a/jormungandr-integration-tests/Cargo.toml
+++ b/jormungandr-integration-tests/Cargo.toml
@@ -58,7 +58,7 @@ assert_cmd = "0.11"
 assert_fs = "0.11"
 mktemp = "0.4.0"
 lazy_static = "1.3"
-ed25519-bip32 = "0.1"
+ed25519-bip32 = "0.3"
 
 [features]
 testnet = []

--- a/jormungandr-lib/Cargo.toml
+++ b/jormungandr-lib/Cargo.toml
@@ -24,6 +24,6 @@ poldercast = "0.11.1"
 rand = "0.7"
 quickcheck = "0.9"
 chain-crypto    = { path = "../chain-deps/chain-crypto", features = [ "property-test-api" ] }
-ed25519-bip32 = "0.1"
+ed25519-bip32 = "0.3"
 serde_yaml = "0.8"
 bincode = "1.1"

--- a/jormungandr-lib/src/interfaces/transaction_witness.rs
+++ b/jormungandr-lib/src/interfaces/transaction_witness.rs
@@ -175,8 +175,12 @@ mod test {
                     use crate::crypto::key::KeyPair;
                     use chain_crypto::Ed25519Bip32;
                     let kp: KeyPair<Ed25519Bip32> = KeyPair::arbitrary(g);
-                    Witness::OldUtxo(kp.identifier().as_ref().clone(), Arbitrary::arbitrary(g))
-                        .into()
+
+                    let pk = kp.identifier().into_public_key().inner();
+                    let cc = pk.chain_code();
+                    let pk_ed = chain_crypto::PublicKey::from_binary(&pk.public_key()).unwrap();
+
+                    Witness::OldUtxo(pk_ed, cc, Arbitrary::arbitrary(g)).into()
                 }
                 3 => unimplemented!(), // Multisig
                 _ => unreachable!(),

--- a/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -10,7 +10,6 @@ use chain_impl_mockchain::{
     block::ConsensusVersion,
     certificate::{PoolPermissions, PoolSignature},
     fee::LinearFee,
-    key::EitherEd25519SecretKey,
     rewards::TaxType,
     transaction::{SingleAccountBindingSignature, TxBuilder},
 };
@@ -180,10 +179,9 @@ impl Settings {
                             .set_ios(&[], &[])
                             .set_witnesses(&[]);
                         let auth_data = txb.get_auth_data();
-                        let sig0 = SingleAccountBindingSignature::new(
-                            &EitherEd25519SecretKey::Normal(owner),
-                            &auth_data,
-                        );
+                        let sig0 = SingleAccountBindingSignature::new(&auth_data, |d| {
+                            owner.sign_slice(&d.0)
+                        });
                         let owner_signed = PoolOwnersSigned {
                             signatures: vec![(0, sig0)],
                         };
@@ -414,7 +412,7 @@ impl Prepare for Mempool {
 }
 
 impl Prepare for Explorer {
-    fn prepare<RNG>(c_ontext: &mut Context<RNG>) -> Self
+    fn prepare<RNG>(_context: &mut Context<RNG>) -> Self
     where
         RNG: RngCore,
     {

--- a/jormungandr-scenario-tests/src/wallet/account.rs
+++ b/jormungandr-scenario-tests/src/wallet/account.rs
@@ -86,7 +86,9 @@ impl Wallet {
             .set_witnesses(&[]);
         let auth_data = txb.get_auth_data();
 
-        let sig = AccountBindingSignature::new_single(self.signing_key.as_ref(), &auth_data);
+        let sig = AccountBindingSignature::new_single(&auth_data, |d| {
+            self.signing_key.as_ref().sign_slice(&d.0)
+        });
         SignedCertificate::StakeDelegation(stake_delegation, sig)
     }
 
@@ -99,7 +101,7 @@ impl Wallet {
             &block0_hash.clone().into_hash(),
             signing_data,
             self.internal_counter(),
-            self.signing_key().as_ref(),
+            |d| self.signing_key().as_ref().sign(d),
         ))
     }
 


### PR DESCRIPTION
* don't use secret key directly in the library code and replace
  by signing closure to move away from having direct secret key
  and also to remove the need for the different ed25519 secret
  types (normal, extended, bip32).
* update ed25519-bip32 to 0.3