### PR TITLE
[Private network tests] progress bar mode which only prints scenario results

### DIFF
--- a/jormungandr-scenario-tests/src/main.rs
+++ b/jormungandr-scenario-tests/src/main.rs
@@ -4,7 +4,9 @@ extern crate jormungandr_integration_tests;
 
 use jormungandr_scenario_tests::{
     node::{LeadershipMode, PersistenceMode},
-    parse_tag_from_str, prepare_command, style, Context, ScenariosRepository, Seed, Tag,
+    parse_tag_from_str, prepare_command,
+    scenario::{parse_progress_bar_mode_from_str, ProgressBarMode},
+    style, Context, ScenariosRepository, Seed, Tag,
 };
 use std::{path::PathBuf, thread, time::Duration};
 use structopt::StructOpt;
@@ -52,8 +54,12 @@ struct CommandArgs {
     /// but simple log on console enabled
     ///
     /// no progress bar, only simple console output
-    #[structopt(long = "disable-progress-bar")]
-    disable_progress_bar: bool,
+    #[structopt(
+        long = "progress-bar-mode",
+        default_value = "Monitor",
+        parse(try_from_str = parse_progress_bar_mode_from_str)
+    )]
+    progress_bar_mode: ProgressBarMode,
 
     /// set exit code based on test result
     #[structopt(long = "set-exit-code")]
@@ -69,7 +75,7 @@ fn main() {
 
     let jormungandr = prepare_command(command_args.jormungandr);
     let jcli = prepare_command(command_args.jcli);
-    let disable_progress_bar = command_args.disable_progress_bar;
+    let progress_bar_mode = command_args.progress_bar_mode;
     let seed = command_args
         .seed
         .unwrap_or_else(|| Seed::generate(rand::rngs::OsRng));
@@ -82,7 +88,7 @@ fn main() {
         jcli,
         testing_directory,
         generate_documentation,
-        disable_progress_bar,
+        progress_bar_mode,
     );
 
     introduction(&context);

--- a/jormungandr-scenario-tests/src/node.rs
+++ b/jormungandr-scenario-tests/src/node.rs
@@ -1,4 +1,7 @@
-use crate::{scenario::settings::NodeSetting, style, Context, NodeAlias};
+use crate::{
+    scenario::{settings::NodeSetting, ProgressBarMode},
+    style, Context, NodeAlias,
+};
 use bawawa::{Control, Process};
 use chain_impl_mockchain::{
     block::Block,
@@ -116,7 +119,7 @@ pub enum Status {
 struct ProgressBarController {
     progress_bar: ProgressBar,
     prefix: String,
-    legacy_logging: bool,
+    logging_mode: ProgressBarMode,
 }
 
 /// send query to a running node
@@ -557,7 +560,7 @@ impl Node {
         let progress_bar = ProgressBarController::new(
             progress_bar,
             format!("{}@{}", alias, node_settings.config().rest.listen),
-            context.disable_progress_bar(),
+            context.progress_bar_mode(),
         );
 
         let config_file = dir.join(NODE_CONFIG);
@@ -674,11 +677,11 @@ impl Node {
 use std::fmt::Display;
 
 impl ProgressBarController {
-    fn new(progress_bar: ProgressBar, prefix: String, legacy_logging: bool) -> Self {
+    fn new(progress_bar: ProgressBar, prefix: String, logging_mode: ProgressBarMode) -> Self {
         ProgressBarController {
             progress_bar,
             prefix,
-            legacy_logging,
+            logging_mode,
         }
     }
 
@@ -701,11 +704,11 @@ impl ProgressBarController {
         L: Display,
         M: Display,
     {
-        match self.legacy_logging {
-            true => {
+        match self.logging_mode {
+            ProgressBarMode::Standard => {
                 println!("[{}][{}]: {}", lvl, &self.prefix, msg);
             }
-            false => {
+            ProgressBarMode::Monitor => {
                 self.progress_bar.println(format!(
                     "[{}][{}{}]: {}",
                     lvl,
@@ -714,6 +717,7 @@ impl ProgressBarController {
                     msg,
                 ));
             }
+            ProgressBarMode::None => (),
         }
     }
 }

--- a/jormungandr-scenario-tests/src/scenario/context.rs
+++ b/jormungandr-scenario-tests/src/scenario/context.rs
@@ -12,6 +12,8 @@ use std::{
     },
 };
 
+use crate::scenario::ProgressBarMode;
+
 pub type ContextChaCha = Context<ChaChaRng>;
 
 #[derive(Clone)]
@@ -39,7 +41,7 @@ pub struct Context<RNG: RngCore + Sized> {
 
     testing_directory: TestingDirectory,
     generate_documentation: bool,
-    disable_progress_bar: bool,
+    progress_bar_mode: ProgressBarMode,
 }
 
 impl Seed {
@@ -61,7 +63,7 @@ impl Context<ChaChaRng> {
         jcli: bawawa::Command,
         testing_directory: Option<PathBuf>,
         generate_documentation: bool,
-        disable_progress_bar: bool,
+        progress_bar_mode: ProgressBarMode,
     ) -> Self {
         let rng = ChaChaRng::from_seed(seed.0);
 
@@ -80,7 +82,7 @@ impl Context<ChaChaRng> {
             jcli,
             testing_directory,
             generate_documentation,
-            disable_progress_bar,
+            progress_bar_mode,
         }
     }
 
@@ -99,7 +101,7 @@ impl Context<ChaChaRng> {
             jcli: self.jcli().clone(),
             testing_directory: self.testing_directory.clone(),
             generate_documentation: self.generate_documentation.clone(),
-            disable_progress_bar: self.disable_progress_bar.clone(),
+            progress_bar_mode: self.progress_bar_mode.clone(),
         }
     }
 
@@ -154,8 +156,8 @@ impl<RNG: RngCore> Context<RNG> {
         &self.seed
     }
 
-    pub fn disable_progress_bar(&self) -> bool {
-        self.disable_progress_bar
+    pub fn progress_bar_mode(&self) -> ProgressBarMode {
+        self.progress_bar_mode
     }
 }
 

--- a/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -1,6 +1,8 @@
 use crate::{
     node::{LeadershipMode, Node, PersistenceMode},
-    scenario::{settings::Settings, Blockchain, ContextChaCha, ErrorKind, Result, Topology},
+    scenario::{
+        settings::Settings, Blockchain, ContextChaCha, ErrorKind, ProgressBarMode, Result, Topology,
+    },
     style, MemPoolCheck, NodeBlock0, NodeController, Wallet,
 };
 use chain_impl_mockchain::header::HeaderId;
@@ -88,8 +90,12 @@ impl ControllerBuilder {
         self.controller_progress.finish_and_clear();
         self.summary();
 
-        if context.disable_progress_bar() {
-            println!("nodes monitoring disabled due to legacy logging setting enabled");
+        match context.progress_bar_mode() {
+            ProgressBarMode::None => println!("nodes logging disabled"),
+            ProgressBarMode::Standard => {
+                println!("nodes monitoring disabled due to legacy logging setting enabled")
+            }
+            _ => (),
         }
 
         Controller::new(self.settings.unwrap(), context, working_directory)
@@ -204,7 +210,7 @@ impl Controller {
     }
 
     pub fn monitor_nodes(&mut self) {
-        if self.context.disable_progress_bar() {
+        if let ProgressBarMode::None = self.context.progress_bar_mode() {
             return;
         }
 

--- a/jormungandr-scenario-tests/src/scenario/mod.rs
+++ b/jormungandr-scenario-tests/src/scenario/mod.rs
@@ -1,6 +1,7 @@
 mod blockchain;
 mod context;
 mod controller;
+mod progress_bar_mode;
 pub mod repository;
 pub mod settings;
 mod topology;
@@ -10,6 +11,7 @@ pub use self::{
     blockchain::Blockchain,
     context::{Context, ContextChaCha, Seed},
     controller::{Controller, ControllerBuilder},
+    progress_bar_mode::{parse_progress_bar_mode_from_str, ProgressBarMode},
     topology::{Node, NodeAlias, Topology, TopologyBuilder},
     wallet::{Wallet, WalletAlias, WalletType},
 };

--- a/jormungandr-scenario-tests/src/scenario/progress_bar_mode.rs
+++ b/jormungandr-scenario-tests/src/scenario/progress_bar_mode.rs
@@ -1,0 +1,24 @@
+use crate::test::Result;
+use std::fmt;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ProgressBarMode {
+    Monitor,
+    Standard,
+    None,
+}
+
+pub fn parse_progress_bar_mode_from_str(progress_bar_mode: &str) -> Result<ProgressBarMode> {
+    let progress_bar_mode_lowercase: &str = &progress_bar_mode.to_lowercase();
+    match progress_bar_mode_lowercase {
+        "standard" => Ok(ProgressBarMode::Standard),
+        "none" => Ok(ProgressBarMode::None),
+        _ => Ok(ProgressBarMode::Monitor),
+    }
+}
+
+impl fmt::Display for ProgressBarMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}


### PR DESCRIPTION
There is a problem when launch large network (~80 nodes) . Using actual progress bar implementation  test prints lot of stuff on console which is a problematic when launching it via nightly test infrastructure. Therefore I expanded parameter `--disable-progress-bar` into `--progress-bar-mod` with 3 values: {MONITOR,PRINT,NONE}, which respective means keep live console , print in standard rust way, disabled log.