### PR TITLE
Sundry improvements and code cleanup in network

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           use-cross: ${{ matrix.config.cross }}
           command: rustc
-          args: --release --target ${{ matrix.config.target }} -p jormungandr --bin jormungandr -- -C target-cpu=${{ matrix.config.target_cpu }} -C lto
+          args: --release --target ${{ matrix.config.target }} -p jormungandr --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.config.target_cpu }} -C lto
 
       - name: Build jcli
         uses: actions-rs/cargo@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           use-cross: ${{ matrix.config.cross }}
           command: rustc
-          args: --release --target ${{ matrix.config.target }} -p jormungandr --bin jormungandr -- -C target-cpu=${{ matrix.config.target_cpu }} -C lto
+          args: --release --target ${{ matrix.config.target }} -p jormungandr --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.config.target_cpu }} -C lto
 
       - name: Build jcli
         uses: actions-rs/cargo@v1

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -87,6 +87,7 @@ nix = "0.17.0"
 slog-syslog = "0.12.0"
 
 [features]
+default = ["codegen-rustfmt"]
 with-bench = []
 codegen-rustfmt = ["chain-network/codegen-rustfmt"]
 integration-test = []

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -52,7 +52,7 @@ slog-json = "2.3.0"
 slog-scope = "4.1"
 slog-term = "2.4.0"
 structopt = "^0.3"
-thiserror = "1.0"
+thiserror = "1.0.16"
 tokio      = "^0.1.16"
 tokio-compat = "^0.1.5"
 tokio02 = { package = "tokio", version = "0.2.12", features = ["full"]}

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -88,6 +88,7 @@ slog-syslog = "0.12.0"
 
 [features]
 with-bench = []
+codegen-rustfmt = ["chain-network/codegen-rustfmt"]
 integration-test = []
 soak-test = []
 systemd = ["slog-journald"]

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -31,7 +31,9 @@ pub fn connect(state: ConnectionState, channels: Channels) -> (ConnectHandle, Co
         logger: state.logger.clone(),
     };
     let cf = async move {
-        let mut grpc_client = grpc::connect(&peer).await.map_err(ConnectError::Connect)?;
+        let mut grpc_client = grpc::connect(&peer)
+            .await
+            .map_err(ConnectError::Transport)?;
         let block0 = grpc_client
             .handshake()
             .await
@@ -112,8 +114,8 @@ pub struct ConnectFuture {
 pub enum ConnectError {
     #[error("connection has been canceled")]
     Canceled,
-    #[error("connection failed")]
-    Connect(#[source] tonic::transport::Error),
+    #[error(transparent)]
+    Transport(tonic::transport::Error),
     #[error("protocol handshake failed: {0}")]
     Handshake(#[source] HandshakeError),
     #[error("failed to decode genesis block in response")]

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -476,7 +476,7 @@ fn connect_and_propagate(
         match connecting.await {
             Err(e) => {
                 let benign = match e {
-                    ConnectError::Connect(e) => {
+                    ConnectError::Transport(e) => {
                         info!(conn_logger, "gRPC connection to peer failed"; "reason" => %e);
                         false
                     }
@@ -489,7 +489,7 @@ fn connect_and_propagate(
                         true
                     }
                     _ => {
-                        info!(conn_logger, "connection to peer failed"; "reason" => %e);
+                        info!(conn_logger, "connection to peer failed"; "error" => ?e);
                         false
                     }
                 };

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -480,6 +480,10 @@ fn connect_and_propagate(
                         info!(conn_logger, "gRPC connection to peer failed"; "reason" => %e);
                         false
                     }
+                    ConnectError::Handshake(e) => {
+                        info!(conn_logger, "protocol handshake with peer failed"; "reason" => %e);
+                        false
+                    }
                     ConnectError::Canceled => {
                         debug!(conn_logger, "connection to peer has been canceled");
                         true


### PR DESCRIPTION
Improvements made while debugging the functionality of the new network implementation.

- Clearer error reporting and a better named enum variant for `client::connect` errors.
- Pretty-format the gRPC code generated by tonic-build by default, but disable formatting in CI
  to avoid an unnecessary rustfmt dependency.