### PR TITLE
jormungandr-lib: move sysinfo to dev-dependencies

### DIFF
--- a/jormungandr-lib/Cargo.toml
+++ b/jormungandr-lib/Cargo.toml
@@ -22,7 +22,7 @@ chrono = { version = "0.4", features = ["serde"] }
 humantime = "2.0"
 thiserror = "1.0"
 poldercast = "0.11.4"
-sysinfo = "0.14.1"
+sysinfo = { version = "0.14.1", optional = true }
 os_info = { version = "2.0.0", default-features = false }
 zip = "0.5.5"
 flate2 = "1.0.14"
@@ -38,6 +38,7 @@ chain-crypto    = { path = "../chain-deps/chain-crypto", features = [ "property-
 ed25519-bip32 = "0.3"
 serde_yaml = "0.8"
 bincode = "1.1"
+sysinfo = "0.14.1"
 
 [target.'cfg(not(target_os = "android"))'.dependencies.reqwest]
 version = "0.10.4"
@@ -54,4 +55,4 @@ features = ["blocking"]
 
 [features]
 default = []
-property-test-api = [ "chain-impl-mockchain/property-test-api", "chain-addr/property-test-api" ]
+property-test-api = [ "chain-impl-mockchain/property-test-api", "chain-addr/property-test-api", "sysinfo" ]


### PR DESCRIPTION
~closes #2126~ not closing actually because of this bug in `backtrace` which is a transitive dependency in a bunch of packages https://github.com/rust-lang/backtrace-rs/issues/304