### PR TITLE
Set peer-address metadata header on the client side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,9 +1870,9 @@ checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d90181c2904c287e5390186be820e5ef311a3c62edebb7d6ca3d6a48ce041d"
+checksum = "1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3100,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.21.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a656821bb6317a84b257737b7934f79c0dbb7eb694710475908280ebad3e64"
+checksum = "45d0fd62e1df63d254714e6cb40d0a0e82e7a1623e7a27f679d851af092ae58b"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -3110,6 +3110,7 @@ dependencies = [
  "libsqlite3-sys",
  "lru-cache",
  "memchr",
+ "smallvec 1.4.0",
  "time",
 ]
 

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -42,6 +42,11 @@ pub fn connect(state: ConnectionState, channels: Channels) -> (ConnectHandle, Co
         let block0_hash = HeaderHash::read(&mut buf).map_err(ConnectError::DecodeBlock0)?;
         let expected = state.global.block0_hash;
         match_block0(expected, block0_hash)?;
+        if let Some(address) = state.global.node_address() {
+            if let Some(addr) = address.to_socketaddr() {
+                grpc_client.set_public_peer(addr.into());
+            }
+        }
         let mut comms = PeerComms::new();
         let (block_sub, fragment_sub, gossip_sub) = future::try_join3(
             grpc_client

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -16,6 +16,7 @@ mod subscription;
 use self::convert::Encode;
 use futures03::future;
 use futures03::prelude::*;
+use poldercast::Address;
 use thiserror::Error;
 use tokio02::time;
 
@@ -156,6 +157,10 @@ impl GlobalState {
 
     fn logger(&self) -> &Logger {
         &self.logger
+    }
+
+    pub fn node_address(&self) -> Option<&Address> {
+        self.config.profile.address()
     }
 
     pub fn topology(&self) -> &P2pTopology {
@@ -458,8 +463,8 @@ fn connect_and_propagate(
     };
     options.evict_clients = state.num_clients_to_bump();
     assert_ne!(
-        &node,
-        state.topology.node_address(),
+        Some(&node),
+        state.node_address(),
         "topology tells the node to connect to itself"
     );
     let peer = Peer::new(addr);

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -22,8 +22,6 @@ pub struct View {
 /// object holding the P2pTopology of the Node
 pub struct P2pTopology {
     lock: RwLock<Topology>,
-    node_address: Address,
-    logger: Logger,
 }
 
 /// Builder object used to initialize the `P2pTopology`
@@ -74,11 +72,8 @@ impl Builder {
     }
 
     fn build(self) -> P2pTopology {
-        let node_address = self.topology.profile().address().unwrap().clone();
         P2pTopology {
             lock: RwLock::new(self.topology),
-            node_address,
-            logger: self.logger,
         }
     }
 }
@@ -118,10 +113,6 @@ impl P2pTopology {
         topology
             .exchange_gossips(with.into(), gossips.into())
             .into()
-    }
-
-    pub fn node_address(&self) -> &Address {
-        &self.node_address
     }
 
     pub async fn node(&self) -> NodeProfile {


### PR DESCRIPTION
Set the header value with the address in the `public_address` setting, if it is provided in the configuration.