### PR TITLE
add Stake Pool retirement command in JCLI

### DIFF
--- a/doc/jcli/certificate.md
+++ b/doc/jcli/certificate.md
@@ -22,6 +22,36 @@ Where:
 - `--operator <operator-public-key>` - *optional*, public key of the operator(s) of the pool.
 - `output-file`                      - *optional*, write the output to the given file or print it to the standard output if not defined
 
+## Retiring a stake pool
+
+It is possible to retire a stake pool from the blockchain. By doing so the stake delegated
+to the stake pool will become dangling and will need to be re-delegated.
+
+Remember though that the action won't be applied until the next following epoch. I.e.
+the certificate will take a whole epoch before being applied, this should leave time
+for stakers to redistribute their stake to other pools before having their stake
+becoming dangling.
+
+It might be valuable for a stake pool operator to keep the stake pool running until
+the stake pool retirement certificate is fully applied in order to not miss any
+potential rewards.
+
+example:
+
+```sh
+jcli certificate new stake-pool-retirement \
+    --pool-id <POOL_ID> \
+    --retirement-time <seconds-since-start> \
+    [<output-file>]
+```
+
+where:
+
+- `output-file` - *optional*, write the output of to the given file
+  or print it to the standard output if not defined.
+- `--retirement-time` is the number of seconds since the start in order
+  to make the stake pool retire. `0` means as soon as possible.
+
 ## Building stake pool delegation certificate
 
 Builds a stake pool delegation certificate.

--- a/jcli/src/jcli_app/certificate/mod.rs
+++ b/jcli/src/jcli_app/certificate/mod.rs
@@ -106,7 +106,7 @@ pub enum NewArgs {
     ///
     /// by doing so all remaining stake delegated to this stake pool will
     /// become pending and will need to be re-delegated.
-    Retire(new_stake_pool_retirement::StakePoolRetirement),
+    StakePoolRetirement(new_stake_pool_retirement::StakePoolRetirement),
 }
 
 #[derive(StructOpt)]

--- a/jcli/src/jcli_app/certificate/mod.rs
+++ b/jcli/src/jcli_app/certificate/mod.rs
@@ -133,7 +133,7 @@ impl NewArgs {
             NewArgs::StakePoolRegistration(args) => args.exec()?,
             NewArgs::StakeDelegation(args) => args.exec()?,
             NewArgs::OwnerStakeDelegation(args) => args.exec()?,
-            NewArgs::Retire(args) => args.exec()?,
+            NewArgs::StakePoolRetirement(args) => args.exec()?,
         }
         Ok(())
     }

--- a/jcli/src/jcli_app/certificate/new_stake_pool_retirement.rs
+++ b/jcli/src/jcli_app/certificate/new_stake_pool_retirement.rs
@@ -1,0 +1,40 @@
+use crate::jcli_app::certificate::{write_cert, Error};
+use chain_crypto::Blake2b256;
+use chain_impl_mockchain::certificate::{Certificate, PoolRetirement};
+use chain_time::DurationSeconds;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// retire the given stake pool ID From the blockchain
+///
+/// by doing so all remaining stake delegated to this stake pool will
+/// become pending and will need to be re-delegated.
+#[derive(StructOpt)]
+pub struct StakePoolRetirement {
+    /// set the 32bytes (in hexadecimal) of the Stake Pool identifier
+    #[structopt(long = "pool-id", name = "POOL_ID")]
+    pool_id: Blake2b256,
+
+    /// start retirement
+    ///
+    /// This state when the stake pool retirement becomes effective in seconds since
+    /// the block0 start time.
+    #[structopt(long = "retirement-time", name = "SECONDS-SINCE-START")]
+    pub retirement_time: u64,
+
+    /// print the output signed certificate in the given file, if no file given
+    /// the output will be printed in the standard output
+    pub output: Option<PathBuf>,
+}
+
+impl StakePoolRetirement {
+    pub fn exec(self) -> Result<(), Error> {
+        let pool_retirement = PoolRetirement {
+            pool_id: self.pool_id.into(),
+            retirement_time: DurationSeconds::from(self.retirement_time).into(),
+        };
+
+        let cert = Certificate::PoolRetirement(pool_retirement);
+        write_cert(self.output, cert.into())
+    }
+}


### PR DESCRIPTION
This command makes it easier for stake pool operator to retire a stake pool via utilising `jcli`.

This PR deprecates cardano-foundation/incentivized-testnet-stakepool-registry#768