### PR TITLE
[Private network tests] Leader promotion

### DIFF
--- a/jormungandr-lib/src/interfaces/config/secret.rs
+++ b/jormungandr-lib/src/interfaces/config/secret.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NodeSecret {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bft: Option<Bft>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub genesis: Option<GenesisPraos>,
 }
 

--- a/jormungandr-lib/src/interfaces/leadership_log.rs
+++ b/jormungandr-lib/src/interfaces/leadership_log.rs
@@ -126,3 +126,15 @@ impl fmt::Display for EnclaveLeaderId {
         self.0.fmt(f)
     }
 }
+
+impl Into<u32> for EnclaveLeaderId {
+    fn into(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<u32> for EnclaveLeaderId {
+    fn from(inner: u32) -> EnclaveLeaderId {
+        EnclaveLeaderId(inner)
+    }
+}

--- a/jormungandr-scenario-tests/src/scenario/repository/mod.rs
+++ b/jormungandr-scenario-tests/src/scenario/repository/mod.rs
@@ -10,8 +10,12 @@ pub use tag::{parse_tag_from_str, Tag};
 
 use crate::{
     test::{
-        comm::leader_leader::*, comm::passive_leader::*, network::topology::scenarios::*,
-        non_functional::soak::*, Result,
+        comm::leader_leader::*,
+        comm::passive_leader::*,
+        features::leader_promotion::*,
+        network::topology::scenarios::*,
+        non_functional::{disruption::*, soak::*},
+        Result,
     },
     Context,
 };
@@ -153,6 +157,13 @@ fn scenarios_repository() -> Vec<Scenario> {
 
     repository.push(Scenario::new("tree", tree, vec![Tag::Short]));
     // repository.push(Scenario::new("relay", relay, vec![Tag::Short]));
+
+    repository.push(Scenario::new(
+        "passive_node_promotion",
+        passive_node_promotion,
+        vec![Tag::Short, Tag::Unstable],
+    ));
+
     repository.push(Scenario::new("relay_soak", relay_soak, vec![Tag::Long]));
     /*   repository.push(Scenario::new(
         "mesh_disruption",

--- a/jormungandr-scenario-tests/src/scenario/repository/tag.rs
+++ b/jormungandr-scenario-tests/src/scenario/repository/tag.rs
@@ -7,6 +7,7 @@ pub enum Tag {
     Perf,
     Long,
     Feature,
+    Unstable,
     All,
 }
 
@@ -17,6 +18,7 @@ pub fn parse_tag_from_str(tag: &str) -> Result<Tag> {
         "long" => Ok(Tag::Long),
         "perf" => Ok(Tag::Perf),
         "feature" => Ok(Tag::Feature),
+        "unstable" => Ok(Tag::Unstable),
         _ => Ok(Tag::All),
     }
 }

--- a/jormungandr-scenario-tests/src/scenario/repository/tag.rs
+++ b/jormungandr-scenario-tests/src/scenario/repository/tag.rs
@@ -6,6 +6,7 @@ pub enum Tag {
     Short,
     Perf,
     Long,
+    Feature,
     All,
 }
 
@@ -15,6 +16,7 @@ pub fn parse_tag_from_str(tag: &str) -> Result<Tag> {
         "short" => Ok(Tag::Short),
         "long" => Ok(Tag::Long),
         "perf" => Ok(Tag::Perf),
+        "feature" => Ok(Tag::Feature),
         _ => Ok(Tag::All),
     }
 }

--- a/jormungandr-scenario-tests/src/test/features/leader_promotion.rs
+++ b/jormungandr-scenario-tests/src/test/features/leader_promotion.rs
@@ -1,0 +1,98 @@
+use crate::{
+    node::NodeController,
+    node::{LeadershipMode, PersistenceMode},
+    test::{utils, Result},
+    Context, ScenarioResult,
+};
+use jormungandr_lib::interfaces::EnclaveLeaderId;
+use rand_chacha::ChaChaRng;
+const LEADER: &str = "Leader";
+const PASSIVE: &str = "Passive";
+
+pub fn passive_node_promotion(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let scenario_settings = prepare_scenario! {
+        "Passive node promotion to leader",
+        &mut context,
+        topology [
+            LEADER,
+            PASSIVE -> LEADER,
+        ]
+        blockchain {
+            consensus = GenesisPraos,
+            number_of_slots_per_epoch = 60,
+            slot_duration = 1,
+            leaders = [ LEADER ],
+            initials = [
+                account "unassigned1" with   500_000_000,
+                account "delegated1" with  2_000_000_000 delegates to LEADER,
+                account "delegated2" with  2_000_000_000 delegates to PASSIVE,
+            ],
+        }
+    };
+
+    let mut controller = scenario_settings.build(context)?;
+
+    let leader =
+        controller.spawn_node(LEADER, LeadershipMode::Leader, PersistenceMode::InMemory)?;
+    leader.wait_for_bootstrap()?;
+    let mut passive =
+        controller.spawn_node(PASSIVE, LeadershipMode::Passive, PersistenceMode::InMemory)?;
+    passive.wait_for_bootstrap()?;
+    controller.monitor_nodes();
+
+    // promote leader
+    promote_and_assert_leaders_id(&passive, 1.into(), 1, "after promotion")?;
+
+    // demote leader
+    demote_and_assert_leaders_id(&passive, 1, 0, "after demotion")?;
+
+    // promote leader again
+    promote_and_assert_leaders_id(&passive, 1.into(), 1, "second promotion")?;
+
+    // promote duplicated leader
+    promote_and_assert_leaders_id(&passive, 1.into(), 1, "duplicated promotion")?;
+
+    passive.shutdown()?;
+    leader.shutdown()?;
+    controller.finalize();
+    Ok(ScenarioResult::passed())
+}
+
+fn promote_and_assert_leaders_id(
+    node: &NodeController,
+    expected_leader_id: EnclaveLeaderId,
+    expected_length: u32,
+    info: &str,
+) -> Result<()> {
+    let leader_id = node.promote()?;
+    let leaders_length: u32 = node.leaders()?.len() as u32;
+
+    utils::assert_equals(
+        &leader_id,
+        &expected_leader_id,
+        &format!("leader id {}", info),
+    )?;
+    utils::assert_equals(
+        &leaders_length,
+        &expected_length,
+        &format!("leaders count {}", info),
+    )?;
+    Ok(())
+}
+
+fn demote_and_assert_leaders_id(
+    node: &NodeController,
+    leader_id: u32,
+    expected_length: u32,
+    info: &str,
+) -> Result<()> {
+    node.demote(leader_id)?;
+    let actual_length: u32 = node.leaders()?.len() as u32;
+
+    utils::assert_equals(
+        &actual_length,
+        &expected_length,
+        &format!("leaders count {}", info),
+    )?;
+    Ok(())
+}

--- a/jormungandr-scenario-tests/src/test/features/mod.rs
+++ b/jormungandr-scenario-tests/src/test/features/mod.rs
@@ -1,0 +1,1 @@
+pub mod leader_promotion;

--- a/jormungandr-scenario-tests/src/test/mod.rs
+++ b/jormungandr-scenario-tests/src/test/mod.rs
@@ -1,4 +1,5 @@
 pub mod comm;
+pub mod features;
 pub mod network;
 pub mod non_functional;
 pub mod utils;


### PR DESCRIPTION
Added test case which automates issue connected with leader promotion:  #1857 

Test flow:

- bootstrap two nodes: 1 passive and 1 leader
- promote passive to leader - passive is leader
- demote leader to passive - passive is no longer leader
- promote passive to leader again - passive is leader again
- promote passive to leader third time - no effect