### PR TITLE
Implement bft leader explorer tracking

### DIFF
--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -170,7 +170,7 @@ impl Block {
             .unwrap_or(None)
             .map(|reference| {
                 let ledger = reference.ledger();
-                let treasury_tax = reference.epoch_ledger_parameters().treasury_tax.clone();
+                let treasury_tax = reference.epoch_ledger_parameters().treasury_tax;
                 Treasury {
                     rewards: ledger.remaining_rewards().into(),
                     treasury: ledger.treasury_value().into(),
@@ -189,11 +189,8 @@ struct BftLeader {
     Context = Context,
 )]
 impl BftLeader {
-    // FIXME: Don't use String
-    fn id(&self) -> String {
-        // FIXME: How to print this
-        let id = &self.id;
-        unimplemented!()
+    fn id(&self) -> PublicKey {
+        self.id.as_public_key().into()
     }
 }
 
@@ -211,7 +208,7 @@ graphql_union!(Leader: Context |&self| {
 
 impl From<&ExplorerBlock> for Block {
     fn from(block: &ExplorerBlock) -> Block {
-        Block::from_valid_hash(block.id().clone())
+        Block::from_valid_hash(block.id())
     }
 }
 

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -222,8 +222,9 @@ impl ExplorerBlock {
                 // Unwrap is safe in this pattern match
                 BlockProducer::StakePool(block.header.get_stakepool_id().unwrap())
             }
-            // TODO: I think there are no accesors for this
-            Proof::Bft(_proof) => unimplemented!(),
+            Proof::Bft(_proof) => {
+                BlockProducer::BftLeader(block.header.get_bft_leader_id().unwrap())
+            }
             Proof::None => BlockProducer::None,
         };
 

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -509,7 +509,7 @@ fn apply_block_to_stake_pools(
                 },
             )
             .expect("block to be created by registered stake pool"),
-        indexing::BlockProducer::BftLeader(_) => unimplemented!(),
+        indexing::BlockProducer::BftLeader(_) => blocks,
         indexing::BlockProducer::None => blocks,
     };
 


### PR DESCRIPTION
~~This updates the submodule too, but it doesn't compile for some other reason (related to the storage), so I'll leave it as a draft for now.~~ EDIT: rebased on master and now it works.

### Example 

#### Query
```graphql
{
  status {
    latestBlock {
      id
      leader {
        __typename
        ... on BftLeader {
          id
        }
      }
    }
  }
}
```
#### Response

```json
{
  "data": {
    "status": {
      "latestBlock": {
        "id": "cfbd38a9b620c8a7916e6c490dc4d4abdddaa08141e4802024e00b7c431d00f6",
        "leader": {
          "__typename": "BftLeader",
          "id": "ed25519_pk1z5hrn33zw830pdxee0rmjldaryq6fx56ezlrskuc8nwc0cujgasqnyceuz"
        }
      }
    }
  }
}
```

The only field available for the BftLeader is the id, which is a public key. Stake pools have a few extra things (most notably the  `blocks` field, but this is not indexed for bft).