### PR TITLE
Don't hold the fragment pool lock for too long

### DIFF
--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -86,8 +86,10 @@ impl Pool {
     }
 
     pub async fn poll_purge(&mut self) -> Result<(), time::Error> {
-        let mut pool = self.pool.lock().await;
-        future::poll_fn(move |cx| pool.poll_purge(cx)).await?;
+        {
+            let mut pool = self.pool.lock().await;
+            future::poll_fn(move |cx| pool.poll_purge(cx)).await?;
+        }
         self.logs.poll_purge().await
     }
 


### PR DESCRIPTION
The scoped lock guard held the lock also while
the poll_purge method is called on logs.