### PR TITLE
Changed default value of max_client_connections

### DIFF
--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -75,7 +75,7 @@ rest:
 - `max_connections`: the maximum number of P2P connections this node should
     maintain. If not specified, an internal limit is used by default `[default: 256]`
 - `max_client_connections`: the maximum number of client P2P connections this
-    node should keep open. `[default: 8]`
+    node should keep open. `[default: 192]`
 - `policy`: (optional) set the setting for the policy module
   - `quarantine_duration` set the time to leave a node in quarantine before allowing
     it back (or not) into the fold.

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -39,7 +39,7 @@ pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
 
 /// The limit on the number of simultaneous P2P client connections
 /// used unless the corresponding configuration option is specified.
-pub const DEFAULT_MAX_CLIENT_CONNECTIONS: usize = 8;
+pub const DEFAULT_MAX_CLIENT_CONNECTIONS: usize = 192;
 
 /// The default timeout for connections
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);


### PR DESCRIPTION
The default value for `max_client_connections` doesn't make sense.

When connections > `max_client_connections` the Jormungandr will initiate a purge of `count - self.config.max_client_connections` connections. With a default value of `8` this means that the node will find it difficult to build up a stable topology because the purge limit is hit far too soon.