### PR TITLE
[Test] legacy disruption tests

### DIFF
--- a/jormungandr-lib/src/testing/network_builder/spawn_params.rs
+++ b/jormungandr-lib/src/testing/network_builder/spawn_params.rs
@@ -139,6 +139,10 @@ impl SpawnParams {
         self
     }
 
+    pub fn get_jormungandr(&self) -> &Option<PathBuf> {
+        &self.jormungandr
+    }
+
     pub fn override_settings(&self, node_config: &mut NodeConfig) {
         if let Some(topics_of_interest) = &self.topics_of_interest {
             node_config.p2p.topics_of_interest = Some(topics_of_interest.clone());

--- a/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -1,4 +1,5 @@
 use crate::{
+    prepare_command,
     scenario::{
         settings::{Dotifier, PrepareSettings},
         ContextChaCha, ErrorKind, ProgressBarMode, Result,
@@ -184,11 +185,16 @@ impl Controller {
             LeadershipMode::Passive => NodeBlock0::Hash(self.block0_hash.clone()),
         };
 
+        let jormungandr = match &params.get_jormungandr() {
+            Some(jormungandr) => prepare_command(jormungandr.clone()),
+            None => self.context.jormungandr().clone(),
+        };
+
         let pb = ProgressBar::new_spinner();
         let pb = self.progress_bar.add(pb);
 
         let mut node = Node::spawn(
-            &self.context.jormungandr(),
+            &jormungandr,
             &self.context,
             pb,
             &params.get_alias(),

--- a/jormungandr-scenario-tests/src/scenario/repository/mod.rs
+++ b/jormungandr-scenario-tests/src/scenario/repository/mod.rs
@@ -231,6 +231,36 @@ fn scenarios_repository() -> Vec<Scenario> {
         vec![Tag::Short],
     ));
 
+    repository.push(Scenario::new(
+        "legacy_disruption_last_5th_release",
+        legacy_disruption_last_5th_release,
+        vec![Tag::Short, Tag::Unstable],
+    ));
+
+    repository.push(Scenario::new(
+        "legacy_disruption_last_4th_release",
+        legacy_disruption_last_4th_release,
+        vec![Tag::Short, Tag::Unstable],
+    ));
+
+    repository.push(Scenario::new(
+        "legacy_disruption_last_3rd_release",
+        legacy_disruption_last_3rd_release,
+        vec![Tag::Short, Tag::Unstable],
+    ));
+
+    repository.push(Scenario::new(
+        "legacy_disruption_last_2nd_release",
+        legacy_disruption_last_2nd_release,
+        vec![Tag::Short, Tag::Unstable],
+    ));
+
+    repository.push(Scenario::new(
+        "legacy_disruption_last_release",
+        legacy_disruption_last_release,
+        vec![Tag::Short, Tag::Unstable],
+    ));
+
     repository.push(Scenario::new("relay_soak", relay_soak, vec![Tag::Long]));
 
     repository.push(Scenario::new(

--- a/jormungandr-scenario-tests/src/test/non_functional/legacy.rs
+++ b/jormungandr-scenario-tests/src/test/non_functional/legacy.rs
@@ -15,28 +15,28 @@ use rand_chacha::ChaChaRng;
 use std::path::PathBuf;
 
 pub fn legacy_last_5th_release(context: Context<ChaChaRng>) -> Result<ScenarioResult> {
-    let releases = download_last_n_releases(1);
+    let releases = download_last_n_releases(5);
     let last_release = releases.last().unwrap();
     let legacy_app = get_jormungandr_bin(last_release);
     test_legacy_release(context, legacy_app, "legacy_last_5th_release")
 }
 
 pub fn legacy_last_4th_release(context: Context<ChaChaRng>) -> Result<ScenarioResult> {
-    let releases = download_last_n_releases(1);
+    let releases = download_last_n_releases(4);
     let last_release = releases.last().unwrap();
     let legacy_app = get_jormungandr_bin(last_release);
     test_legacy_release(context, legacy_app, "legacy_last_4th_release")
 }
 
 pub fn legacy_last_3rd_release(context: Context<ChaChaRng>) -> Result<ScenarioResult> {
-    let releases = download_last_n_releases(1);
+    let releases = download_last_n_releases(3);
     let last_release = releases.last().unwrap();
     let legacy_app = get_jormungandr_bin(last_release);
     test_legacy_release(context, legacy_app, "legacy_last_3rd_release")
 }
 
 pub fn legacy_last_2nd_release(context: Context<ChaChaRng>) -> Result<ScenarioResult> {
-    let releases = download_last_n_releases(1);
+    let releases = download_last_n_releases(2);
     let last_release = releases.last().unwrap();
     let legacy_app = get_jormungandr_bin(last_release);
     test_legacy_release(context, legacy_app, "legacy_last_2nd_release")
@@ -107,6 +107,158 @@ fn test_legacy_release(
         &mut wallet1,
         &mut wallet2,
         &leader1,
+    )?;
+
+    utils::measure_and_log_sync_time(
+        vec![&leader1, &leader2, &leader3, &leader4],
+        SyncWaitParams::network_size(4, 2).into(),
+        name,
+        MeasurementReportInterval::Standard,
+    )?;
+
+    leader4.shutdown()?;
+    leader3.shutdown()?;
+    leader2.shutdown()?;
+    leader1.shutdown()?;
+
+    controller.finalize();
+    Ok(ScenarioResult::passed())
+}
+
+pub fn legacy_disruption_last_5th_release(context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let releases = download_last_n_releases(5);
+    let last_release = releases.last().unwrap();
+    let legacy_app = get_jormungandr_bin(last_release);
+    test_legacy_disruption_release(context, legacy_app, "legacy_disruption_last_5th_release")
+}
+
+pub fn legacy_disruption_last_4th_release(context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let releases = download_last_n_releases(4);
+    let last_release = releases.last().unwrap();
+    let legacy_app = get_jormungandr_bin(last_release);
+    test_legacy_disruption_release(context, legacy_app, "legacy_disruption_last_4th_release")
+}
+
+pub fn legacy_disruption_last_3rd_release(context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let releases = download_last_n_releases(3);
+    let last_release = releases.last().unwrap();
+    let legacy_app = get_jormungandr_bin(last_release);
+    test_legacy_disruption_release(context, legacy_app, "legacy_disruption_last_3rd_release")
+}
+
+pub fn legacy_disruption_last_2nd_release(context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let releases = download_last_n_releases(2);
+    let last_release = releases.last().unwrap();
+    let legacy_app = get_jormungandr_bin(last_release);
+    test_legacy_disruption_release(context, legacy_app, "legacy_disruption_last_2nd_release")
+}
+
+pub fn legacy_disruption_last_release(context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let releases = download_last_n_releases(1);
+    let last_release = releases.last().unwrap();
+    let legacy_app = get_jormungandr_bin(last_release);
+    test_legacy_disruption_release(context, legacy_app, "legacy_disruption_last_release")
+}
+
+fn test_legacy_disruption_release(
+    mut context: Context<ChaChaRng>,
+    legacy_app: PathBuf,
+    name: &str,
+) -> Result<ScenarioResult> {
+    let scenario_settings = prepare_scenario! {
+        name,
+        &mut context,
+        topology [
+            LEADER_1,
+            LEADER_2 -> LEADER_1,
+            LEADER_3 -> LEADER_1,
+            LEADER_4 -> LEADER_1,
+        ]
+        blockchain {
+            consensus = GenesisPraos,
+            number_of_slots_per_epoch = 60,
+            slot_duration = 1,
+            leaders = [ LEADER_1 ],
+            initials = [
+                account "unassigned1" with   500_000_000,
+                account "delegated1" with  2_000_000_000 delegates to LEADER_1,
+                account "delegated2" with  2_000_000_000 delegates to LEADER_2,
+                account "delegated3" with  2_000_000_000 delegates to LEADER_3,
+                account "delegated4" with  2_000_000_000 delegates to LEADER_4
+            ],
+        }
+    };
+
+    let mut controller = scenario_settings.build(context)?;
+
+    controller.monitor_nodes();
+
+    let mut leader1 = controller.spawn_node_custom(
+        controller
+            .new_spawn_params(LEADER_1)
+            .persistence_mode(PersistenceMode::Persistent)
+            .jormungandr(legacy_app.clone()),
+    )?;
+    leader1.wait_for_bootstrap()?;
+
+    let leader2 = controller.spawn_node(
+        LEADER_2,
+        LeadershipMode::Leader,
+        PersistenceMode::Persistent,
+    )?;
+    leader2.wait_for_bootstrap()?;
+
+    let leader3 = controller.spawn_node(
+        LEADER_3,
+        LeadershipMode::Leader,
+        PersistenceMode::Persistent,
+    )?;
+    leader3.wait_for_bootstrap()?;
+
+    let mut leader4 = controller.spawn_node(
+        LEADER_4,
+        LeadershipMode::Leader,
+        PersistenceMode::Persistent,
+    )?;
+    leader4.wait_for_bootstrap()?;
+
+    let mut wallet1 = controller.wallet("unassigned1")?;
+    let mut wallet2 = controller.wallet("delegated1")?;
+
+    utils::sending_transactions_to_node_sequentially(
+        10,
+        &mut controller,
+        &mut wallet1,
+        &mut wallet2,
+        &leader2,
+    )?;
+
+    leader4 =
+        controller.restart_node(leader4, LeadershipMode::Leader, PersistenceMode::Persistent)?;
+
+    utils::sending_transactions_to_node_sequentially(
+        10,
+        &mut controller,
+        &mut wallet1,
+        &mut wallet2,
+        &leader3,
+    )?;
+
+    leader1.shutdown()?;
+    leader1 = controller.spawn_node_custom(
+        controller
+            .new_spawn_params(LEADER_1)
+            .persistence_mode(PersistenceMode::Persistent)
+            .jormungandr(legacy_app),
+    )?;
+    leader1.wait_for_bootstrap()?;
+
+    utils::sending_transactions_to_node_sequentially(
+        10,
+        &mut controller,
+        &mut wallet1,
+        &mut wallet2,
+        &leader2,
     )?;
 
     utils::measure_and_log_sync_time(


### PR DESCRIPTION
added 5 test cases for testing compatibility between node from master and respective legacy version. Test flow is simple. 3 nodes are from master and connected to central node ( legacy node). Then one node from master is restarted and after the while legacy node. test verifies if network is in sync despite past events