### PR TITLE
Clean unused and redundant members from P2pTopology

### DIFF
--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -16,6 +16,7 @@ mod subscription;
 use self::convert::Encode;
 use futures03::future;
 use futures03::prelude::*;
+use poldercast::Address;
 use thiserror::Error;
 use tokio02::time;
 
@@ -156,6 +157,10 @@ impl GlobalState {
 
     fn logger(&self) -> &Logger {
         &self.logger
+    }
+
+    pub fn node_address(&self) -> Option<&Address> {
+        self.config.profile.address()
     }
 
     pub fn topology(&self) -> &P2pTopology {
@@ -458,8 +463,8 @@ fn connect_and_propagate(
     };
     options.evict_clients = state.num_clients_to_bump();
     assert_ne!(
-        &node,
-        state.topology.node_address(),
+        Some(&node),
+        state.node_address(),
         "topology tells the node to connect to itself"
     );
     let peer = Peer::new(addr);

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -22,8 +22,6 @@ pub struct View {
 /// object holding the P2pTopology of the Node
 pub struct P2pTopology {
     lock: RwLock<Topology>,
-    node_address: Address,
-    logger: Logger,
 }
 
 /// Builder object used to initialize the `P2pTopology`
@@ -74,11 +72,8 @@ impl Builder {
     }
 
     fn build(self) -> P2pTopology {
-        let node_address = self.topology.profile().address().unwrap().clone();
         P2pTopology {
             lock: RwLock::new(self.topology),
-            node_address,
-            logger: self.logger,
         }
     }
 }
@@ -118,10 +113,6 @@ impl P2pTopology {
         topology
             .exchange_gossips(with.into(), gossips.into())
             .into()
-    }
-
-    pub fn node_address(&self) -> &Address {
-        &self.node_address
     }
 
     pub async fn node(&self) -> NodeProfile {


### PR DESCRIPTION
No need for a copy of the node address. Where it is used, it's also available from the network configuration.

Remove the logger member which was not used.