### PR TITLE
Blockchain tip tracking in stats_counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,7 @@ dependencies = [
  "actix-rt",
  "actix-threadpool",
  "actix-web",
+ "arc-swap",
  "async-trait",
  "bech32",
  "bincode",

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -16,6 +16,7 @@ actix-cors = "0.2.0"
 actix-rt = "^1.0.0"
 actix-threadpool = "^0.3.1"
 actix-web = { version = "2.0.0", default-features = false, features = [ "rustls" ] }
+arc-swap = "0.4.4"
 juniper = "0.14.2"
 bincode = "1.0.1"
 bytes = "0.4"

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -409,7 +409,7 @@ async fn process_leadership_block(
     try_request_fragment_removal(&mut tx_msg_box, fragments, new_block_ref.header())
         .map_err(|_| "cannot remove fragments from pool".to_string())?;
 
-    // Add block to
+    // Track block as new new tip block
     stats_counter.set_tip_block(Some(block.clone()));
 
     process_and_propagate_new_ref(
@@ -550,6 +550,7 @@ async fn process_network_blocks(
                 match res {
                     Ok(Some(r)) => {
                         stats_counter.add_block_recv_cnt(1);
+                        // Track block as new new tip block
                         stats_counter.set_tip_block(Some(block.clone()));
                         stream = new_stream;
                         candidate = Some(r);

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -369,15 +369,11 @@ async fn process_and_propagate_new_ref(
     tip: Tip,
     new_block_ref: Arc<Ref>,
     network_msg_box: MessageBox<NetworkMsg>,
-    stats_counter: StatsCounter,
 ) -> Result<(), Error> {
     let header = new_block_ref.header().clone();
     let hash = header.hash();
 
     debug!(logger, "processing the new block and propagating"; "hash" => %hash);
-
-    let block = blockchain.storage().get(hash).await?;
-    stats_counter.set_tip_block(block);
 
     process_new_ref(logger, blockchain, tip, new_block_ref).await?;
 
@@ -418,7 +414,6 @@ async fn process_leadership_block(
         blockchain_tip,
         Arc::clone(&new_block_ref),
         network_msg_box,
-        stats_counter,
     )
     .await?;
 
@@ -585,7 +580,6 @@ async fn process_network_blocks(
                 blockchain_tip,
                 Arc::clone(&new_block_ref),
                 network_msg_box,
-                stats_counter,
             )
             .await?;
             Ok(r)

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -406,7 +406,7 @@ async fn process_leadership_block(
         .map_err(|_| "cannot remove fragments from pool".to_string())?;
 
     // Track block as new new tip block
-    stats_counter.set_tip_block(Some(block.clone()));
+    stats_counter.set_tip_block(Some(block.clone())).await;
 
     process_and_propagate_new_ref(
         &logger,
@@ -546,7 +546,7 @@ async fn process_network_blocks(
                     Ok(Some(r)) => {
                         stats_counter.add_block_recv_cnt(1);
                         // Track block as new new tip block
-                        stats_counter.set_tip_block(Some(block.clone()));
+                        stats_counter.set_tip_block(Some(block.clone())).await;
                         stream = new_stream;
                         candidate = Some(r);
                     }

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -409,6 +409,9 @@ async fn process_leadership_block(
     try_request_fragment_removal(&mut tx_msg_box, fragments, new_block_ref.header())
         .map_err(|_| "cannot remove fragments from pool".to_string())?;
 
+    // Add block to
+    stats_counter.set_tip_block(Some(block.clone()));
+
     process_and_propagate_new_ref(
         &logger,
         &mut blockchain,
@@ -537,7 +540,7 @@ async fn process_network_blocks(
             Some(block) => {
                 let res = process_network_block(
                     &mut blockchain,
-                    block,
+                    block.clone(),
                     &mut tx_msg_box,
                     explorer_msg_box.as_mut(),
                     &mut get_next_block_scheduler,
@@ -547,6 +550,7 @@ async fn process_network_blocks(
                 match res {
                     Ok(Some(r)) => {
                         stats_counter.add_block_recv_cnt(1);
+                        stats_counter.set_tip_block(Some(block.clone()));
                         stream = new_stream;
                         candidate = Some(r);
                     }

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -527,7 +527,7 @@ async fn process_network_blocks(
     let (stream, reply) = handle.into_stream_and_reply();
     let mut stream = stream.map_err(|()| Error::from("Error while processing block input stream"));
     let mut candidate = None;
-    let mut latest_block : Option<Block> = None;
+    let mut latest_block: Option<Block> = None;
 
     let maybe_updated: Option<Arc<Ref>> = loop {
         let (maybe_block, new_stream) = stream.into_future().map_err(|(e, _)| e).compat().await?;

--- a/jormungandr/src/rest/mod.rs
+++ b/jormungandr/src/rest/mod.rs
@@ -139,5 +139,12 @@ async fn update_stats_tip_from_storage(context: &FullContext) {
         .compat()
         .await
         .unwrap_or(None);
-    context.stats_counter.set_tip_block(block.clone()).await;
+
+    // Update block if found
+    match block {
+        Some(b) => {
+            context.stats_counter.set_tip_block(Arc::new(b));
+        }
+        None => (),
+    }
 }

--- a/jormungandr/src/rest/mod.rs
+++ b/jormungandr/src/rest/mod.rs
@@ -24,8 +24,8 @@ use crate::intercom::{NetworkMsg, TransactionMsg};
 use crate::utils::async_msg::MessageBox;
 
 use chain_impl_mockchain::block::Block;
-use futures03::executor::block_on;
 use futures03::compat::Future01CompatExt;
+use futures03::executor::block_on;
 use jormungandr_lib::interfaces::NodeState;
 use tokio02::sync::RwLock;
 

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -27,8 +27,8 @@ use jormungandr_lib::interfaces::NodeState;
 use std::str::FromStr;
 use std::sync::Arc;
 
-pub use crate::rest::{Context, FullContext};
 use crate::rest::update_stats_tip_from_storage;
+pub use crate::rest::{Context, FullContext};
 
 async fn chain_tip(context: &Data<Context>) -> Result<Arc<Ref>, Error> {
     Ok(chain_tip_from_full(&*context.try_full().await?).await)
@@ -122,7 +122,6 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
     let mut block_tx_count = 0u64;
     let mut block_input_sum = Value::zero();
     let mut block_fee_sum = Value::zero();
-
 
     let mut header_block = context.stats_counter.get_tip_block().await;
 

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -121,7 +121,7 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
     let mut block_tx_count = 0u64;
     let mut block_input_sum = Value::zero();
     let mut block_fee_sum = Value::zero();
-    let header_block = context.stats_counter.get_tip_block();
+    let header_block = context.stats_counter.get_tip_block().await;
     header_block
         .as_ref()
         .as_ref()

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -123,13 +123,13 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
     let mut block_input_sum = Value::zero();
     let mut block_fee_sum = Value::zero();
 
-    let mut header_block = context.stats_counter.get_tip_block().await;
+    let mut header_block = context.stats_counter.get_tip_block();
 
     // In case we do not have a cached block in the stats_counter we can retrieve it from the
     // storage, this should happen just once.
     if header_block.is_none() {
         update_stats_tip_from_storage(context).await;
-        header_block = context.stats_counter.get_tip_block().await;
+        header_block = context.stats_counter.get_tip_block();
     }
 
     header_block

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -122,6 +122,7 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
     let mut block_input_sum = Value::zero();
     let mut block_fee_sum = Value::zero();
     let header_block = context.stats_counter.get_tip_block().await;
+
     header_block
         .as_ref()
         .as_ref()

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -123,7 +123,8 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
     let mut block_fee_sum = Value::zero();
     let header_block = context.stats_counter.get_tip_block();
     header_block
-        .as_ref().as_ref()
+        .as_ref()
+        .as_ref()
         .ok_or(ErrorInternalServerError("Could not find block for tip"))?
         .contents
         .iter()

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -123,6 +123,7 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
     let mut block_fee_sum = Value::zero();
     let header_block = context.stats_counter.get_tip_block();
     header_block
+        .as_ref().as_ref()
         .ok_or(ErrorInternalServerError("Could not find block for tip"))?
         .contents
         .iter()

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -121,13 +121,8 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
     let mut block_tx_count = 0u64;
     let mut block_input_sum = Value::zero();
     let mut block_fee_sum = Value::zero();
-    context
-        .blockchain
-        .storage()
-        .get(tip.hash())
-        .compat()
-        .await
-        .map_err(ErrorInternalServerError)?
+    let header_block = context.stats_counter.get_tip_block();
+    header_block
         .ok_or(ErrorInternalServerError("Could not find block for tip"))?
         .contents
         .iter()
@@ -136,7 +131,7 @@ async fn create_stats(context: &FullContext) -> Result<serde_json::Value, Error>
                 Ok((t.total_input()?, t.total_output()?))
             }
 
-            let (total_input, total_output) = match fragment {
+            let (total_input, total_output) = match &fragment {
                 Fragment::Transaction(tx) => totals(tx),
                 Fragment::OwnerStakeDelegation(tx) => totals(tx),
                 Fragment::StakeDelegation(tx) => totals(tx),

--- a/jormungandr/src/stats_counter.rs
+++ b/jormungandr/src/stats_counter.rs
@@ -4,7 +4,6 @@ use jormungandr_lib::time::SecondsSinceUnixEpoch;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use tokio02::sync::RwLock;
 
 const SLOT_START_TIME_UNDEFINED: u64 = u64::max_value();
 

--- a/jormungandr/src/stats_counter.rs
+++ b/jormungandr/src/stats_counter.rs
@@ -80,6 +80,6 @@ impl StatsCounter {
     }
 
     pub fn get_tip_block(&self) -> Option<Arc<Block>> {
-        self.stats.tip_block.load_full().clone()
+        self.stats.tip_block.load_full()
     }
 }

--- a/jormungandr/src/stats_counter.rs
+++ b/jormungandr/src/stats_counter.rs
@@ -1,7 +1,8 @@
 use chain_impl_mockchain::block::Block;
 use jormungandr_lib::time::SecondsSinceUnixEpoch;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio02::sync::RwLock;
 use std::time::Instant;
 
 const SLOT_START_TIME_UNDEFINED: u64 = u64::max_value();
@@ -73,11 +74,11 @@ impl StatsCounter {
         .map(SecondsSinceUnixEpoch::from_secs)
     }
 
-    pub fn set_tip_block(&self, block: Option<Block>) {
-        *self.stats.tip_block.write().unwrap() = Arc::new(block);
+    pub async fn set_tip_block(&self, block: Option<Block>) {
+        *self.stats.tip_block.write().await = Arc::new(block);
     }
 
-    pub fn get_tip_block(&self) -> Arc<Option<Block>> {
-        self.stats.tip_block.read().unwrap().clone()
+    pub async fn get_tip_block(&self) -> Arc<Option<Block>> {
+        self.stats.tip_block.read().await.clone()
     }
 }

--- a/jormungandr/src/stats_counter.rs
+++ b/jormungandr/src/stats_counter.rs
@@ -17,7 +17,7 @@ struct StatsCounterImpl {
     block_recv_cnt: AtomicUsize,
     start_time: Instant,
     slot_start_time: AtomicU64,
-    tip_block: RwLock<Option<Block>>,
+    tip_block: RwLock<Arc<Option<Block>>>,
 }
 
 impl Default for StatsCounterImpl {
@@ -27,7 +27,7 @@ impl Default for StatsCounterImpl {
             block_recv_cnt: AtomicUsize::default(),
             start_time: Instant::now(),
             slot_start_time: AtomicU64::new(SLOT_START_TIME_UNDEFINED),
-            tip_block: RwLock::new(None),
+            tip_block: RwLock::new(Arc::new(None)),
         }
     }
 }
@@ -74,10 +74,10 @@ impl StatsCounter {
     }
 
     pub fn set_tip_block(&self, block: Option<Block>) {
-        *self.stats.tip_block.write().unwrap() = block;
+        *self.stats.tip_block.write().unwrap() = Arc::new(block);
     }
 
-    pub fn get_tip_block(&self) -> Option<Block> {
+    pub fn get_tip_block(&self) -> Arc<Option<Block>> {
         self.stats.tip_block.read().unwrap().clone()
     }
 }

--- a/jormungandr/src/stats_counter.rs
+++ b/jormungandr/src/stats_counter.rs
@@ -2,8 +2,8 @@ use chain_impl_mockchain::block::Block;
 use jormungandr_lib::time::SecondsSinceUnixEpoch;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio02::sync::RwLock;
 use std::time::Instant;
+use tokio02::sync::RwLock;
 
 const SLOT_START_TIME_UNDEFINED: u64 = u64::max_value();
 

--- a/jormungandr/src/stats_counter.rs
+++ b/jormungandr/src/stats_counter.rs
@@ -1,6 +1,7 @@
+use chain_impl_mockchain::block::Block;
 use jormungandr_lib::time::SecondsSinceUnixEpoch;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 const SLOT_START_TIME_UNDEFINED: u64 = u64::max_value();
@@ -16,6 +17,7 @@ struct StatsCounterImpl {
     block_recv_cnt: AtomicUsize,
     start_time: Instant,
     slot_start_time: AtomicU64,
+    tip_block: RwLock<Option<Block>>,
 }
 
 impl Default for StatsCounterImpl {
@@ -25,6 +27,7 @@ impl Default for StatsCounterImpl {
             block_recv_cnt: AtomicUsize::default(),
             start_time: Instant::now(),
             slot_start_time: AtomicU64::new(SLOT_START_TIME_UNDEFINED),
+            tip_block: RwLock::new(None),
         }
     }
 }
@@ -68,5 +71,13 @@ impl StatsCounter {
             slot_start_time => Some(slot_start_time),
         }
         .map(SecondsSinceUnixEpoch::from_secs)
+    }
+
+    pub fn set_tip_block(&self, block: Option<Block>) {
+        *self.stats.tip_block.write().unwrap() = block;
+    }
+
+    pub fn get_tip_block(&self) -> Option<Block> {
+        self.stats.tip_block.read().unwrap().clone()
     }
 }


### PR DESCRIPTION
In order to avoid storage access from the REST service, the latest tip block is dumped into the stats_counter each time it is updated. That way is directly available by the REST service when it is needed.