### PR TITLE
separate REST Context and methods implementations from Actix

### DIFF
--- a/jormungandr-lib/src/interfaces/mod.rs
+++ b/jormungandr-lib/src/interfaces/mod.rs
@@ -49,7 +49,7 @@ pub use self::reward_parameters::RewardParams;
 pub use self::rewards_info::EpochRewardsInfo;
 pub use self::settings::{ParametersDef, RatioDef, SettingsDto, TaxTypeDef, TaxTypeSerde};
 pub use self::stake::{Stake, StakeDef};
-pub use self::stake_distribution::StakeDistributionDto;
+pub use self::stake_distribution::{StakeDistribution, StakeDistributionDto};
 pub use self::stake_pool_stats::{Rewards, StakePoolStats};
 pub use self::stats::{NodeState, NodeStats, NodeStatsDto};
 pub use self::tax_type::TaxType;

--- a/jormungandr/src/rest/context.rs
+++ b/jormungandr/src/rest/context.rs
@@ -1,0 +1,141 @@
+use std::sync::Arc;
+
+use crate::{
+    blockchain::{Blockchain, Tip},
+    diagnostic::Diagnostic,
+    intercom::{NetworkMsg, TransactionMsg},
+    leadership::Logs as LeadershipLogs,
+    network::p2p::P2pTopology,
+    rest::ServerStopper,
+    secure::enclave::Enclave,
+    stats_counter::StatsCounter,
+    utils::async_msg::MessageBox,
+};
+use jormungandr_lib::interfaces::NodeState;
+
+use slog::Logger;
+use tokio02::sync::RwLock;
+
+#[derive(Clone)]
+pub struct Context {
+    full: Arc<RwLock<Option<Arc<FullContext>>>>,
+    server_stopper: Arc<RwLock<Option<ServerStopper>>>,
+    node_state: Arc<RwLock<NodeState>>,
+    logger: Arc<RwLock<Option<Logger>>>,
+    diagnostic: Arc<RwLock<Option<Diagnostic>>>,
+    blockchain: Arc<RwLock<Option<Blockchain>>>,
+    blockchain_tip: Arc<RwLock<Option<Tip>>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Full REST context not available yet")]
+    FullContext,
+    #[error("Server stopper not set in REST context")]
+    ServerStopper,
+    #[error("Logger not set in REST context")]
+    Logger,
+    #[error("Blockchain not set in REST context")]
+    Blockchain,
+    #[error("Blockchain tip not set in REST context")]
+    BlockchainTip,
+    #[error("Diagnostic data not set in REST context")]
+    Diagnostic,
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Context {
+            full: Default::default(),
+            server_stopper: Default::default(),
+            node_state: Arc::new(RwLock::new(NodeState::StartingRestServer)),
+            logger: Default::default(),
+            diagnostic: Default::default(),
+            blockchain: Default::default(),
+            blockchain_tip: Default::default(),
+        }
+    }
+
+    pub async fn set_full(&self, full_context: FullContext) {
+        *self.full.write().await = Some(Arc::new(full_context));
+    }
+
+    pub async fn try_full(&self) -> Result<Arc<FullContext>, Error> {
+        self.full.read().await.clone().ok_or(Error::FullContext)
+    }
+
+    pub async fn set_server_stopper(&self, server_stopper: ServerStopper) {
+        *self.server_stopper.write().await = Some(server_stopper);
+    }
+
+    pub async fn server_stopper(&self) -> Result<ServerStopper, Error> {
+        self.server_stopper
+            .read()
+            .await
+            .clone()
+            .ok_or(Error::ServerStopper)
+    }
+
+    pub async fn set_node_state(&self, node_state: NodeState) {
+        *self.node_state.write().await = node_state;
+    }
+
+    pub async fn node_state(&self) -> NodeState {
+        self.node_state.read().await.clone()
+    }
+
+    pub async fn set_logger(&self, logger: Logger) {
+        *self.logger.write().await = Some(logger);
+    }
+
+    pub async fn logger(&self) -> Result<Logger, Error> {
+        self.logger.read().await.clone().ok_or(Error::Logger)
+    }
+
+    pub async fn set_diagnostic_data(&self, diagnostic: Diagnostic) {
+        *self.diagnostic.write().await = Some(diagnostic);
+    }
+
+    pub async fn get_diagnostic_data(&self) -> Result<Diagnostic, Error> {
+        self.diagnostic
+            .read()
+            .await
+            .clone()
+            .ok_or(Error::Diagnostic)
+    }
+
+    pub async fn set_blockchain(&self, blockchain: Blockchain) {
+        *self.blockchain.write().await = Some(blockchain)
+    }
+
+    pub async fn blockchain(&self) -> Result<Blockchain, Error> {
+        self.blockchain
+            .read()
+            .await
+            .clone()
+            .ok_or(Error::Blockchain)
+    }
+
+    pub async fn set_blockchain_tip(&self, blockchain_tip: Tip) {
+        *self.blockchain_tip.write().await = Some(blockchain_tip)
+    }
+
+    pub async fn blockchain_tip(&self) -> Result<Tip, Error> {
+        self.blockchain_tip
+            .read()
+            .await
+            .clone()
+            .ok_or(Error::BlockchainTip)
+    }
+}
+
+#[derive(Clone)]
+pub struct FullContext {
+    pub stats_counter: StatsCounter,
+    pub network_task: MessageBox<NetworkMsg>,
+    pub transaction_task: MessageBox<TransactionMsg>,
+    pub leadership_logs: LeadershipLogs,
+    pub enclave: Enclave,
+    pub p2p: P2pTopology,
+    pub explorer: Option<crate::explorer::Explorer>,
+}

--- a/jormungandr/src/rest/explorer/handlers.rs
+++ b/jormungandr/src/rest/explorer/handlers.rs
@@ -19,7 +19,8 @@ pub async fn graphql(
 ) -> Result<impl Responder, Error> {
     let explorer = context
         .try_full()
-        .await?
+        .await
+        .map_err(ErrorInternalServerError)?
         .explorer
         .clone()
         .ok_or(ErrorServiceUnavailable("Explorer not enabled"))?;

--- a/jormungandr/src/rest/mod.rs
+++ b/jormungandr/src/rest/mod.rs
@@ -2,148 +2,19 @@
 
 mod server;
 
+pub mod context;
 pub mod explorer;
 pub mod v0;
 
-pub use self::server::{Error, Server, ServerStopper};
+pub use self::{
+    context::{Context, FullContext},
+    server::{Error, Server, ServerStopper},
+};
 
-use actix_web::error::{Error as ActixError, ErrorInternalServerError, ErrorServiceUnavailable};
-use actix_web::web::ServiceConfig;
-
-use slog::Logger;
-use std::sync::Arc;
-
-use crate::blockchain::{Blockchain, Tip};
-use crate::diagnostic::Diagnostic;
-use crate::leadership::Logs as LeadershipLogs;
-use crate::network::p2p::P2pTopology;
-use crate::secure::enclave::Enclave;
 use crate::settings::start::{Error as ConfigError, Rest};
-use crate::stats_counter::StatsCounter;
 
-use crate::intercom::{NetworkMsg, TransactionMsg};
-use crate::utils::async_msg::MessageBox;
-
-use chain_impl_mockchain::block::Block;
+use actix_web::web::ServiceConfig;
 use futures03::executor::block_on;
-use jormungandr_lib::interfaces::NodeState;
-use tokio02::sync::RwLock;
-
-#[derive(Clone)]
-pub struct Context {
-    full: Arc<RwLock<Option<Arc<FullContext>>>>,
-    server_stopper: Arc<RwLock<Option<ServerStopper>>>,
-    node_state: Arc<RwLock<NodeState>>,
-    logger: Arc<RwLock<Option<Logger>>>,
-    diagnostic: Arc<RwLock<Option<Diagnostic>>>,
-    blockchain: Arc<RwLock<Option<Blockchain>>>,
-    blockchain_tip: Arc<RwLock<Option<Tip>>>,
-}
-
-impl Context {
-    pub fn new() -> Self {
-        Context {
-            full: Default::default(),
-            server_stopper: Default::default(),
-            node_state: Arc::new(RwLock::new(NodeState::StartingRestServer)),
-            logger: Default::default(),
-            diagnostic: Default::default(),
-            blockchain: Default::default(),
-            blockchain_tip: Default::default(),
-        }
-    }
-
-    pub async fn set_full(&self, full_context: FullContext) {
-        *self.full.write().await = Some(Arc::new(full_context));
-    }
-
-    pub async fn try_full(&self) -> Result<Arc<FullContext>, ActixError> {
-        self.full
-            .read()
-            .await
-            .clone()
-            .ok_or_else(|| ErrorServiceUnavailable("Full REST context not available yet"))
-    }
-
-    async fn set_server_stopper(&self, server_stopper: ServerStopper) {
-        *self.server_stopper.write().await = Some(server_stopper);
-    }
-
-    pub async fn server_stopper(&self) -> Result<ServerStopper, ActixError> {
-        self.server_stopper
-            .read()
-            .await
-            .clone()
-            .ok_or_else(|| ErrorInternalServerError("Server stopper not set in REST context"))
-    }
-
-    pub async fn set_node_state(&self, node_state: NodeState) {
-        *self.node_state.write().await = node_state;
-    }
-
-    pub async fn node_state(&self) -> NodeState {
-        self.node_state.read().await.clone()
-    }
-
-    pub async fn set_logger(&self, logger: Logger) {
-        *self.logger.write().await = Some(logger);
-    }
-
-    pub async fn logger(&self) -> Result<Logger, ActixError> {
-        self.logger
-            .read()
-            .await
-            .clone()
-            .ok_or_else(|| ErrorInternalServerError("Logger not set in REST context"))
-    }
-
-    pub async fn set_diagnostic_data(&self, diagnostic: Diagnostic) {
-        *self.diagnostic.write().await = Some(diagnostic);
-    }
-
-    pub async fn get_diagnostic_data(&self) -> Result<Diagnostic, ActixError> {
-        self.diagnostic
-            .read()
-            .await
-            .clone()
-            .ok_or_else(|| ErrorInternalServerError("Diagnostic data not set in REST context"))
-    }
-
-    pub async fn set_blockchain(&self, blockchain: Blockchain) {
-        *self.blockchain.write().await = Some(blockchain)
-    }
-
-    pub async fn blockchain(&self) -> Result<Blockchain, ActixError> {
-        self.blockchain
-            .read()
-            .await
-            .clone()
-            .ok_or_else(|| ErrorInternalServerError("Blockchain not set in REST context"))
-    }
-
-    pub async fn set_blockchain_tip(&self, blockchain_tip: Tip) {
-        *self.blockchain_tip.write().await = Some(blockchain_tip)
-    }
-
-    pub async fn blockchain_tip(&self) -> Result<Tip, ActixError> {
-        self.blockchain_tip
-            .read()
-            .await
-            .clone()
-            .ok_or_else(|| ErrorInternalServerError("Blockchain tip not set in REST context"))
-    }
-}
-
-#[derive(Clone)]
-pub struct FullContext {
-    pub stats_counter: StatsCounter,
-    pub network_task: MessageBox<NetworkMsg>,
-    pub transaction_task: MessageBox<TransactionMsg>,
-    pub leadership_logs: LeadershipLogs,
-    pub enclave: Enclave,
-    pub p2p: P2pTopology,
-    pub explorer: Option<crate::explorer::Explorer>,
-}
 
 pub fn start_rest_server(
     config: Rest,

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -1,218 +1,66 @@
 use actix_web::error::{ErrorBadRequest, ErrorInternalServerError, ErrorNotFound};
-use actix_web::web::{Bytes, BytesMut, Data, Json, Path, Query};
+use actix_web::web::{Bytes, Data, Json, Path, Query};
 use actix_web::{Error, HttpResponse, Responder};
-use chain_core::property::{Block, Deserialize, Serialize as _};
-use chain_crypto::{bech32::Bech32, Blake2b256, PublicKey};
-use chain_impl_mockchain::account::{AccountAlg, Identifier};
-use chain_impl_mockchain::block::Block as ChainBlock;
-use chain_impl_mockchain::fragment::{Fragment, FragmentId};
-use chain_impl_mockchain::key::Hash;
-use chain_impl_mockchain::leadership::{Leader, LeadershipConsensus};
-use chain_impl_mockchain::stake::StakeDistribution;
-use chain_impl_mockchain::transaction::Transaction;
-use chain_impl_mockchain::value::{Value, ValueError};
-use chain_storage_sqlite_old::Error as StorageError;
-use jormungandr_lib::interfaces::{
-    AccountState, Address, EnclaveLeaderId, EpochRewardsInfo, FragmentOrigin,
-    Rewards as StakePoolRewards, StakePoolStats, TaxTypeSerde,
-};
-use jormungandr_lib::interfaces::{NodeStats, NodeStatsDto, PeerStats};
-use jormungandr_lib::time::SystemTime;
+use jormungandr_lib::interfaces::EnclaveLeaderId;
 
-use crate::intercom::{self, NetworkMsg, TransactionMsg};
+use crate::rest::v0::logic::Error as LogicError;
 use crate::secure::NodeSecret;
-use futures03::{
-    compat::Future01CompatExt,
-    stream::{StreamExt, TryStreamExt},
-};
 
-use std::str::FromStr;
-use std::sync::Arc;
-
-pub use crate::rest::{Context, FullContext};
-
-fn parse_account_id(id_hex: &str) -> Result<Identifier, Error> {
-    PublicKey::<AccountAlg>::from_str(id_hex)
-        .map(Into::into)
-        .map_err(ErrorBadRequest)
-}
-
-fn parse_fragment_id(id_hex: &str) -> Result<FragmentId, Error> {
-    FragmentId::from_str(id_hex).map_err(ErrorBadRequest)
-}
-
-fn parse_block_hash(hex: &str) -> Result<Hash, Error> {
-    Blake2b256::from_str(hex)
-        .map_err(ErrorBadRequest)
-        .map(Into::into)
-}
+pub use crate::rest::{v0::logic, Context, FullContext};
 
 pub async fn get_account_state(
     context: Data<Context>,
     account_id_hex: Path<String>,
 ) -> Result<impl Responder, Error> {
-    let account_id = parse_account_id(&account_id_hex)?;
-    let chain_tip = context.blockchain_tip().await?.get_ref().await;
-    let ledger = chain_tip.ledger();
-    let state = ledger
-        .accounts()
-        .get_state(&account_id)
-        .map_err(ErrorNotFound)?;
-    Ok(Json(AccountState::from(state)))
+    logic::get_account_state(&context, &account_id_hex)
+        .await
+        .map_err(|err| match err {
+            LogicError::PublicKey(e) => ErrorBadRequest(e),
+            e => ErrorInternalServerError(e),
+        })?
+        .map(Json)
+        .ok_or(ErrorNotFound("account not found"))
 }
 
 pub async fn get_message_logs(context: Data<Context>) -> Result<impl Responder, Error> {
-    let logs = intercom::unary_future(
-        context.try_full().await?.transaction_task.clone(),
-        context.logger().await?,
-        |handle| TransactionMsg::GetLogs(handle),
-    )
-    .compat()
-    .await
-    .map_err(|e: intercom::Error| ErrorInternalServerError(e))?;
-    Ok(Json(logs))
+    logic::get_message_logs(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn post_message(context: Data<Context>, message: Bytes) -> Result<impl Responder, Error> {
-    let fragment = Fragment::deserialize(&*message).map_err(ErrorBadRequest)?;
-    let msg = TransactionMsg::SendTransaction(FragmentOrigin::Rest, vec![fragment]);
-    context
-        .try_full()
-        .await?
-        .transaction_task
-        .clone()
-        .try_send(msg)
-        .map_err(ErrorInternalServerError)?;
-    Ok(HttpResponse::Ok().finish())
+    logic::post_message(&context, &message)
+        .await
+        .map(|()| HttpResponse::Ok().finish())
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_tip(context: Data<Context>) -> Result<impl Responder, Error> {
-    Ok(context
-        .blockchain_tip()
-        .await?
-        .get_ref()
+    logic::get_tip(&context)
         .await
-        .hash()
-        .to_string())
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_stats_counter(context: Data<Context>) -> Result<impl Responder, Error> {
-    let stats = create_stats(&context).await?;
-    Ok(Json(NodeStatsDto {
-        version: env!("SIMPLE_VERSION").to_string(),
-        state: context.node_state().await,
-        stats,
-    }))
-}
-
-async fn create_stats(context: &Context) -> Result<Option<NodeStats>, Error> {
-    use futures03::future::try_join3;
-
-    let (tip, blockchain, full_context) = match try_join3(
-        context.blockchain_tip(),
-        context.blockchain(),
-        context.try_full(),
-    )
-    .await
-    {
-        Ok(result) => result,
-        Err(_) => return Ok(None),
-    };
-
-    let tip = tip.get_ref().await;
-
-    let mut block_tx_count = 0u64;
-    let mut block_input_sum = Value::zero();
-    let mut block_fee_sum = Value::zero();
-
-    let mut header_block = full_context.stats_counter.get_tip_block();
-
-    // In case we do not have a cached block in the stats_counter we can retrieve it from the
-    // storage, this should happen just once.
-    if header_block.is_none() {
-        let block: Option<ChainBlock> = blockchain.storage().get(tip.hash()).await.unwrap_or(None);
-
-        // Update block if found
-        if let Some(block) = block {
-            full_context.stats_counter.set_tip_block(Arc::new(block));
-        };
-
-        header_block = full_context.stats_counter.get_tip_block();
-    }
-
-    header_block
-        .as_ref()
-        .as_ref()
-        .ok_or(ErrorInternalServerError("Could not find block for tip"))?
-        .contents
-        .iter()
-        .map(|fragment| {
-            fn totals<T>(t: &Transaction<T>) -> Result<(Value, Value), ValueError> {
-                Ok((t.total_input()?, t.total_output()?))
-            }
-
-            let (total_input, total_output) = match &fragment {
-                Fragment::Transaction(tx) => totals(tx),
-                Fragment::OwnerStakeDelegation(tx) => totals(tx),
-                Fragment::StakeDelegation(tx) => totals(tx),
-                Fragment::PoolRegistration(tx) => totals(tx),
-                Fragment::PoolRetirement(tx) => totals(tx),
-                Fragment::PoolUpdate(tx) => totals(tx),
-                Fragment::Initial(_)
-                | Fragment::OldUtxoDeclaration(_)
-                | Fragment::UpdateProposal(_)
-                | Fragment::UpdateVote(_) => return Ok(()),
-            }?;
-            block_tx_count += 1;
-            block_input_sum = (block_input_sum + total_input)?;
-            let fee = (total_input - total_output).unwrap_or(Value::zero());
-            block_fee_sum = (block_fee_sum + fee)?;
-            Ok(())
-        })
-        .collect::<Result<(), ValueError>>()
-        .map_err(|e| ErrorInternalServerError(format!("Block value calculation error: {}", e)))?;
-    let nodes_count = &full_context.p2p.nodes_count::<Error>().compat().await?;
-    let tip_header = tip.header();
-    let stats = &full_context.stats_counter;
-    let node_id = &full_context.p2p.node_id().to_string();
-    let node_stats = NodeStats {
-        block_recv_cnt: stats.block_recv_cnt(),
-        last_block_content_size: tip_header.block_content_size(),
-        last_block_date: tip_header.block_date().to_string().into(),
-        last_block_fees: block_fee_sum.0,
-        last_block_hash: tip_header.hash().to_string().into(),
-        last_block_height: tip_header.chain_length().to_string().into(),
-        last_block_sum: block_input_sum.0,
-        last_block_time: SystemTime::from(tip.time()).into(),
-        last_block_tx: block_tx_count,
-        last_received_block_time: stats.slot_start_time().map(SystemTime::from),
-        node_id: node_id.to_owned(),
-        peer_available_cnt: nodes_count.available_count,
-        peer_connected_cnt: stats.peer_connected_cnt(),
-        peer_quarantined_cnt: nodes_count.quarantined_count,
-        peer_total_cnt: nodes_count.all_count,
-        peer_unreachable_cnt: nodes_count.not_reachable_count,
-        tx_recv_cnt: stats.tx_recv_cnt(),
-        uptime: stats.uptime_sec().into(),
-    };
-    Ok(Some(node_stats))
+    logic::get_stats_counter(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_block_id(
     context: Data<Context>,
     block_id_hex: Path<String>,
 ) -> Result<impl Responder, Error> {
-    context
-        .blockchain()
-        .await?
-        .storage()
-        .get(parse_block_hash(&block_id_hex)?)
+    logic::get_block_id(&context, &block_id_hex)
         .await
-        .map_err(ErrorInternalServerError)?
-        .ok_or(ErrorNotFound("Block not found"))?
-        .serialize_as_vec()
-        .map_err(ErrorInternalServerError)
+        .map_err(|err| match err {
+            LogicError::Hash(e) => ErrorBadRequest(e),
+            e => ErrorInternalServerError(e),
+        })?
         .map(Bytes::from)
+        .ok_or(ErrorNotFound("Block not found"))
 }
 
 pub async fn get_block_next_id(
@@ -220,25 +68,14 @@ pub async fn get_block_next_id(
     block_id_hex: Path<String>,
     query_params: Query<QueryParams>,
 ) -> Result<impl Responder, Error> {
-    let blockchain = context.blockchain().await?;
-    let block_id = parse_block_hash(&block_id_hex)?;
-    let tip = context.blockchain_tip().await?.get_ref().await;
-    blockchain
-        .storage()
-        .stream_from_to(block_id, tip.hash())
+    logic::get_block_next_id(&context, &block_id_hex, query_params.get_count() as usize)
         .await
-        .map_err(|e| match e {
-            StorageError::CannotIterate => ErrorNotFound("Block is not in chain of the tip"),
-            StorageError::BlockNotFound => ErrorNotFound(e),
-            _ => ErrorInternalServerError(e),
+        .map_err(|err| match err {
+            LogicError::Hash(e) => ErrorBadRequest(e),
+            e => ErrorInternalServerError(e),
         })?
-        .map_err(ErrorInternalServerError)
-        .take(query_params.get_count() as usize)
-        .try_fold(BytesMut::new(), |mut bytes, block| async move {
-            bytes.extend_from_slice(block.id().as_ref());
-            Result::<BytesMut, Error>::Ok(bytes)
-        })
-        .await
+        .ok_or(ErrorNotFound("Block is not in chain of the tip"))
+        .map(Bytes::from)
 }
 
 const MAX_COUNT: u64 = 100;
@@ -255,253 +92,107 @@ impl QueryParams {
 }
 
 pub async fn get_stake_distribution(context: Data<Context>) -> Result<impl Responder, Error> {
-    let blockchain_tip = context.blockchain_tip().await?.get_ref().await;
-    let leadership = blockchain_tip.epoch_leadership_schedule();
-    let last_epoch = blockchain_tip.block_date().epoch;
-    let stake = if let LeadershipConsensus::GenesisPraos(gp) = leadership.consensus() {
-        Some(create_stake(gp.distribution()))
-    } else {
-        None
-    };
-    Ok(Json(json!({
-        "epoch": last_epoch,
-        "stake": stake,
-    })))
+    logic::get_stake_distribution(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_stake_distribution_at(
     context: Data<Context>,
     epoch: Path<u32>,
 ) -> Result<impl Responder, Error> {
-    let mut tip_ref = context.blockchain_tip().await?.get_ref().await;
-    let epoch = epoch.into_inner();
-
-    if epoch > tip_ref.block_date().epoch {
-        return Err(ErrorNotFound("Invalid epoch, does not exist yet..."));
-    }
-
-    loop {
-        if tip_ref.block_date().epoch == epoch {
-            break;
-        }
-        match tip_ref.last_ref_previous_epoch() {
-            Some(previous_epoch) => {
-                if epoch > previous_epoch.block_date().epoch {
-                    return Err(ErrorNotFound("Epoch not found..."));
-                }
-                tip_ref = Arc::clone(previous_epoch);
-            }
-            _ => return Err(ErrorNotFound("Epoch not found...")),
-        }
-    }
-
-    let stake = tip_ref
-        .epoch_leadership_schedule()
-        .stake_distribution()
-        .map(create_stake);
-
-    Ok(Json(json!({
-        "epoch": epoch,
-        "stake": stake,
-    })))
-}
-
-fn create_stake(stake: &StakeDistribution) -> serde_json::Value {
-    let unassigned: u64 = stake.unassigned.into();
-    let dangling: u64 = stake.dangling.into();
-    let pools: Vec<(String, u64)> = stake
-        .to_pools
-        .iter()
-        .map(|(h, p)| (format!("{}", h), p.stake.total.into()))
-        .collect();
-    json!({
-        "unassigned": unassigned,
-        "dangling": dangling,
-        "pools": pools,
-    })
+    logic::get_stake_distribution_at(&context, epoch.into_inner())
+        .await
+        .map_err(ErrorInternalServerError)?
+        .map(Json)
+        .ok_or(ErrorNotFound("Epoch not found"))
 }
 
 pub async fn get_settings(context: Data<Context>) -> Result<impl Responder, Error> {
-    let full_context = context.try_full().await?;
-    let blockchain_tip = context.blockchain_tip().await?.get_ref().await;
-    let ledger = blockchain_tip.ledger();
-    let static_params = ledger.get_static_parameters();
-    let consensus_version = ledger.consensus_version();
-    let current_params = blockchain_tip.epoch_ledger_parameters();
-    let fees = current_params.fees;
-    let block_content_max_size = current_params.block_content_max_size;
-    let epoch_stability_depth = current_params.epoch_stability_depth;
-    let slots_per_epoch = blockchain_tip
-        .epoch_leadership_schedule()
-        .era()
-        .slots_per_epoch();
-    let settings = jormungandr_lib::interfaces::SettingsDto {
-        block0_hash: static_params.block0_initial_hash.to_string(),
-        block0_time: SystemTime::from_secs_since_epoch(static_params.block0_start_time.0),
-        curr_slot_start_time: full_context
-            .stats_counter
-            .slot_start_time()
-            .map(SystemTime::from),
-        consensus_version: consensus_version.to_string(),
-        fees: fees,
-        block_content_max_size: block_content_max_size,
-        epoch_stability_depth: epoch_stability_depth,
-        slot_duration: blockchain_tip.time_frame().slot_duration(),
-        slots_per_epoch,
-        treasury_tax: current_params.treasury_tax,
-        reward_params: current_params.reward_params.clone(),
-    };
-    Ok(Json(json!(settings)))
+    logic::get_settings(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_shutdown(context: Data<Context>) -> Result<impl Responder, Error> {
-    // Verify that node has fully started and is able to process shutdown
-    context.try_full().await?;
-    // Server finishes ongoing tasks before stopping, so user will get response to this request
-    // Node should be shutdown automatically when server stopping is finished
-    context.server_stopper().await?.stop();
-    Ok(HttpResponse::Ok().finish())
+    logic::get_shutdown(&context)
+        .await
+        .map(|_| HttpResponse::Ok().finish())
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_leaders(context: Data<Context>) -> Result<impl Responder, Error> {
-    Ok(Json(json! {
-        context.try_full().await?.enclave.get_leader_ids().await
-    }))
+    logic::get_leader_ids(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn post_leaders(
     secret: Json<NodeSecret>,
     context: Data<Context>,
 ) -> Result<impl Responder, Error> {
-    let leader = Leader {
-        bft_leader: secret.bft(),
-        genesis_leader: secret.genesis(),
-    };
-    let leader_id = context.try_full().await?.enclave.add_leader(leader).await;
-    Ok(Json(leader_id))
+    logic::post_leaders(&context, secret.into_inner())
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn delete_leaders(
     context: Data<Context>,
     leader_id: Path<EnclaveLeaderId>,
 ) -> Result<impl Responder, Error> {
-    match context
-        .try_full()
-        .await?
-        .enclave
-        .remove_leader(*leader_id)
+    logic::delete_leaders(&context, leader_id.into_inner())
         .await
-    {
-        true => Ok(HttpResponse::Ok().finish()),
-        false => Err(ErrorNotFound("Leader with given ID not found")),
-    }
+        .map_err(ErrorInternalServerError)?
+        .map(|()| HttpResponse::Ok().finish())
+        .ok_or(ErrorNotFound("Leader not found"))
 }
 
 pub async fn get_leaders_logs(context: Data<Context>) -> Result<impl Responder, Error> {
-    Ok(Json(context.try_full().await?.leadership_logs.logs().await))
+    logic::get_leaders_logs(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_stake_pools(context: Data<Context>) -> Result<impl Responder, Error> {
-    let stake_pool_ids = context
-        .blockchain_tip()
-        .await?
-        .get_ref()
+    logic::get_stake_pools(&context)
         .await
-        .ledger()
-        .delegation()
-        .stake_pool_ids()
-        .map(|id| id.to_string())
-        .collect::<Vec<_>>();
-    Ok(Json(stake_pool_ids))
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_network_stats(context: Data<Context>) -> Result<impl Responder, Error> {
-    let full_context = context.try_full().await?;
-    let peer_stats = intercom::unary_future(
-        full_context.network_task.clone(),
-        context.logger().await?,
-        |reply_handle| NetworkMsg::PeerInfo(reply_handle),
-    )
-    .compat()
-    .await
-    .map_err(|e: intercom::Error| ErrorInternalServerError(e))?;
-    let network_stats = peer_stats
-        .into_iter()
-        .map(|info| {
-            json!(PeerStats {
-                node_id: info.id.to_string(),
-                addr: info.addr,
-                established_at: SystemTime::from(info.stats.connection_established()),
-                last_block_received: info.stats.last_block_received().map(SystemTime::from),
-                last_fragment_received: info.stats.last_fragment_received().map(SystemTime::from),
-                last_gossip_received: info.stats.last_gossip_received().map(SystemTime::from),
-            })
-        })
-        .collect::<Vec<_>>();
-    Ok(Json(network_stats))
+    logic::get_network_stats(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_rewards_info_epoch(
     context: Data<Context>,
     epoch: Path<u32>,
 ) -> Result<impl Responder, Error> {
-    let mut tip_ref = context.blockchain_tip().await?.get_ref().await;
-    let epoch = epoch.into_inner();
-
-    if epoch > tip_ref.block_date().epoch {
-        return Err(ErrorNotFound("Invalid epoch, does not exist yet..."));
-    }
-
-    loop {
-        if tip_ref.block_date().epoch == epoch {
-            break;
-        }
-        match tip_ref.last_ref_previous_epoch() {
-            Some(previous_epoch) => {
-                if epoch > previous_epoch.block_date().epoch {
-                    return Err(ErrorNotFound("Epoch not found..."));
-                }
-                tip_ref = Arc::clone(previous_epoch);
-            }
-            _ => return Err(ErrorNotFound("Epoch not found...")),
-        }
-    }
-
-    if let Some(epoch_rewards_info) = tip_ref.epoch_rewards_info() {
-        let v = EpochRewardsInfo::from(tip_ref.block_date().epoch, epoch_rewards_info.as_ref());
-
-        Ok(Json(v))
-    } else {
-        Err(ErrorNotFound("No rewards for this epoch..."))
-    }
+    logic::get_rewards_info_epoch(&context, epoch.into_inner())
+        .await
+        .map_err(ErrorInternalServerError)?
+        .map(Json)
+        .ok_or(ErrorNotFound(
+            "Epoch not found or no rewards for this epoch",
+        ))
 }
 
 pub async fn get_rewards_info_history(
     context: Data<Context>,
     length: Path<usize>,
 ) -> Result<impl Responder, Error> {
-    let mut tip_ref = context.blockchain_tip().await?.get_ref().await;
-    let length = length.into_inner();
-
-    let mut vec = Vec::new();
-    while let Some(epoch_rewards_info) = tip_ref.epoch_rewards_info() {
-        vec.push(EpochRewardsInfo::from(
-            tip_ref.block_date().epoch,
-            epoch_rewards_info.as_ref(),
-        ));
-
-        if let Some(previous_epoch) = tip_ref.last_ref_previous_epoch() {
-            tip_ref = Arc::clone(previous_epoch);
-        } else {
-            break;
-        }
-
-        if vec.len() >= length {
-            break;
-        }
-    }
-
-    Ok(Json(vec))
+    logic::get_rewards_info_history(&context, length.into_inner())
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_utxo(
@@ -509,117 +200,68 @@ pub async fn get_utxo(
     path_params: Path<(String, u8)>,
 ) -> Result<impl Responder, Error> {
     let (fragment_id_hex, output_index) = path_params.into_inner();
-    let fragment_id = parse_fragment_id(&fragment_id_hex)?;
-    let tip_reference = context.blockchain_tip().await?.get_ref().await;
-    let ledger = tip_reference.ledger();
-    let output = ledger.utxo_out(fragment_id, output_index).ok_or_else(|| {
-        ErrorNotFound(format!(
-            "no UTxO found for address '{}' on index {}",
-            fragment_id_hex, output_index
-        ))
-    })?;
-    Ok(Json(json!({
-        "address": Address::from(output.address.clone()),
-        "value": output.value.0,
-    })))
+    logic::get_utxo(&context, &fragment_id_hex, output_index)
+        .await
+        .map_err(|err| match err {
+            LogicError::Hash(e) => ErrorBadRequest(e),
+            e => ErrorInternalServerError(e),
+        })?
+        .map(Json)
+        .ok_or(ErrorNotFound("No UTXO found for address or index"))
 }
 
 pub async fn get_stake_pool(
     context: Data<Context>,
     pool_id_hex: Path<String>,
 ) -> Result<impl Responder, Error> {
-    let pool_id = pool_id_hex.parse().map_err(ErrorBadRequest)?;
-    let chain_tip = context.blockchain_tip().await?.get_ref().await;
-    let ledger = chain_tip.ledger();
-    let pool = ledger
-        .delegation()
-        .lookup(&pool_id)
-        .ok_or_else(|| ErrorNotFound(format!("Stake pool '{}' not found", pool_id_hex)))?;
-    let total_stake: u64 = ledger
-        .get_stake_distribution()
-        .to_pools
-        .get(&pool_id)
-        .map(|pool| pool.stake.total.into())
-        .unwrap_or(0);
-    Ok(Json(json!(StakePoolStats {
-        kes_public_key: pool
-            .registration
-            .keys
-            .kes_public_key
-            .to_bech32_str()
-            .to_owned(),
-        vrf_public_key: pool
-            .registration
-            .keys
-            .vrf_public_key
-            .to_bech32_str()
-            .to_owned(),
-        total_stake: total_stake,
-        rewards: StakePoolRewards {
-            epoch: pool.last_rewards.epoch,
-            value_taxed: pool.last_rewards.value_taxed,
-            value_for_stakers: pool.last_rewards.value_for_stakers,
-        },
-        tax: TaxTypeSerde(pool.registration.rewards),
-    })))
+    logic::get_stake_pool(&context, &pool_id_hex)
+        .await
+        .map_err(ErrorInternalServerError)?
+        .map(Json)
+        .ok_or(ErrorNotFound("Stake pool not found"))
 }
 
 pub async fn get_diagnostic(context: Data<Context>) -> Result<impl Responder, Error> {
-    let diagnostic = context.get_diagnostic_data().await?;
-    serde_json::to_string(&diagnostic).map_err(ErrorInternalServerError)
+    logic::get_diagnostic(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_network_p2p_quarantined(context: Data<Context>) -> Result<impl Responder, Error> {
-    let ctx = context.try_full().await?;
-    let list = ctx.p2p.list_quarantined::<Error>().compat().await?;
-    Ok(Json(json!(list)))
+    logic::get_network_p2p_quarantined(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_network_p2p_non_public(context: Data<Context>) -> Result<impl Responder, Error> {
-    let ctx = context.try_full().await?;
-    let list = ctx.p2p.list_non_public::<Error>().compat().await?;
-    Ok(Json(json!(list)))
+    logic::get_network_p2p_non_public(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_network_p2p_available(context: Data<Context>) -> Result<impl Responder, Error> {
-    let ctx = context.try_full().await?;
-    let list = ctx.p2p.list_available::<Error>().compat().await?;
-    Ok(Json(json!(list)))
+    logic::get_network_p2p_available(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_network_p2p_view(context: Data<Context>) -> Result<impl Responder, Error> {
-    let ctx = context.try_full().await?;
-    let view = ctx
-        .p2p
-        .view::<Error>(poldercast::Selection::Any)
-        .compat()
-        .await?;
-    let node_infos: Vec<poldercast::NodeInfo> = view.peers.into_iter().map(Into::into).collect();
-    Ok(Json(json!(node_infos)))
+    logic::get_network_p2p_view(&context)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }
 
 pub async fn get_network_p2p_view_topic(
     context: Data<Context>,
     topic: Path<String>,
 ) -> Result<impl Responder, Error> {
-    fn parse_topic(s: &str) -> Result<poldercast::Selection, Error> {
-        use crate::network::p2p::topic;
-        use poldercast::Selection;
-        match s {
-            "blocks" => Ok(Selection::Topic {
-                topic: topic::BLOCKS,
-            }),
-            "fragments" => Ok(Selection::Topic {
-                topic: topic::MESSAGES,
-            }),
-            "" => Ok(Selection::Any),
-            _ => Err(ErrorBadRequest("invalid topic")),
-        }
-    }
-
-    let topic = parse_topic(&topic.into_inner())?;
-    let ctx = context.try_full().await?;
-    let view = ctx.p2p.view::<Error>(topic).compat().await?;
-    let node_infos: Vec<poldercast::NodeInfo> = view.peers.into_iter().map(Into::into).collect();
-    Ok(Json(json!(node_infos)))
+    logic::get_network_p2p_view_topic(&context, &topic)
+        .await
+        .map(Json)
+        .map_err(ErrorInternalServerError)
 }

--- a/jormungandr/src/rest/v0/logic.rs
+++ b/jormungandr/src/rest/v0/logic.rs
@@ -1,0 +1,676 @@
+// This module contains framework-independent implementations of REST API
+// methods. The convention is the following:
+//
+// - Everything returns Result<T, Error>
+// - When the Ok type is Option<T> - None should be converted to 404
+// - All errors should be processed on the framework  integration side. Usually
+//   they are 400 or 500.
+
+use crate::{
+    diagnostic::Diagnostic,
+    intercom::{self, NetworkMsg, TransactionMsg},
+    rest::Context,
+    secure::NodeSecret,
+};
+use chain_core::property::{Block as _, Deserialize, FromStr, Serialize};
+use chain_crypto::{
+    bech32::Bech32, digest::Error as DigestError, hash::Error as HashError, Blake2b256, PublicKey,
+    PublicKeyFromStrError,
+};
+use chain_impl_mockchain::{
+    account::{AccountAlg, Identifier},
+    block::Block as ChainBlock,
+    fragment::{Fragment, FragmentId},
+    key::Hash,
+    leadership::{Leader, LeadershipConsensus},
+    transaction::Transaction,
+    value::{Value, ValueError},
+};
+use chain_storage_sqlite_old::Error as StorageError;
+use jormungandr_lib::{
+    interfaces::{
+        AccountState, EnclaveLeaderId, EpochRewardsInfo, FragmentLog, FragmentOrigin,
+        LeadershipLog, NodeStats, NodeStatsDto, PeerStats, Rewards as StakePoolRewards,
+        SettingsDto, StakeDistribution, StakeDistributionDto, StakePoolStats, TaxTypeSerde,
+        TransactionOutput,
+    },
+    time::SystemTime,
+};
+
+use std::{convert::Infallible, sync::Arc};
+
+use futures::sync::mpsc::TrySendError;
+use futures03::{compat::*, prelude::*};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    ContextError(#[from] crate::rest::context::Error),
+    #[error(transparent)]
+    PublicKey(#[from] PublicKeyFromStrError),
+    #[error(transparent)]
+    IntercomError(#[from] intercom::Error),
+    #[error(transparent)]
+    Serialize(std::io::Error),
+    #[error(transparent)]
+    Deserialize(std::io::Error),
+    #[error(transparent)]
+    TxMsgSendError(#[from] TrySendError<TransactionMsg>),
+    #[error(transparent)]
+    NetworkMsgSendError(#[from] TrySendError<NetworkMsg>),
+    #[error("Block value calculation error")]
+    Value(#[from] ValueError),
+    #[error("Could not find block for tip")]
+    TipBlockNotFound,
+    #[error(transparent)]
+    Hash(#[from] HashError),
+    #[error(transparent)]
+    Digest(#[from] DigestError),
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+    #[error("Invalid topic")]
+    InvalidTopic,
+}
+
+fn parse_account_id(id_hex: &str) -> Result<Identifier, Error> {
+    PublicKey::<AccountAlg>::from_str(id_hex)
+        .map(Into::into)
+        .map_err(Error::PublicKey)
+}
+
+fn parse_block_hash(hex: &str) -> Result<Hash, Error> {
+    Blake2b256::from_str(hex)
+        .map(Into::into)
+        .map_err(Error::Hash)
+}
+
+fn parse_fragment_id(id_hex: &str) -> Result<FragmentId, Error> {
+    FragmentId::from_str(id_hex).map_err(Error::Hash)
+}
+
+pub async fn get_account_state(
+    context: &Context,
+    account_id_hex: &str,
+) -> Result<Option<AccountState>, Error> {
+    Ok(context
+        .blockchain_tip()
+        .await?
+        .get_ref()
+        .await
+        .ledger()
+        .accounts()
+        .get_state(&parse_account_id(account_id_hex)?)
+        .ok()
+        .map(Into::into))
+}
+
+pub async fn get_message_logs(context: &Context) -> Result<Vec<FragmentLog>, Error> {
+    let logger = context.logger().await?.new(o!("request" => "message_logs"));
+    intercom::unary_future(
+        context.try_full().await?.transaction_task.clone(),
+        logger,
+        |handle| TransactionMsg::GetLogs(handle),
+    )
+    .compat()
+    .await
+}
+
+pub async fn post_message(context: &Context, message: &[u8]) -> Result<(), Error> {
+    let fragment = Fragment::deserialize(message).map_err(Error::Deserialize)?;
+    let msg = TransactionMsg::SendTransaction(FragmentOrigin::Rest, vec![fragment]);
+    context
+        .try_full()
+        .await?
+        .transaction_task
+        .clone()
+        .try_send(msg)?;
+
+    Ok(())
+}
+
+pub async fn get_tip(context: &Context) -> Result<String, Error> {
+    Ok(context
+        .blockchain_tip()
+        .await?
+        .get_ref()
+        .await
+        .hash()
+        .to_string())
+}
+
+pub async fn get_stats_counter(context: &Context) -> Result<NodeStatsDto, Error> {
+    let stats = create_stats(&context).await?;
+    Ok(NodeStatsDto {
+        version: env!("SIMPLE_VERSION").to_string(),
+        state: context.node_state().await,
+        stats,
+    })
+}
+
+async fn create_stats(context: &Context) -> Result<Option<NodeStats>, Error> {
+    use futures03::future::try_join3;
+
+    let (tip, blockchain, full_context) = match try_join3(
+        context.blockchain_tip(),
+        context.blockchain(),
+        context.try_full(),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => return Ok(None),
+    };
+
+    let tip = tip.get_ref().await;
+
+    let mut block_tx_count = 0u64;
+    let mut block_input_sum = Value::zero();
+    let mut block_fee_sum = Value::zero();
+
+    let mut header_block = full_context.stats_counter.get_tip_block();
+
+    // In case we do not have a cached block in the stats_counter we can retrieve it from the
+    // storage, this should happen just once.
+    if header_block.is_none() {
+        let block: Option<ChainBlock> = blockchain.storage().get(tip.hash()).await.unwrap_or(None);
+
+        // Update block if found
+        if let Some(block) = block {
+            full_context.stats_counter.set_tip_block(Arc::new(block));
+        };
+
+        header_block = full_context.stats_counter.get_tip_block();
+    }
+
+    header_block
+        .as_ref()
+        .as_ref()
+        .ok_or(Error::TipBlockNotFound)?
+        .contents
+        .iter()
+        .map(|fragment| {
+            fn totals<T>(t: &Transaction<T>) -> Result<(Value, Value), ValueError> {
+                Ok((t.total_input()?, t.total_output()?))
+            }
+
+            let (total_input, total_output) = match &fragment {
+                Fragment::Transaction(tx) => totals(tx),
+                Fragment::OwnerStakeDelegation(tx) => totals(tx),
+                Fragment::StakeDelegation(tx) => totals(tx),
+                Fragment::PoolRegistration(tx) => totals(tx),
+                Fragment::PoolRetirement(tx) => totals(tx),
+                Fragment::PoolUpdate(tx) => totals(tx),
+                Fragment::Initial(_)
+                | Fragment::OldUtxoDeclaration(_)
+                | Fragment::UpdateProposal(_)
+                | Fragment::UpdateVote(_) => return Ok(()),
+            }?;
+            block_tx_count += 1;
+            block_input_sum = (block_input_sum + total_input)?;
+            let fee = (total_input - total_output).unwrap_or(Value::zero());
+            block_fee_sum = (block_fee_sum + fee)?;
+            Ok(())
+        })
+        .collect::<Result<(), ValueError>>()?;
+    let nodes_count = full_context
+        .p2p
+        .nodes_count::<Infallible>()
+        .compat()
+        .await
+        .unwrap();
+    let tip_header = tip.header();
+    let stats = &full_context.stats_counter;
+    let node_id = &full_context.p2p.node_id().to_string();
+    let node_stats = NodeStats {
+        block_recv_cnt: stats.block_recv_cnt(),
+        last_block_content_size: tip_header.block_content_size(),
+        last_block_date: tip_header.block_date().to_string().into(),
+        last_block_fees: block_fee_sum.0,
+        last_block_hash: tip_header.hash().to_string().into(),
+        last_block_height: tip_header.chain_length().to_string().into(),
+        last_block_sum: block_input_sum.0,
+        last_block_time: SystemTime::from(tip.time()).into(),
+        last_block_tx: block_tx_count,
+        last_received_block_time: stats.slot_start_time().map(SystemTime::from),
+        peer_available_cnt: nodes_count.available_count,
+        peer_connected_cnt: stats.peer_connected_cnt(),
+        peer_quarantined_cnt: nodes_count.quarantined_count,
+        peer_total_cnt: nodes_count.all_count,
+        peer_unreachable_cnt: nodes_count.not_reachable_count,
+        tx_recv_cnt: stats.tx_recv_cnt(),
+        uptime: stats.uptime_sec().into(),
+        node_id: node_id.to_owned(),
+    };
+    Ok(Some(node_stats))
+}
+
+pub async fn get_block_id(context: &Context, block_id_hex: &str) -> Result<Option<Vec<u8>>, Error> {
+    context
+        .blockchain()
+        .await?
+        .storage()
+        .get(parse_block_hash(&block_id_hex)?)
+        .await?
+        .map(|b| b.serialize_as_vec().map_err(Error::Serialize))
+        .transpose()
+}
+
+pub async fn get_block_next_id(
+    context: &Context,
+    block_id_hex: &str,
+    count: usize,
+) -> Result<Option<Vec<u8>>, Error> {
+    let blockchain = context.blockchain().await?;
+    let block_id = parse_block_hash(&block_id_hex)?;
+    let tip = context.blockchain_tip().await?.get_ref().await;
+    let maybe_stream = blockchain
+        .storage()
+        .stream_from_to(block_id, tip.hash())
+        .await
+        .map(Some)
+        .or_else(|e| match e {
+            StorageError::CannotIterate | StorageError::BlockNotFound => Ok(None),
+            e => Err(Error::Storage(e)),
+        })?;
+
+    if let Some(stream) = maybe_stream {
+        Some(
+            stream
+                .map_err(Into::into)
+                .take(count)
+                .try_fold(Vec::new(), |mut bytes, block| async move {
+                    bytes.extend_from_slice(block.id().as_ref());
+                    Ok(bytes)
+                })
+                .await,
+        )
+        .transpose()
+    } else {
+        Ok(None)
+    }
+}
+
+pub async fn get_stake_distribution(
+    context: &Context,
+) -> Result<Option<StakeDistributionDto>, Error> {
+    let blockchain_tip = context.blockchain_tip().await?.get_ref().await;
+    let leadership = blockchain_tip.epoch_leadership_schedule();
+    if let LeadershipConsensus::GenesisPraos(gp) = leadership.consensus() {
+        let last_epoch = blockchain_tip.block_date().epoch;
+        let distribution = gp.distribution();
+        let stake = StakeDistribution {
+            dangling: distribution.dangling.into(),
+            unassigned: distribution.unassigned.into(),
+            pools: distribution
+                .to_pools
+                .iter()
+                .map(|(key, value)| (key.clone().into(), value.stake.total.clone().into()))
+                .collect(),
+        };
+        Ok(Some(StakeDistributionDto {
+            epoch: last_epoch,
+            stake,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+pub async fn get_stake_distribution_at(
+    context: &Context,
+    epoch: u32,
+) -> Result<Option<StakeDistributionDto>, Error> {
+    let mut tip_ref = context.blockchain_tip().await?.get_ref().await;
+
+    if epoch > tip_ref.block_date().epoch {
+        return Ok(None);
+    }
+
+    loop {
+        if tip_ref.block_date().epoch == epoch {
+            break;
+        }
+        match tip_ref.last_ref_previous_epoch() {
+            Some(previous_epoch) => {
+                if epoch > previous_epoch.block_date().epoch {
+                    return Ok(None);
+                }
+                tip_ref = Arc::clone(previous_epoch);
+            }
+            _ => return Ok(None),
+        }
+    }
+
+    Ok(tip_ref
+        .epoch_leadership_schedule()
+        .stake_distribution()
+        .map(|distribution| {
+            let stake = StakeDistribution {
+                dangling: distribution.dangling.into(),
+                unassigned: distribution.unassigned.into(),
+                pools: distribution
+                    .to_pools
+                    .iter()
+                    .map(|(key, value)| (key.clone().into(), value.stake.total.clone().into()))
+                    .collect(),
+            };
+
+            StakeDistributionDto { epoch, stake }
+        }))
+}
+
+pub async fn get_settings(context: &Context) -> Result<SettingsDto, Error> {
+    let full_context = context.try_full().await?;
+    let blockchain_tip = context.blockchain_tip().await?.get_ref().await;
+    let ledger = blockchain_tip.ledger();
+    let static_params = ledger.get_static_parameters();
+    let consensus_version = ledger.consensus_version();
+    let current_params = blockchain_tip.epoch_ledger_parameters();
+    let fees = current_params.fees;
+    let block_content_max_size = current_params.block_content_max_size;
+    let epoch_stability_depth = current_params.epoch_stability_depth;
+    let slots_per_epoch = blockchain_tip
+        .epoch_leadership_schedule()
+        .era()
+        .slots_per_epoch();
+    Ok(SettingsDto {
+        block0_hash: static_params.block0_initial_hash.to_string(),
+        block0_time: SystemTime::from_secs_since_epoch(static_params.block0_start_time.0),
+        curr_slot_start_time: full_context
+            .stats_counter
+            .slot_start_time()
+            .map(SystemTime::from),
+        consensus_version: consensus_version.to_string(),
+        fees,
+        block_content_max_size,
+        epoch_stability_depth,
+        slot_duration: blockchain_tip.time_frame().slot_duration(),
+        slots_per_epoch,
+        treasury_tax: current_params.treasury_tax,
+        reward_params: current_params.reward_params.clone(),
+    })
+}
+
+pub async fn get_shutdown(context: &Context) -> Result<(), Error> {
+    // Verify that node has fully started and is able to process shutdown
+    context.try_full().await?;
+    context.server_stopper().await?.stop();
+    Ok(())
+}
+
+pub async fn get_leader_ids(context: &Context) -> Result<Vec<EnclaveLeaderId>, Error> {
+    Ok(context.try_full().await?.enclave.get_leader_ids().await)
+}
+
+pub async fn post_leaders(context: &Context, secret: NodeSecret) -> Result<EnclaveLeaderId, Error> {
+    let leader = Leader {
+        bft_leader: secret.bft(),
+        genesis_leader: secret.genesis(),
+    };
+    let leader_id = context.try_full().await?.enclave.add_leader(leader).await;
+    Ok(leader_id)
+}
+
+pub async fn delete_leaders(
+    context: &Context,
+    leader_id: EnclaveLeaderId,
+) -> Result<Option<()>, Error> {
+    let removed = context
+        .try_full()
+        .await?
+        .enclave
+        .remove_leader(leader_id)
+        .await;
+
+    if removed {
+        Ok(Some(()))
+    } else {
+        Ok(None)
+    }
+}
+
+pub async fn get_leaders_logs(context: &Context) -> Result<Vec<LeadershipLog>, Error> {
+    Ok(context.try_full().await?.leadership_logs.logs().await)
+}
+
+pub async fn get_stake_pools(context: &Context) -> Result<Vec<String>, Error> {
+    Ok(context
+        .blockchain_tip()
+        .await?
+        .get_ref()
+        .await
+        .ledger()
+        .delegation()
+        .stake_pool_ids()
+        .map(|id| id.to_string())
+        .collect())
+}
+
+pub async fn get_network_stats(context: &Context) -> Result<Vec<PeerStats>, Error> {
+    let logger = context
+        .logger()
+        .await?
+        .new(o!("request" => "network_stats"));
+    let peer_stats = intercom::unary_future::<_, _, Error, _>(
+        context.try_full().await?.network_task.clone(),
+        logger,
+        |handle| NetworkMsg::PeerInfo(handle),
+    )
+    .compat()
+    .await?;
+    Ok(peer_stats
+        .into_iter()
+        .map(|info| PeerStats {
+            node_id: info.id.to_string(),
+            addr: info.addr,
+            established_at: SystemTime::from(info.stats.connection_established()),
+            last_block_received: info.stats.last_block_received().map(SystemTime::from),
+            last_fragment_received: info.stats.last_fragment_received().map(SystemTime::from),
+            last_gossip_received: info.stats.last_gossip_received().map(SystemTime::from),
+        })
+        .collect())
+}
+
+pub async fn get_rewards_info_epoch(
+    context: &Context,
+    epoch: u32,
+) -> Result<Option<EpochRewardsInfo>, Error> {
+    let mut tip_ref = context.blockchain_tip().await?.get_ref().await;
+
+    if epoch > tip_ref.block_date().epoch {
+        return Ok(None);
+    }
+
+    loop {
+        if tip_ref.block_date().epoch == epoch {
+            break;
+        }
+        match tip_ref.last_ref_previous_epoch() {
+            Some(previous_epoch) => {
+                if epoch > previous_epoch.block_date().epoch {
+                    return Ok(None);
+                }
+                tip_ref = Arc::clone(previous_epoch);
+            }
+            _ => return Ok(None),
+        }
+    }
+
+    if let Some(epoch_rewards_info) = tip_ref.epoch_rewards_info() {
+        Ok(Some(EpochRewardsInfo::from(
+            tip_ref.block_date().epoch,
+            epoch_rewards_info.as_ref(),
+        )))
+    } else {
+        Ok(None)
+    }
+}
+
+pub async fn get_rewards_info_history(
+    context: &Context,
+    length: usize,
+) -> Result<Vec<EpochRewardsInfo>, Error> {
+    let mut tip_ref = context.blockchain_tip().await?.get_ref().await;
+
+    let mut vec = Vec::new();
+    while let Some(epoch_rewards_info) = tip_ref.epoch_rewards_info() {
+        vec.push(EpochRewardsInfo::from(
+            tip_ref.block_date().epoch,
+            epoch_rewards_info.as_ref(),
+        ));
+
+        if let Some(previous_epoch) = tip_ref.last_ref_previous_epoch() {
+            tip_ref = Arc::clone(previous_epoch);
+        } else {
+            break;
+        }
+
+        if vec.len() >= length {
+            break;
+        }
+    }
+
+    Ok(vec)
+}
+
+pub async fn get_utxo(
+    context: &Context,
+    fragment_id_hex: &str,
+    output_index: u8,
+) -> Result<Option<TransactionOutput>, Error> {
+    let fragment_id = parse_fragment_id(fragment_id_hex)?;
+    Ok(context
+        .blockchain_tip()
+        .await?
+        .get_ref()
+        .await
+        .ledger()
+        .utxo_out(fragment_id, output_index)
+        .cloned()
+        .map(Into::into))
+}
+
+pub async fn get_stake_pool(
+    context: &Context,
+    pool_id_hex: &str,
+) -> Result<Option<StakePoolStats>, Error> {
+    let pool_id = pool_id_hex.parse()?;
+    let ledger = context.blockchain_tip().await?.get_ref().await.ledger();
+    Ok(ledger.delegation().lookup(&pool_id).map(|pool| {
+        let total_stake: u64 = ledger
+            .get_stake_distribution()
+            .to_pools
+            .get(&pool_id)
+            .map(|pool| pool.stake.total.into())
+            .unwrap_or(0);
+        StakePoolStats {
+            kes_public_key: pool
+                .registration
+                .keys
+                .kes_public_key
+                .to_bech32_str()
+                .to_owned(),
+            vrf_public_key: pool
+                .registration
+                .keys
+                .vrf_public_key
+                .to_bech32_str()
+                .to_owned(),
+            total_stake,
+            rewards: StakePoolRewards {
+                epoch: pool.last_rewards.epoch,
+                value_taxed: pool.last_rewards.value_taxed,
+                value_for_stakers: pool.last_rewards.value_for_stakers,
+            },
+            tax: TaxTypeSerde(pool.registration.rewards),
+        }
+    }))
+}
+
+pub async fn get_diagnostic(context: &Context) -> Result<Diagnostic, Error> {
+    context.get_diagnostic_data().await.map_err(Into::into)
+}
+
+pub async fn get_network_p2p_quarantined(
+    context: &Context,
+) -> Result<Vec<poldercast::Node>, Error> {
+    Ok(context
+        .try_full()
+        .await?
+        .p2p
+        .list_quarantined::<Infallible>()
+        .compat()
+        .await
+        .unwrap())
+}
+
+pub async fn get_network_p2p_non_public(context: &Context) -> Result<Vec<poldercast::Node>, Error> {
+    Ok(context
+        .try_full()
+        .await?
+        .p2p
+        .list_non_public::<Infallible>()
+        .compat()
+        .await
+        .unwrap())
+}
+
+pub async fn get_network_p2p_available(context: &Context) -> Result<Vec<poldercast::Node>, Error> {
+    Ok(context
+        .try_full()
+        .await?
+        .p2p
+        .list_available::<Infallible>()
+        .compat()
+        .await
+        .unwrap())
+}
+
+pub async fn get_network_p2p_view(context: &Context) -> Result<Vec<poldercast::NodeInfo>, Error> {
+    Ok(context
+        .try_full()
+        .await?
+        .p2p
+        .view::<Infallible>(poldercast::Selection::Any)
+        .compat()
+        .await
+        .unwrap()
+        .peers
+        .into_iter()
+        .map(Into::into)
+        .collect())
+}
+
+pub async fn get_network_p2p_view_topic(
+    context: &Context,
+    topic: &str,
+) -> Result<Vec<poldercast::NodeInfo>, Error> {
+    fn parse_topic(s: &str) -> Result<poldercast::Selection, Error> {
+        use crate::network::p2p::topic;
+        use poldercast::Selection;
+        match s {
+            "blocks" => Ok(Selection::Topic {
+                topic: topic::BLOCKS,
+            }),
+            "fragments" => Ok(Selection::Topic {
+                topic: topic::MESSAGES,
+            }),
+            "" => Ok(Selection::Any),
+            _ => Err(Error::InvalidTopic),
+        }
+    }
+
+    let topic = parse_topic(topic)?;
+    Ok(context
+        .try_full()
+        .await?
+        .p2p
+        .view::<Infallible>(topic)
+        .compat()
+        .await
+        .unwrap()
+        .peers
+        .into_iter()
+        .map(Into::into)
+        .collect())
+}

--- a/jormungandr/src/rest/v0/mod.rs
+++ b/jormungandr/src/rest/v0/mod.rs
@@ -1,4 +1,5 @@
 mod handlers;
+pub mod logic;
 
 use actix_web::{
     dev::HttpServiceFactory,


### PR DESCRIPTION
Separate rest::Context and methods implementation so that they do not
depend on Actix anymore. This will allow for easier conversion to warp
and facilitate better coding style.