### PR TITLE
huge simplication of the code for the leader enclave holder

### DIFF
--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -316,7 +316,7 @@ pub async fn get_shutdown(context: Data<Context>) -> Result<impl Responder, Erro
 
 pub async fn get_leaders(context: Data<Context>) -> Result<impl Responder, Error> {
     Ok(Json(json! {
-        context.try_full().await?.enclave.get_leaderids().await
+        context.try_full().await?.enclave.get_leader_ids().await
     }))
 }
 


### PR DESCRIPTION
separate the inner operations of maintaining the enclave so it is easier
to review and to follow what is actually happening to keep the enclave
DB in order.

Have only one lock done when performing the `add_leader`. This will
reduce the query for a Mutex...

also in previous code we were removing the leader id from the `leaders`
but not from the `added_leaders_cache`. This resulted in having an invalid
state and preventing users to add back the same value

fix #1857