### PR TITLE
[Test] Backward compatibility for nodes in jormungandr integration tests

### DIFF
--- a/testing/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
+++ b/testing/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
@@ -1,7 +1,10 @@
 #![allow(dead_code)]
 
-use crate::common::configuration::{Block0ConfigurationBuilder, NodeConfigBuilder};
-use crate::common::file_utils;
+use crate::common::{
+    configuration::{Block0ConfigurationBuilder, NodeConfigBuilder},
+    file_utils,
+    legacy::BackwardCompatibleConfig,
+};
 use chain_core::mempack;
 use chain_impl_mockchain::{block::Block, fee::LinearFee, fragment::Fragment};
 use jormungandr_lib::interfaces::{
@@ -12,40 +15,103 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct JormungandrConfig {
-    pub genesis_block_path: PathBuf,
-    pub genesis_block_hash: String,
-    pub node_config_path: PathBuf,
-    pub secret_model_paths: Vec<PathBuf>,
-    pub block0_configuration: Block0Configuration,
-    pub node_config: NodeConfig,
-    pub secret_models: Vec<NodeSecret>,
-    pub log_file_path: PathBuf,
-    pub rewards_history: bool,
+    inner: BackwardCompatibleConfig,
 }
 
 impl JormungandrConfig {
+    pub fn new(
+        genesis_block_path: PathBuf,
+        genesis_block_hash: String,
+        node_config_path: PathBuf,
+        secret_model_paths: Vec<PathBuf>,
+        log_file_path: PathBuf,
+        block0_configuration: Block0Configuration,
+        secret_models: Vec<NodeSecret>,
+        rewards_history: bool,
+    ) -> Self {
+        Self {
+            inner: BackwardCompatibleConfig {
+                genesis_block_path,
+                genesis_block_hash,
+                node_config_path,
+                secret_model_paths,
+                log_file_path,
+                block0_configuration,
+                secret_models,
+                rewards_history,
+            },
+        }
+    }
+
+    pub fn block0_configuration(&self) -> &Block0Configuration {
+        &self.inner.block0_configuration
+    }
+
+    pub fn block0_configuration_mut(&mut self) -> &mut Block0Configuration {
+        &mut self.inner.block0_configuration
+    }
+
+    pub fn genesis_block_path(&self) -> &PathBuf {
+        &self.inner.genesis_block_path
+    }
+
+    pub fn genesis_block_hash(&self) -> &String {
+        &self.inner.genesis_block_hash
+    }
+
+    pub fn node_config_path(&self) -> &PathBuf {
+        &self.inner.node_config_path
+    }
+
+    pub fn rewards_history(&self) -> bool {
+        self.inner.rewards_history
+    }
+
+    pub fn log_file_path(&self) -> &PathBuf {
+        &self.inner.log_file_path
+    }
+
+    pub fn secret_model_paths_mut(&mut self) -> &mut Vec<PathBuf> {
+        &mut self.inner.secret_model_paths
+    }
+
+    pub fn secret_models_mut(&mut self) -> &mut Vec<NodeSecret> {
+        &mut self.inner.secret_models
+    }
+
+    pub fn secret_model_paths(&self) -> &Vec<PathBuf> {
+        &self.inner.secret_model_paths
+    }
+
+    pub fn secret_models(&self) -> &Vec<NodeSecret> {
+        &self.inner.secret_models
+    }
+
     pub fn get_node_address(&self) -> String {
-        let rest = &self.node_config.rest;
-        let output = format!("http://{}/api", rest.listen);
-        output
+        format!("http://{}/api", self.node_config().rest.listen)
+    }
+
+    pub fn node_config(&self) -> NodeConfig {
+        let content = file_utils::read_file(&self.inner.node_config_path);
+        serde_yaml::from_str(&content).expect("Canot serialize node config")
     }
 
     pub fn refresh_node_dynamic_params(&mut self) {
         self.regenerate_ports();
         self.update_node_config();
-        self.log_file_path = file_utils::get_path_in_temp("log_file.log");
+        self.inner.log_file_path = file_utils::get_path_in_temp("log_file.log");
     }
 
     pub fn update_node_config(&mut self) {
-        self.node_config_path = NodeConfigBuilder::serialize(&self.node_config);
+        self.inner.node_config_path = NodeConfigBuilder::serialize(&self.node_config());
     }
 
     fn regenerate_ports(&mut self) {
-        self.node_config.rest.listen =
-            format!("127.0.0.1:{}", super::get_available_port().to_string())
-                .parse()
-                .unwrap();
-        self.node_config.p2p.public_address = format!(
+        let mut node_config = self.node_config();
+        node_config.rest.listen = format!("127.0.0.1:{}", super::get_available_port().to_string())
+            .parse()
+            .unwrap();
+        node_config.p2p.public_address = format!(
             "/ip4/127.0.0.1/tcp/{}",
             super::get_available_port().to_string()
         )
@@ -54,14 +120,15 @@ impl JormungandrConfig {
     }
 
     pub fn fees(&self) -> LinearFee {
-        self.block0_configuration
+        self.inner
+            .block0_configuration
             .blockchain_configuration
             .linear_fees
             .clone()
     }
 
     pub fn get_p2p_listen_port(&self) -> u16 {
-        let address = self.node_config.p2p.get_listen_address().to_string();
+        let address = self.node_config().p2p.get_listen_address().to_string();
         let tokens: Vec<&str> = address.split("/").collect();
         let port_str = tokens
             .get(4)
@@ -69,40 +136,19 @@ impl JormungandrConfig {
         port_str.parse().unwrap()
     }
 
-    pub fn new() -> Self {
-        JormungandrConfig::from(
-            Block0ConfigurationBuilder::new().build(),
-            NodeConfigBuilder::new().build(),
-        )
-    }
-
     pub fn as_trusted_peer(&self) -> TrustedPeer {
-        self.node_config.p2p.make_trusted_peer_setting()
-    }
-
-    pub fn from(block0_configuration: Block0Configuration, node_config: NodeConfig) -> Self {
-        JormungandrConfig {
-            genesis_block_path: PathBuf::from(""),
-            genesis_block_hash: String::from(""),
-            node_config_path: PathBuf::from(""),
-            secret_model_paths: Vec::new(),
-            log_file_path: PathBuf::from(""),
-            block0_configuration: block0_configuration,
-            node_config: node_config,
-            secret_models: Vec::new(),
-            rewards_history: false,
-        }
+        self.node_config().p2p.make_trusted_peer_setting()
     }
 
     pub fn block0_utxo(&self) -> Vec<UTxOInfo> {
-        let block0_bytes = std::fs::read(&self.genesis_block_path).expect(&format!(
+        let block0_bytes = std::fs::read(self.genesis_block_path()).expect(&format!(
             "Failed to load block 0 binary file '{}'",
-            self.genesis_block_path.display()
+            self.genesis_block_path().display()
         ));
         mempack::read_from_raw::<Block>(&block0_bytes)
             .expect(&format!(
                 "Failed to parse block in block 0 file '{}'",
-                self.genesis_block_path.display()
+                self.genesis_block_path().display()
             ))
             .contents
             .iter()
@@ -144,5 +190,26 @@ impl JormungandrConfig {
             &utxo
         );
         utxo
+    }
+}
+
+impl Default for JormungandrConfig {
+    fn default() -> JormungandrConfig {
+        JormungandrConfig::new(
+            PathBuf::from(""),
+            "".to_owned(),
+            PathBuf::from(""),
+            vec![],
+            PathBuf::from(""),
+            Block0ConfigurationBuilder::new().build(),
+            vec![],
+            false,
+        )
+    }
+}
+
+impl Into<BackwardCompatibleConfig> for JormungandrConfig {
+    fn into(self) -> BackwardCompatibleConfig {
+        self.inner
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
+++ b/testing/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code)]
 
 use crate::common::{
-    configuration::{Block0ConfigurationBuilder, NodeConfigBuilder},
-    file_utils,
+    configuration::NodeConfigBuilder, file_utils, jormungandr::ConfigurationBuilder,
     legacy::BackwardCompatibleConfig,
 };
 use chain_core::mempack;
@@ -196,16 +195,7 @@ impl JormungandrConfig {
 
 impl Default for JormungandrConfig {
     fn default() -> JormungandrConfig {
-        JormungandrConfig::new(
-            PathBuf::from(""),
-            "".to_owned(),
-            PathBuf::from(""),
-            vec![],
-            PathBuf::from(""),
-            Block0ConfigurationBuilder::new().build(),
-            vec![],
-            false,
-        )
+        ConfigurationBuilder::new().build()
     }
 }
 

--- a/testing/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
+++ b/testing/jormungandr-integration-tests/src/common/configuration/jormungandr_config.rs
@@ -97,16 +97,16 @@ impl JormungandrConfig {
     }
 
     pub fn refresh_node_dynamic_params(&mut self) {
-        self.regenerate_ports();
-        self.update_node_config();
+        let node_config = self.regenerate_ports();
+        self.update_node_config(node_config);
         self.inner.log_file_path = file_utils::get_path_in_temp("log_file.log");
     }
 
-    pub fn update_node_config(&mut self) {
-        self.inner.node_config_path = NodeConfigBuilder::serialize(&self.node_config());
+    fn update_node_config(&mut self, node_config: NodeConfig) {
+        self.inner.node_config_path = NodeConfigBuilder::serialize(&node_config);
     }
 
-    fn regenerate_ports(&mut self) {
+    fn regenerate_ports(&mut self) -> NodeConfig {
         let mut node_config = self.node_config();
         node_config.rest.listen = format!("127.0.0.1:{}", super::get_available_port().to_string())
             .parse()
@@ -117,6 +117,7 @@ impl JormungandrConfig {
         )
         .parse()
         .unwrap();
+        node_config
     }
 
     pub fn fees(&self) -> LinearFee {

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -215,23 +215,23 @@ impl ConfigurationBuilder {
             .build();
 
         let path_to_output_block = build_genesis_block(&block0_config);
-
-        let mut config = JormungandrConfig::from(block0_config, node_config);
+        let genesis_block_hash = match self.block0_hash {
+            Some(ref value) => value.clone(),
+            None => jcli_wrapper::assert_genesis_hash(&path_to_output_block),
+        };
 
         let secret_model = SecretModelFactory::bft(leader_key_pair.signing_key());
         let secret_model_path = SecretModelFactory::serialize(&secret_model);
 
-        config.rewards_history = self.rewards_history;
-        config.secret_models = vec![secret_model];
-        config.secret_model_paths = vec![secret_model_path];
-        config.genesis_block_path = path_to_output_block.clone();
-        config.node_config_path = node_config_path;
-        config.log_file_path = file_utils::get_path_in_temp("log_file.log");
-
-        config.genesis_block_hash = match self.block0_hash {
-            Some(ref value) => value.clone(),
-            None => jcli_wrapper::assert_genesis_hash(&path_to_output_block),
-        };
-        config
+        JormungandrConfig::new(
+            path_to_output_block.clone(),
+            genesis_block_hash,
+            node_config_path,
+            vec![secret_model_path],
+            file_utils::get_path_in_temp("log_file.log"),
+            block0_config,
+            vec![secret_model],
+            self.rewards_history,
+        )
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/logger.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/logger.rs
@@ -43,6 +43,7 @@ pub struct LogEntry {
     pub task: Option<String>,
     pub hash: Option<String>,
     pub reason: Option<String>,
+    pub error: Option<String>,
     pub peer_addr: Option<String>,
 }
 
@@ -50,6 +51,13 @@ impl LogEntry {
     pub fn reason_contains(&self, reason_part: &str) -> bool {
         match &self.reason {
             Some(reason) => reason.contains(reason_part),
+            None => false,
+        }
+    }
+
+    pub fn error_contains(&self, error_part: &str) -> bool {
+        match &self.error {
+            Some(error) => error.contains(error_part),
             None => false,
         }
     }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/logger.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/logger.rs
@@ -72,7 +72,7 @@ impl JormungandrLogger {
     }
 
     pub fn get_error_indicators() -> Vec<&'static str> {
-        vec!["panicked", "|->"]
+        vec!["panicked", "error"]
     }
 
     pub fn get_log_content(&self) -> String {

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -1,6 +1,6 @@
 use super::{logger::JormungandrLogger, JormungandrError, JormungandrRest};
 use crate::common::{
-    configuration::jormungandr_config::JormungandrConfig,
+    configuration::JormungandrConfig,
     explorer::Explorer,
     jcli_wrapper,
     jormungandr::starter::{Starter, StartupError},
@@ -14,31 +14,30 @@ pub struct JormungandrProcess {
     pub child: Child,
     pub logger: JormungandrLogger,
     pub config: JormungandrConfig,
-    description: String,
+    alias: String,
 }
 
 impl JormungandrProcess {
-    pub fn from_config(child: Child, config: JormungandrConfig) -> Self {
-        JormungandrProcess::new(
-            child,
-            String::from("Jormungandr node"),
-            config.log_file_path.clone(),
-            config,
-        )
+    pub fn from_config(child: Child, config: JormungandrConfig, alias: String) -> Self {
+        JormungandrProcess::new(child, alias, config.log_file_path().clone(), config)
     }
 
     pub fn new(
         child: Child,
-        description: String,
+        alias: String,
         log_file_path: PathBuf,
         config: JormungandrConfig,
     ) -> Self {
         JormungandrProcess {
             child: child,
-            description: description,
+            alias: alias,
             logger: JormungandrLogger::new(log_file_path.clone()),
             config: config,
         }
+    }
+
+    pub fn alias(&self) -> String {
+        self.alias.clone()
     }
 
     pub fn rest(&self) -> JormungandrRest {
@@ -47,6 +46,14 @@ impl JormungandrProcess {
 
     pub fn shutdown(&self) {
         jcli_wrapper::assert_rest_shutdown(&self.config.get_node_address());
+    }
+
+    pub fn address(&self) -> poldercast::Address {
+        self.config.node_config().p2p.public_address.clone()
+    }
+
+    pub fn log_stats(&self) {
+        println!("{:?}", self.rest().stats());
     }
 
     pub fn assert_no_errors_in_log_with_message(&self, message: &str) {
@@ -96,7 +103,7 @@ impl JormungandrProcess {
     }
 
     pub fn genesis_block_hash(&self) -> Hash {
-        Hash::from_str(&self.config.genesis_block_hash).unwrap()
+        Hash::from_str(&self.config.genesis_block_hash()).unwrap()
     }
 
     pub fn config(&self) -> JormungandrConfig {
@@ -108,7 +115,7 @@ impl JormungandrProcess {
     }
 
     pub fn explorer(&self) -> Explorer {
-        Explorer::new(self.config.node_config.rest.listen.to_string())
+        Explorer::new(self.config.node_config().rest.listen.to_string())
     }
 
     pub fn as_trusted_peer(&self) -> TrustedPeer {
@@ -118,7 +125,7 @@ impl JormungandrProcess {
     pub fn launch(&mut self) -> Result<Self, StartupError> {
         let mut starter = Starter::new();
         starter.config(self.config());
-        if self.config().genesis_block_hash != "" {
+        if *self.config().genesis_block_hash() != "" {
             starter.from_genesis_hash();
         }
         starter.start()
@@ -129,8 +136,8 @@ impl Drop for JormungandrProcess {
     fn drop(&mut self) {
         self.logger.print_error_and_invalid_logs();
         match self.child.kill() {
-            Err(e) => println!("Could not kill {}: {}", self.description, e),
-            Ok(_) => println!("Successfully killed {}", self.description),
+            Err(e) => println!("Could not kill {}: {}", self.alias, e),
+            Ok(_) => println!("Successfully killed {}", self.alias),
         }
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/rest.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/rest.rs
@@ -1,4 +1,4 @@
-use crate::common::configuration::jormungandr_config::JormungandrConfig;
+use crate::common::{configuration::jormungandr_config::JormungandrConfig, legacy};
 use jormungandr_lib::interfaces::{
     EpochRewardsInfo, Info, NodeStatsDto, PeerRecord, PeerStats, StakeDistributionDto,
 };
@@ -9,17 +9,20 @@ pub enum RestError {
     #[error("could not deserialize response")]
     CannotDeserialize(#[from] serde_json::Error),
     #[error("could not send reqeuest")]
-    SendRequestError(#[from] reqwest::Error),
+    RequestError(#[from] reqwest::Error),
 }
 
+/// Specialized rest api
 #[derive(Debug)]
 pub struct JormungandrRest {
-    config: JormungandrConfig,
+    inner: legacy::BackwardCompatibleRest,
 }
 
 impl JormungandrRest {
     pub fn new(config: JormungandrConfig) -> Self {
-        Self { config: config }
+        Self {
+            inner: legacy::BackwardCompatibleRest::new(config.get_node_address()),
+        }
     }
 
     fn print_response_text(&self, text: &str) {
@@ -27,69 +30,56 @@ impl JormungandrRest {
     }
 
     pub fn epoch_reward_history(&self, epoch: u32) -> Result<EpochRewardsInfo, RestError> {
-        let request = format!("rewards/epoch/{}", epoch);
-        let response_text = self.get(&request)?.text()?;
-        self.print_response_text(&response_text);
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        let content = self.inner.epoch_reward_history(epoch)?;
+        serde_json::from_str(&content).map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn reward_history(&self, length: u32) -> Result<Vec<EpochRewardsInfo>, RestError> {
-        let request = format!("rewards/history/{}", length);
-        let response_text = self.get(&request)?.text()?;
-        self.print_response_text(&response_text);
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
-    }
-
-    fn get(&self, path: &str) -> Result<reqwest::blocking::Response, reqwest::Error> {
-        reqwest::blocking::get(&format!("{}/v0/{}", self.config.get_node_address(), path))
+        serde_json::from_str(&self.inner.reward_history(length)?)
+            .map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn stake_distribution(&self) -> Result<StakeDistributionDto, RestError> {
-        let response_text = self.get("stake")?.text()?;
-        self.print_response_text(&response_text);
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        serde_json::from_str(&self.inner.stake_distribution()?)
+            .map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn stake_pools(&self) -> Result<Vec<String>, RestError> {
-        let response_text = self.get("stake_pools")?.text()?;
-        self.print_response_text(&response_text);
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        serde_json::from_str(&self.inner.stake_pools()?)
+            .map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn stake_distribution_at(&self, epoch: u32) -> Result<StakeDistributionDto, RestError> {
-        let request = format!("stake/{}", epoch);
-        let response_text = self.get(&request)?.text()?;
-        self.print_response_text(&response_text);
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        serde_json::from_str(&self.inner.stake_distribution_at(epoch)?)
+            .map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn stats(&self) -> Result<NodeStatsDto, RestError> {
-        let response_text = self.get("node/stats")?.text()?;
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        serde_json::from_str(&self.inner.stats()?).map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn network_stats(&self) -> Result<Vec<PeerStats>, RestError> {
-        let response_text = self.get("network/stats")?.text()?;
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        serde_json::from_str(&self.inner.network_stats()?)
+            .map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn p2p_quarantined(&self) -> Result<Vec<PeerRecord>, RestError> {
-        let response_text = self.get("network/p2p/quarantined")?.text()?;
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        serde_json::from_str(&self.inner.p2p_quarantined()?)
+            .map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn p2p_non_public(&self) -> Result<Vec<PeerRecord>, RestError> {
-        let response_text = self.get("network/p2p/non_public")?.text()?;
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        serde_json::from_str(&self.inner.p2p_non_public()?)
+            .map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn p2p_available(&self) -> Result<Vec<PeerRecord>, RestError> {
-        let response_text = self.get("network/p2p/available")?.text()?;
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        serde_json::from_str(&self.inner.p2p_available()?)
+            .map_err(|err| RestError::CannotDeserialize(err))
     }
 
     pub fn p2p_view(&self) -> Result<Vec<Info>, RestError> {
-        let response_text = self.get("network/p2p/view")?.text()?;
-        serde_json::from_str(&response_text).map_err(|err| RestError::CannotDeserialize(err))
+        serde_json::from_str(&self.inner.p2p_view()?)
+            .map_err(|err| RestError::CannotDeserialize(err))
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
@@ -1,0 +1,108 @@
+use super::BackwardCompatibleConfig;
+use super::Version;
+use crate::common::{
+    configuration::JormungandrConfig, file_utils, jormungandr::starter::StartupError,
+};
+use hex;
+use jormungandr_testing_utils::legacy::{NodeConfig, P2p, Rest, TrustedPeer};
+use rand::RngCore;
+use rand_core::OsRng;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LegacyConfigConverterError {
+    #[error("unsupported version")]
+    UnsupportedVersion(Version),
+    #[error("serialization error")]
+    SpawnError(#[from] StartupError),
+}
+
+fn version_08_19() -> Version {
+    Version::new(8, 19, 0)
+}
+
+/// Used to build configuration for legacy nodes.
+/// It uses yaml_rust instead of serde yaml serializer
+/// beacuse config model is always up to date with newest config schema
+/// while legacy node requires na old one
+pub struct LegacyConfigConverter {
+    version: Version,
+}
+
+impl LegacyConfigConverter {
+    pub fn new(version: Version) -> Self {
+        Self { version }
+    }
+
+    pub fn convert(
+        &self,
+        config: JormungandrConfig,
+    ) -> Result<BackwardCompatibleConfig, LegacyConfigConverterError> {
+        if self.version > version_08_19() {
+            return Err(LegacyConfigConverterError::UnsupportedVersion(
+                self.version.clone(),
+            ));
+        }
+        Ok(self.build_configuration_before_08_19(config))
+    }
+
+    fn generate_legacy_poldercast_id(rng: &mut OsRng) -> String {
+        let mut bytes: [u8; 24] = [0; 24];
+        rng.fill_bytes(&mut bytes);
+        hex::encode(&bytes).to_string()
+    }
+
+    pub fn build_configuration_before_08_19(
+        &self,
+        config: JormungandrConfig,
+    ) -> BackwardCompatibleConfig {
+        let source = config.node_config();
+        let mut rng = OsRng;
+        let trusted_peers: Vec<TrustedPeer> = source
+            .p2p
+            .trusted_peers
+            .iter()
+            .map(|peer| TrustedPeer {
+                id: Some(Self::generate_legacy_poldercast_id(&mut rng)),
+                address: peer.address.clone(),
+            })
+            .collect();
+
+        let backward_compatible_config = NodeConfig {
+            storage: source.storage.clone(),
+            log: source.log.clone(),
+            rest: Rest {
+                listen: source.rest.listen.clone(),
+            },
+            p2p: P2p {
+                trusted_peers: trusted_peers,
+                public_address: source.p2p.public_address.clone(),
+                listen_address: None,
+                max_inbound_connections: None,
+                max_connections: None,
+                topics_of_interest: source.p2p.topics_of_interest.clone(),
+                allow_private_addresses: false,
+                policy: source.p2p.policy.clone(),
+                layers: None,
+            },
+            mempool: source.mempool.clone(),
+            explorer: source.explorer.clone(),
+            bootstrap_from_trusted_peers: source.bootstrap_from_trusted_peers,
+            skip_bootstrap: source.skip_bootstrap,
+        };
+        let content = serde_yaml::to_string(&backward_compatible_config)
+            .expect("cannot serializer node config before 08.19 version");
+        let node_config_path = file_utils::create_file_in_temp("node_config.xml", &content);
+
+        BackwardCompatibleConfig::new(
+            config.genesis_block_path().clone(),
+            config.genesis_block_hash().clone(),
+            node_config_path,
+            config.secret_model_paths().clone(),
+            config.log_file_path().clone(),
+            config.block0_configuration().clone(),
+            config.secret_models().clone(),
+            config.rewards_history(),
+        )
+    }
+}

--- a/testing/jormungandr-integration-tests/src/common/legacy/jormungandr_configuration.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/jormungandr_configuration.rs
@@ -1,0 +1,87 @@
+#![allow(dead_code)]
+
+use crate::common::configuration::get_available_port;
+use crate::common::file_utils;
+use jormungandr_lib::interfaces::{Block0Configuration, NodeSecret};
+use jormungandr_testing_utils::legacy::NodeConfig;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct BackwardCompatibleConfig {
+    pub genesis_block_path: PathBuf,
+    pub genesis_block_hash: String,
+    pub node_config_path: PathBuf,
+    pub secret_model_paths: Vec<PathBuf>,
+    pub block0_configuration: Block0Configuration,
+    pub secret_models: Vec<NodeSecret>,
+    pub log_file_path: PathBuf,
+    pub rewards_history: bool,
+}
+
+impl BackwardCompatibleConfig {
+    pub fn new(
+        genesis_block_path: PathBuf,
+        genesis_block_hash: String,
+        node_config_path: PathBuf,
+        secret_model_paths: Vec<PathBuf>,
+        log_file_path: PathBuf,
+        block0_configuration: Block0Configuration,
+        secret_models: Vec<NodeSecret>,
+        rewards_history: bool,
+    ) -> Self {
+        Self {
+            genesis_block_path,
+            genesis_block_hash,
+            node_config_path,
+            secret_model_paths,
+            log_file_path,
+            block0_configuration,
+            secret_models,
+            rewards_history,
+        }
+    }
+
+    pub fn get_node_address(&self) -> String {
+        format!("http://{}/api", self.deserialize_node_config().rest.listen)
+    }
+
+    pub fn refresh_node_dynamic_params(&mut self) {
+        self.regenerate_ports();
+        self.log_file_path = file_utils::get_path_in_temp("log_file.log");
+    }
+
+    fn deserialize_node_config(&self) -> NodeConfig {
+        serde_yaml::from_str(&file_utils::read_file(&self.node_config_path))
+            .expect("cannot deserialize legacy")
+    }
+
+    fn serialize_node_config(&mut self, model: NodeConfig) {
+        let content = serde_yaml::to_string(&model).expect("cannot serialize legacy");
+        self.node_config_path = file_utils::create_file_in_temp("node_config.xml", &content);
+    }
+
+    fn regenerate_ports(&mut self) {
+        let mut node_config = self.deserialize_node_config();
+        node_config.rest.listen = format!("127.0.0.1:{}", get_available_port().to_string())
+            .parse()
+            .unwrap();
+        node_config.p2p.public_address =
+            format!("/ip4/127.0.0.1/tcp/{}", get_available_port().to_string())
+                .parse()
+                .unwrap();
+        self.serialize_node_config(node_config);
+    }
+
+    pub fn get_p2p_listen_port(&self) -> u16 {
+        let address = self
+            .deserialize_node_config()
+            .p2p
+            .public_address
+            .to_string();
+        let tokens: Vec<&str> = address.split("/").collect();
+        let port_str = tokens
+            .get(4)
+            .expect("cannot extract port from p2p.public_address");
+        port_str.parse().unwrap()
+    }
+}

--- a/testing/jormungandr-integration-tests/src/common/legacy/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/mod.rs
@@ -3,6 +3,20 @@ use jormungandr_testing_utils::testing::{
     github::{GitHubApi, Release},
 };
 
+mod configuration_builder;
+mod jormungandr_configuration;
+mod node;
+mod rest;
+mod starter;
+mod version;
+
+pub use configuration_builder::{LegacyConfigConverter, LegacyConfigConverterError};
+pub use jormungandr_configuration::BackwardCompatibleConfig;
+pub use node::BackwardCompatibleJormungandr;
+pub use rest::BackwardCompatibleRest;
+pub use starter::Starter;
+pub use version::Version;
+
 use crate::common::file_utils;
 
 use std::path::PathBuf;
@@ -15,6 +29,7 @@ pub fn download_last_n_releases(n: usize) -> Vec<Release> {
         .unwrap()
         .iter()
         .cloned()
+        .filter(|x| !x.prerelease())
         .take(n)
         .collect()
 }

--- a/testing/jormungandr-integration-tests/src/common/legacy/node.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/node.rs
@@ -1,0 +1,116 @@
+use super::{BackwardCompatibleConfig, BackwardCompatibleRest};
+use crate::common::{
+    explorer::Explorer,
+    jcli_wrapper,
+    jormungandr::{JormungandrError, JormungandrLogger},
+};
+use jormungandr_lib::crypto::hash::Hash;
+use std::{path::PathBuf, process::Child, str::FromStr};
+
+#[derive(Debug)]
+pub struct BackwardCompatibleJormungandr {
+    pub child: Child,
+    pub logger: JormungandrLogger,
+    pub config: BackwardCompatibleConfig,
+    alias: String,
+}
+
+impl BackwardCompatibleJormungandr {
+    pub fn from_config(child: Child, config: BackwardCompatibleConfig, alias: String) -> Self {
+        Self::new(child, alias, config.log_file_path.clone(), config)
+    }
+
+    pub fn new(
+        child: Child,
+        alias: String,
+        log_file_path: PathBuf,
+        config: BackwardCompatibleConfig,
+    ) -> Self {
+        Self {
+            child: child,
+            alias: alias,
+            logger: JormungandrLogger::new(log_file_path.clone()),
+            config: config,
+        }
+    }
+
+    pub fn alias(&self) -> String {
+        self.alias.clone()
+    }
+
+    pub fn rest(&self) -> BackwardCompatibleRest {
+        BackwardCompatibleRest::new(self.config.get_node_address())
+    }
+
+    pub fn shutdown(&self) {
+        jcli_wrapper::assert_rest_shutdown(&self.config.get_node_address());
+    }
+
+    pub fn assert_no_errors_in_log_with_message(&self, message: &str) {
+        let error_lines = self.logger.get_lines_with_error().collect::<Vec<String>>();
+
+        assert_eq!(
+            error_lines.len(),
+            0,
+            "{} there are some errors in log ({:?}): {:?}",
+            message,
+            self.logger.log_file_path,
+            error_lines,
+        );
+    }
+
+    pub fn assert_no_errors_in_log(&self) {
+        let error_lines = self.logger.get_lines_with_error().collect::<Vec<String>>();
+
+        assert_eq!(
+            error_lines.len(),
+            0,
+            "there are some errors in log ({:?}): {:?}",
+            self.logger.log_file_path,
+            error_lines
+        );
+    }
+
+    pub fn check_no_errors_in_log(&self) -> Result<(), JormungandrError> {
+        let error_lines = self.logger.get_lines_with_error().collect::<Vec<String>>();
+
+        if error_lines.len() != 0 {
+            return Err(JormungandrError::ErrorInLogs {
+                logs: self.logger.get_log_content(),
+                log_location: self.logger.log_file_path.clone(),
+                error_lines: format!("{:?}", error_lines).to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn rest_address(&self) -> String {
+        self.config.get_node_address()
+    }
+
+    pub fn genesis_block_hash(&self) -> Hash {
+        Hash::from_str(&self.config.genesis_block_hash).unwrap()
+    }
+
+    pub fn config(&self) -> BackwardCompatibleConfig {
+        self.config.clone()
+    }
+
+    pub fn pid(&self) -> u32 {
+        self.child.id()
+    }
+
+    pub fn explorer(&self) -> Explorer {
+        Explorer::new(self.rest_address())
+    }
+}
+
+impl Drop for BackwardCompatibleJormungandr {
+    fn drop(&mut self) {
+        self.logger.print_error_and_invalid_logs();
+        match self.child.kill() {
+            Err(e) => println!("Could not kill {}: {}", self.alias, e),
+            Ok(_) => println!("Successfully killed {}", self.alias),
+        }
+    }
+}

--- a/testing/jormungandr-integration-tests/src/common/legacy/rest.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/rest.rs
@@ -1,0 +1,78 @@
+/// Legacy tolerant rest api
+/// This layer returns raw strings without deserialization
+/// in order to assure compatibility and lack of serde errors
+#[derive(Debug)]
+pub struct BackwardCompatibleRest {
+    endpoint: String,
+}
+
+impl BackwardCompatibleRest {
+    pub fn new(endpoint: String) -> Self {
+        Self { endpoint }
+    }
+
+    fn print_response_text(&self, text: &str) {
+        println!("Response: {}", text);
+    }
+
+    pub fn epoch_reward_history(&self, epoch: u32) -> Result<String, reqwest::Error> {
+        let request = format!("rewards/epoch/{}", epoch);
+        let response_text = self.get(&request)?.text()?;
+        self.print_response_text(&response_text);
+        Ok(response_text)
+    }
+
+    pub fn reward_history(&self, length: u32) -> Result<String, reqwest::Error> {
+        let request = format!("rewards/history/{}", length);
+        let response_text = self.get(&request)?.text()?;
+        self.print_response_text(&response_text);
+        Ok(response_text)
+    }
+
+    fn get(&self, path: &str) -> Result<reqwest::blocking::Response, reqwest::Error> {
+        reqwest::blocking::get(&format!("{}/v0/{}", self.endpoint, path))
+    }
+
+    pub fn stake_distribution(&self) -> Result<String, reqwest::Error> {
+        let response_text = self.get("stake")?.text()?;
+        self.print_response_text(&response_text);
+        Ok(response_text)
+    }
+
+    pub fn stake_pools(&self) -> Result<String, reqwest::Error> {
+        let response_text = self.get("stake_pools")?.text()?;
+        self.print_response_text(&response_text);
+        Ok(response_text)
+    }
+
+    pub fn stake_distribution_at(&self, epoch: u32) -> Result<String, reqwest::Error> {
+        let request = format!("stake/{}", epoch);
+        let response_text = self.get(&request)?.text()?;
+        self.print_response_text(&response_text);
+        Ok(response_text)
+    }
+
+    pub fn stats(&self) -> Result<String, reqwest::Error> {
+        self.get("node/stats")?.text()
+    }
+
+    pub fn network_stats(&self) -> Result<String, reqwest::Error> {
+        self.get("network/stats")?.text()
+    }
+
+    pub fn p2p_quarantined(&self) -> Result<String, reqwest::Error> {
+        self.get("network/p2p/quarantined")?.text()
+    }
+
+    pub fn p2p_non_public(&self) -> Result<String, reqwest::Error> {
+        self.get("network/p2p/non_public")?.text()
+    }
+
+    pub fn p2p_available(&self) -> Result<String, reqwest::Error> {
+        self.get("network/p2p/available")?.text()
+    }
+
+    pub fn p2p_view(&self) -> Result<String, reqwest::Error> {
+        self.get("network/p2p/view")?.text()
+    }
+}

--- a/testing/jormungandr-integration-tests/src/common/legacy/starter.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/starter.rs
@@ -1,0 +1,286 @@
+use super::BackwardCompatibleConfig;
+use super::BackwardCompatibleJormungandr;
+use super::Version;
+use super::{LegacyConfigConverter, LegacyConfigConverterError};
+use crate::common::{
+    configuration::JormungandrConfig,
+    file_utils,
+    jcli_wrapper::jcli_commands,
+    jormungandr::{
+        logger::JormungandrLogger,
+        starter::{get_command, FromGenesis, OnFail, Role},
+        ConfigurationBuilder,
+    },
+    process_utils::{self, output_extensions::ProcessOutput, ProcessError},
+};
+use jormungandr_testing_utils::testing::{SpeedBenchmarkDef, SpeedBenchmarkRun};
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::{
+    process::Child,
+    time::{Duration, Instant},
+};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StartupError {
+    #[error("could not start jormungandr due to process issue")]
+    JormungandrNotLaunched(#[from] ProcessError),
+    #[error("could not start jormungandr due to process issue")]
+    ConfigurationError(#[from] LegacyConfigConverterError),
+    #[error("node wasn't properly bootstrap after {timeout} s. Log file: {log_content}")]
+    Timeout { timeout: u64, log_content: String },
+    #[error("error(s) in log detected: {log_content}")]
+    ErrorInLogsFound { log_content: String },
+    #[error("error(s) in log detected: port already in use")]
+    PortAlreadyInUse,
+    #[error("expected message not found: {entry} in logs: {log_content}")]
+    EntryNotFoundInLogs { entry: String, log_content: String },
+}
+
+const DEFAULT_SLEEP_BETWEEN_ATTEMPTS: u64 = 2;
+const DEFAULT_MAX_ATTEMPTS: u64 = 6;
+
+pub struct Starter {
+    timeout: Duration,
+    jormungandr_app_path: PathBuf,
+    sleep: u64,
+    role: Role,
+    alias: String,
+    from_genesis: FromGenesis,
+    on_fail: OnFail,
+    version: Version,
+    config: Option<JormungandrConfig>,
+    benchmark: Option<SpeedBenchmarkDef>,
+}
+
+impl Starter {
+    pub fn new(version: Version, jormungandr_app_path: PathBuf) -> Self {
+        Starter {
+            timeout: Duration::from_secs(300),
+            sleep: 2,
+            role: Role::Leader,
+            from_genesis: FromGenesis::File,
+            on_fail: OnFail::RetryUnlimitedOnPortOccupied,
+            version: version,
+            alias: "".to_owned(),
+            config: None,
+            benchmark: None,
+            jormungandr_app_path: jormungandr_app_path,
+        }
+    }
+
+    pub fn alias(&mut self, alias: String) -> &mut Self {
+        self.alias = alias;
+        self
+    }
+
+    pub fn jormungandr_app(&mut self, path: PathBuf) -> &mut Self {
+        self.jormungandr_app_path = path;
+        self
+    }
+
+    pub fn timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn passive(&mut self) -> &mut Self {
+        self.role = Role::Passive;
+        self
+    }
+
+    pub fn benchmark(&mut self, name: &str) -> &mut Self {
+        self.benchmark = Some(SpeedBenchmarkDef::new(name.to_owned()));
+        self
+    }
+
+    pub fn role(&mut self, role: Role) -> &mut Self {
+        self.role = role;
+        self
+    }
+
+    pub fn from_genesis_hash(&mut self) -> &mut Self {
+        self.from_genesis(FromGenesis::Hash)
+    }
+
+    pub fn from_genesis_file(&mut self) -> &mut Self {
+        self.from_genesis(FromGenesis::File)
+    }
+
+    pub fn from_genesis(&mut self, from_genesis: FromGenesis) -> &mut Self {
+        self.from_genesis = from_genesis;
+        self
+    }
+
+    pub fn config(&mut self, config: JormungandrConfig) -> &mut Self {
+        self.config = Some(config);
+        self
+    }
+
+    fn build_configuration(&mut self) -> JormungandrConfig {
+        if self.config.is_none() {
+            self.config = Some(ConfigurationBuilder::new().build());
+        }
+        self.config.as_ref().unwrap().clone()
+    }
+
+    pub fn start_benchmark_run(&self) -> Option<SpeedBenchmarkRun> {
+        match &self.benchmark {
+            Some(benchmark_def) => Some(benchmark_def.clone().target(self.timeout).start()),
+            None => None,
+        }
+    }
+
+    pub fn finish_benchmark(&self, benchmark_run: Option<SpeedBenchmarkRun>) {
+        if let Some(benchmark_run) = benchmark_run {
+            benchmark_run.stop().print();
+        }
+    }
+
+    fn start_process(&self, config: &BackwardCompatibleConfig) -> Child {
+        println!("Starting legacy node: {}", self.version);
+        println!(
+            "Blockchain configuration: {:?}",
+            &config.block0_configuration
+        );
+        println!(
+            "Node settings configuration: {}",
+            file_utils::read_file(&config.node_config_path)
+        );
+
+        let mut command = get_command(
+            config,
+            self.jormungandr_app_path.clone(),
+            self.role,
+            self.from_genesis,
+        );
+
+        println!("Bootstrapping...");
+
+        command
+            .spawn()
+            .expect("failed to execute 'start jormungandr node'")
+    }
+
+    pub fn start(&mut self) -> Result<BackwardCompatibleJormungandr, StartupError> {
+        let mut config =
+            LegacyConfigConverter::new(self.version.clone()).convert(self.build_configuration())?;
+        let benchmark = self.start_benchmark_run();
+        let mut retry_counter = 1;
+        loop {
+            let process = self.start_process(&config);
+
+            match (self.verify_is_up(process, &config), self.on_fail) {
+                (Ok(jormungandr_process), _) => {
+                    self.finish_benchmark(benchmark);
+                    return Ok(jormungandr_process);
+                }
+
+                (
+                    Err(StartupError::PortAlreadyInUse { .. }),
+                    OnFail::RetryUnlimitedOnPortOccupied,
+                ) => {
+                    println!(
+                        "Port already in use error detected. Retrying with different port... "
+                    );
+                    config.refresh_node_dynamic_params();
+                }
+                (Err(err), OnFail::Panic) => {
+                    panic!(format!(
+                        "Jormungandr node cannot start due to error: {}",
+                        err
+                    ));
+                }
+                (Err(err), _) => {
+                    println!(
+                        "Jormungandr failed to start due to error {}. Retrying... ",
+                        err
+                    );
+                    retry_counter = retry_counter - 1;
+                }
+            }
+
+            if retry_counter < 0 {
+                panic!("Jormungandr node cannot start due despite retry attempts. see logs for more details");
+            }
+        }
+    }
+
+    fn if_succeed(&self, config: &BackwardCompatibleConfig) -> bool {
+        let output = jcli_commands::get_rest_stats_command(&config.get_node_address())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap()
+            .wait_with_output()
+            .expect("failed to execute get_rest_stats command");
+
+        let content_result = output.try_as_single_node_yaml();
+        if content_result.is_err() {
+            return false;
+        }
+
+        match content_result.unwrap().get("uptime") {
+            Some(uptime) => {
+                uptime
+                    .parse::<i32>()
+                    .expect(&format!("Cannot parse uptime {}", uptime.to_string()))
+                    > 2
+            }
+            None => false,
+        }
+    }
+
+    fn if_stopped(&self, config: &BackwardCompatibleConfig) -> bool {
+        let logger = JormungandrLogger::new(config.log_file_path.clone());
+        logger.contains_error().unwrap_or_else(|_| false)
+    }
+
+    fn custom_errors_found(&self, config: &BackwardCompatibleConfig) -> Result<(), StartupError> {
+        let logger = JormungandrLogger::new(config.log_file_path.clone());
+        let port_occupied_msgs = ["error 87", "error 98", "panicked at 'Box<Any>'"];
+        match logger
+            .raw_log_contains_any_of(&port_occupied_msgs)
+            .unwrap_or_else(|_| false)
+        {
+            true => Err(StartupError::PortAlreadyInUse),
+            false => Ok(()),
+        }
+    }
+
+    fn verify_is_up(
+        &self,
+        process: Child,
+        config: &BackwardCompatibleConfig,
+    ) -> Result<BackwardCompatibleJormungandr, StartupError> {
+        let start = Instant::now();
+        let logger = JormungandrLogger::new(config.log_file_path.clone());
+        loop {
+            if start.elapsed() > self.timeout {
+                return Err(StartupError::Timeout {
+                    timeout: self.timeout.as_secs(),
+                    log_content: file_utils::read_file(&config.log_file_path),
+                });
+            }
+            if self.if_succeed(config) {
+                println!("jormungandr is up");
+                return Ok(BackwardCompatibleJormungandr::from_config(
+                    process,
+                    config.clone(),
+                    self.alias.clone(),
+                ));
+            }
+            self.custom_errors_found(config)?;
+            if self.if_stopped(config) {
+                println!("attempt stopped due to error signal recieved");
+                logger.print_raw_log();
+                return Err(StartupError::ErrorInLogsFound {
+                    log_content: file_utils::read_file(&config.log_file_path),
+                });
+            }
+            process_utils::sleep(self.sleep);
+        }
+    }
+}

--- a/testing/jormungandr-integration-tests/src/common/legacy/version.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/version.rs
@@ -1,6 +1,4 @@
-use std::cmp::Ordering;
-use std::num::ParseIntError;
-use std::str::FromStr;
+use std::{cmp::Ordering, fmt, num::ParseIntError, str::FromStr};
 
 #[derive(Eq, Debug, Clone)]
 pub struct Version {
@@ -46,7 +44,7 @@ impl Ord for Version {
     }
 }
 
-impl Display for Version {
+impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(v{}.{}.{})", self.major, self.minor, self.patch)
     }

--- a/testing/jormungandr-integration-tests/src/common/legacy/version.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/version.rs
@@ -1,0 +1,65 @@
+use std::cmp::Ordering;
+use std::num::ParseIntError;
+use std::str::FromStr;
+
+#[derive(Eq, Debug, Clone)]
+pub struct Version {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl Version {
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Version {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+impl FromStr for Version {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        //remove first char
+        let version_str = s.chars().next().map(|c| &s[c.len_utf8()..]).unwrap();
+        let mut tokens = version_str.split(".");
+        let major: u32 = tokens.next().unwrap().parse().unwrap();
+        let minor: u32 = tokens.next().unwrap().parse().unwrap();
+        let patch: u32 = tokens.next().unwrap().parse().unwrap();
+        Ok(Version {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.major
+            .cmp(&other.major)
+            .then(self.minor.cmp(&other.minor))
+            .then(self.patch.cmp(&other.patch))
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(v{}.{}.{})", self.major, self.minor, self.patch)
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Version {
+    fn eq(&self, other: &Self) -> bool {
+        self.major == other.major && self.minor == other.minor && self.patch == other.patch
+    }
+}

--- a/testing/jormungandr-integration-tests/src/common/network/node.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/node.rs
@@ -29,7 +29,7 @@ impl Node {
     pub fn address(&self) -> poldercast::Address {
         self.jormungandr
             .config
-            .node_config
+            .node_config()
             .p2p
             .public_address
             .clone()
@@ -37,10 +37,6 @@ impl Node {
 
     pub fn shutdown(&self) {
         self.jormungandr.shutdown();
-    }
-
-    pub fn log_stats(&self) {
-        println!("{}: {:?}", self.alias(), self.rest().stats().unwrap());
     }
 
     pub fn genesis_block_hash(&self) -> Hash {

--- a/testing/jormungandr-integration-tests/src/common/startup/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/startup/mod.rs
@@ -126,8 +126,8 @@ pub fn start_stake_pool(
         .map(|x| SecretModelFactory::serialize(&x))
         .collect();
 
-    config.secret_models = secrets;
-    config.secret_model_paths = secret_model_paths;
+    *config.secret_models_mut() = secrets;
+    *config.secret_model_paths_mut() = secret_model_paths;
 
     Starter::new()
         .config(config)
@@ -138,12 +138,12 @@ pub fn start_stake_pool(
 pub fn sleep_till_epoch(epoch_interval: u32, grace_period: u32, config: &JormungandrConfig) {
     let coeff = epoch_interval * 2;
     let slots_per_epoch: u32 = config
-        .block0_configuration
+        .block0_configuration()
         .blockchain_configuration
         .slots_per_epoch
         .into();
     let slot_duration: u8 = config
-        .block0_configuration
+        .block0_configuration()
         .blockchain_configuration
         .slot_duration
         .into();

--- a/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -15,26 +15,24 @@ pub fn test_genesis_block_is_built_from_correct_yaml() {
 
 #[test]
 pub fn test_genesis_with_empty_consenus_leaders_list_fails_to_build() {
-    let mut config = JormungandrConfig::new();
-    config
-        .block0_configuration
+    let mut config: JormungandrConfig = Default::default();
+    let mut block0_configuration = config.block0_configuration_mut();
+    block0_configuration
         .blockchain_configuration
-        .consensus_leader_ids = vec![];
+        .consensus_leader_ids = Vec::new();
     jcli_wrapper::assert_genesis_encode_fails(
-        &config.block0_configuration,
+        &config.block0_configuration(),
         r"Missing consensus leader id list in the initial fragment",
     );
 }
 
 #[test]
 pub fn test_genesis_for_production_is_successfully_built() {
-    let mut config = JormungandrConfig::new();
-    config.block0_configuration.initial.clear();
-    config
-        .block0_configuration
-        .blockchain_configuration
-        .discrimination = Discrimination::Production;
-    let input_yaml_file_path = startup::serialize_block0_config(&config.block0_configuration);
+    let mut config: JormungandrConfig = Default::default();
+    let mut block0_configuration = config.block0_configuration_mut();
+    block0_configuration.initial.clear();
+    block0_configuration.blockchain_configuration.discrimination = Discrimination::Production;
+    let input_yaml_file_path = startup::serialize_block0_config(&config.block0_configuration());
     let path_to_output_block = file_utils::get_path_in_temp("block0.bin");
     jcli_wrapper::assert_genesis_encode(&input_yaml_file_path, &path_to_output_block);
 }
@@ -45,46 +43,43 @@ pub fn test_genesis_for_prod_with_initial_funds_for_testing_address_fail_to_buil
     let public_key = jcli_wrapper::assert_key_to_public_default(&private_key);
     let test_address = jcli_wrapper::assert_address_single(&public_key, Discrimination::Test);
 
-    let mut config = JormungandrConfig::new();
-    config.block0_configuration.initial = vec![Initial::Fund(vec![InitialUTxO {
+    let mut config: JormungandrConfig = Default::default();
+    let mut block0_configuration = config.block0_configuration_mut();
+    block0_configuration.initial = vec![Initial::Fund(vec![InitialUTxO {
         value: 100.into(),
         address: test_address.parse().unwrap(),
     }])];
-    config
-        .block0_configuration
-        .blockchain_configuration
-        .discrimination = Discrimination::Production;
+    block0_configuration.blockchain_configuration.discrimination = Discrimination::Production;
     jcli_wrapper::assert_genesis_encode_fails(
-        &config.block0_configuration,
+        config.block0_configuration(),
         "Invalid discrimination",
     );
 }
 
 #[test]
 pub fn test_genesis_for_prod_with_wrong_discrimination_fail_to_build() {
-    let mut config = JormungandrConfig::new();
-    config
-        .block0_configuration
-        .blockchain_configuration
-        .discrimination = Discrimination::Production;
+    let mut config: JormungandrConfig = Default::default();
+    let mut block0_configuration = config.block0_configuration_mut();
+    block0_configuration.blockchain_configuration.discrimination = Discrimination::Production;
     jcli_wrapper::assert_genesis_encode_fails(
-        &config.block0_configuration,
+        config.block0_configuration(),
         "Invalid discrimination",
     );
 }
 
 #[test]
 pub fn test_genesis_without_initial_funds_is_built_successfully() {
-    let mut config = JormungandrConfig::new();
-    config.block0_configuration.initial.clear();
-    let input_yaml_file_path = startup::serialize_block0_config(&config.block0_configuration);
+    let mut config: JormungandrConfig = Default::default();
+    let block0_configuration = config.block0_configuration_mut();
+    block0_configuration.initial.clear();
+    let input_yaml_file_path = startup::serialize_block0_config(config.block0_configuration());
     let path_to_output_block = file_utils::get_path_in_temp("block0.bin");
     jcli_wrapper::assert_genesis_encode(&input_yaml_file_path, &path_to_output_block);
 }
 
 #[test]
 pub fn test_genesis_with_many_initial_funds_is_built_successfully() {
-    let mut config = JormungandrConfig::new();
+    let mut config: JormungandrConfig = Default::default();
     let address_1 = startup::create_new_account_address();
     let address_2 = startup::create_new_account_address();
     let initial_funds = Initial::Fund(vec![
@@ -97,15 +92,16 @@ pub fn test_genesis_with_many_initial_funds_is_built_successfully() {
             address: address_2.address(),
         },
     ]);
-    config.block0_configuration.initial.push(initial_funds);
-    let input_yaml_file_path = startup::serialize_block0_config(&config.block0_configuration);
+    let block0_configuration = config.block0_configuration_mut();
+    block0_configuration.initial.push(initial_funds);
+    let input_yaml_file_path = startup::serialize_block0_config(&config.block0_configuration());
     let path_to_output_block = file_utils::get_path_in_temp("block0.bin");
     jcli_wrapper::assert_genesis_encode(&input_yaml_file_path, &path_to_output_block);
 }
 
 #[test]
 pub fn test_genesis_with_legacy_funds_is_built_successfully() {
-    let mut config = JormungandrConfig::new();
+    let mut config: JormungandrConfig = Default::default();
     let legacy_funds = Initial::LegacyFund(
             vec![
                 LegacyUTxO{
@@ -114,8 +110,10 @@ pub fn test_genesis_with_legacy_funds_is_built_successfully() {
                 },
             ]
         );
-    config.block0_configuration.initial.push(legacy_funds);
-    let input_yaml_file_path = startup::serialize_block0_config(&config.block0_configuration);
+
+    let block0_configuration = config.block0_configuration_mut();
+    block0_configuration.initial.push(legacy_funds);
+    let input_yaml_file_path = startup::serialize_block0_config(&config.block0_configuration());
     let path_to_output_block = file_utils::get_path_in_temp("block0.bin");
     jcli_wrapper::assert_genesis_encode(&input_yaml_file_path, &path_to_output_block);
 }
@@ -134,18 +132,18 @@ pub fn test_genesis_decode_bijection() {
     ));
     let config = ConfigurationBuilder::new().with_linear_fees(fee).build();
 
-    let expected_yaml_file_path = startup::serialize_block0_config(&config.block0_configuration);
+    let expected_yaml_file_path = startup::serialize_block0_config(config.block0_configuration());
     let actual_yaml_file_path = file_utils::get_path_in_temp("actual_yaml.yaml");
 
-    jcli_wrapper::assert_genesis_decode(&config.genesis_block_path, &actual_yaml_file_path);
+    jcli_wrapper::assert_genesis_decode(&config.genesis_block_path(), &actual_yaml_file_path);
     file_assert::are_equal(&expected_yaml_file_path, &actual_yaml_file_path);
 
     let block0_after = file_utils::get_path_in_temp("block0_after.bin");
     jcli_wrapper::assert_genesis_encode(&actual_yaml_file_path, &block0_after);
 
-    file_assert::are_equal(&config.genesis_block_path, &block0_after);
+    file_assert::are_equal(&config.genesis_block_path(), &block0_after);
 
     let right_hash = jcli_wrapper::assert_genesis_hash(&block0_after);
 
-    assert_eq!(config.genesis_block_hash, right_hash);
+    assert_eq!(config.genesis_block_hash().clone(), right_hash);
 }

--- a/testing/jormungandr-integration-tests/src/jcli/rest/tip.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/rest/tip.rs
@@ -12,7 +12,7 @@ pub fn test_correct_id_is_returned_for_block_tip_if_only_genesis_block_exists() 
 
 #[test]
 pub fn test_correct_error_is_returned_for_incorrect_path() {
-    let config = JormungandrConfig::new();
+    let config: JormungandrConfig = Default::default();
     let mut incorrect_host = config.get_node_address();
     incorrect_host.push_str("/api");
 

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
@@ -33,7 +33,7 @@ pub fn test_utxo_transaction_with_more_than_one_witness_per_input_is_rejected() 
     let utxo = config.block0_utxo_for_address(&sender);
 
     let mut transaction_wrapper =
-        JCLITransactionWrapper::new_transaction(&config.genesis_block_hash);
+        JCLITransactionWrapper::new_transaction(&config.genesis_block_hash());
     let transaction_wrapper = transaction_wrapper
         .assert_add_input_from_utxo(&utxo)
         .assert_add_output(&receiver.address().to_string(), &utxo.associated_fund())
@@ -68,7 +68,7 @@ pub fn test_two_correct_utxo_to_utxo_transactions_are_accepted_by_node() {
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
 
     let utxo = config.block0_utxo_for_address(&sender);
-    let block0_hash = jcli_wrapper::assert_genesis_hash(&config.genesis_block_path);
+    let block0_hash = jcli_wrapper::assert_genesis_hash(config.genesis_block_path());
     let first_transaction = JCLITransactionWrapper::build_transaction_from_utxo(
         &utxo,
         &utxo.associated_fund(),
@@ -111,7 +111,7 @@ pub fn test_correct_utxo_transaction_is_accepted_by_node() {
 
     let utxo = jormungandr.config.block0_utxo_for_address(&sender);
     let transaction_message =
-        JCLITransactionWrapper::new_transaction(&jormungandr.config.genesis_block_hash)
+        JCLITransactionWrapper::new_transaction(&jormungandr.config.genesis_block_hash())
             .assert_add_input_from_utxo(&utxo)
             .assert_add_output(&receiver.address().to_string(), &utxo.associated_fund())
             .assert_finalize()
@@ -139,7 +139,7 @@ pub fn test_correct_utxo_transaction_replaces_old_utxo_by_node() {
     let rest_addr = jormungandr.rest_address();
     let utxo = config.block0_utxo_for_address(&sender);
 
-    let mut tx = JCLITransactionWrapper::new_transaction(&config.genesis_block_hash);
+    let mut tx = JCLITransactionWrapper::new_transaction(&config.genesis_block_hash());
     let tx_message = tx
         .assert_add_input_from_utxo(&utxo)
         .assert_add_output(&receiver.address().to_string(), &utxo.associated_fund())
@@ -173,7 +173,7 @@ pub fn test_account_is_created_if_transaction_out_is_account() {
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
 
-    let transaction_message = JCLITransactionWrapper::new_transaction(&config.genesis_block_hash)
+    let transaction_message = JCLITransactionWrapper::new_transaction(&config.genesis_block_hash())
         .assert_add_input_from_utxo(&utxo)
         .assert_add_output(&receiver.address().to_string(), &transfer_amount)
         .assert_finalize()
@@ -219,7 +219,7 @@ pub fn test_transaction_from_delegation_to_delegation_is_accepted_by_node() {
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
-    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash)
+    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash())
         .assert_new_transaction()
         .assert_add_input_from_utxo(&utxo)
         .assert_add_output(&receiver.address().to_string(), &transfer_amount)
@@ -245,7 +245,7 @@ pub fn test_transaction_from_delegation_to_account_is_accepted_by_node() {
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
-    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash)
+    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash())
         .assert_new_transaction()
         .assert_add_input_from_utxo(&utxo)
         .assert_add_output(&receiver.address().to_string(), &transfer_amount)
@@ -271,7 +271,7 @@ pub fn test_transaction_from_delegation_to_utxo_is_accepted_by_node() {
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
-    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash)
+    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash())
         .assert_new_transaction()
         .assert_add_input_from_utxo(&utxo)
         .assert_add_output(&receiver.address().to_string(), &transfer_amount)
@@ -296,7 +296,7 @@ pub fn test_transaction_from_utxo_to_account_is_accepted_by_node() {
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
-    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash)
+    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash())
         .assert_new_transaction()
         .assert_add_input_from_utxo(&utxo)
         .assert_add_output(&receiver.address().to_string(), &utxo.associated_fund())
@@ -321,7 +321,7 @@ pub fn test_transaction_from_account_to_account_is_accepted_by_node() {
         .build();
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
-    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash)
+    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash())
         .assert_new_transaction()
         .assert_add_account(&sender.address().to_string(), &transfer_amount)
         .assert_add_output(&receiver.address().to_string(), &transfer_amount)
@@ -346,7 +346,7 @@ pub fn test_transaction_from_account_to_delegation_is_accepted_by_node() {
         .build();
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
-    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash)
+    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash())
         .assert_new_transaction()
         .assert_add_account(&sender.address().to_string(), &transfer_amount)
         .assert_add_output(&receiver.address().to_string(), &transfer_amount)
@@ -371,7 +371,7 @@ pub fn test_transaction_from_utxo_to_delegation_is_accepted_by_node() {
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
-    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash)
+    let transaction_message = JCLITransactionWrapper::new(&config.genesis_block_hash())
         .assert_new_transaction()
         .assert_add_input_from_utxo(&utxo)
         .assert_add_output(&receiver.address().to_string(), &transfer_amount)
@@ -394,7 +394,7 @@ pub fn test_input_with_smaller_value_than_initial_utxo_is_rejected_by_node() {
         .build();
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
-    let block0_hash = jcli_wrapper::assert_genesis_hash(&config.genesis_block_path);
+    let block0_hash = jcli_wrapper::assert_genesis_hash(&config.genesis_block_path());
     let utxo = config.block0_utxo_for_address(&sender);
     let transaction_message = JCLITransactionWrapper::build_transaction_from_utxo(
         &utxo,
@@ -422,7 +422,7 @@ pub fn test_transaction_with_non_existing_id_should_be_rejected_by_node() {
         }])
         .build();
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
-    let block0_hash = jcli_wrapper::assert_genesis_hash(&config.genesis_block_path);
+    let block0_hash = jcli_wrapper::assert_genesis_hash(&config.genesis_block_path());
     let transaction_message = JCLITransactionWrapper::build_transaction(
         &FAKE_INPUT_TRANSACTION_ID,
         0,
@@ -453,7 +453,7 @@ pub fn test_transaction_with_input_address_equal_to_output_is_accepted_by_node()
         &sender,
         &utxo.associated_fund(),
         &sender,
-        &config.genesis_block_hash,
+        &config.genesis_block_hash(),
     );
 
     jcli_wrapper::assert_transaction_in_block(&transaction_message, &jormungandr);
@@ -478,7 +478,7 @@ pub fn test_input_with_no_spending_utxo_is_rejected_by_node() {
         &receiver,
         &50.into(),
         &sender,
-        &config.genesis_block_hash,
+        &config.genesis_block_hash(),
     );
 
     jcli_wrapper::assert_transaction_rejected(
@@ -503,7 +503,7 @@ pub fn test_transaction_with_non_zero_linear_fees() {
 
     let jormungandr = Starter::new().config(config.clone()).start().unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
-    let mut tx = JCLITransactionWrapper::new_transaction(&config.genesis_block_hash);
+    let mut tx = JCLITransactionWrapper::new_transaction(&config.genesis_block_hash());
     let transaction_message = tx
         .assert_add_input_from_utxo(&utxo)
         .assert_add_output(&receiver.address().to_string(), &50.into())

--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
@@ -17,7 +17,7 @@ pub fn test_jormungandr_passive_node_starts_successfully() {
 
     let passive_config = ConfigurationBuilder::new()
         .with_trusted_peers(vec![jormungandr_leader.as_trusted_peer()])
-        .with_block_hash(leader_config.genesis_block_hash)
+        .with_block_hash(leader_config.genesis_block_hash().clone())
         .build();
 
     let jormungandr_passive = Starter::new()
@@ -44,7 +44,8 @@ pub fn test_jormungandr_passive_node_without_trusted_peers_fails_to_start() {
 #[test]
 pub fn test_jormungandr_without_initial_funds_starts_sucessfully() {
     let mut config = ConfigurationBuilder::new().build();
-    config.block0_configuration.initial.clear();
+    let block0_configuration = config.block0_configuration_mut();
+    block0_configuration.initial.clear();
     let _jormungandr = Starter::new().config(config).start().unwrap();
 }
 
@@ -72,7 +73,7 @@ pub fn test_jormungandr_with_wrong_logger_fails_to_start() {
 
 #[test]
 pub fn test_jormungandr_without_logger_starts_successfully() {
-    let mut config = ConfigurationBuilder::new().build();
-    config.node_config.log = None;
+    let config = ConfigurationBuilder::new().build();
+    config.node_config().log = None;
     let _jormungandr = Starter::new().config(config).start().unwrap();
 }

--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
@@ -34,21 +34,21 @@ pub fn create_delegate_retire_stake_pool() {
 
     let stake_pool_id = create_new_stake_pool(
         &mut actor_account,
-        &config.genesis_block_hash,
+        config.genesis_block_hash(),
         &jormungandr,
         &Default::default(),
     );
     delegate_stake(
         &mut actor_account,
         &stake_pool_id,
-        &config.genesis_block_hash,
+        config.genesis_block_hash(),
         &jormungandr,
         &Default::default(),
     );
     retire_stake_pool(
         &stake_pool_id,
         &mut actor_account,
-        &config.genesis_block_hash,
+        config.genesis_block_hash(),
         &jormungandr,
         &Default::default(),
     );

--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/start_node.rs
@@ -81,8 +81,8 @@ pub fn test_genesis_stake_pool_with_utxo_faucet_starts_successfully() {
         &stake_pool_id,
     );
     let secret_file = SecretModelFactory::serialize(&secret);
-    config.secret_models = vec![secret];
-    config.secret_model_paths = vec![secret_file];
+    *config.secret_models_mut() = vec![secret];
+    *config.secret_model_paths_mut() = vec![secret_file];
 
     let _jormungandr = Starter::new().config(config).start().unwrap();
 }

--- a/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -51,7 +51,7 @@ pub fn do_simple_transaction(
 ) -> UTxOInfo {
     const TX_VALUE: u64 = 50;
     let config = jormungandr.config();
-    let mut tx = JCLITransactionWrapper::new_transaction(&config.genesis_block_hash);
+    let mut tx = JCLITransactionWrapper::new_transaction(config.genesis_block_hash());
     let transaction_message = tx
         .assert_add_input_from_utxo(utxo_sender)
         .assert_add_output(&account_receiver.address().to_string(), &TX_VALUE.into())

--- a/testing/jormungandr-integration-tests/src/mock/testing/client_tests.rs
+++ b/testing/jormungandr-integration-tests/src/mock/testing/client_tests.rs
@@ -17,7 +17,7 @@ use chain_impl_mockchain::{
     testing::builders::{GenesisPraosBlockBuilder, StakePoolBuilder},
 };
 use chain_time::{Epoch, TimeEra};
-use jormungandr_lib::interfaces::{InitialUTxO, Log};
+use jormungandr_lib::interfaces::InitialUTxO;
 
 fn fake_hash() -> Hash {
     Hash::from_str("efe2d4e5c4ad84b8e67e7b5676fff41cad5902a60b8cb6f072f42d7c7d26c944").unwrap()
@@ -31,7 +31,7 @@ pub fn handshake_sanity() {
     let handshake_response = client.handshake();
 
     assert_eq!(
-        config.genesis_block_hash,
+        *config.genesis_block_hash(),
         hex::encode(handshake_response.get_block0()),
         "Genesis Block"
     );
@@ -107,7 +107,7 @@ pub fn pull_blocks_to_tip_correct_hash() {
     let (server, config) = bootstrap_node();
     let client = Config::attach_to_local_node(config.get_p2p_listen_port()).client();
     let blocks_headers: Vec<Block> = response_to_vec!(
-        client.pull_blocks_to_tip(Hash::from_str(&config.genesis_block_hash).unwrap())
+        client.pull_blocks_to_tip(Hash::from_str(config.genesis_block_hash()).unwrap())
     );
     let blocks_hashes: Vec<Hash> = blocks_headers.iter().map(|x| x.header.hash()).collect();
 
@@ -194,7 +194,7 @@ pub fn push_headers() {
         0u64.into(),
         Epoch(0u32),
         config
-            .block0_configuration
+            .block0_configuration()
             .blockchain_configuration
             .slots_per_epoch
             .into(),
@@ -223,7 +223,7 @@ pub fn upload_block_incompatible_protocol() {
         0u64.into(),
         Epoch(0u32),
         config
-            .block0_configuration
+            .block0_configuration()
             .blockchain_configuration
             .slots_per_epoch
             .into(),
@@ -236,7 +236,7 @@ pub fn upload_block_incompatible_protocol() {
     let result = client.upload_blocks(block.clone());
     assert!(result.is_err(),
     "upload block with incompatible protocol should result with error expected protocol {:?}, but found block signed with: {:?}",
-    config.block0_configuration.blockchain_configuration.block0_consensus,&block.header.version());
+    config.block0_configuration().blockchain_configuration.block0_consensus,&block.header.version());
 
     match result.err().unwrap() {
         client::Error(
@@ -274,7 +274,7 @@ pub fn upload_block_nonexisting_stake_pool() {
         0u64.into(),
         Epoch(0u32),
         config
-            .block0_configuration
+            .block0_configuration()
             .blockchain_configuration
             .slots_per_epoch
             .into(),

--- a/testing/jormungandr-integration-tests/src/mock/testing/server_tests.rs
+++ b/testing/jormungandr-integration-tests/src/mock/testing/server_tests.rs
@@ -91,8 +91,8 @@ pub fn wrong_protocol() {
     server.shutdown();
     assert!(
         server.logger.get_log_entries().any(|x| {
-            x.msg == "connection to peer failed"
-                && x.reason_contains("protocol handshake failed: unsupported protocol version 0")
+            x.msg == "protocol handshake with peer failed"
+                && x.reason_contains("unsupported protocol version 0")
                 && x.peer_addr == peer_addr(mock_port)
                 && x.level == Level::INFO
         }),
@@ -122,7 +122,7 @@ pub fn wrong_genesis_hash() {
     assert!(
         server.logger.get_log_entries().any(|x| {
             x.msg == "connection to peer failed"
-                && x.reason_contains("genesis block hash")
+                && x.error_contains("Block0Mismatch")
                 && x.peer_addr == peer_addr(mock_port)
                 && x.level == Level::INFO
         }),

--- a/testing/jormungandr-integration-tests/src/mock/testing/server_tests.rs
+++ b/testing/jormungandr-integration-tests/src/mock/testing/server_tests.rs
@@ -75,7 +75,7 @@ pub fn wrong_protocol() {
 
     let mock_thread = start_mock(
         mock_port,
-        Hash::from_str(&config.genesis_block_hash).unwrap(),
+        Hash::from_str(&config.genesis_block_hash()).unwrap(),
         fake_hash(),
         ProtocolVersion::Bft,
         |logger: &MockLogger| logger.executed_at_least_once(MethodType::Handshake),
@@ -139,7 +139,7 @@ pub fn handshake_ok() {
 
     let mock_thread = start_mock(
         mock_port,
-        Hash::from_str(&config.genesis_block_hash).unwrap(),
+        Hash::from_str(&config.genesis_block_hash()).unwrap(),
         fake_hash(),
         ProtocolVersion::GenesisPraos,
         |logger: &MockLogger| logger.executed_at_least_once(MethodType::Handshake),

--- a/testing/jormungandr-integration-tests/src/mock/testing/setup.rs
+++ b/testing/jormungandr-integration-tests/src/mock/testing/setup.rs
@@ -28,7 +28,7 @@ impl Config {
 
 pub fn bootstrap_node() -> (JormungandrProcess, JormungandrConfig) {
     let config = ConfigurationBuilder::new().with_slot_duration(4).build();
-    let server = Starter::new().config(config.clone()).start().unwrap();
+    let server = Starter::new().config(config.clone()).start_async().unwrap();
     thread::sleep(Duration::from_secs(4));
     (server, config)
 }
@@ -49,7 +49,7 @@ pub fn build_configuration(mock_port: u16) -> JormungandrConfig {
 
 pub fn bootstrap_node_with_peer(mock_port: u16) -> (JormungandrProcess, JormungandrConfig) {
     let config = build_configuration(mock_port);
-    let server = Starter::new().config(config.clone()).start().unwrap();
+    let server = Starter::new().config(config.clone()).start_async().unwrap();
     thread::sleep(Duration::from_secs(4));
     (server, config)
 }

--- a/testing/jormungandr-integration-tests/src/networking/communication.rs
+++ b/testing/jormungandr-integration-tests/src/networking/communication.rs
@@ -25,7 +25,7 @@ pub fn two_nodes_communication() {
 
     let trusted_node_config = ConfigurationBuilder::new()
         .with_trusted_peers(vec![leader_jormungandr.as_trusted_peer()])
-        .with_block_hash(leader_config.genesis_block_hash.clone())
+        .with_block_hash(leader_config.genesis_block_hash().clone())
         .build();
 
     let trusted_jormungandr = Starter::new()
@@ -41,7 +41,7 @@ pub fn two_nodes_communication() {
         &sender,
         &utxo.associated_fund(),
         &reciever,
-        &trusted_node_config.genesis_block_hash,
+        trusted_node_config.genesis_block_hash(),
     );
 
     jcli_wrapper::assert_post_transaction(

--- a/testing/jormungandr-integration-tests/src/networking/p2p.rs
+++ b/testing/jormungandr-integration-tests/src/networking/p2p.rs
@@ -1,7 +1,9 @@
 use crate::common::{
-    network::{builder, params, wallet, Node},
+    jormungandr::process::JormungandrProcess,
+    network::{builder, params, wallet},
     process_utils,
 };
+
 use jormungandr_lib::{
     interfaces::{
         Explorer, LayersConfig, PeerRecord, Policy, PreferredListConfig, TopicsOfInterest,
@@ -11,7 +13,7 @@ use jormungandr_lib::{
 const CLIENT: &str = "CLIENT";
 const SERVER: &str = "SERVER";
 
-pub fn assert_empty_quarantine(node: &Node, info: &str) {
+pub fn assert_empty_quarantine(node: &JormungandrProcess, info: &str) {
     let quarantine = node
         .rest()
         .p2p_quarantined()
@@ -24,7 +26,11 @@ pub fn assert_empty_quarantine(node: &Node, info: &str) {
     );
 }
 
-pub fn assert_are_in_quarantine(node: &Node, peers: Vec<&Node>, info: &str) {
+pub fn assert_are_in_quarantine(
+    node: &JormungandrProcess,
+    peers: Vec<&JormungandrProcess>,
+    info: &str,
+) {
     let available_list = node
         .rest()
         .p2p_quarantined()
@@ -34,7 +40,7 @@ pub fn assert_are_in_quarantine(node: &Node, peers: Vec<&Node>, info: &str) {
 
 pub fn assert_record_is_present(
     peer_list: Vec<PeerRecord>,
-    peers: Vec<&Node>,
+    peers: Vec<&JormungandrProcess>,
     list_name: &str,
     info: &str,
 ) {
@@ -55,7 +61,7 @@ pub fn assert_record_is_present(
 
 pub fn assert_record_is_not_present(
     peer_list: Vec<PeerRecord>,
-    peers: Vec<&Node>,
+    peers: Vec<&JormungandrProcess>,
     list_name: &str,
 ) {
     for peer in peers {
@@ -72,7 +78,7 @@ pub fn assert_record_is_not_present(
 }
 
 pub fn assert_node_stats(
-    node: &Node,
+    node: &JormungandrProcess,
     peer_available_cnt: usize,
     peer_quarantined_cnt: usize,
     peer_total_cnt: usize,

--- a/testing/jormungandr-integration-tests/src/networking/stats.rs
+++ b/testing/jormungandr-integration-tests/src/networking/stats.rs
@@ -41,7 +41,7 @@ pub fn passive_node_last_block_info() {
             .encode();
         jcli_wrapper::assert_transaction_in_block_with_wait(
             &fragment,
-            leader.process(),
+            &leader,
             &Default::default(),
         );
 

--- a/testing/jormungandr-integration-tests/src/networking/testnet.rs
+++ b/testing/jormungandr-integration-tests/src/networking/testnet.rs
@@ -12,7 +12,8 @@ use crate::{
     },
     jormungandr::genesis::stake_pool::{create_new_stake_pool, delegate_stake, retire_stake_pool},
 };
-use jormungandr_lib::{interfaces::TrustedPeer, wallet::Wallet};
+use jormungandr_lib::interfaces::TrustedPeer;
+use jormungandr_testing_utils::wallet::Wallet;
 use std::{env, time::Duration};
 
 #[derive(Clone, Debug)]
@@ -89,10 +90,6 @@ impl TestnetConfig {
             trusted_peers.push(TrustedPeer {
                 address: trusted_peer_address
                     .expect("incorrect trusted peer address")
-                    .parse()
-                    .expect("cannot parse trusted peer address"),
-                id: trusted_peer_id
-                    .expect("incorrect trusted peer id")
                     .parse()
                     .expect("cannot parse trusted peer address"),
             });

--- a/testing/jormungandr-integration-tests/src/non_functional/compatibility.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/compatibility.rs
@@ -1,13 +1,13 @@
 use crate::common::{
     jormungandr::{ConfigurationBuilder, Starter},
-    legacy::{download_last_n_releases, get_jormungandr_bin},
+    legacy::{self, download_last_n_releases, get_jormungandr_bin, Version},
     startup,
     transaction_utils::TransactionHash,
 };
 use jormungandr_lib::interfaces::InitialUTxO;
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
-fn test_connectivity_between_master_and_legacy_app(legacy_jormungandr: PathBuf, version: String) {
+fn test_connectivity_between_master_and_legacy_app(jormungandr_bin: PathBuf, version: String) {
     println!("Testing version: {}", version);
 
     let mut sender = startup::create_new_account_address();
@@ -27,15 +27,15 @@ fn test_connectivity_between_master_and_legacy_app(legacy_jormungandr: PathBuf, 
 
     let trusted_node_config = ConfigurationBuilder::new()
         .with_trusted_peers(vec![leader_jormungandr.as_trusted_peer()])
-        .with_block_hash(leader_config.genesis_block_hash.clone())
+        .with_block_hash(leader_config.genesis_block_hash().clone())
         .build();
 
-    let trusted_jormungandr = Starter::new()
-        .config(trusted_node_config.clone())
-        .jormungandr_app(legacy_jormungandr)
-        .passive()
-        .start()
-        .unwrap();
+    let trusted_jormungandr =
+        legacy::Starter::new(Version::from_str(&version).unwrap(), jormungandr_bin)
+            .config(trusted_node_config)
+            .passive()
+            .start()
+            .unwrap();
 
     let new_transaction = sender
         .transaction_to(
@@ -56,13 +56,12 @@ fn test_connectivity_between_master_and_legacy_app(legacy_jormungandr: PathBuf, 
             .is_ok(),
         message
     );
-    super::assert_no_errors_in_logs(
-        vec![&trusted_jormungandr, &leader_jormungandr],
-        &format!(
-            "connection between newest master and node from {} version",
-            version
-        ),
-    )
+
+    trusted_jormungandr.assert_no_errors_in_log_with_message("newest master has errors in log");
+    leader_jormungandr.assert_no_errors_in_log_with_message(&format!(
+        "Legacy nodes from {} version, has errrors in logs",
+        version
+    ));
 }
 
 #[test]

--- a/testing/jormungandr-integration-tests/src/non_functional/explorer.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/explorer.rs
@@ -7,7 +7,9 @@ use crate::common::{
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{ActiveSlotCoefficient, KESUpdateSpeed},
-    testing::{benchmark_endurance, Endurance, EnduranceBenchmarkRun, Thresholds},
+};
+use jormungandr_testing_utils::testing::{
+    benchmark_endurance, Endurance, EnduranceBenchmarkRun, Thresholds,
 };
 use std::{str::FromStr, time::Duration};
 
@@ -35,7 +37,7 @@ pub fn test_explorer_is_in_sync_with_node_for_15_minutes() {
 
     loop {
         let transaction =
-            JCLITransactionWrapper::new_transaction(&jormungandr.config.genesis_block_hash)
+            JCLITransactionWrapper::new_transaction(&jormungandr.config.genesis_block_hash())
                 .assert_add_account(&sender.address().to_string(), &output_value.into())
                 .assert_add_output(&receiver.address().to_string(), &output_value.into())
                 .assert_finalize()

--- a/testing/jormungandr-integration-tests/src/non_functional/mod.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/mod.rs
@@ -26,7 +26,8 @@ use crate::common::{
     jormungandr::{JormungandrError, JormungandrProcess},
     process_utils,
 };
-use jormungandr_lib::{crypto::hash::Hash, interfaces::Value, wallet::Wallet};
+use jormungandr_lib::{crypto::hash::Hash, interfaces::Value};
+use jormungandr_testing_utils::wallet::Wallet;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/testing/jormungandr-integration-tests/src/non_functional/rewards.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/rewards.rs
@@ -3,9 +3,9 @@ use crate::common::{
     transaction_utils::TransactionHash,
 };
 
-use jormungandr_lib::{
-    interfaces::ActiveSlotCoefficient,
-    testing::{benchmark_consumption, benchmark_endurance, ResourcesUsage},
+use jormungandr_lib::interfaces::ActiveSlotCoefficient;
+use jormungandr_testing_utils::testing::{
+    benchmark_consumption, benchmark_endurance, ResourcesUsage,
 };
 use std::time::Duration;
 

--- a/testing/jormungandr-integration-tests/src/non_functional/sanity.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/sanity.rs
@@ -4,8 +4,8 @@ use crate::common::{
     startup,
 };
 
-use jormungandr_lib::{
-    interfaces::{ActiveSlotCoefficient, KESUpdateSpeed},
+use jormungandr_lib::interfaces::{ActiveSlotCoefficient, KESUpdateSpeed};
+use jormungandr_testing_utils::{
     testing::{
         benchmark_efficiency, benchmark_endurance, EfficiencyBenchmarkDef,
         EfficiencyBenchmarkFinish, Endurance, Thresholds,
@@ -71,13 +71,14 @@ fn send_100_transaction_in_10_packs_for_recievers(
         let transation_messages: Vec<String> = receivers
             .iter()
             .map(|receiver| {
-                let message =
-                    JCLITransactionWrapper::new_transaction(&jormungandr.config.genesis_block_hash)
-                        .assert_add_account(&sender.address().to_string(), &output_value.into())
-                        .assert_add_output(&receiver.address().to_string(), &output_value.into())
-                        .assert_finalize()
-                        .seal_with_witness_for_address(&sender)
-                        .assert_to_message();
+                let message = JCLITransactionWrapper::new_transaction(
+                    &jormungandr.config.genesis_block_hash(),
+                )
+                .assert_add_account(&sender.address().to_string(), &output_value.into())
+                .assert_add_output(&receiver.address().to_string(), &output_value.into())
+                .assert_finalize()
+                .seal_with_witness_for_address(&sender)
+                .assert_to_message();
                 sender.confirm_transaction();
                 message
             })
@@ -120,7 +121,7 @@ pub fn test_100_transaction_is_processed_simple() {
 
     for i in 0..transaction_max_count {
         let transaction =
-            JCLITransactionWrapper::new_transaction(&jormungandr.config.genesis_block_hash)
+            JCLITransactionWrapper::new_transaction(&jormungandr.config.genesis_block_hash())
                 .assert_add_account(&sender.address().to_string(), &output_value.into())
                 .assert_add_output(&receiver.address().to_string(), &output_value.into())
                 .assert_finalize()
@@ -171,7 +172,7 @@ pub fn test_blocks_are_being_created_for_more_than_15_minutes() {
 
     loop {
         let transaction =
-            JCLITransactionWrapper::new_transaction(&jormungandr.config.genesis_block_hash)
+            JCLITransactionWrapper::new_transaction(&jormungandr.config.genesis_block_hash())
                 .assert_add_account(&sender.address().to_string(), &output_value.into())
                 .assert_add_output(&receiver.address().to_string(), &output_value.into())
                 .assert_finalize()

--- a/testing/jormungandr-integration-tests/src/non_functional/soak.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/soak.rs
@@ -3,10 +3,8 @@ use crate::common::{
     transaction_utils::TransactionHash,
 };
 
-use jormungandr_lib::{
-    interfaces::{ActiveSlotCoefficient, KESUpdateSpeed, Mempool},
-    testing::{benchmark_consumption, benchmark_endurance},
-};
+use jormungandr_lib::interfaces::{ActiveSlotCoefficient, KESUpdateSpeed, Mempool};
+use jormungandr_testing_utils::testing::{benchmark_consumption, benchmark_endurance};
 use std::time::Duration;
 
 #[test]

--- a/testing/jormungandr-testing-utils/src/legacy/config/mod.rs
+++ b/testing/jormungandr-testing-utils/src/legacy/config/mod.rs
@@ -1,0 +1,6 @@
+mod node;
+
+pub use jormungandr_lib::interfaces::{
+    Explorer, LayersConfig, Log, Mempool, Policy, Rest, TopicsOfInterest,
+};
+pub use node::{NodeConfig, P2p, TrustedPeer};

--- a/testing/jormungandr-testing-utils/src/legacy/config/node.rs
+++ b/testing/jormungandr-testing-utils/src/legacy/config/node.rs
@@ -1,0 +1,51 @@
+use super::{Explorer, LayersConfig, Log, Mempool, Policy, Rest, TopicsOfInterest};
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct P2p {
+    /// The public address to which other peers may connect to
+    pub public_address: poldercast::Address,
+
+    /// the rendezvous points for the peer to connect to in order to initiate
+    /// the p2p discovery from.
+    pub trusted_peers: Vec<TrustedPeer>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen_address: Option<poldercast::Address>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_connections: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_inbound_connections: Option<u32>,
+
+    pub allow_private_addresses: bool,
+
+    pub topics_of_interest: Option<TopicsOfInterest>,
+
+    pub policy: Option<Policy>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layers: Option<LayersConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrustedPeer {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub address: poldercast::Address,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct NodeConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage: Option<PathBuf>,
+    pub rest: Rest,
+    pub p2p: P2p,
+    pub log: Option<Log>,
+    pub explorer: Explorer,
+    pub mempool: Option<Mempool>,
+    pub bootstrap_from_trusted_peers: Option<bool>,
+    pub skip_bootstrap: Option<bool>,
+}

--- a/testing/jormungandr-testing-utils/src/legacy/mod.rs
+++ b/testing/jormungandr-testing-utils/src/legacy/mod.rs
@@ -1,0 +1,5 @@
+mod config;
+
+pub use config::{
+    Explorer, Log, Mempool, NodeConfig, P2p, Policy, Rest, TopicsOfInterest, TrustedPeer,
+};

--- a/testing/jormungandr-testing-utils/src/lib.rs
+++ b/testing/jormungandr-testing-utils/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod legacy;
 pub mod testing;
 pub mod wallet;

--- a/testing/jormungandr-testing-utils/src/testing/github/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/github/mod.rs
@@ -21,6 +21,7 @@ pub struct Release {
     version: String,
     released_date: SystemTime,
     releases_per_os: HashMap<OsType, AssetDto>,
+    prerelease: bool,
 }
 
 impl Release {
@@ -57,6 +58,10 @@ impl Release {
 
     pub fn version(&self) -> String {
         self.version.clone()
+    }
+
+    pub fn prerelease(&self) -> bool {
+        self.prerelease
     }
 }
 

--- a/testing/jormungandr-testing-utils/src/testing/github/release.rs
+++ b/testing/jormungandr-testing-utils/src/testing/github/release.rs
@@ -8,6 +8,7 @@ pub struct ReleaseDto {
     tag_name: String,
     published_at: SystemTime,
     assets: Vec<AssetDto>,
+    prerelease: bool,
 }
 
 impl Into<Release> for ReleaseDto {
@@ -21,6 +22,7 @@ impl Into<Release> for ReleaseDto {
                 .cloned()
                 .map(|x| (x.os_type(), x))
                 .collect(),
+            prerelease: self.prerelease,
         }
     }
 }
@@ -36,6 +38,10 @@ impl ReleaseDto {
 
     pub fn assets(&self) -> &Vec<AssetDto> {
         &self.assets
+    }
+
+    pub fn prerelease(&self) -> bool {
+        self.prerelease
     }
 }
 


### PR DESCRIPTION
Test code tries to use as much production code as possible with focus on configuration model and rest api. However, from time to time there are some breaking changes introduced. It was not a problem before when there was a lack of compatibility tests. Right we have them and need to ensure that node before breaking changes are working and we can interact with them in limited way (bootstrap, get some stats, check logs). 

This commit introduced split between test implementation for newest node which is in line with dev code and legacy node, which should be more elastic in sense of how to start node and how to e.g. last block height. 

Legacy Api will have separate configuration which can be formatted for particular version, also rest api is more fault tolerant and can interact with legacy version (like retrieve stats for version before 08.19)