### PR TITLE
compile the tests and the doc in separate jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           name: Test
           environment:
             RUST_BACKTRACE: 1
-          command: cargo test --offline --verbose --frozen --doc
+          command: cargo test --offline --verbose --frozen --doc -- --test-threads=1
 
   test_release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,10 @@ workflows:
           requires:
             - rustfmt
             - cargo_fetch
+      - test_doc:
+          requires:
+            - rustfmt
+            - cargo_fetch
       - test_release:
           requires:
             - rustfmt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,29 @@ jobs:
           name: Test
           environment:
             RUST_BACKTRACE: 1
-          command: cargo test --offline --verbose --frozen
+          command: cargo test --offline --verbose --frozen --tests
+
+  test_doc:
+    docker:
+      - image: inputoutput/rust:stable
+    environment:
+      CARGO_INCREMENTAL: 0
+    working_directory: /home/circleci/project
+    steps:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+      - restore_cache:
+          keys:
+            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Print version information
+          command: rustc --version; cargo --version
+      - run:
+          name: Test
+          environment:
+            RUST_BACKTRACE: 1
+          command: cargo test --offline --verbose --frozen --doc
 
   test_release:
     docker:
@@ -108,7 +130,7 @@ jobs:
           command: cargo build --tests --release --offline --verbose --frozen
       - run:
           name: Test
-          command: cargo test --release --offline --verbose
+          command: cargo test --release --offline --verbose --tests
 
   test_beta:
     docker:
@@ -136,7 +158,7 @@ jobs:
           name: Test
           environment:
             RUST_BACKTRACE: 1
-          command: cargo test --offline --verbose
+          command: cargo test --offline --verbose --tests
 
 workflows:
   version: 2


### PR DESCRIPTION
tests started to fail due to high memory usage of the doc tests when executed in multiple threads in parallels. Now the doc tests is separated and run on one thread.