### PR TITLE
remove log_ttl for the leadership and use a LruCache instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "linked-hash-map",
+ "lru",
  "network-core",
  "network-grpc",
  "nix 0.17.0",

--- a/doc/configuration/leadership.md
+++ b/doc/configuration/leadership.md
@@ -3,11 +3,9 @@ as follow:
 
 ```yaml
 leadership:
-    log_ttl: 1h
-    garbage_collection_interval: 15m
+    logs_capacity: 1024
 ```
 
-* `log_ttl` describes for how long the node will keep logs of leader events.
-  This is link to the data you receives from the REST leadership logs end point;
-* `garbage_collection_interval` describes the interval between 2 garbage collection
-  runs: i.e. when the node removes item logs that have timed out
+* `logs_capacity`: the maximum number of logs to keep in memory. Once the capacity
+  is reached, older logs will be removed in order to leave more space for new ones
+  [default: 1024]

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -64,6 +64,7 @@ tokio-threadpool = "0.1"
 bech32 = "0.7"
 async-trait = "0.1"
 reqwest = "0.10"
+lru = "^0.4.3"
 
 [build-dependencies]
 versionisator = "1.0.2"

--- a/jormungandr/src/leadership/logs.rs
+++ b/jormungandr/src/leadership/logs.rs
@@ -1,8 +1,7 @@
-use futures03::future::poll_fn;
 pub use jormungandr_lib::interfaces::LeadershipLogStatus;
 use jormungandr_lib::interfaces::{LeadershipLog, LeadershipLogId};
-use std::{sync::Arc, time::Duration};
-use tokio02::{sync::RwLock, time};
+use std::sync::Arc;
+use tokio02::sync::RwLock;
 
 /// all leadership logs, allow for following up on the different entity
 /// of the blockchain
@@ -53,15 +52,11 @@ impl LeadershipLogHandle {
 }
 
 impl Logs {
-    /// create a Leadership Logs. This will make sure we delete from time to time
-    /// some of the logs that are not necessary.
+    /// create a Leadership Logs. Logs will be removed once the `Logs` passed
+    /// beyond a certain number of entries.
     ///
-    /// the `ttl` can be any sensible value the user will see appropriate. The log will
-    /// live at least its scheduled time + `ttl`.
-    ///
-    /// On changes, the log's TTL will be reset to this `ttl`.
-    pub fn new(ttl: Duration) -> Self {
-        Logs(Arc::new(RwLock::new(internal::Logs::new(ttl))))
+    pub fn new(cap: usize) -> Self {
+        Logs(Arc::new(RwLock::new(internal::Logs::new(cap))))
     }
 
     pub async fn insert(&self, log: LeadershipLog) -> Result<LeadershipLogHandle, ()> {
@@ -91,12 +86,6 @@ impl Logs {
         inner.write().await.mark_finished(&leadership_log_id.into());
     }
 
-    pub async fn poll_purge(&mut self) -> Result<(), time::Error> {
-        let inner = self.0.clone();
-        let mut guard = inner.write().await;
-        poll_fn(move |mut cx| guard.poll_purge(&mut cx)).await
-    }
-
     pub async fn logs(&self) -> Vec<LeadershipLog> {
         let inner = self.0.clone();
         let guard = inner.read().await;
@@ -106,60 +95,29 @@ impl Logs {
 
 pub(super) mod internal {
     use super::{LeadershipLog, LeadershipLogId, LeadershipLogStatus};
-    use futures03::{
-        task::{Context, Poll},
-        Stream,
-    };
-    use std::{
-        collections::HashMap,
-        pin::Pin,
-        time::{Duration, Instant},
-    };
-    use tokio02::time::{self, delay_queue, DelayQueue, Instant as TokioInstant};
+    use lru::LruCache;
 
     pub struct Logs {
-        entries: HashMap<LeadershipLogId, (LeadershipLog, delay_queue::Key)>,
-        expirations: Pin<Box<DelayQueue<LeadershipLogId>>>,
-        ttl: Duration,
+        entries: LruCache<LeadershipLogId, LeadershipLog>,
     }
 
     impl Logs {
-        pub fn new(ttl: Duration) -> Self {
+        pub fn new(cap: usize) -> Self {
             Logs {
-                entries: HashMap::new(),
-                expirations: Box::pin(DelayQueue::new()),
-                ttl,
+                entries: LruCache::new(cap),
             }
         }
 
         pub fn insert(&mut self, log: LeadershipLog) -> LeadershipLogId {
             let id = log.leadership_log_id();
 
-            let now = std::time::SystemTime::now();
-            let minimal_duration = if &now < log.scheduled_at_time().as_ref() {
-                log.scheduled_at_time()
-                    .as_ref()
-                    .duration_since(now)
-                    .unwrap()
-            } else {
-                Duration::from_secs(0)
-            };
-            let ttl = minimal_duration.checked_add(self.ttl).unwrap_or(self.ttl);
-
-            let delay = self.expirations.insert(id.clone(), ttl);
-
-            self.entries.insert(id, (log, delay));
+            self.entries.put(id, log);
             id
         }
 
         pub fn mark_wake(&mut self, leadership_log_id: &LeadershipLogId) {
-            if let Some((ref mut log, ref key)) = self.entries.get_mut(leadership_log_id) {
+            if let Some(ref mut log) = self.entries.get_mut(leadership_log_id) {
                 log.mark_wake();
-
-                self.expirations
-                    .reset_at(key, TokioInstant::from_std(Instant::now() + self.ttl));
-            } else {
-                unimplemented!()
             }
         }
 
@@ -168,46 +126,19 @@ pub(super) mod internal {
             leadership_log_id: &LeadershipLogId,
             status: LeadershipLogStatus,
         ) {
-            if let Some((ref mut log, ref key)) = self.entries.get_mut(leadership_log_id) {
+            if let Some(ref mut log) = self.entries.get_mut(leadership_log_id) {
                 log.set_status(status);
-
-                self.expirations
-                    .reset_at(key, TokioInstant::from_std(Instant::now() + self.ttl));
-            } else {
-                unimplemented!()
             }
         }
 
         pub fn mark_finished(&mut self, leadership_log_id: &LeadershipLogId) {
-            if let Some((ref mut log, ref key)) = self.entries.get_mut(leadership_log_id) {
+            if let Some(ref mut log) = self.entries.get_mut(leadership_log_id) {
                 log.mark_finished();
-
-                self.expirations
-                    .reset_at(key, TokioInstant::from_std(Instant::now() + self.ttl));
-            } else {
-                unimplemented!()
-            }
-        }
-
-        pub fn poll_purge(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), time::Error>> {
-            loop {
-                match self.expirations.as_mut().poll_next(cx) {
-                    Poll::Ready(Some(Ok(entry))) => {
-                        self.entries.remove(entry.get_ref());
-                    }
-                    Poll::Ready(Some(Err(e))) => return Poll::Ready(Err(e)),
-                    Poll::Ready(None) => return Poll::Ready(Ok(())),
-
-                    // Here Pending means there are still items in the DelayQueue but
-                    // they are not expired. We don't want this function to wait for these
-                    // ones to expired. We only cared about removing the expired ones.
-                    Poll::Pending => return Poll::Ready(Ok(())),
-                }
             }
         }
 
         pub fn logs<'a>(&'a self) -> impl Iterator<Item = &'a LeadershipLog> {
-            self.entries.values().map(|(v, _)| v)
+            self.entries.iter().map(|(_, v)| v)
         }
     }
 }

--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -79,24 +79,14 @@ impl Module {
     pub async fn new(
         service_info: TokioServiceInfo,
         logs: Logs,
-        garbage_collection_interval: Duration,
         tip: Tip,
         pool: MessageBox<TransactionMsg>,
         enclave: Enclave,
         block_message: MessageBox<BlockMsg>,
     ) -> Result<Self, LeadershipError> {
-        let logs_to_purge = logs.clone();
+        let tip_ref = tip.get_ref_std().await;
 
-        service_info.run_periodic(
-            "garbage collection",
-            garbage_collection_interval,
-            move || {
-                let mut logs_to_purge_local = logs_to_purge.clone();
-                Box::pin(async move { logs_to_purge_local.poll_purge().await }).compat()
-            },
-        );
-
-        tip.get_ref().compat().await.map(move |tip_ref| Self {
+        Ok(Self {
             schedule: Schedule::default(),
             service_info,
             logs,

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -96,9 +96,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
     let blockchain_tip = bootstrapped_node.blockchain_tip;
     let blockchain = bootstrapped_node.blockchain;
     let leadership_logs =
-        leadership::Logs::new(bootstrapped_node.settings.leadership.log_ttl.into());
-    let leadership_garbage_collection_interval =
-        bootstrapped_node.settings.leadership.log_ttl.into();
+        leadership::Logs::new(bootstrapped_node.settings.leadership.logs_capacity);
 
     let topology = P2pTopology::new(
         &bootstrapped_node.settings.network,
@@ -236,7 +234,6 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
             let fut = leadership::Module::new(
                 info,
                 leadership_logs,
-                leadership_garbage_collection_interval,
                 blockchain_tip,
                 fragment_msgbox,
                 enclave,

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -174,11 +174,10 @@ pub struct TrustedPeer {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Leadership {
-    /// LeadershipLog time to live, it is for information purposes, we log all the Leadership
-    /// event logs in a cache. The log will be discarded at the end of the ttl.
-    pub log_ttl: Duration,
-    /// interval between 2 garbage collection check logs
-    pub garbage_collection_interval: Duration,
+    /// the number of entries allowed in the leadership logs, beyond this point
+    /// the least recently used log will be erased from the logs for a new one
+    /// to be inserted.
+    pub logs_capacity: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,8 +234,7 @@ impl Default for P2pConfig {
 impl Default for Leadership {
     fn default() -> Self {
         Leadership {
-            log_ttl: Duration::new(3600, 0),
-            garbage_collection_interval: Duration::new(3600 / 4, 0),
+            logs_capacity: 1_024,
         }
     }
 }


### PR DESCRIPTION
breaking change, now the leadership settings (from the configuration file) does not require any of 

```yaml
leadership:
    log_ttl: 1h
    garbage_collection_interval: 15m	
```

but

```yaml
leadership:
    logs_capacity: 1024
```

The default value is 1024. It means that the number of entries in the logs won't exceed 1024. Older entries will be removed to make space to new ones.