### PR TITLE
Print error lines as such

### DIFF
--- a/testing/jormungandr-integration-tests/src/common/jormungandr/logger.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/logger.rs
@@ -220,7 +220,10 @@ impl JormungandrLogger {
     pub fn print_error_and_invalid_logs(&self) {
         let error_lines: Vec<_> = self.get_lines_with_error_and_invalid().collect();
         if !error_lines.is_empty() {
-            println!("Error lines: {:?}", error_lines);
+            println!("Error lines:");
+            for line in error_lines {
+                println!("{}", line);
+            }
         }
     }
 


### PR DESCRIPTION
Given the log lines of a failed test, print them one per line rather than using a `Debug` impl of `Vec` that jams them together.