### PR TITLE
Restore connect error message formatting

### DIFF
--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -507,7 +507,7 @@ fn connect_and_propagate(
                     true
                 }
                 _ => {
-                    info!(conn_logger, "connection to peer failed"; "error" => ?e);
+                    info!(conn_logger, "connection to peer failed"; "reason" => %e);
                     false
                 }
             };


### PR DESCRIPTION
Restore the human-readable log message for non-drilled down connection errors, since they can occur for expected reasons and the integration tests depend on it.