### PR TITLE
fix the per vote certificate fee configuration in the block0

### DIFF
--- a/jcli/src/jcli_app/transaction/common.rs
+++ b/jcli/src/jcli_app/transaction/common.rs
@@ -1,5 +1,5 @@
 use crate::jcli_app::transaction::{staging::Staging, Error};
-use chain_impl_mockchain::fee::{LinearFee, PerCertificateFee};
+use chain_impl_mockchain::fee::{LinearFee, PerCertificateFee, PerVoteCertificateFee};
 use std::{num::NonZeroU64, path::PathBuf};
 use structopt::StructOpt;
 
@@ -52,10 +52,13 @@ impl CommonFees {
             self.certificate_stake_delegation.and_then(NonZeroU64::new),
             self.certificate_owner_stake_delegation
                 .and_then(NonZeroU64::new),
+        );
+        let per_vote_certificate_fees = PerVoteCertificateFee::new(
             self.certificate_vote_plan.and_then(NonZeroU64::new),
             self.certificate_vote_cast.and_then(NonZeroU64::new),
         );
         fees.per_certificate_fees(per_certificate_fees);
+        fees.per_vote_certificate_fees(per_vote_certificate_fees);
         fees
     }
 }

--- a/jormungandr-lib/src/interfaces/linear_fee.rs
+++ b/jormungandr-lib/src/interfaces/linear_fee.rs
@@ -1,4 +1,4 @@
-use chain_impl_mockchain::fee::{LinearFee, PerCertificateFee};
+use chain_impl_mockchain::fee::{LinearFee, PerCertificateFee, PerVoteCertificateFee};
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroU64;
 
@@ -15,6 +15,15 @@ pub struct PerCertificateFeeDef {
     pub certificate_stake_delegation: Option<NonZeroU64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub certificate_owner_stake_delegation: Option<NonZeroU64>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    remote = "PerVoteCertificateFee"
+)]
+pub struct PerVoteCertificateFeeDef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub certificate_vote_plan: Option<NonZeroU64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -33,10 +42,20 @@ pub struct LinearFeeDef {
         skip_serializing_if = "per_certificate_fee_is_zero"
     )]
     per_certificate_fees: PerCertificateFee,
+    #[serde(
+        default,
+        with = "PerVoteCertificateFeeDef",
+        skip_serializing_if = "per_vote_certificate_fee_is_zero"
+    )]
+    per_vote_certificate_fees: PerVoteCertificateFee,
 }
 
 pub(crate) fn per_certificate_fee_is_zero(fee: &PerCertificateFee) -> bool {
     fee.certificate_stake_delegation.is_none()
         && fee.certificate_owner_stake_delegation.is_none()
         && fee.certificate_pool_registration.is_none()
+}
+
+pub(crate) fn per_vote_certificate_fee_is_zero(fee: &PerVoteCertificateFee) -> bool {
+    fee.certificate_vote_plan.is_none() && fee.certificate_vote_cast.is_none()
 }

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -963,6 +963,7 @@ impl Status {
             coefficient,
             certificate,
             per_certificate_fees,
+            per_vote_certificate_fees,
         } = context.db.blockchain_config.fees;
 
         FeeSettings {
@@ -987,6 +988,20 @@ impl Status {
                 "{}",
                 per_certificate_fees
                     .certificate_owner_stake_delegation
+                    .map(|v| v.get())
+                    .unwrap_or(certificate)
+            )),
+            certificate_vote_plan: Value(format!(
+                "{}",
+                per_vote_certificate_fees
+                    .certificate_vote_plan
+                    .map(|v| v.get())
+                    .unwrap_or(certificate)
+            )),
+            certificate_vote_cast: Value(format!(
+                "{}",
+                per_vote_certificate_fees
+                    .certificate_vote_cast
                     .map(|v| v.get())
                     .unwrap_or(certificate)
             )),
@@ -1025,6 +1040,8 @@ struct FeeSettings {
     certificate_pool_registration: Value,
     certificate_stake_delegation: Value,
     certificate_owner_stake_delegation: Value,
+    certificate_vote_plan: Value,
+    certificate_vote_cast: Value,
 }
 
 struct Epoch {


### PR DESCRIPTION
this will prevent adding the certificate fee for the votes if
it was not set, allowing reproducing the same blocks for previous
versions