### PR TITLE
Time limits on client connections

### DIFF
--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -28,13 +28,13 @@ pub fn connect(
     channels: Channels,
 ) -> (ConnectHandle, ConnectFuture<grpc::ConnectFuture>) {
     let (sender, receiver) = oneshot::channel();
-    let addr = state.connection;
+    let peer = state.peer();
     let node_id = state.global.topology.node_id();
     let builder = Some(ClientBuilder {
         channels,
         logger: state.logger,
     });
-    let cf = grpc::connect(addr, Some(node_id), state.global.executor.clone());
+    let cf = grpc::connect(&peer, Some(node_id), state.global.executor.clone());
     let handle = ConnectHandle { receiver };
     let future = ConnectFuture {
         sender: Some(sender),

--- a/jormungandr/src/network/grpc/client.rs
+++ b/jormungandr/src/network/grpc/client.rs
@@ -41,7 +41,7 @@ pub type ConnectError = network_grpc::client::ConnectError<io::Error>;
 
 pub fn connect(addr: SocketAddr, node_id: Option<Id>, executor: TaskExecutor) -> ConnectFuture {
     let uri = destination_uri(addr);
-    let mut connector = HttpConnector::new(2);
+    let mut connector = HttpConnector::new_with_executor(executor.clone(), None);
     connector.set_nodelay(true);
     let mut builder = Connect::with_executor(connector, executor);
     if let Some(id) = node_id {

--- a/jormungandr/src/network/grpc/client.rs
+++ b/jormungandr/src/network/grpc/client.rs
@@ -1,7 +1,7 @@
 use crate::{
     blockcfg::{Block, HeaderHash},
     network::{p2p::Id, BlockConfig},
-    settings::start::network::Peer,
+    settings::start::network::{Peer, Protocol},
 };
 use futures::prelude::*;
 use http::{HttpTryFrom, Uri};
@@ -11,6 +11,7 @@ use network_core::error as core_error;
 use network_grpc::client::Connect;
 use slog::Logger;
 use thiserror::Error;
+use tokio::timer::{self, Timeout};
 use tokio_compat::prelude::*;
 use tokio_compat::runtime::{Runtime, TaskExecutor};
 
@@ -35,19 +36,54 @@ pub enum FetchBlockError {
 }
 
 pub type Connection = network_grpc::client::Connection<BlockConfig>;
-pub type ConnectFuture =
-    network_grpc::client::ConnectFuture<BlockConfig, HttpConnector, TaskExecutor>;
-pub type ConnectError = network_grpc::client::ConnectError<io::Error>;
 
-pub fn connect(addr: SocketAddr, node_id: Option<Id>, executor: TaskExecutor) -> ConnectFuture {
-    let uri = destination_uri(addr);
+#[derive(Debug, thiserror::Error)]
+pub enum ConnectError {
+    #[error("{0}")]
+    Failed(#[source] network_grpc::client::ConnectError<io::Error>),
+    #[error("connection timed out")]
+    TimedOut,
+    #[error("timer error occurred during connection")]
+    Timer(#[source] timer::Error),
+}
+
+pub struct ConnectFuture {
+    inner: Timeout<network_grpc::client::ConnectFuture<BlockConfig, HttpConnector, TaskExecutor>>,
+}
+
+impl Future for ConnectFuture {
+    type Item = Connection;
+    type Error = ConnectError;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll().map_err(|e| {
+            if e.is_inner() {
+                return ConnectError::Failed(e.into_inner().unwrap());
+            }
+            if e.is_elapsed() {
+                return ConnectError::TimedOut;
+            }
+            if e.is_timer() {
+                return ConnectError::Timer(e.into_timer().unwrap());
+            }
+            unreachable!("unexpected timeout error: {:?}", e);
+        })
+    }
+}
+
+pub fn connect(peer: &Peer, node_id: Option<Id>, executor: TaskExecutor) -> ConnectFuture {
+    assert!(peer.protocol == Protocol::Grpc);
+    let uri = destination_uri(peer.connection);
     let mut connector = HttpConnector::new_with_executor(executor.clone(), None);
     connector.set_nodelay(true);
     let mut builder = Connect::with_executor(connector, executor);
     if let Some(id) = node_id {
         builder.node_id(id);
     }
-    builder.connect(Destination::try_from_uri(uri).unwrap())
+    let connect = builder.connect(Destination::try_from_uri(uri).unwrap());
+    ConnectFuture {
+        inner: Timeout::new(connect, peer.timeout),
+    }
 }
 
 fn destination_uri(addr: SocketAddr) -> Uri {
@@ -62,13 +98,13 @@ fn destination_uri(addr: SocketAddr) -> Uri {
 // Fetches a block from a network peer in a one-off, blocking call.
 // This function is used during node bootstrap to fetch the genesis block.
 pub fn fetch_block(
-    peer: Peer,
+    peer: &Peer,
     hash: HeaderHash,
     logger: &Logger,
 ) -> Result<Block, FetchBlockError> {
     info!(logger, "fetching block {}", hash);
     let mut runtime = Runtime::new().map_err(|e| FetchBlockError::RuntimeInit { source: e })?;
-    let fetch = connect(peer.address(), None, runtime.executor())
+    let fetch = connect(peer, None, runtime.executor())
         .map_err(|err| FetchBlockError::Connect { source: err })
         .and_then(move |client: Connection| {
             client

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -42,7 +42,7 @@ pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
 pub const DEFAULT_MAX_CLIENT_CONNECTIONS: usize = 8;
 
 /// The default timeout for connections
-const DEFAULT_TIMEOUT_MILLISECONDS: u64 = 10_000;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
 ///
 /// The network static configuration settings
@@ -109,10 +109,7 @@ impl From<super::config::TrustedPeer> for TrustedPeer {
 
 impl Peer {
     pub fn new(connection: SocketAddr) -> Self {
-        Peer::with_timeout(
-            connection,
-            Duration::from_millis(DEFAULT_TIMEOUT_MILLISECONDS),
-        )
+        Peer::with_timeout(connection, DEFAULT_TIMEOUT)
     }
 
     pub fn with_timeout(connection: SocketAddr, timeout: Duration) -> Self {
@@ -133,7 +130,7 @@ impl Listen {
         Listen {
             connection,
             protocol: Protocol::Grpc,
-            timeout: Duration::from_micros(DEFAULT_TIMEOUT_MILLISECONDS),
+            timeout: DEFAULT_TIMEOUT,
         }
     }
 

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -41,7 +41,8 @@ pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
 /// used unless the corresponding configuration option is specified.
 pub const DEFAULT_MAX_CLIENT_CONNECTIONS: usize = 8;
 
-const DEFAULT_TIMEOUT_MICROSECONDS: u64 = 500_000;
+/// The default timeout for connections
+const DEFAULT_TIMEOUT_MILLISECONDS: u64 = 10_000;
 
 ///
 /// The network static configuration settings
@@ -107,24 +108,32 @@ impl From<super::config::TrustedPeer> for TrustedPeer {
 }
 
 impl Peer {
-    pub fn new(connection: SocketAddr, protocol: Protocol) -> Self {
+    pub fn new(connection: SocketAddr) -> Self {
+        Peer::with_timeout(
+            connection,
+            Duration::from_millis(DEFAULT_TIMEOUT_MILLISECONDS),
+        )
+    }
+
+    pub fn with_timeout(connection: SocketAddr, timeout: Duration) -> Self {
         Peer {
             connection,
-            protocol,
-            timeout: Duration::from_micros(DEFAULT_TIMEOUT_MICROSECONDS),
+            protocol: Protocol::Grpc,
+            timeout,
         }
     }
+
     pub fn address(&self) -> SocketAddr {
         self.connection
     }
 }
 
 impl Listen {
-    pub fn new(connection: SocketAddr, protocol: Protocol) -> Self {
+    pub fn new(connection: SocketAddr) -> Self {
         Listen {
             connection,
-            protocol,
-            timeout: Duration::from_micros(DEFAULT_TIMEOUT_MICROSECONDS),
+            protocol: Protocol::Grpc,
+            timeout: Duration::from_micros(DEFAULT_TIMEOUT_MILLISECONDS),
         }
     }
 
@@ -146,6 +155,6 @@ impl Configuration {
                 .profile
                 .address()
                 .and_then(|address| address.to_socketaddr()))
-            .map(|addr| Listen::new(addr, self.protocol))
+            .map(|addr| Listen::new(addr))
     }
 }


### PR DESCRIPTION
Limit time it can take to establish a client connection, taking the timeout value in `Peer` to its intended use.
Unfortunately, `hyper` 0.12 does not provide a way to pass it down the TCP stack, ~so we may still end up with sockets hanging in connecting state~. With the port to `hyper` 0.13 and Tokio 0.2, a more organic solution will be possible.

An attempt to fix #1829 (or at least figure out that the executor is stuck).
Fixes #991