### PR TITLE
A more efficient way to synchronize storage writes

### DIFF
--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -524,7 +524,7 @@ impl Blockchain {
         post_checked_header: PostCheckedHeader,
         block: Block,
     ) -> Result<AppliedBlock> {
-        let storage = self.storage.back_to_the_future().clone();
+        let mut storage = self.storage.back_to_the_future().clone();
         let block_ref = self.apply_block(post_checked_header, &block).await?;
         let res = storage.put_block(block).await;
         match res {
@@ -628,7 +628,7 @@ impl Blockchain {
 
         let block0_branch = self.apply_block0(&block0).await?;
 
-        let storage = self.storage.clone();
+        let mut storage = self.storage.clone();
 
         storage
             .put_block(block0)

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -34,6 +34,6 @@ pub use self::{
     multiverse::Multiverse,
     process::{process_new_ref_owned, Process},
     reference::Ref,
-    storage::Storage,
+    storage::{Storage, StorageSyncQueryExecutor},
     tip::Tip,
 };

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -299,7 +299,7 @@ pub async fn process_new_ref(
     candidate: Arc<Ref>,
 ) -> Result<(), Error> {
     let candidate_hash = candidate.hash();
-    let storage = blockchain.storage().clone();
+    let mut storage = blockchain.storage().clone();
 
     let tip_ref = tip.get_ref_std().await;
 

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -446,7 +446,11 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     if let Some(context) = rest_context.as_ref() {
         block_on(context.set_node_state(NodeState::PreparingStorage))
     }
-    let storage = start_up::prepare_storage(&settings, &init_logger)?;
+
+    let (storage, storage_query_executor) = start_up::prepare_storage(&settings, &init_logger)?;
+    services.spawn_future_std("storage sync queries", |_info| async move {
+        storage_query_executor.start().await;
+    });
 
     // TODO: load network module here too (if needed)
 

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -3,7 +3,9 @@ mod error;
 pub use self::error::{Error, ErrorKind};
 use crate::{
     blockcfg::{Block, HeaderId},
-    blockchain::{Blockchain, ErrorKind as BlockchainError, Storage, Tip},
+    blockchain::{
+        Blockchain, ErrorKind as BlockchainError, Storage, StorageSyncQueryExecutor, Tip,
+    },
     log, network,
     settings::start::Settings,
 };
@@ -16,7 +18,10 @@ pub type NodeStorageConnection = BlockStoreConnection<Block>;
 
 /// prepare the block storage from the given settings
 ///
-pub fn prepare_storage(setting: &Settings, logger: &Logger) -> Result<Storage, Error> {
+pub fn prepare_storage(
+    setting: &Settings,
+    logger: &Logger,
+) -> Result<(Storage, StorageSyncQueryExecutor), Error> {
     let raw_block_store = match &setting.storage {
         None => {
             info!(logger, "storing blockchain in memory");


### PR DESCRIPTION
## Background

We allowed parallel reads/writes from/to the storage without any application-level which was introduced in #1412. While providing a significant performance benefit, it resulted in a bug: storage operations involving write transactions:

1) could've been scheduled to different executor threads
2) almost always used different connections

This led to a situation when a block could've been written to the storage before its parent (causing a panic) or less likely when a tag was written before the corresponding block.

An obvious way to fix that was to synchronize the writes like it was before #1412 but to keep reads parallel. To achieve that, a lock for write operations was introduced (#1441).

## Motivation

The downside of the previous approach was that it involved a number of costly operations, namely: locking on a mutex and multiple operations of acquiring and releasing a DB connection. This what a write operation looked like:

- acquire the mutex
- acquire a connection
- get a connection
- do _one_ operation in a thread pool
- release a connection
- release a lock

## Approach

Instead of locking the database for certain cases we use a queue of writes. A separate process (service) receives requests for write operations. Instead of performing the above sequence of operations for each request, this process reads all of the incoming operations from the incoming stream and executes them in a batch. Thus, we avoid costly locking and repeated connections operations. This may improve the performance in places like network bootstrap.

## Further uses

Similar approach can be applied explicitly for processing large streams of requests.

## TBD in this PR

- [ ] Use `intercom` utils instead of bare `futures` channels.
- [ ] Limit the size of requests batches.
- [ ] Logging in the requests process.