### PR TITLE
fix errors in REST API and remove node_id

### DIFF
--- a/jormungandr-lib/src/interfaces/peer_stats.rs
+++ b/jormungandr-lib/src/interfaces/peer_stats.rs
@@ -6,7 +6,6 @@ use std::net::SocketAddr;
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct PeerStats {
-    pub node_id: String,
     pub addr: Option<SocketAddr>,
     pub established_at: SystemTime,
     pub last_block_received: Option<SystemTime>,

--- a/jormungandr-lib/src/interfaces/stats.rs
+++ b/jormungandr-lib/src/interfaces/stats.rs
@@ -23,7 +23,6 @@ pub struct NodeStats {
     pub last_block_time: Option<SystemTime>,
     pub last_block_tx: u64,
     pub last_received_block_time: Option<SystemTime>,
-    pub node_id: String,
     pub peer_available_cnt: usize,
     pub peer_connected_cnt: usize,
     pub peer_quarantined_cnt: usize,

--- a/jormungandr-scenario-tests/src/test/features/mod.rs
+++ b/jormungandr-scenario-tests/src/test/features/mod.rs
@@ -73,54 +73,11 @@ pub fn assert_are_not_in_network_view(
     let network_view = node.network_stats()?;
     for peer in peers {
         utils::assert(
-            network_view.iter().any(|info| {
-                info.node_id == peer.public_id().to_string()
-                    && info.addr == peer.address().to_socketaddr()
-            }),
+            network_view
+                .iter()
+                .any(|info| info.addr == peer.address().to_socketaddr()),
             &format!(
                 "{}: Peer {} is present in network view list, while it should not",
-                info,
-                peer.alias()
-            ),
-        )?;
-    }
-    Ok(())
-}
-
-pub fn assert_are_in_network_stats(
-    node: &NodeController,
-    peers: Vec<&NodeController>,
-    info: &str,
-) -> Result<()> {
-    let network_stats = node.network_stats()?;
-    for peer in peers {
-        utils::assert(
-            network_stats
-                .iter()
-                .any(|x| x.node_id == peer.public_id().to_string()),
-            &format!(
-                "{}: Peer {} is not present in network_stats list",
-                info,
-                peer.alias()
-            ),
-        )?;
-    }
-    Ok(())
-}
-
-pub fn assert_are_not_in_network_stats(
-    node: &NodeController,
-    peers: Vec<&NodeController>,
-    info: &str,
-) -> Result<()> {
-    let network_stats = node.network_stats()?;
-    for peer in peers {
-        utils::assert(
-            network_stats
-                .iter()
-                .any(|x| x.node_id == peer.public_id().to_string()),
-            &format!(
-                "{}: Peer {} is present in network_stats list, while it should not",
                 info,
                 peer.alias()
             ),

--- a/jormungandr-scenario-tests/src/test/features/node_id.rs
+++ b/jormungandr-scenario-tests/src/test/features/node_id.rs
@@ -1,17 +1,13 @@
 use crate::{
-    node::NodeController,
     node::{LeadershipMode, PersistenceMode},
     test::{utils, Result},
     Context, ScenarioResult,
 };
 
-use jormungandr_lib::{
-    interfaces::{PeerRecord, Policy},
-    time::Duration,
-};
+use jormungandr_lib::{interfaces::Policy, time::Duration};
 
 use rand_chacha::ChaChaRng;
-use std::str::FromStr;
+
 const LEADER1: &str = "LEADER1";
 const LEADER2: &str = "LEADER2";
 const LEADER3: &str = "LEADER3";
@@ -58,8 +54,6 @@ pub fn duplicated_node_id_test(mut context: Context<ChaChaRng>) -> Result<Scenar
         controller.spawn_node(LEADER2, LeadershipMode::Leader, PersistenceMode::Persistent)?;
     leader2.wait_for_bootstrap()?;
 
-    let leader2_node_id = leader2.stats()?.stats.expect("empty stats").node_id.clone();
-
     let mut leader3 =
         controller.spawn_node(LEADER3, LeadershipMode::Leader, PersistenceMode::Persistent)?;
     leader3.wait_for_bootstrap()?;
@@ -68,17 +62,12 @@ pub fn duplicated_node_id_test(mut context: Context<ChaChaRng>) -> Result<Scenar
 
     let info_before = "before duplicated node id";
     super::assert_node_stats(&leader1, 2, 0, 2, 0, info_before)?;
-    super::assert_are_in_network_stats(&leader1, vec![&leader2, &leader3], info_before)?;
     super::assert_are_available(&leader1, vec![&leader2, &leader3], info_before)?;
     super::assert_empty_quarantine(&leader1, info_before)?;
     super::assert_are_in_network_view(&leader1, vec![&leader2, &leader3], info_before)?;
 
     leader3.shutdown()?;
-    leader3 = controller.spawn_node_custom(
-        controller
-            .new_spawn_params(LEADER3)
-            .node_id(poldercast::Id::from_str(&leader2_node_id).unwrap()),
-    )?;
+    leader3 = controller.spawn_node_custom(&mut controller.new_spawn_params(LEADER3))?;
     leader3.wait_for_bootstrap()?;
 
     utils::wait(30);
@@ -89,8 +78,6 @@ pub fn duplicated_node_id_test(mut context: Context<ChaChaRng>) -> Result<Scenar
 
     let info_after = "after leader3 duplicated node id";
     super::assert_node_stats(&leader1, 1, 1, 2, 0, &info_after)?;
-    super::assert_are_in_network_stats(&leader1, vec![&&leader3], &info_after)?;
-    super::assert_are_available(&leader1, vec![&leader3], &info_after)?;
     super::assert_are_in_quarantine(&leader1, vec![], &info_after)?;
     super::assert_are_in_network_view(&leader1, vec![&leader3], &info_after)?;
 
@@ -146,7 +133,6 @@ pub fn duplicated_trusted_peer_id_test(mut context: Context<ChaChaRng>) -> Resul
 
     let info_before = "before duplicated node id";
     super::assert_node_stats(&leader2, 1, 0, 1, 0, info_before)?;
-    super::assert_are_in_network_stats(&leader2, vec![&leader1], info_before)?;
     super::assert_are_available(&leader2, vec![&leader1], info_before)?;
     super::assert_empty_quarantine(&leader2, info_before)?;
     super::assert_are_in_network_view(&leader2, vec![&leader1], info_before)?;
@@ -163,7 +149,6 @@ pub fn duplicated_trusted_peer_id_test(mut context: Context<ChaChaRng>) -> Resul
 
     let info_after = "after leader3 duplicated node id";
     super::assert_node_stats(&leader2, 1, 0, 1, 0, info_after)?;
-    super::assert_are_in_network_stats(&leader2, vec![&leader1], info_after)?;
     super::assert_are_available(&leader2, vec![&leader1], info_after)?;
     super::assert_are_in_quarantine(&leader2, vec![], info_after)?;
     super::assert_are_in_network_view(&leader2, vec![&leader1], info_after)?;


### PR DESCRIPTION
Since we are not using node_id anymore it was removed from REST API and
corresponding structures.