### PR TITLE
p2p quarantine policy update and vicinity randomnisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,10 +2834,11 @@ checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
 name = "poldercast"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c4760dc0b6e9765be96a3e4d8f5bcf644df8990c253a8440c68d70242e551e"
+checksum = "0c78ef8bcc24fc1b8d4f6429d3c3f97ebfe433e92b9e3bc43ca5842335213774"
 dependencies = [
+ "cid",
  "hex",
  "lru",
  "multiaddr",

--- a/jormungandr-integration-tests/Cargo.toml
+++ b/jormungandr-integration-tests/Cargo.toml
@@ -37,7 +37,7 @@ regex = "1.1"
 error-chain = "0.12"
 jormungandr = { path = "../jormungandr" }
 jcli = { path = "../jcli" }
-poldercast = "0.11.3"
+poldercast = "0.11.4"
 thiserror = "1.0"
 reqwest = "0.9.24"
 

--- a/jormungandr-lib/Cargo.toml
+++ b/jormungandr-lib/Cargo.toml
@@ -18,7 +18,7 @@ rand_chacha = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 humantime = "2.0"
 thiserror = "1.0"
-poldercast = "0.11.3"
+poldercast = "0.11.4"
 
 [dev-dependencies]
 rand = "0.7"

--- a/jormungandr-scenario-tests/Cargo.toml
+++ b/jormungandr-scenario-tests/Cargo.toml
@@ -21,7 +21,7 @@ chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain", features =
 chain-time           = { path = "../chain-deps/chain-time"}
 jormungandr-integration-tests = { path = "../jormungandr-integration-tests"}
 jormungandr-lib = { path = "../jormungandr-lib" }
-poldercast = "0.11.3"
+poldercast = "0.11.4"
 rand = "0.7"
 rand_core = "0.5"
 rand_chacha = "0.2"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -41,7 +41,7 @@ linked-hash-map = "0.5"
 network-core    = { path = "../chain-deps/network-core" }
 network-grpc    = { path = "../chain-deps/network-grpc" }
 pin-utils = "0.1.0-alpha.4"
-poldercast = "0.11.3"
+poldercast = "0.11.4"
 r2d2 = "0.8"
 rand = "0.7"
 rustls = "^0.16.0 "

--- a/jormungandr/src/network/p2p/gossip.rs
+++ b/jormungandr/src/network/p2p/gossip.rs
@@ -178,9 +178,8 @@ impl property::Deserialize for Gossip {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use poldercast::{Address, NodeProfile, NodeProfileBuilder};
-    use std::net::{Ipv4Addr, Ipv6Addr};
-    use std::str::FromStr;
+    use poldercast::{Address, NodeProfileBuilder};
+    use std::net::Ipv4Addr;
 
     #[test]
     fn gossip_global_ipv4_private() {

--- a/jormungandr/src/network/p2p/policy.rs
+++ b/jormungandr/src/network/p2p/policy.rs
@@ -36,16 +36,24 @@ pub struct Records {
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct PolicyConfig {
     quarantine_duration: Duration,
-    max_quarantine: Duration,
-    max_num_quarantine_records: usize,
+    #[serde(default)]
+    max_quarantine: Option<Duration>,
+    #[serde(default)]
+    max_num_quarantine_records: Option<usize>,
 }
 
 impl Policy {
     pub fn new(pc: PolicyConfig, logger: Logger) -> Self {
         Self {
             quarantine_duration: pc.quarantine_duration.into(),
-            max_quarantine: pc.max_quarantine.into(),
-            records: LruCache::new(pc.max_num_quarantine_records),
+            max_quarantine: pc
+                .max_quarantine
+                .unwrap_or(DEFAULT_MAX_QUARANTINE_DURATION.into())
+                .into(),
+            records: LruCache::new(
+                pc.max_num_quarantine_records
+                    .unwrap_or(DEFAULT_MAX_NUM_QUARANTINE_RECORDS),
+            ),
             logger,
         }
     }
@@ -75,8 +83,8 @@ impl Default for PolicyConfig {
     fn default() -> Self {
         Self {
             quarantine_duration: Duration::from(DEFAULT_QUARANTINE_DURATION),
-            max_quarantine: Duration::from(DEFAULT_MAX_QUARANTINE_DURATION),
-            max_num_quarantine_records: DEFAULT_MAX_NUM_QUARANTINE_RECORDS,
+            max_quarantine: Some(Duration::from(DEFAULT_MAX_QUARANTINE_DURATION)),
+            max_num_quarantine_records: Some(DEFAULT_MAX_NUM_QUARANTINE_RECORDS),
         }
     }
 }

--- a/jormungandr/src/network/p2p/policy.rs
+++ b/jormungandr/src/network/p2p/policy.rs
@@ -1,32 +1,72 @@
 use jormungandr_lib::time::Duration;
-use poldercast::{Node, PolicyReport};
+use lru::LruCache;
+use poldercast::{Id, Node, PolicyReport};
 use serde::{Deserialize, Serialize};
 use slog::Logger;
+use std::time::{Duration as StdDuration, Instant};
 
-/// default quarantine duration is 30min
-const DEFAULT_QUARANTINE_DURATION: std::time::Duration = std::time::Duration::from_secs(1800);
+/// default quarantine duration is 10min
+const DEFAULT_QUARANTINE_DURATION: StdDuration = StdDuration::from_secs(10 * 60);
+
+/// default max quarantine is 2 days
+const DEFAULT_MAX_QUARANTINE_DURATION: StdDuration = StdDuration::from_secs(2 * 24 * 3600);
+
+/// default number of records is 24_000
+const DEFAULT_MAX_NUM_QUARANTINE_RECORDS: usize = 24_000;
 
 /// This is the P2P policy. Right now it is very similar to the default policy
 /// defined in `poldercast` crate.
 ///
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Policy {
-    quarantine_duration: std::time::Duration,
+    quarantine_duration: StdDuration,
+    max_quarantine: StdDuration,
+    records: LruCache<Id, Records>,
 
     logger: Logger,
+}
+
+pub struct Records {
+    /// record the number of time the given node has been quarantined
+    /// in known time.
+    quarantine: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct PolicyConfig {
     quarantine_duration: Duration,
+    max_quarantine: Duration,
+    max_num_quarantine_records: usize,
 }
 
 impl Policy {
     pub fn new(pc: PolicyConfig, logger: Logger) -> Self {
         Self {
             quarantine_duration: pc.quarantine_duration.into(),
+            max_quarantine: pc.max_quarantine.into(),
+            records: LruCache::new(pc.max_num_quarantine_records),
             logger,
+        }
+    }
+
+    fn quarantine_duration_for(&mut self, id: Id) -> StdDuration {
+        if let Some(r) = self.records.get_mut(&id) {
+            r.quarantine_for(self.quarantine_duration, self.max_quarantine)
+        } else {
+            let r = Records::new();
+            let t = r.quarantine_for(self.quarantine_duration, self.max_quarantine);
+            self.records.put(id, r);
+            t
+        }
+    }
+
+    fn update(&mut self, id: Id) {
+        if let Some(r) = self.records.get_mut(&id) {
+            r.update();
+        } else {
+            let r = Records::new();
+            self.records.put(id, r);
         }
     }
 }
@@ -35,7 +75,32 @@ impl Default for PolicyConfig {
     fn default() -> Self {
         Self {
             quarantine_duration: Duration::from(DEFAULT_QUARANTINE_DURATION),
+            max_quarantine: Duration::from(DEFAULT_MAX_QUARANTINE_DURATION),
+            max_num_quarantine_records: DEFAULT_MAX_NUM_QUARANTINE_RECORDS,
         }
+    }
+}
+
+impl Records {
+    fn new() -> Records {
+        Self { quarantine: 0 }
+    }
+
+    fn update(&mut self) {
+        self.quarantine += 1;
+    }
+
+    fn quarantine_for(
+        &self,
+        quarantine_instant: StdDuration,
+        max_quarantine: StdDuration,
+    ) -> StdDuration {
+        std::cmp::max(
+            quarantine_instant
+                .checked_mul(self.quarantine)
+                .unwrap_or(max_quarantine),
+            max_quarantine,
+        )
     }
 }
 
@@ -47,8 +112,9 @@ impl poldercast::Policy for Policy {
         // if the node is already quarantined
         if let Some(since) = node.logs().quarantined() {
             let duration = since.elapsed().unwrap();
+            let quarantine_duration = self.quarantine_duration_for(node.id().clone());
 
-            if duration < self.quarantine_duration {
+            if duration < quarantine_duration {
                 // the node still need to do some quarantine time
                 PolicyReport::None
             } else if node.logs().last_update().elapsed().unwrap() < self.quarantine_duration {
@@ -73,6 +139,7 @@ impl poldercast::Policy for Policy {
         } else {
             // if the record is not `clear` then we quarantine the block for some time
             debug!(logger, "move node to quarantine");
+            self.update(node.id().clone());
             PolicyReport::Quarantine
         }
     }


### PR DESCRIPTION
thanks for help and support from @michaeljfazio we are now addressing the last issues of the p2p layer.

This PR introduce updates on the policy, making the nodes more reliable against recurring failing to connect nodes (or nodes with bad data).

It always bump the version of poldercast module to include a changes from @michaeljfazio 's vicinity layer for randomised selection.