### PR TITLE
[Test] ignore qa bootstrap network test

### DIFF
--- a/jormungandr-integration-tests/src/networking/testnet.rs
+++ b/jormungandr-integration-tests/src/networking/testnet.rs
@@ -225,6 +225,7 @@ pub fn nightly_bootstrap() {
         .unwrap();
 }
 
+#[ignore]
 #[test]
 pub fn qa_bootstrap() {
     let testnet_config = TestnetConfig::new_qa();


### PR DESCRIPTION
QA network is shut down. Disabling test which targeted this network. In nearest future I'll setup new network with legacy nodes enabled for testing