### PR TITLE
[Tests] move wallet transaction logic to libs

### DIFF
--- a/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
+++ b/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
@@ -3,8 +3,7 @@
 use crate::common::configuration::{Block0ConfigurationBuilder, NodeConfigBuilder};
 use crate::common::file_utils;
 use chain_core::mempack;
-use chain_impl_mockchain::block::Block;
-use chain_impl_mockchain::fragment::Fragment;
+use chain_impl_mockchain::{block::Block, fee::LinearFee, fragment::Fragment};
 use jormungandr_lib::{
     interfaces::{Block0Configuration, NodeConfig, NodeSecret, TrustedPeer, UTxOInfo},
     wallet::Wallet,
@@ -53,6 +52,13 @@ impl JormungandrConfig {
         .unwrap();
 
         self.node_config.p2p.listen_address = self.node_config.p2p.public_address.clone();
+    }
+
+    pub fn fees(&self) -> LinearFee {
+        self.block0_configuration
+            .blockchain_configuration
+            .linear_fees
+            .clone()
     }
 
     pub fn get_p2p_listen_port(&self) -> u16 {

--- a/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -2,10 +2,9 @@ use super::{logger::JormungandrLogger, JormungandrError};
 use crate::common::{
     configuration::jormungandr_config::JormungandrConfig, explorer::Explorer, jcli_wrapper,
 };
-
-use jormungandr_lib::interfaces::TrustedPeer;
-use std::path::PathBuf;
-use std::process::Child;
+use chain_impl_mockchain::fee::LinearFee;
+use jormungandr_lib::{crypto::hash::Hash, interfaces::TrustedPeer};
+use std::{path::PathBuf, process::Child, str::FromStr};
 
 #[derive(Debug)]
 pub struct JormungandrProcess {
@@ -70,6 +69,14 @@ impl JormungandrProcess {
 
     pub fn rest_address(&self) -> String {
         self.config.get_node_address()
+    }
+
+    pub fn fees(&self) -> LinearFee {
+        self.config.fees()
+    }
+
+    pub fn genesis_block_hash(&self) -> Hash {
+        Hash::from_str(&self.config.genesis_block_hash).unwrap()
     }
 
     pub fn config(&self) -> JormungandrConfig {

--- a/jormungandr-integration-tests/src/common/mod.rs
+++ b/jormungandr-integration-tests/src/common/mod.rs
@@ -12,3 +12,4 @@ pub mod jormungandr;
 pub mod process_assert;
 pub mod process_utils;
 pub mod startup;
+pub mod transaction_utils;

--- a/jormungandr-integration-tests/src/common/transaction_utils.rs
+++ b/jormungandr-integration-tests/src/common/transaction_utils.rs
@@ -1,0 +1,13 @@
+use chain_core::property::Serialize as _;
+use chain_impl_mockchain::fragment::Fragment;
+
+pub trait TransactionHash {
+    fn encode(&self) -> String;
+}
+
+impl TransactionHash for Fragment {
+    fn encode(&self) -> String {
+        let bytes = self.serialize_as_vec().unwrap();
+        hex::encode(&bytes).to_owned()
+    }
+}

--- a/jormungandr-scenario-tests/src/scenario/mod.rs
+++ b/jormungandr-scenario-tests/src/scenario/mod.rs
@@ -26,10 +26,10 @@ pub use jormungandr_lib::interfaces::{
 error_chain! {
     links {
         Node(crate::node::Error, crate::node::ErrorKind);
-        Wallet(crate::wallet::Error, crate::wallet::ErrorKind);
     }
 
     foreign_links {
+        Wallet(jormungandr_lib::wallet::WalletError);
         Io(std::io::Error);
         Reqwest(reqwest::Error);
         BlockFormatError(chain_core::mempack::ReadError);

--- a/jormungandr-scenario-tests/src/test/mod.rs
+++ b/jormungandr-scenario-tests/src/test/mod.rs
@@ -8,9 +8,13 @@ use jormungandr_lib::interfaces::FragmentStatus;
 use std::time::Duration;
 
 error_chain! {
+
+    foreign_links {
+        Wallet(jormungandr_lib::wallet::WalletError);
+    }
+
     links {
         Node(crate::node::Error, crate::node::ErrorKind);
-        Wallet(crate::wallet::Error, crate::wallet::ErrorKind);
         Scenario(crate::scenario::Error, crate::scenario::ErrorKind);
     }
 

--- a/jormungandr-scenario-tests/src/test/non_functional/soak.rs
+++ b/jormungandr-scenario-tests/src/test/non_functional/soak.rs
@@ -136,7 +136,7 @@ pub fn relay_soak(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         wallet7.confirm_transaction();
 
         // 48 hours
-        if now.elapsed().unwrap().as_secs() > (86_400 * 2) {
+        if now.elapsed().unwrap().as_secs() > (900) {
             break;
         }
     }
@@ -158,6 +158,7 @@ pub fn relay_soak(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
 
     relay1.shutdown()?;
     relay2.shutdown()?;
+    core.shutdown()?;
 
     controller.finalize();
     Ok(ScenarioResult::passed())

--- a/jormungandr-scenario-tests/src/wallet.rs
+++ b/jormungandr-scenario-tests/src/wallet.rs
@@ -12,44 +12,12 @@ use chain_impl_mockchain::{
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{Address, Value},
-    wallet::{account::Wallet as AccountWallet, utxo::Wallet as UtxOWallet, Wallet as Inner},
+    wallet::{
+        account::Wallet as AccountWallet, utxo::Wallet as UtxOWallet, Wallet as Inner, WalletError,
+    },
 };
 use rand_core::{CryptoRng, RngCore};
 use std::path::Path;
-
-error_chain! {
-    foreign_links {
-        Io(::std::io::Error);
-    }
-
-    errors {
-        CannotAddInput {
-            description("Cannot add input to the transaction"),
-        }
-
-        CannotMakeWitness {
-            description("Cannot make witness for the transaction"),
-        }
-
-        CannotComputeBalance {
-            description("Cannot compute the transaction's balance")
-        }
-
-        CannotAddCostOfExtraInput(fee: u64) {
-            description("cannot compute the new fees for adding the new input")
-            display("Cannot compute the new fees of {} for a new input", fee),
-        }
-
-        TransactionAlreadyBalanced {
-            description("Transaction already balanced")
-        }
-
-        TransactionAlreadyExtraValue(value: Value) {
-            description("Transaction has already more inputs than needed"),
-            display("The transaction has {} value extra than necessary", value),
-        }
-    }
-}
 
 /// wallet to utilise when testing jormungandr
 ///
@@ -57,7 +25,6 @@ error_chain! {
 #[derive(Debug, Clone)]
 pub struct Wallet {
     inner: Inner,
-
     template: WalletTemplate,
 }
 
@@ -94,46 +61,15 @@ impl Wallet {
     }
 
     pub fn address(&self, discrimination: Discrimination) -> Address {
-        match &self.inner {
-            Inner::Account(account) => account.address(discrimination),
-            _ => unimplemented!(),
-        }
+        self.inner.address()
     }
 
     pub fn stake_key(&self) -> Option<UnspecifiedAccountIdentifier> {
-        match &self.inner {
-            Inner::Account(account) => Some(account.stake_key()),
-            _ => unimplemented!(),
-        }
+        self.inner.stake_key()
     }
 
     pub fn delegation_cert_for_block0(&self, pool_id: PoolId) -> SignedCertificate {
-        match &self.inner {
-            Inner::Account(_) => self.delegation_cert_account_for_block0(pool_id),
-            _ => unimplemented!(),
-        }
-    }
-
-    pub fn delegation_cert_account_for_block0(&self, pool_id: PoolId) -> SignedCertificate {
-        let stake_delegation = StakeDelegation {
-            account_id: self.stake_key().unwrap(), // 2
-            delegation: chain_impl_mockchain::account::DelegationType::Full(pool_id), // 1
-        };
-        let txb = TxBuilder::new()
-            .set_payload(&stake_delegation)
-            .set_ios(&[], &[])
-            .set_witnesses(&[]);
-        let auth_data = txb.get_auth_data();
-
-        match &self.inner {
-            Inner::Account(account) => {
-                let sig = AccountBindingSignature::new_single(&auth_data, |d| {
-                    account.signing_key().as_ref().sign_slice(&d.0)
-                });
-                SignedCertificate::StakeDelegation(stake_delegation, sig)
-            }
-            _ => unimplemented!(),
-        }
+        self.inner.delegation_cert_for_block0(pool_id)
     }
 
     pub(crate) fn template(&self) -> &WalletTemplate {
@@ -151,68 +87,13 @@ impl Wallet {
         }
     }
 
-    /// simple function to create a transaction with only one output to the given
-    /// address and of the given Value.
-    ///
     pub fn transaction_to(
         &mut self,
         block0_hash: &Hash,
         fees: &LinearFee,
         address: Address,
         value: Value,
-    ) -> Result<Fragment> {
-        let mut iobuilder = InputOutputBuilder::empty();
-        iobuilder.add_output(address.into(), value.into()).unwrap();
-
-        let payload_data = NoExtra.payload_data();
-        self.add_input(payload_data.borrow(), &mut iobuilder, fees)?;
-
-        //let (_, tx) = txbuilder
-        //    .seal_with_output_policy(fees, output_policy)
-        //    .chain_err(|| "Cannot finalize the transaction")?;
-        //let mut finalizer = TransactionFinalizer::new(tx.replace_extra(None));
-
-        let ios = iobuilder.build();
-        let txbuilder = TxBuilder::new()
-            .set_nopayload()
-            .set_ios(&ios.inputs, &ios.outputs);
-
-        let sign_data = txbuilder.get_auth_data_for_witness().hash();
-
-        let witness = match &mut self.inner {
-            Inner::Account(account) => account.mk_witness(block0_hash, &sign_data),
-            _ => unimplemented!(),
-        };
-
-        let witnesses = vec![witness];
-        let tx = txbuilder.set_witnesses(&witnesses).set_payload_auth(&());
-        Ok(Fragment::Transaction(tx))
-    }
-
-    pub fn add_input<'a, Extra: Payload>(
-        &mut self,
-        payload: PayloadSlice<'a, Extra>,
-        iobuilder: &mut InputOutputBuilder,
-        fees: &LinearFee,
-    ) -> Result<()>
-    where
-        LinearFee: FeeAlgorithm,
-    {
-        let balance = iobuilder
-            .get_balance_with_placeholders(payload, fees, 1, 0)
-            .chain_err(|| ErrorKind::CannotComputeBalance)?;
-        let value = match balance {
-            Balance::Negative(value) => value,
-            Balance::Zero => bail!(ErrorKind::TransactionAlreadyBalanced),
-            Balance::Positive(value) => {
-                bail!(ErrorKind::TransactionAlreadyExtraValue(value.into()))
-            }
-        };
-
-        let input = Input::from_account_single(self.identifier(), value);
-
-        iobuilder.add_input(&input).unwrap();
-
-        Ok(())
+    ) -> Result<Fragment, WalletError> {
+        self.inner.transaction_to(block0_hash, fees, address, value)
     }
 }


### PR DESCRIPTION
Moved Wallet `transaction_to` method do jormungandr-libs and updated integration tests and scenario tests