### PR TITLE
use the View instead of the All

### DIFF
--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -169,14 +169,15 @@ impl P2pTopology {
     pub fn list_available_limit<E>(
         &self,
         n: usize,
-    ) -> impl Future<Item = Vec<poldercast::Node>, Error = E> {
-        self.read().map(move |topology| {
+    ) -> impl Future<Item = Vec<poldercast::NodeInfo>, Error = E> {
+        // we need write access because we need to be able to update
+        // the used marker in poldercast when querying the view
+        // otherwise the operation is just a Read anyway
+        self.write().map(move |mut topology| {
             topology
-                .nodes()
-                .all_available_nodes()
+                .view(None, poldercast::Selection::Any)
                 .into_iter()
                 .take(n)
-                .cloned()
                 .collect()
         })
     }


### PR DESCRIPTION
this will give a more granulated list of peers:

* partly not random: rings will return the neighbours and the vicinity will return the similar nodes for everyone;
* partly random: poldercast's module `cyclon` will peek a random set of nodes;