### PR TITLE
jcli: certificate get-stake-pool-id - make valid also for retirement

### DIFF
--- a/jcli/src/jcli_app/certificate/get_stake_pool_id.rs
+++ b/jcli/src/jcli_app/certificate/get_stake_pool_id.rs
@@ -23,6 +23,10 @@ impl GetStakePoolId {
                 self.output.as_ref().map(|x| x.deref()),
                 stake_pool_info.to_id(),
             ),
+            Certificate::PoolRetirement(stake_pool_info) => write_output(
+                self.output.as_ref().map(|x| x.deref()),
+                stake_pool_info.pool_id,
+            ),
             _ => Err(Error::NotStakePoolRegistration),
         }
     }


### PR DESCRIPTION
Get `pool_id` also from a retirement certificate.