### PR TITLE
GitHub actions cross compiling fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
           override: true
           default: true
 
+      - name: Downgrade cross
+        uses: actions-rs/cargo@v1
+        if: ${{ matrix.config.cross }}
+        args: install --version 0.1.16 cross
+
       - name: Checkout code
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Downgrade cross
         uses: actions-rs/cargo@v1
         if: ${{ matrix.config.cross }}
-        args: install --version 0.1.16 cross
+        with:
+          command: install
+          args: --version 0.1.16 cross
 
       - name: Checkout code
         uses: actions/checkout@v1


### PR DESCRIPTION
Bring back older version of `cross` supporting OpenSSL in order to cross-compile properly.

This was triggered by [this](https://github.com/rust-embedded/cross/issues/229)
It is related to #1796 although it does not fix that.

fix #1856 