### PR TITLE
multiple config files and merging configs

### DIFF
--- a/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
+++ b/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
@@ -66,7 +66,7 @@ pub fn test_jormungandr_with_wrong_logger_fails_to_start() {
         }]))
         .build();
     Starter::new().config(config).start_fail(
-        r"Error while parsing the node configuration file: log\[0\]\.format: unknown variant",
+        r"Error while parsing the node configuration file: unknown variant `xml`, expected `plain` or `json`",
     );
 }
 

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -15,9 +15,11 @@ pub struct StartArguments {
     #[structopt(long = "storage", parse(from_os_str))]
     pub storage: Option<PathBuf>,
 
-    /// Set the node config (in YAML format) to use as general configuration
+    /// Set the node config (in YAML format) to use as general configuration.
+    /// You may provide multiple configuration files. In this case, settings in
+    /// the last file will override settings from all previous files.
     #[structopt(long = "config", parse(from_os_str))]
-    pub node_config: Option<PathBuf>,
+    pub node_config: Vec<PathBuf>,
 
     /// Set the secret node config (in YAML format). Can be given
     /// multiple times.


### PR DESCRIPTION
A user may provide multiple configuration files to jormungandr. When
more than one file was provided, values from the last will override
all values set in previous file.

For example, jormungandr is started with the following line:

	jormungandr --config config.yaml --config config-1.yaml

If the configs value are:

	p2p.public_address = "/ip4/127.0.0.1/tcp/8299" # config.yaml
	p2p.public_address = "/ip6/::1/tcp/9000" # config-1.yaml

then **"/ip6/::1/tcp/9000"** will be used.