### PR TITLE
Cargo lock update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3957,9 +3957,9 @@ checksum = "095064aa1f5b94d14e635d0a5684cf140c43ae40a0fd990708d38f5d669e5f64"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
  "quote 1.0.2",
- "syn 1.0.15",
+ "syn 1.0.16",
 ]
 
 [[package]]


### PR DESCRIPTION
Last merge (57b4d5ebe8642e6d173a5528d2ef780076279863) had some missing deps in `cargo.lock`. This is just an update of those.