### PR TITLE
use the exact version of rustls in jormungandr

### DIFF
--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -45,7 +45,7 @@ poldercast = { version = "0.11.7" }
 r2d2 = "0.8"
 rand = "0.7"
 rand_chacha = "0.2.2"
-rustls = "^0.16.0 "
+rustls = "0.16.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0.50"


### PR DESCRIPTION
This import is only used for providing the configuration for
Actix 2.0.0, so we cannot update without updating Actix.