### PR TITLE
CORS origin validation

### DIFF
--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -79,10 +79,13 @@ pub struct Tls {
 pub struct Cors {
     /// If none provided, echos request origin
     #[serde(default)]
-    pub allowed_origins: Vec<String>,
+    pub allowed_origins: Vec<CorsOrigin>,
     /// If none provided, CORS responses won't be cached
     pub max_age_secs: Option<u64>,
 }
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct CorsOrigin(String);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -386,6 +389,49 @@ impl<'de> Deserialize<'de> for InterestLevel {
             }
         }
         deserializer.deserialize_str(InterestLevelVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for CorsOrigin {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CorsOriginVisitor;
+        impl<'de> Visitor<'de> for CorsOriginVisitor {
+            type Value = CorsOrigin;
+
+            fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                write!(fmt, "an origin in format http[s]://example.com[:3000]",)
+            }
+
+            fn visit_str<'a, E>(self, v: &'a str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                use serde::de::Unexpected;
+
+                let uri = warp::http::uri::Uri::from_str(v).map_err(E::custom)?;
+                if let Some(s) = uri.scheme_str() {
+                    if s != "http" && s != "https" {
+                        return Err(E::invalid_value(Unexpected::Str(v), &self));
+                    }
+                }
+                if let Some(p) = uri.path_and_query() {
+                    if p.as_str() != "/" {
+                        return Err(E::invalid_value(Unexpected::Str(v), &self));
+                    }
+                }
+                Ok(CorsOrigin(v.trim_end_matches('/').to_owned()))
+            }
+        }
+        deserializer.deserialize_str(CorsOriginVisitor)
+    }
+}
+
+impl AsRef<str> for CorsOrigin {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 


### PR DESCRIPTION
Check the value in the configuration before it gets to warp, which panics on invalid values.