### PR TITLE
rest - /api/v0/block/block0 - endpoint added

### DIFF
--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -124,6 +124,24 @@ paths:
         '404':
           description: Account with given ID was not found
 
+  '/api/v0/block/block0':
+    get:
+      description: Gets block0
+      operationId: Block0
+      tags:
+        - block
+      responses:
+        '200':
+          description: Success
+          content:
+            application/octet-stream:
+              schema:
+                description: Binary blob with block0
+                type: string
+                format: binary
+        '400':
+          description: Block was not found
+
   '/api/v0/block/{block_id}':
     get:
       description: Gets block

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -50,6 +50,14 @@ pub async fn get_stats_counter(context: ContextLock) -> Result<impl Reply, Rejec
         .map_err(warp::reject::custom)
 }
 
+pub async fn get_block0(context: ContextLock) -> Result<impl Reply, Rejection> {
+    let context = context.read().await;
+    logic::get_block0(&context)
+        .await
+        .map_err(warp::reject::custom)?
+        .ok_or(warp::reject::not_found())
+}
+
 pub async fn get_block_id(
     block_id_hex: String,
     context: ContextLock,

--- a/jormungandr/src/rest/v0/logic.rs
+++ b/jormungandr/src/rest/v0/logic.rs
@@ -227,6 +227,17 @@ async fn create_stats(context: &Context) -> Result<Option<NodeStats>, Error> {
     Ok(Some(node_stats))
 }
 
+pub async fn get_block0(context: &Context) -> Result<Option<Vec<u8>>, Error> {
+    let blockchain = context.blockchain()?;
+    let block_id = blockchain.block0().to_owned();
+    blockchain
+        .storage()
+        .get(block_id)
+        .await?
+        .map(|b| b.serialize_as_vec().map_err(Error::Serialize))
+        .transpose()
+}
+
 pub async fn get_block_id(context: &Context, block_id_hex: &str) -> Result<Option<Vec<u8>>, Error> {
     context
         .blockchain()?

--- a/jormungandr/src/rest/v0/mod.rs
+++ b/jormungandr/src/rest/v0/mod.rs
@@ -26,6 +26,12 @@ pub fn filter(
     let block = {
         let root = warp::path!("block" / ..);
 
+        let get_block0 = warp::path!("block0")
+            .and(warp::get())
+            .and(with_context.clone())
+            .and_then(handlers::get_block0)
+            .boxed();
+
         let get = warp::path!(String)
             .and(warp::get())
             .and(with_context.clone())
@@ -39,7 +45,7 @@ pub fn filter(
             .and_then(handlers::get_block_next_id)
             .boxed();
 
-        root.and(get.or(get_next)).boxed()
+        root.and(get.or(get_next).or(get_block0)).boxed()
     };
 
     let fragment = warp::path!("fragment" / "logs")


### PR DESCRIPTION
Fetch block0 bytes without the need to pass block0 hash.
Added for convenience to be used directly from remote http clients that may not be aware of the block0 hash and have to go through
- /api/v0/settings
- parse block0Hash
- /api/v0/block/abcdef0123456789