### PR TITLE
Remove delay queue from ref cache

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -260,10 +260,10 @@ impl AppliedBlock {
 }
 
 impl Blockchain {
-    pub fn new(block0: HeaderHash, storage: Storage) -> Self {
+    pub fn new(block0: HeaderHash, storage: Storage, cache_capacity: usize) -> Self {
         Blockchain {
             branches: Branches::new(),
-            ref_cache: RefCache::new(),
+            ref_cache: RefCache::new(cache_capacity),
             ledgers: Multiverse::new(),
             storage,
             block0,

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -61,7 +61,7 @@ use chain_impl_mockchain::{leadership::Verification, ledger};
 use chain_storage_sqlite_old::Error as StorageError;
 use chain_time::TimeFrame;
 use slog::Logger;
-use std::{convert::Infallible, sync::Arc, time::Duration};
+use std::{convert::Infallible, sync::Arc};
 use tokio::prelude::{future as future01, future::Either as Either01, Future as Future01};
 use tokio02::stream::StreamExt;
 use tokio_compat::prelude::*;
@@ -260,10 +260,10 @@ impl AppliedBlock {
 }
 
 impl Blockchain {
-    pub fn new(block0: HeaderHash, storage: Storage, ref_cache_ttl: Duration) -> Self {
+    pub fn new(block0: HeaderHash, storage: Storage) -> Self {
         Blockchain {
             branches: Branches::new(),
-            ref_cache: RefCache::new(ref_cache_ttl),
+            ref_cache: RefCache::new(),
             ledgers: Multiverse::new(),
             storage,
             block0,

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -337,8 +337,10 @@ fn bootstrap(initialized_node: InitializedNode) -> Result<BootstrappedNode, star
 
     let block0_explorer = block0.clone();
 
+    let cache_capacity = 10_240;
+
     let (blockchain, blockchain_tip) =
-        start_up::load_blockchain(block0, storage, &bootstrap_logger)?;
+        start_up::load_blockchain(block0, storage, cache_capacity, &bootstrap_logger)?;
 
     let mut bootstrap_attempt: usize = 0;
     loop {

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -337,11 +337,8 @@ fn bootstrap(initialized_node: InitializedNode) -> Result<BootstrappedNode, star
 
     let block0_explorer = block0.clone();
 
-    // TODO: we should get this value from the configuration
-    let block_cache_ttl: Duration = Duration::from_secs(5 * 24 * 3600);
-
     let (blockchain, blockchain_tip) =
-        start_up::load_blockchain(block0, storage, block_cache_ttl, &bootstrap_logger)?;
+        start_up::load_blockchain(block0, storage, &bootstrap_logger)?;
 
     let mut bootstrap_attempt: usize = 0;
     loop {

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -337,7 +337,7 @@ fn bootstrap(initialized_node: InitializedNode) -> Result<BootstrappedNode, star
 
     let block0_explorer = block0.clone();
 
-    let cache_capacity = 10_240;
+    let cache_capacity = 102_400;
 
     let (blockchain, blockchain_tip) =
         start_up::load_blockchain(block0, storage, cache_capacity, &bootstrap_logger)?;

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use chain_storage_sqlite_old::{BlockStore, BlockStoreConnection};
 use slog::Logger;
-use std::time::Duration;
 use tokio_compat::runtime;
 
 pub type NodeStorage = BlockStore;
@@ -191,9 +190,10 @@ pub fn prepare_block_0(
 pub fn load_blockchain(
     block0: Block,
     storage: Storage,
+    cache_capacity: usize,
     logger: &Logger,
 ) -> Result<(Blockchain, Tip), Error> {
-    let blockchain = Blockchain::new(block0.header.hash(), storage);
+    let blockchain = Blockchain::new(block0.header.hash(), storage, cache_capacity);
 
     let mut rt = tokio02::runtime::Runtime::new().unwrap();
     rt.block_on(async {

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -191,10 +191,9 @@ pub fn prepare_block_0(
 pub fn load_blockchain(
     block0: Block,
     storage: Storage,
-    block_cache_ttl: Duration,
     logger: &Logger,
 ) -> Result<(Blockchain, Tip), Error> {
-    let blockchain = Blockchain::new(block0.header.hash(), storage, block_cache_ttl);
+    let blockchain = Blockchain::new(block0.header.hash(), storage);
 
     let mut rt = tokio02::runtime::Runtime::new().unwrap();
     rt.block_on(async {


### PR DESCRIPTION
This continues the work to remove the slow entry points where some locks are blocking un order to perform GC.