### PR TITLE
[Tests] Backward compatibility in scenario tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
  "slog",
  "structopt",
  "tokio 0.1.22",
+ "yaml-rust",
 ]
 
 [[package]]

--- a/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
@@ -3,8 +3,8 @@ use super::Version;
 use crate::common::{
     configuration::JormungandrConfig, file_utils, jormungandr::starter::StartupError,
 };
-use jormungandr_lib::interfaces::NodeConfig as NewestNodeConfig;
 use hex;
+use jormungandr_lib::interfaces::NodeConfig as NewestNodeConfig;
 use jormungandr_testing_utils::legacy::{NodeConfig, P2p, Rest, TrustedPeer};
 use rand::RngCore;
 use rand_core::OsRng;
@@ -47,16 +47,16 @@ impl LegacyConfigConverter {
 
         let node_config_converter = LegacyNodeConfigConverter::new(self.version.clone());
         let node_config = node_config_converter.convert(config.node_config())?;
-        Ok(self.build_configuration_before_08_19(config,node_config))
+        Ok(self.build_configuration_before_08_19(config, node_config))
     }
 
     pub fn build_configuration_before_08_19(
         &self,
         config: JormungandrConfig,
-        backward_compatible_config: NodeConfig
+        backward_compatible_config: NodeConfig,
     ) -> BackwardCompatibleConfig {
         let _source = config.node_config();
-      
+
         let content = serde_yaml::to_string(&backward_compatible_config)
             .expect("cannot serializer node config before 08.19 version");
         let node_config_path = file_utils::create_file_in_temp("node_config.xml", &content);
@@ -74,7 +74,7 @@ impl LegacyConfigConverter {
     }
 }
 
-pub struct LegacyNodeConfigConverter{
+pub struct LegacyNodeConfigConverter {
     version: Version,
 }
 
@@ -94,7 +94,7 @@ impl LegacyNodeConfigConverter {
         }
         Ok(self.build_node_config_before_08_19(source))
     }
-    
+
     fn generate_legacy_poldercast_id(rng: &mut OsRng) -> String {
         let mut bytes: [u8; 24] = [0; 24];
         rng.fill_bytes(&mut bytes);
@@ -102,38 +102,38 @@ impl LegacyNodeConfigConverter {
     }
 
     fn build_node_config_before_08_19(&self, source: NewestNodeConfig) -> NodeConfig {
-            let mut rng = OsRng;
-            let trusted_peers: Vec<TrustedPeer> = source
-                .p2p
-                .trusted_peers
-                .iter()
-                .map(|peer| TrustedPeer {
-                    id: Some(Self::generate_legacy_poldercast_id(&mut rng)),
-                    address: peer.address.clone(),
-                })
-                .collect();
-    
-            NodeConfig {
-                storage: source.storage.clone(),
-                log: source.log.clone(),
-                rest: Rest {
-                    listen: source.rest.listen.clone(),
-                },
-                p2p: P2p {
-                    trusted_peers: trusted_peers,
-                    public_address: source.p2p.public_address.clone(),
-                    listen_address: None,
-                    max_inbound_connections: None,
-                    max_connections: None,
-                    topics_of_interest: source.p2p.topics_of_interest.clone(),
-                    allow_private_addresses: false,
-                    policy: source.p2p.policy.clone(),
-                    layers: None,
-                },
-                mempool: source.mempool.clone(),
-                explorer: source.explorer.clone(),
-                bootstrap_from_trusted_peers: source.bootstrap_from_trusted_peers,
-                skip_bootstrap: source.skip_bootstrap,
-            }
+        let mut rng = OsRng;
+        let trusted_peers: Vec<TrustedPeer> = source
+            .p2p
+            .trusted_peers
+            .iter()
+            .map(|peer| TrustedPeer {
+                id: Some(Self::generate_legacy_poldercast_id(&mut rng)),
+                address: peer.address.clone(),
+            })
+            .collect();
+
+        NodeConfig {
+            storage: source.storage.clone(),
+            log: source.log.clone(),
+            rest: Rest {
+                listen: source.rest.listen.clone(),
+            },
+            p2p: P2p {
+                trusted_peers: trusted_peers,
+                public_address: source.p2p.public_address.clone(),
+                listen_address: None,
+                max_inbound_connections: None,
+                max_connections: None,
+                topics_of_interest: source.p2p.topics_of_interest.clone(),
+                allow_private_addresses: false,
+                policy: source.p2p.policy.clone(),
+                layers: None,
+            },
+            mempool: source.mempool.clone(),
+            explorer: source.explorer.clone(),
+            bootstrap_from_trusted_peers: source.bootstrap_from_trusted_peers,
+            skip_bootstrap: source.skip_bootstrap,
+        }
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
@@ -3,6 +3,7 @@ use super::Version;
 use crate::common::{
     configuration::JormungandrConfig, file_utils, jormungandr::starter::StartupError,
 };
+use jormungandr_lib::interfaces::NodeConfig as NewestNodeConfig;
 use hex;
 use jormungandr_testing_utils::legacy::{NodeConfig, P2p, Rest, TrustedPeer};
 use rand::RngCore;
@@ -43,53 +44,19 @@ impl LegacyConfigConverter {
                 self.version.clone(),
             ));
         }
-        Ok(self.build_configuration_before_08_19(config))
-    }
 
-    fn generate_legacy_poldercast_id(rng: &mut OsRng) -> String {
-        let mut bytes: [u8; 24] = [0; 24];
-        rng.fill_bytes(&mut bytes);
-        hex::encode(&bytes).to_string()
+        let node_config_converter = LegacyNodeConfigConverter::new(self.version.clone());
+        let node_config = node_config_converter.convert(config.node_config())?;
+        Ok(self.build_configuration_before_08_19(config,node_config))
     }
 
     pub fn build_configuration_before_08_19(
         &self,
         config: JormungandrConfig,
+        backward_compatible_config: NodeConfig
     ) -> BackwardCompatibleConfig {
-        let source = config.node_config();
-        let mut rng = OsRng;
-        let trusted_peers: Vec<TrustedPeer> = source
-            .p2p
-            .trusted_peers
-            .iter()
-            .map(|peer| TrustedPeer {
-                id: Some(Self::generate_legacy_poldercast_id(&mut rng)),
-                address: peer.address.clone(),
-            })
-            .collect();
-
-        let backward_compatible_config = NodeConfig {
-            storage: source.storage.clone(),
-            log: source.log.clone(),
-            rest: Rest {
-                listen: source.rest.listen.clone(),
-            },
-            p2p: P2p {
-                trusted_peers: trusted_peers,
-                public_address: source.p2p.public_address.clone(),
-                listen_address: None,
-                max_inbound_connections: None,
-                max_connections: None,
-                topics_of_interest: source.p2p.topics_of_interest.clone(),
-                allow_private_addresses: false,
-                policy: source.p2p.policy.clone(),
-                layers: None,
-            },
-            mempool: source.mempool.clone(),
-            explorer: source.explorer.clone(),
-            bootstrap_from_trusted_peers: source.bootstrap_from_trusted_peers,
-            skip_bootstrap: source.skip_bootstrap,
-        };
+        let _source = config.node_config();
+      
         let content = serde_yaml::to_string(&backward_compatible_config)
             .expect("cannot serializer node config before 08.19 version");
         let node_config_path = file_utils::create_file_in_temp("node_config.xml", &content);
@@ -104,5 +71,69 @@ impl LegacyConfigConverter {
             config.secret_models().clone(),
             config.rewards_history(),
         )
+    }
+}
+
+pub struct LegacyNodeConfigConverter{
+    version: Version,
+}
+
+impl LegacyNodeConfigConverter {
+    pub fn new(version: Version) -> Self {
+        Self { version }
+    }
+
+    pub fn convert(
+        &self,
+        source: NewestNodeConfig,
+    ) -> Result<NodeConfig, LegacyConfigConverterError> {
+        if self.version > version_08_19() {
+            return Err(LegacyConfigConverterError::UnsupportedVersion(
+                self.version.clone(),
+            ));
+        }
+        Ok(self.build_node_config_before_08_19(source))
+    }
+    
+    fn generate_legacy_poldercast_id(rng: &mut OsRng) -> String {
+        let mut bytes: [u8; 24] = [0; 24];
+        rng.fill_bytes(&mut bytes);
+        hex::encode(&bytes).to_string()
+    }
+
+    fn build_node_config_before_08_19(&self, source: NewestNodeConfig) -> NodeConfig {
+            let mut rng = OsRng;
+            let trusted_peers: Vec<TrustedPeer> = source
+                .p2p
+                .trusted_peers
+                .iter()
+                .map(|peer| TrustedPeer {
+                    id: Some(Self::generate_legacy_poldercast_id(&mut rng)),
+                    address: peer.address.clone(),
+                })
+                .collect();
+    
+            NodeConfig {
+                storage: source.storage.clone(),
+                log: source.log.clone(),
+                rest: Rest {
+                    listen: source.rest.listen.clone(),
+                },
+                p2p: P2p {
+                    trusted_peers: trusted_peers,
+                    public_address: source.p2p.public_address.clone(),
+                    listen_address: None,
+                    max_inbound_connections: None,
+                    max_connections: None,
+                    topics_of_interest: source.p2p.topics_of_interest.clone(),
+                    allow_private_addresses: false,
+                    policy: source.p2p.policy.clone(),
+                    layers: None,
+                },
+                mempool: source.mempool.clone(),
+                explorer: source.explorer.clone(),
+                bootstrap_from_trusted_peers: source.bootstrap_from_trusted_peers,
+                skip_bootstrap: source.skip_bootstrap,
+            }
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/legacy/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/mod.rs
@@ -10,7 +10,7 @@ mod rest;
 mod starter;
 mod version;
 
-pub use configuration_builder::{LegacyConfigConverter, LegacyConfigConverterError};
+pub use configuration_builder::{LegacyConfigConverter, LegacyConfigConverterError, LegacyNodeConfigConverter};
 pub use jormungandr_configuration::BackwardCompatibleConfig;
 pub use node::BackwardCompatibleJormungandr;
 pub use rest::BackwardCompatibleRest;

--- a/testing/jormungandr-integration-tests/src/common/legacy/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/mod.rs
@@ -10,7 +10,9 @@ mod rest;
 mod starter;
 mod version;
 
-pub use configuration_builder::{LegacyConfigConverter, LegacyConfigConverterError, LegacyNodeConfigConverter};
+pub use configuration_builder::{
+    LegacyConfigConverter, LegacyConfigConverterError, LegacyNodeConfigConverter,
+};
 pub use jormungandr_configuration::BackwardCompatibleConfig;
 pub use node::BackwardCompatibleJormungandr;
 pub use rest::BackwardCompatibleRest;

--- a/testing/jormungandr-integration-tests/src/common/legacy/version.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/version.rs
@@ -1,4 +1,5 @@
 use std::{cmp::Ordering, fmt, num::ParseIntError, str::FromStr};
+use std::fmt;
 
 #[derive(Eq, Debug, Clone)]
 pub struct Version {

--- a/testing/jormungandr-integration-tests/src/common/legacy/version.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/version.rs
@@ -1,5 +1,4 @@
 use std::{cmp::Ordering, fmt, num::ParseIntError, str::FromStr};
-use std::fmt;
 
 #[derive(Eq, Debug, Clone)]
 pub struct Version {

--- a/testing/jormungandr-scenario-tests/Cargo.toml
+++ b/testing/jormungandr-scenario-tests/Cargo.toml
@@ -33,6 +33,7 @@ serde_yaml = "0.8"
 structopt = "0.3"
 hex = "0.4"
 console = "0.10"
+yaml-rust = "0.4.3"
 indicatif = "0.14"
 lazy_static = "1"
 

--- a/testing/jormungandr-scenario-tests/src/legacy/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/mod.rs
@@ -1,5 +1,5 @@
 mod node;
 mod settings;
 
-pub use node::{LegacyNode,LegacyNodeController,Error,ErrorKind};
+pub use node::{Error, ErrorKind, LegacyNode, LegacyNodeController};
 pub use settings::LegacySettings;

--- a/testing/jormungandr-scenario-tests/src/legacy/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/mod.rs
@@ -1,0 +1,5 @@
+mod node;
+mod settings;
+
+pub use node::{LegacyNode,LegacyNodeController,Error,ErrorKind};
+pub use settings::LegacySettings;

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -1,10 +1,9 @@
 /// Specialized node which is supposed to be compatible with 5 last jormungandr releases
 use crate::{
+    legacy::LegacySettings,
+    node::{MemPoolCheck, ProgressBarController, Status},
     style, Context,
-    legacy::{LegacySettings},
-    node::{Status,ProgressBarController,MemPoolCheck},
 };
-use yaml_rust::{YamlLoader,Yaml};
 use bawawa::{Control, Process};
 use chain_impl_mockchain::{
     block::Block,
@@ -18,12 +17,12 @@ use jormungandr_integration_tests::{
     response_to_vec,
 };
 use jormungandr_lib::interfaces::{
-    EnclaveLeaderId, FragmentLog, FragmentStatus, Info, PeerRecord,
-    PeerStats,
+    EnclaveLeaderId, FragmentLog, FragmentStatus, Info, PeerRecord, PeerStats,
 };
 pub use jormungandr_testing_utils::testing::network_builder::{
     LeadershipMode, NodeAlias, NodeBlock0, NodeSetting, PersistenceMode, Settings,
 };
+use yaml_rust::{Yaml, YamlLoader};
 
 use rand_core::RngCore;
 use std::{
@@ -33,7 +32,6 @@ use std::{
     time::Duration,
 };
 use tokio::prelude::*;
-
 
 error_chain! {
     foreign_links {
@@ -103,7 +101,6 @@ error_chain! {
         }
     }
 }
-
 
 /// send query to a running node
 #[derive(Clone)]
@@ -370,20 +367,25 @@ impl LegacyNodeController {
                 let status = log.status().clone();
                 match log.status() {
                     Pending => {
-                        self.progress_bar
-                            .log_info(format!("Fragment '{}' is still pending", check.fragment_id()));
+                        self.progress_bar.log_info(format!(
+                            "Fragment '{}' is still pending",
+                            check.fragment_id()
+                        ));
                     }
                     Rejected { reason } => {
                         self.progress_bar.log_info(format!(
                             "Fragment '{}' rejected: {}",
-                            check.fragment_id(), reason
+                            check.fragment_id(),
+                            reason
                         ));
                         return Ok(status);
                     }
                     InABlock { date, block } => {
                         self.progress_bar.log_info(format!(
                             "Fragment '{}' in block: {} ({})",
-                            check.fragment_id(), block, date
+                            check.fragment_id(),
+                            block,
+                            date
                         ));
                         return Ok(status);
                     }

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -1,0 +1,773 @@
+/// Specialized node which is supposed to be compatible with 5 last jormungandr releases
+use crate::{
+    style, Context,
+    legacy::{LegacySettings},
+    node::{Status,ProgressBarController,MemPoolCheck},
+};
+use yaml_rust::{YamlLoader,Yaml};
+use bawawa::{Control, Process};
+use chain_impl_mockchain::{
+    block::Block,
+    fragment::{Fragment, FragmentId},
+    header::HeaderId,
+};
+use indicatif::ProgressBar;
+use jormungandr_integration_tests::{
+    common::jormungandr::logger::JormungandrLogger,
+    mock::{client::JormungandrClient, read_into},
+    response_to_vec,
+};
+use jormungandr_lib::interfaces::{
+    EnclaveLeaderId, FragmentLog, FragmentStatus, Info, PeerRecord,
+    PeerStats,
+};
+pub use jormungandr_testing_utils::testing::network_builder::{
+    LeadershipMode, NodeAlias, NodeBlock0, NodeSetting, PersistenceMode, Settings,
+};
+
+use rand_core::RngCore;
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::prelude::*;
+
+
+error_chain! {
+    foreign_links {
+        Io(std::io::Error);
+        Reqwest(reqwest::Error);
+        BlockFormatError(chain_core::mempack::ReadError);
+        SerializationError(yaml_rust::scanner::ScanError);
+    }
+
+    errors {
+        CannotCreateTemporaryDirectory {
+            description("Cannot create a temporary directory")
+        }
+
+        CannotSpawnNode {
+            description("Cannot spawn the node"),
+        }
+
+        InvalidHeaderId {
+            description("Invalid header id"),
+        }
+
+        InvalidBlock {
+            description("Invalid block"),
+        }
+        InvalidFragmentLogs {
+            description("Fragment logs in an invalid format")
+        }
+        InvalidNodeStats {
+            description("Node stats in an invalid format")
+        }
+
+        InvalidNetworkStats {
+            description("Network stats in an invalid format")
+        }
+
+        InvalidEnclaveLeaderIds {
+            description("Leaders ids in an invalid format")
+        }
+
+        InvalidPeerStats{
+            description("Peer in an invalid format")
+        }
+
+        NodeStopped (status: Status) {
+            description("the node is no longer running"),
+        }
+
+        NodeFailedToBootstrap (alias: String, duration: Duration, log: String) {
+            description("cannot start node"),
+            display("node '{}' failed to start after {} s. log: {}", alias, duration.as_secs(), log),
+        }
+
+        NodeFailedToShutdown (alias: String, message: String, log: String) {
+            description("cannot shutdown node"),
+            display("node '{}' failed to shutdown. Message: {}. Log: {}", alias, message, log),
+        }
+
+        FragmentNoInMemPoolLogs (alias: String, fragment_id: FragmentId, log: String) {
+            description("cannot find fragment in mempool logs"),
+            display("fragment '{}' not in the mempool of the node '{}'. logs: {}", fragment_id, alias, log),
+        }
+
+        FragmentIsPendingForTooLong (fragment_id: FragmentId, duration: Duration, alias: String, log: String) {
+            description("fragment is pending for too long"),
+            display("fragment '{}' is pending for too long ({} s). Node: {}, Logs: {}", fragment_id, duration.as_secs(), alias, log),
+        }
+    }
+}
+
+
+/// send query to a running node
+#[derive(Clone)]
+pub struct LegacyNodeController {
+    alias: NodeAlias,
+    grpc_client: JormungandrClient,
+    settings: LegacySettings,
+    progress_bar: ProgressBarController,
+    status: Arc<Mutex<Status>>,
+}
+
+pub struct LegacyNode {
+    alias: NodeAlias,
+
+    #[allow(unused)]
+    dir: PathBuf,
+
+    process: Process,
+
+    progress_bar: ProgressBarController,
+    node_settings: LegacySettings,
+    status: Arc<Mutex<Status>>,
+}
+
+const NODE_CONFIG: &str = "node_config.yaml";
+const NODE_SECRET: &str = "node_secret.yaml";
+const NODE_STORAGE: &str = "storage.db";
+
+impl LegacyNodeController {
+    pub fn alias(&self) -> &NodeAlias {
+        &self.alias
+    }
+
+    pub fn status(&self) -> Status {
+        *self.status.lock().unwrap()
+    }
+
+    pub fn check_running(&self) -> bool {
+        self.status() == Status::Running
+    }
+
+    fn path(&self, path: &str) -> String {
+        format!("{}/{}", self.base_url(), path)
+    }
+
+    pub fn address(&self) -> poldercast::Address {
+        self.settings.config.p2p.public_address.clone()
+    }
+
+    fn post(&self, path: &str, body: Vec<u8>) -> Result<reqwest::blocking::Response> {
+        self.progress_bar.log_info(format!("POST '{}'", path));
+
+        let client = reqwest::blocking::Client::new();
+        let res = client
+            .post(&format!("{}/{}", self.base_url(), path))
+            .body(body)
+            .send();
+
+        match res {
+            Err(err) => {
+                self.progress_bar
+                    .log_err(format!("Failed to send request {}", &err));
+                Err(err.into())
+            }
+            Ok(r) => Ok(r),
+        }
+    }
+
+    fn get(&self, path: &str) -> Result<reqwest::blocking::Response> {
+        self.progress_bar.log_info(format!("GET '{}'", path));
+
+        match reqwest::blocking::get(&format!("{}/{}", self.base_url(), path)) {
+            Err(err) => {
+                self.progress_bar
+                    .log_err(format!("Failed to send request {}", &err));
+                Err(err.into())
+            }
+            Ok(r) => Ok(r),
+        }
+    }
+
+    fn base_url(&self) -> String {
+        format!("http://{}/api/v0", self.settings.config.rest.listen.clone())
+    }
+
+    pub fn send_fragment(&self, fragment: Fragment) -> Result<MemPoolCheck> {
+        use chain_core::property::Fragment as _;
+        use chain_core::property::Serialize as _;
+
+        let raw = fragment.serialize_as_vec().unwrap();
+        let fragment_id = fragment.id();
+
+        let response = self.post("message", raw.clone())?;
+        self.progress_bar
+            .log_info(format!("Fragment '{}' sent", fragment_id,));
+
+        let res = response.error_for_status_ref();
+        if let Err(err) = res {
+            self.progress_bar.log_err(format!(
+                "Fragment '{}' ({}) fail to send: {}",
+                hex::encode(&raw),
+                fragment_id,
+                err,
+            ));
+        }
+
+        Ok(MemPoolCheck::new(fragment_id))
+    }
+
+    pub fn log(&self, info: &str) {
+        self.progress_bar.log_info(info);
+    }
+
+    pub fn tip(&self) -> Result<HeaderId> {
+        let hash = self.get("tip")?.text()?;
+
+        let hash = hash.parse().chain_err(|| ErrorKind::InvalidHeaderId)?;
+
+        self.progress_bar.log_info(format!("tip '{}'", hash));
+
+        Ok(hash)
+    }
+
+    pub fn blocks_to_tip(&self, from: HeaderId) -> Result<Vec<Block>> {
+        let response = self.grpc_client.pull_blocks_to_tip(from);
+        Ok(response_to_vec!(response))
+    }
+
+    pub fn network_stats(&self) -> Result<Vec<PeerStats>> {
+        let response_text = self.get("network/stats")?.text()?;
+        self.progress_bar
+            .log_info(format!("network/stats: {}", response_text));
+
+        let network_stats: Vec<PeerStats> = if response_text.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(&response_text).chain_err(|| ErrorKind::InvalidNetworkStats)?
+        };
+        Ok(network_stats)
+    }
+
+    pub fn p2p_quarantined(&self) -> Result<Vec<PeerRecord>> {
+        let response_text = self.get("network/p2p/quarantined")?.text()?;
+
+        self.progress_bar
+            .log_info(format!("network/p2p_quarantined: {}", response_text));
+
+        let network_stats: Vec<PeerRecord> = if response_text.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(&response_text).chain_err(|| ErrorKind::InvalidNetworkStats)?
+        };
+        Ok(network_stats)
+    }
+
+    pub fn p2p_non_public(&self) -> Result<Vec<PeerRecord>> {
+        let response_text = self.get("network/p2p/non_public")?.text()?;
+
+        self.progress_bar
+            .log_info(format!("network/non_publicS: {}", response_text));
+
+        let network_stats: Vec<PeerRecord> = if response_text.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(&response_text).chain_err(|| ErrorKind::InvalidNetworkStats)?
+        };
+        Ok(network_stats)
+    }
+
+    pub fn p2p_available(&self) -> Result<Vec<PeerRecord>> {
+        let response_text = self.get("network/p2p/available")?.text()?;
+
+        self.progress_bar
+            .log_info(format!("network/available: {}", response_text));
+
+        let network_stats: Vec<PeerRecord> = if response_text.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(&response_text).chain_err(|| ErrorKind::InvalidNetworkStats)?
+        };
+        Ok(network_stats)
+    }
+
+    pub fn p2p_view(&self) -> Result<Vec<Info>> {
+        let response_text = self.get("network/p2p/view")?.text()?;
+
+        self.progress_bar
+            .log_info(format!("network/view: {}", response_text));
+
+        let network_stats: Vec<Info> = if response_text.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(&response_text).chain_err(|| ErrorKind::InvalidNetworkStats)?
+        };
+        Ok(network_stats)
+    }
+
+    pub fn all_blocks_hashes(&self) -> Result<Vec<HeaderId>> {
+        let genesis_hash = self
+            .genesis_block_hash()
+            .expect("Cannot download genesis hash");
+        self.blocks_hashes_to_tip(genesis_hash)
+    }
+
+    pub fn blocks_hashes_to_tip(&self, from: HeaderId) -> Result<Vec<HeaderId>> {
+        Ok(self
+            .blocks_to_tip(from)
+            .unwrap()
+            .iter()
+            .map(|x| x.header.hash())
+            .collect())
+    }
+
+    pub fn genesis_block_hash(&self) -> Result<HeaderId> {
+        Ok(self.grpc_client.get_genesis_block_hash())
+    }
+
+    pub fn block(&self, header_hash: &HeaderId) -> Result<Block> {
+        use chain_core::mempack::{ReadBuf, Readable as _};
+
+        let mut resp = self.get(&format!("block/{}", header_hash))?;
+        let mut bytes = Vec::new();
+        resp.copy_to(&mut bytes)?;
+        let block =
+            Block::read(&mut ReadBuf::from(&bytes)).chain_err(|| ErrorKind::InvalidBlock)?;
+
+        self.progress_bar.log_info(format!(
+            "block{} ({}) '{}'",
+            block.header.chain_length(),
+            block.header.block_date(),
+            header_hash,
+        ));
+
+        Ok(block)
+    }
+
+    pub fn fragment_logs(&self) -> Result<HashMap<FragmentId, FragmentLog>> {
+        let logs = self.get("fragment/logs")?.text()?;
+
+        let logs: Vec<FragmentLog> = if logs.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(&logs).chain_err(|| ErrorKind::InvalidFragmentLogs)?
+        };
+
+        self.progress_bar
+            .log_info(format!("fragment logs ({})", logs.len()));
+
+        let logs = logs
+            .into_iter()
+            .map(|log| (log.fragment_id().clone().into_hash(), log))
+            .collect();
+
+        Ok(logs)
+    }
+
+    pub fn wait_fragment(&self, duration: Duration, check: MemPoolCheck) -> Result<FragmentStatus> {
+        let max_try = 50;
+        for _ in 0..max_try {
+            let logs = self.fragment_logs()?;
+
+            if let Some(log) = logs.get(&check.fragment_id()) {
+                use jormungandr_lib::interfaces::FragmentStatus::*;
+                let status = log.status().clone();
+                match log.status() {
+                    Pending => {
+                        self.progress_bar
+                            .log_info(format!("Fragment '{}' is still pending", check.fragment_id()));
+                    }
+                    Rejected { reason } => {
+                        self.progress_bar.log_info(format!(
+                            "Fragment '{}' rejected: {}",
+                            check.fragment_id(), reason
+                        ));
+                        return Ok(status);
+                    }
+                    InABlock { date, block } => {
+                        self.progress_bar.log_info(format!(
+                            "Fragment '{}' in block: {} ({})",
+                            check.fragment_id(), block, date
+                        ));
+                        return Ok(status);
+                    }
+                }
+            } else {
+                bail!(ErrorKind::FragmentNoInMemPoolLogs(
+                    self.alias().to_string(),
+                    check.fragment_id().clone(),
+                    self.logger().get_log_content()
+                ))
+            }
+            std::thread::sleep(duration);
+        }
+
+        bail!(ErrorKind::FragmentIsPendingForTooLong(
+            check.fragment_id().clone(),
+            Duration::from_secs(duration.as_secs() * max_try),
+            self.alias().to_string(),
+            self.logger().get_log_content()
+        ))
+    }
+
+    pub fn leaders(&self) -> Result<Vec<EnclaveLeaderId>> {
+        let leaders = self.get("leaders")?.text()?;
+        let leaders: Vec<EnclaveLeaderId> = if leaders.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(&leaders).chain_err(|| ErrorKind::InvalidEnclaveLeaderIds)?
+        };
+
+        self.progress_bar
+            .log_info(format!("leaders ids ({})", leaders.len()));
+
+        Ok(leaders)
+    }
+
+    pub fn promote(&self) -> Result<EnclaveLeaderId> {
+        let path = "leaders";
+        let secrets = self.settings.secrets();
+        self.progress_bar.log_info(format!("POST '{}'", &path));
+        let response = reqwest::blocking::Client::new()
+            .post(&self.path(path))
+            .json(&secrets)
+            .send()?;
+
+        self.progress_bar
+            .log_info(format!("Leader promotion for '{}' sent", self.alias()));
+
+        let res = response.error_for_status_ref();
+        if let Err(err) = res {
+            self.progress_bar.log_err(format!(
+                "Leader promotion for '{}' fail to sent: {}",
+                self.alias(),
+                err,
+            ));
+        }
+
+        let leader_id: EnclaveLeaderId = response.json()?;
+        Ok(leader_id)
+    }
+
+    pub fn demote(&self, leader_id: u32) -> Result<()> {
+        let path = format!("leaders/{}", leader_id);
+        self.progress_bar.log_info(format!("DELETE '{}'", &path));
+        let response = reqwest::blocking::Client::new()
+            .delete(&self.path(&path))
+            .send()?;
+
+        self.progress_bar
+            .log_info(format!("Leader demote for '{}' sent", self.alias()));
+
+        let res = response.error_for_status_ref();
+        if let Err(err) = res {
+            self.progress_bar.log_err(format!(
+                "Leader demote for '{}' fail to sent: {}",
+                self.alias(),
+                err,
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn stats(&self) -> Result<Yaml> {
+        let stats = self.get("node/stats")?.text()?;
+        let docs = YamlLoader::load_from_str(&stats)?;
+        Ok(docs.get(0).unwrap().clone())
+    }
+
+    pub fn log_stats(&self) {
+        self.progress_bar
+            .log_info(format!("node stats ({:?})", self.stats()));
+    }
+
+    pub fn wait_for_bootstrap(&self) -> Result<()> {
+        let max_try = 20;
+        let sleep = Duration::from_secs(8);
+        for _ in 0..max_try {
+            let stats = self.stats();
+            match stats {
+                Ok(stats) => {
+                    if stats["state"].as_str().unwrap() == "Running" {
+                        self.log_stats();
+                        return Ok(());
+                    }
+                }
+                Err(err) => self
+                    .progress_bar
+                    .log_info(format!("node stats failure({:?})", err)),
+            };
+            std::thread::sleep(sleep);
+        }
+        bail!(ErrorKind::NodeFailedToBootstrap(
+            self.alias().to_string(),
+            Duration::from_secs(sleep.as_secs() * max_try),
+            self.logger().get_log_content()
+        ))
+    }
+
+    pub fn wait_for_shutdown(&self) -> Result<()> {
+        let max_try = 2;
+        let sleep = Duration::from_secs(2);
+        for _ in 0..max_try {
+            if self.stats().is_err() && self.ports_are_opened() {
+                return Ok(());
+            };
+            std::thread::sleep(sleep);
+        }
+        bail!(ErrorKind::NodeFailedToShutdown(
+            self.alias().to_string(),
+            format!(
+                "node is still up after {} s from sending shutdown request",
+                sleep.as_secs()
+            ),
+            self.logger().get_log_content()
+        ))
+    }
+
+    fn ports_are_opened(&self) -> bool {
+        self.port_opened(self.settings.config.rest.listen.port())
+            && self.port_opened(
+                self.settings
+                    .config
+                    .p2p
+                    .public_address
+                    .to_socketaddr()
+                    .unwrap()
+                    .port(),
+            )
+    }
+
+    fn port_opened(&self, port: u16) -> bool {
+        use std::net::TcpListener;
+        match TcpListener::bind(("127.0.0.1", port)) {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+
+    pub fn is_up(&self) -> bool {
+        let stats = self.stats();
+        match stats {
+            Ok(stats) => stats["state"].as_str().unwrap() == "Running",
+            Err(_) => false,
+        }
+    }
+
+    pub fn shutdown(&self) -> Result<()> {
+        let result = self.get("shutdown")?.text()?;
+
+        if result == "" {
+            self.progress_bar.log_info("shuting down");
+            return self.wait_for_shutdown();
+        } else {
+            bail!(ErrorKind::NodeFailedToShutdown(
+                self.alias().to_string(),
+                result,
+                self.logger().get_log_content()
+            ))
+        }
+    }
+
+    pub fn logger(&self) -> JormungandrLogger {
+        let log_file = self
+            .settings
+            .config
+            .log
+            .clone()
+            .unwrap()
+            .log_file()
+            .unwrap();
+        JormungandrLogger::new(log_file)
+    }
+
+    pub fn log_content(&self) -> String {
+        self.logger().get_log_content()
+    }
+}
+
+impl LegacyNode {
+    pub fn alias(&self) -> &NodeAlias {
+        &self.alias
+    }
+
+    pub fn controller(&self) -> LegacyNodeController {
+        let p2p_address = format!("{}", self.node_settings.config().p2p.public_address);
+
+        LegacyNodeController {
+            alias: self.alias().clone(),
+            grpc_client: JormungandrClient::from_address(&p2p_address)
+                .expect("cannot setup grpc client"),
+            settings: self.node_settings.clone(),
+            status: self.status.clone(),
+            progress_bar: self.progress_bar.clone(),
+        }
+    }
+
+    pub fn spawn<R: RngCore>(
+        jormungandr: &bawawa::Command,
+        context: &Context<R>,
+        progress_bar: ProgressBar,
+        alias: &str,
+        node_settings: &mut LegacySettings,
+        block0: NodeBlock0,
+        working_dir: &PathBuf,
+        peristence_mode: PersistenceMode,
+    ) -> Result<Self> {
+        let mut command = jormungandr.clone();
+        let dir = working_dir.join(alias);
+        std::fs::DirBuilder::new().recursive(true).create(&dir)?;
+
+        let progress_bar = ProgressBarController::new(
+            progress_bar,
+            format!("{}@{}", alias, node_settings.config().rest.listen),
+            context.progress_bar_mode(),
+        );
+
+        let config_file = dir.join(NODE_CONFIG);
+        let config_secret = dir.join(NODE_SECRET);
+
+        if peristence_mode == PersistenceMode::Persistent {
+            let path_to_storage = dir.join(NODE_STORAGE);
+            node_settings.config.storage = Some(path_to_storage);
+        }
+
+        serde_yaml::to_writer(
+            std::fs::File::create(&config_file)
+                .chain_err(|| format!("Cannot create file {:?}", config_file))?,
+            node_settings.config(),
+        )
+        .chain_err(|| format!("cannot write in {:?}", config_file))?;
+
+        serde_yaml::to_writer(
+            std::fs::File::create(&config_secret)
+                .chain_err(|| format!("Cannot create file {:?}", config_secret))?,
+            node_settings.secrets(),
+        )
+        .chain_err(|| format!("cannot write in {:?}", config_secret))?;
+
+        command.arguments(&[
+            "--config",
+            &config_file.display().to_string(),
+            "--log-level=warn",
+        ]);
+
+        match block0 {
+            NodeBlock0::File(path) => {
+                command.arguments(&[
+                    "--genesis-block",
+                    &path.display().to_string(),
+                    "--secret",
+                    &config_secret.display().to_string(),
+                ]);
+            }
+            NodeBlock0::Hash(hash) => {
+                command.arguments(&["--genesis-block-hash", &hash.to_string()]);
+            }
+        }
+
+        let process = Process::spawn(command).chain_err(|| ErrorKind::CannotSpawnNode)?;
+
+        let node = LegacyNode {
+            alias: alias.into(),
+
+            dir,
+
+            process,
+
+            progress_bar,
+            node_settings: node_settings.clone(),
+            status: Arc::new(Mutex::new(Status::Running)),
+        };
+
+        node.progress_bar_start();
+
+        Ok(node)
+    }
+
+    pub fn capture_logs(&mut self) -> impl Future<Item = (), Error = ()> {
+        let stderr = self.process.stderr().take().unwrap();
+
+        let stderr = tokio::codec::FramedRead::new(stderr, tokio::codec::LinesCodec::new());
+
+        let progress_bar = self.progress_bar.clone();
+
+        stderr
+            .for_each(move |line| future::ok(progress_bar.log_info(&line)))
+            .map_err(|err| unimplemented!("{}", err))
+    }
+
+    fn progress_bar_start(&self) {
+        self.progress_bar.set_style(
+            indicatif::ProgressStyle::default_spinner()
+                .template("{spinner:.green} {wide_msg}")
+                .tick_chars(style::TICKER),
+        );
+        self.progress_bar.enable_steady_tick(100);
+        self.progress_bar.set_message(&format!(
+            "{} {} ... [{}]",
+            *style::icons::jormungandr,
+            style::binary.apply_to(self.alias()),
+            self.node_settings.config().rest.listen,
+        ));
+    }
+
+    fn progress_bar_failure(&self) {
+        self.progress_bar.finish_with_message(&format!(
+            "{} {} {}",
+            *style::icons::jormungandr,
+            style::binary.apply_to(self.alias()),
+            style::error.apply_to(*style::icons::failure)
+        ));
+    }
+
+    fn progress_bar_success(&self) {
+        self.progress_bar.finish_with_message(&format!(
+            "{} {} {}",
+            *style::icons::jormungandr,
+            style::binary.apply_to(self.alias()),
+            style::success.apply_to(*style::icons::success)
+        ));
+    }
+
+    fn set_status(&self, status: Status) {
+        *self.status.lock().unwrap() = status
+    }
+}
+
+impl Future for LegacyNode {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.process.poll() {
+            Err(err) => {
+                self.progress_bar.log_err(&err);
+                self.progress_bar_failure();
+                self.set_status(Status::Failure);
+                Err(())
+            }
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Ok(Async::Ready(status)) => {
+                if status.success() {
+                    self.progress_bar_success();
+                } else {
+                    self.progress_bar.log_err(&status);
+                    self.progress_bar_failure()
+                }
+                self.set_status(Status::Exit(status));
+                Ok(Async::Ready(()))
+            }
+        }
+    }
+}
+
+impl Control for LegacyNode {
+    fn command(&self) -> &bawawa::Command {
+        &self.process.command()
+    }
+
+    fn id(&self) -> u32 {
+        self.process.id()
+    }
+
+    fn kill(&mut self) -> bawawa::Result<()> {
+        self.process.kill()
+    }
+}

--- a/testing/jormungandr-scenario-tests/src/legacy/settings.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/settings.rs
@@ -1,0 +1,35 @@
+use jormungandr_integration_tests::common::legacy::LegacyNodeConfigConverter;
+use jormungandr_testing_utils::{
+    legacy::NodeConfig as LegacyConfig,
+    testing::network_builder::{Node as NodeTemplate,NodeSetting}
+};
+use jormungandr_lib::interfaces::NodeSecret;
+use jormungandr_integration_tests::common::legacy::Version;
+
+#[derive(Debug, Clone)]
+pub struct LegacySettings{
+    pub alias: String,
+    pub config: LegacyConfig,
+    pub secret: NodeSecret,
+    pub node_topology: NodeTemplate,
+}
+
+impl LegacySettings {
+    pub fn from_settings(settings: NodeSetting, version: &Version) -> Self {
+        let converter = LegacyNodeConfigConverter::new(version.clone());
+        LegacySettings{
+            alias: settings.alias.clone(),
+            config: converter.convert(settings.config.clone()).expect("cannot convert node config to legacy"),
+            secret: settings.secrets().clone(),
+            node_topology: settings.node_topology.clone(),
+        }
+    }
+
+    pub fn secrets(&self) -> &NodeSecret {
+        &self.secret
+    }
+
+    pub fn config(&self) -> &LegacyConfig {
+        &self.config
+    }
+}

--- a/testing/jormungandr-scenario-tests/src/legacy/settings.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/settings.rs
@@ -1,13 +1,13 @@
 use jormungandr_integration_tests::common::legacy::LegacyNodeConfigConverter;
+use jormungandr_integration_tests::common::legacy::Version;
+use jormungandr_lib::interfaces::NodeSecret;
 use jormungandr_testing_utils::{
     legacy::NodeConfig as LegacyConfig,
-    testing::network_builder::{Node as NodeTemplate,NodeSetting}
+    testing::network_builder::{Node as NodeTemplate, NodeSetting},
 };
-use jormungandr_lib::interfaces::NodeSecret;
-use jormungandr_integration_tests::common::legacy::Version;
 
 #[derive(Debug, Clone)]
-pub struct LegacySettings{
+pub struct LegacySettings {
     pub alias: String,
     pub config: LegacyConfig,
     pub secret: NodeSecret,
@@ -17,9 +17,11 @@ pub struct LegacySettings{
 impl LegacySettings {
     pub fn from_settings(settings: NodeSetting, version: &Version) -> Self {
         let converter = LegacyNodeConfigConverter::new(version.clone());
-        LegacySettings{
+        LegacySettings {
             alias: settings.alias.clone(),
-            config: converter.convert(settings.config.clone()).expect("cannot convert node config to legacy"),
+            config: converter
+                .convert(settings.config.clone())
+                .expect("cannot convert node config to legacy"),
             secret: settings.secrets().clone(),
             node_topology: settings.node_topology.clone(),
         }

--- a/testing/jormungandr-scenario-tests/src/lib.rs
+++ b/testing/jormungandr-scenario-tests/src/lib.rs
@@ -3,6 +3,7 @@ extern crate error_chain;
 #[macro_use(lazy_static)]
 extern crate lazy_static;
 
+pub mod legacy;
 pub mod node;
 mod programs;
 #[macro_use]

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -102,13 +102,12 @@ pub struct MemPoolCheck {
 }
 
 impl MemPoolCheck {
-    
     pub fn new(fragment_id: FragmentId) -> Self {
         Self {
-            fragment_id: fragment_id
+            fragment_id: fragment_id,
         }
     }
-    
+
     pub fn fragment_id(&self) -> &FragmentId {
         &self.fragment_id
     }

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -102,6 +102,13 @@ pub struct MemPoolCheck {
 }
 
 impl MemPoolCheck {
+    
+    pub fn new(fragment_id: FragmentId) -> Self {
+        Self {
+            fragment_id: fragment_id
+        }
+    }
+    
     pub fn fragment_id(&self) -> &FragmentId {
         &self.fragment_id
     }
@@ -115,7 +122,7 @@ pub enum Status {
 }
 
 #[derive(Clone)]
-struct ProgressBarController {
+pub struct ProgressBarController {
     progress_bar: ProgressBar,
     prefix: String,
     logging_mode: ProgressBarMode,
@@ -756,7 +763,7 @@ impl Node {
 use std::fmt::Display;
 
 impl ProgressBarController {
-    fn new(progress_bar: ProgressBar, prefix: String, logging_mode: ProgressBarMode) -> Self {
+    pub fn new(progress_bar: ProgressBar, prefix: String, logging_mode: ProgressBarMode) -> Self {
         ProgressBarController {
             progress_bar,
             prefix,
@@ -764,21 +771,21 @@ impl ProgressBarController {
         }
     }
 
-    fn log_info<M>(&self, msg: M)
+    pub fn log_info<M>(&self, msg: M)
     where
         M: Display,
     {
         self.log(style::info.apply_to("INFO "), msg)
     }
 
-    fn log_err<M>(&self, msg: M)
+    pub fn log_err<M>(&self, msg: M)
     where
         M: Display,
     {
         self.log(style::error.apply_to("ERROR"), style::error.apply_to(msg))
     }
 
-    fn log<L, M>(&self, lvl: L, msg: M)
+    pub fn log<L, M>(&self, lvl: L, msg: M)
     where
         L: Display,
         M: Display,

--- a/testing/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -1,15 +1,15 @@
 use crate::{
+    legacy::{LegacyNode, LegacyNodeController, LegacySettings},
     prepare_command,
-    legacy::{LegacySettings,LegacyNode,LegacyNodeController},
     scenario::{
         settings::{Dotifier, PrepareSettings},
         ContextChaCha, ErrorKind, ProgressBarMode, Result,
     },
     style, MemPoolCheck, Node, NodeBlock0, NodeController, Wallet,
 };
-use jormungandr_integration_tests::common::legacy::Version;
 use chain_impl_mockchain::header::HeaderId;
 use indicatif::{MultiProgress, ProgressBar};
+use jormungandr_integration_tests::common::legacy::Version;
 use jormungandr_lib::interfaces::Value;
 use jormungandr_testing_utils::testing::network_builder::{
     Blockchain, LeadershipMode, PersistenceMode, Settings, SpawnParams, Topology,
@@ -171,7 +171,11 @@ impl Controller {
         SpawnParams::new(node_alias)
     }
 
-    pub fn spawn_legacy_node(&mut self, params: &mut SpawnParams, version: &Version) -> Result<LegacyNodeController> {
+    pub fn spawn_legacy_node(
+        &mut self,
+        params: &mut SpawnParams,
+        version: &Version,
+    ) -> Result<LegacyNodeController> {
         let node_setting = if let Some(node_setting) = self.settings.nodes.get(&params.get_alias())
         {
             node_setting
@@ -195,12 +199,10 @@ impl Controller {
         let pb = ProgressBar::new_spinner();
         let pb = self.progress_bar.add(pb);
 
+        let mut legacy_node_settings =
+            LegacySettings::from_settings(node_setting_overriden, version);
 
-
-        let mut legacy_node_settings = LegacySettings::from_settings(node_setting_overriden,version);
-        
-        println!("settings: {:?}, debug: {:?}", legacy_node_settings,version);
-
+        println!("settings: {:?}, debug: {:?}", legacy_node_settings, version);
 
         let mut node = LegacyNode::spawn(
             &jormungandr,

--- a/testing/jormungandr-scenario-tests/src/scenario/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/mod.rs
@@ -24,6 +24,7 @@ pub use jormungandr_testing_utils::testing::network_builder::{
 error_chain! {
     links {
         Node(crate::node::Error, crate::node::ErrorKind);
+        LegacyNode(crate::legacy::Error, crate::legacy::ErrorKind);
     }
 
     foreign_links {

--- a/testing/jormungandr-scenario-tests/src/test/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/mod.rs
@@ -16,6 +16,7 @@ error_chain! {
 
     links {
         Node(crate::node::Error, crate::node::ErrorKind);
+        LegacyNode(crate::legacy::Error, crate::legacy::ErrorKind);
         Scenario(crate::scenario::Error, crate::scenario::ErrorKind);
     }
 

--- a/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -1,7 +1,8 @@
 mod wait;
 
 pub use wait::SyncWaitParams;
-
+use chain_impl_mockchain::key::Hash;
+use crate::legacy::LegacyNodeController;
 use crate::{
     node::NodeController,
     scenario::Controller,
@@ -143,8 +144,62 @@ pub fn measure_single_transaction_propagation_speed(
     Ok(())
 }
 
-pub fn measure_and_log_sync_time(
-    nodes: Vec<&NodeController>,
+
+pub trait SyncNode {
+    fn alias(&self) -> &str;
+    fn last_block_height(&self) -> u32;
+    fn log_stats(&self);
+    fn all_blocks_hashes(&self) -> Vec<Hash>;
+    fn log_content(&self) -> String;
+}
+
+//.stats()?.stats.unwrap().
+impl SyncNode for NodeController {
+    fn alias(&self) -> &str {
+        self.alias()
+    }
+
+    fn last_block_height(&self) -> u32 {
+        self.stats().unwrap().stats.unwrap().last_block_height.unwrap().parse().unwrap()
+    }
+    
+    fn log_stats(&self) {
+        println!("Node: {} -> {:?}", self.alias(), self.stats());
+    }
+
+    fn all_blocks_hashes(&self) -> Vec<Hash>{
+        self.all_blocks_hashes().unwrap()
+    }
+
+    fn log_content(&self) -> String {
+        self.logger().get_log_content()
+    }
+}
+
+impl SyncNode for LegacyNodeController {
+    fn alias(&self) -> &str {
+        self.alias()
+    }
+
+    fn last_block_height(&self) -> u32 {
+        self.stats().unwrap()["lastBlockHeight"].as_str().unwrap().parse().unwrap()
+    }
+    
+    fn log_stats(&self) {
+        println!("Node: {} -> {:?}", self.alias(), self.stats());
+    }
+
+    fn all_blocks_hashes(&self) -> Vec<Hash>{
+        self.all_blocks_hashes().unwrap()
+    }
+
+    fn log_content(&self) -> String {
+        self.logger().get_log_content()
+    }
+} 
+
+pub fn measure_and_log_sync_time<A: SyncNode +  ?Sized>(
+    nodes: Vec<&A>,
     sync_wait: Thresholds<Speed>,
     info: &str,
     report_node_stats_interval: MeasurementReportInterval,
@@ -160,13 +215,10 @@ pub fn measure_and_log_sync_time(
         let block_heights: Vec<u32> = nodes
             .iter()
             .map(|node| {
-                let stats = node.stats().unwrap().stats.unwrap();
-
                 if report_node_stats_counter >= interval {
-                    println!("Node: {} -> {:?}", node.alias(), stats);
+                    node.log_stats();
                 }
-
-                stats.last_block_height.unwrap().parse().unwrap()
+                node.last_block_height()
             })
             .collect();
 
@@ -239,7 +291,7 @@ pub fn assert_is_in_block(status: FragmentStatus, node: &NodeController) -> Resu
     Ok(())
 }
 
-pub fn assert_are_in_sync(sync_wait: SyncWaitParams, nodes: Vec<&NodeController>) -> Result<()> {
+pub fn assert_are_in_sync<A: SyncNode +  ?Sized>(sync_wait: SyncWaitParams, nodes: Vec<&A>) -> Result<()> {
     if nodes.len() < 2 {
         return Ok(());
     }
@@ -248,11 +300,11 @@ pub fn assert_are_in_sync(sync_wait: SyncWaitParams, nodes: Vec<&NodeController>
     let duration: LibsDuration = sync_wait.wait_time().into();
     let first_node = nodes.iter().next().unwrap();
 
-    let expected_block_hashes = first_node.all_blocks_hashes()?;
-    let block_height = first_node.stats()?.stats.unwrap().last_block_height;
+    let expected_block_hashes = first_node.all_blocks_hashes();
+    let block_height = first_node.last_block_height();
 
     for node in nodes.iter().skip(1) {
-        let all_block_hashes = node.all_blocks_hashes()?;
+        let all_block_hashes = node.all_blocks_hashes();
         assert_equals(
             &expected_block_hashes,
             &all_block_hashes,
@@ -265,7 +317,7 @@ pub fn assert_are_in_sync(sync_wait: SyncWaitParams, nodes: Vec<&NodeController>
         )?;
         assert_equals(
             &block_height,
-            &node.stats()?.stats.unwrap().last_block_height,
+            &node.last_block_height(),
             &format!("nodes are out of sync (different block height) after sync grace period: ({}) . Left node: alias: {}, content: {}, Right node: alias: {}, content: {}",
                 duration,
                 first_node.alias(),

--- a/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -1,13 +1,12 @@
 mod wait;
 
-pub use wait::SyncWaitParams;
-use chain_impl_mockchain::key::Hash;
 use crate::legacy::LegacyNodeController;
 use crate::{
     node::NodeController,
     scenario::Controller,
     test::{ErrorKind, Result},
 };
+use chain_impl_mockchain::key::Hash;
 use jormungandr_lib::{
     interfaces::{FragmentStatus, NodeState},
     time::Duration as LibsDuration,
@@ -19,6 +18,7 @@ use std::{
     fmt, thread,
     time::{Duration, SystemTime},
 };
+pub use wait::SyncWaitParams;
 
 pub fn wait_for_nodes_sync(sync_wait_params: &SyncWaitParams) {
     let wait_time = sync_wait_params.wait_time();
@@ -144,7 +144,6 @@ pub fn measure_single_transaction_propagation_speed(
     Ok(())
 }
 
-
 pub trait SyncNode {
     fn alias(&self) -> &str;
     fn last_block_height(&self) -> u32;
@@ -160,14 +159,21 @@ impl SyncNode for NodeController {
     }
 
     fn last_block_height(&self) -> u32 {
-        self.stats().unwrap().stats.unwrap().last_block_height.unwrap().parse().unwrap()
+        self.stats()
+            .unwrap()
+            .stats
+            .unwrap()
+            .last_block_height
+            .unwrap()
+            .parse()
+            .unwrap()
     }
-    
+
     fn log_stats(&self) {
         println!("Node: {} -> {:?}", self.alias(), self.stats());
     }
 
-    fn all_blocks_hashes(&self) -> Vec<Hash>{
+    fn all_blocks_hashes(&self) -> Vec<Hash> {
         self.all_blocks_hashes().unwrap()
     }
 
@@ -182,23 +188,27 @@ impl SyncNode for LegacyNodeController {
     }
 
     fn last_block_height(&self) -> u32 {
-        self.stats().unwrap()["lastBlockHeight"].as_str().unwrap().parse().unwrap()
+        self.stats().unwrap()["lastBlockHeight"]
+            .as_str()
+            .unwrap()
+            .parse()
+            .unwrap()
     }
-    
+
     fn log_stats(&self) {
         println!("Node: {} -> {:?}", self.alias(), self.stats());
     }
 
-    fn all_blocks_hashes(&self) -> Vec<Hash>{
+    fn all_blocks_hashes(&self) -> Vec<Hash> {
         self.all_blocks_hashes().unwrap()
     }
 
     fn log_content(&self) -> String {
         self.logger().get_log_content()
     }
-} 
+}
 
-pub fn measure_and_log_sync_time<A: SyncNode +  ?Sized>(
+pub fn measure_and_log_sync_time<A: SyncNode + ?Sized>(
     nodes: Vec<&A>,
     sync_wait: Thresholds<Speed>,
     info: &str,
@@ -291,7 +301,10 @@ pub fn assert_is_in_block(status: FragmentStatus, node: &NodeController) -> Resu
     Ok(())
 }
 
-pub fn assert_are_in_sync<A: SyncNode +  ?Sized>(sync_wait: SyncWaitParams, nodes: Vec<&A>) -> Result<()> {
+pub fn assert_are_in_sync<A: SyncNode + ?Sized>(
+    sync_wait: SyncWaitParams,
+    nodes: Vec<&A>,
+) -> Result<()> {
     if nodes.len() < 2 {
         return Ok(());
     }


### PR DESCRIPTION
Right now scenario tests have separate api for running network of nodes. Therefore changes in scenario test are needed. Similar approach is done as in integration tests. Controller struct can now bootstrap legacy node for particular version and perform some operations (bootstrap/shutdown/check stats/logs) to satisfy backward compatibility legacy node won't use strict schema and relay on loosely coupled one, in order to freely manipulate data. Some interfaces were introduced to unified measurement and assertions between legacy and standard nodes