### PR TITLE
Restore stepwise processing for inbound fragments and gossip

### DIFF
--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -276,9 +276,14 @@ impl Sink<net_data::Header> for BlockAnnouncementProcessor {
                 };
                 Poll::Pending
             }
-            Poll::Ready(()) => Pin::new(&mut self.mbox)
-                .poll_close(cx)
-                .map_err(|e| handle_mbox_error(e, &self.logger)),
+            Poll::Ready(()) => Pin::new(&mut self.mbox).poll_close(cx).map_err(|e| {
+                warn!(
+                    self.logger,
+                    "failed to close communication channel to the block task";
+                    "reason" => %e,
+                );
+                Error::new(Code::Internal, e)
+            }),
         }
     }
 }


### PR DESCRIPTION
The `Forward` futures tend to do too much.
While at it, improve error handling in the client and remove some data duplication.