### PR TITLE
Warnings cleaning

### DIFF
--- a/jormungandr-integration-tests/build.rs
+++ b/jormungandr-integration-tests/build.rs
@@ -1,8 +1,5 @@
 extern crate protoc_rust;
 
-use protoc_rust::Customize;
-use std::env;
-
 fn main() {
     // generate grpc mock
 

--- a/jormungandr-integration-tests/src/common/configuration/node_config_builder.rs
+++ b/jormungandr-integration-tests/src/common/configuration/node_config_builder.rs
@@ -27,7 +27,6 @@ impl NodeConfigBuilder {
     pub fn new() -> NodeConfigBuilder {
         let rest_port = super::get_available_port();
         let public_address_port = super::get_available_port();
-        let _listen_address_port = super::get_available_port();
         let storage_file = file_utils::get_path_in_temp("storage");
         let public_id = poldercast::Id::generate(rand::rngs::OsRng);
         let log = Some(Log(vec![LogEntry {

--- a/jormungandr-integration-tests/src/common/configuration/node_config_builder.rs
+++ b/jormungandr-integration-tests/src/common/configuration/node_config_builder.rs
@@ -27,7 +27,7 @@ impl NodeConfigBuilder {
     pub fn new() -> NodeConfigBuilder {
         let rest_port = super::get_available_port();
         let public_address_port = super::get_available_port();
-        let listen_address_port = super::get_available_port();
+        let _listen_address_port = super::get_available_port();
         let storage_file = file_utils::get_path_in_temp("storage");
         let public_id = poldercast::Id::generate(rand::rngs::OsRng);
         let log = Some(Log(vec![LogEntry {

--- a/jormungandr-integration-tests/src/common/jormungandr/starter.rs
+++ b/jormungandr-integration-tests/src/common/jormungandr/starter.rs
@@ -8,14 +8,12 @@ use crate::common::{
     process_utils::{self, output_extensions::ProcessOutput, ProcessError},
 };
 use jormungandr_lib::testing::{SpeedBenchmarkDef, SpeedBenchmarkRun};
+use std::process::Stdio;
 use std::{
     process::{Child, Command},
     time::{Duration, Instant},
 };
-use std::{
-    process::{Output, Stdio},
-    thread, time,
-};
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/jormungandr-integration-tests/src/non_functional/mod.rs
+++ b/jormungandr-integration-tests/src/non_functional/mod.rs
@@ -42,7 +42,7 @@ pub fn send_transaction_and_ensure_block_was_produced(
     let block_counter_before_transaction = jormungandr.logger.get_created_blocks_counter();
 
     jcli_wrapper::send_transactions_and_wait_until_in_block(&transation_messages, &jormungandr)
-        .map_err(|err| NodeStuckError::InternalJcliError(err));
+        .map_err(|err| NodeStuckError::InternalJcliError(err))?;
 
     let block_tip_after_transaction =
         jcli_wrapper::assert_rest_get_block_tip(&jormungandr.rest_address());

--- a/jormungandr-lib/src/interfaces/config/mempool.rs
+++ b/jormungandr-lib/src/interfaces/config/mempool.rs
@@ -1,4 +1,3 @@
-use crate::time::Duration;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]

--- a/jormungandr-scenario-tests/src/node.rs
+++ b/jormungandr-scenario-tests/src/node.rs
@@ -377,7 +377,7 @@ impl NodeController {
         let max_try = 2;
         let sleep = Duration::from_secs(2);
         for _ in 0..max_try {
-            if let Err(err) = self.stats() {
+            if let Err(_err) = self.stats() {
                 return Ok(());
             };
             std::thread::sleep(sleep);

--- a/jormungandr-scenario-tests/src/scenario/repository/mod.rs
+++ b/jormungandr-scenario-tests/src/scenario/repository/mod.rs
@@ -10,11 +10,8 @@ pub use tag::{parse_tag_from_str, Tag};
 
 use crate::{
     test::{
-        comm::leader_leader::*,
-        comm::passive_leader::*,
-        network::topology::scenarios::*,
-        non_functional::{disruption::*, soak::*},
-        Result,
+        comm::leader_leader::*, comm::passive_leader::*, network::topology::scenarios::*,
+        non_functional::soak::*, Result,
     },
     Context,
 };

--- a/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -64,7 +64,7 @@ pub fn measure_and_log_sync_time(
     }
 
     // we know it fails, this method is used only for reporting
-    assert_are_in_sync(SyncWaitParams::ZeroWait, nodes);
+    assert_are_in_sync(SyncWaitParams::ZeroWait, nodes).unwrap();
     benchmark.stop().print();
 }
 

--- a/jormungandr-scenario-tests/src/wallet.rs
+++ b/jormungandr-scenario-tests/src/wallet.rs
@@ -165,7 +165,7 @@ impl Wallet {
         iobuilder.add_output(address.into(), value.into()).unwrap();
 
         let payload_data = NoExtra.payload_data();
-        self.add_input(payload_data.borrow(), &mut iobuilder, fees);
+        self.add_input(payload_data.borrow(), &mut iobuilder, fees)?;
 
         //let (_, tx) = txbuilder
         //    .seal_with_output_policy(fees, output_policy)

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -712,7 +712,7 @@ async fn process_chain_headers(
             );
             reply.reply_error(chain_header_error_into_reply(e));
         }
-        Ok((header_ids, maybe_remainder)) => {
+        Ok((header_ids, _maybe_remainder)) => {
             header_ids
                 .iter()
                 .try_for_each(|header_id| pull_headers_scheduler.declare_completed(*header_id))

--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -21,11 +21,7 @@ use jormungandr_lib::{
     time::SystemTime,
 };
 use slog::Logger;
-use std::{
-    collections::VecDeque,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{collections::VecDeque, sync::Arc, time::Instant};
 use thiserror::Error;
 use tokio02::time::{delay_until, timeout_at, Instant as TokioInstant};
 


### PR DESCRIPTION
Cleaned some warnings about:
* Unused import
* Unused variables
* No captured results

Left:
* Warnings in `chain-deps`
* Deadcode warnings
* Deprecated code warnings (they should be update in forward PRs related to other issues) 