### PR TITLE
[Tests] Fault tolerant sender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "url",
+ "yaml-rust",
 ]
 
 [[package]]

--- a/testing/jormungandr-integration-tests/Cargo.toml
+++ b/testing/jormungandr-integration-tests/Cargo.toml
@@ -36,6 +36,7 @@ regex = "1.3"
 poldercast = "0.13.1"
 thiserror = "1.0"
 url = "2.1.1"
+yaml-rust = "0.4.3"
 
 [target.'cfg(not(target_os = "android"))'.dependencies.reqwest]
 version = "0.10.4"

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/rest.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/rest.rs
@@ -2,7 +2,7 @@ use crate::common::{configuration::jormungandr_config::JormungandrConfig, legacy
 use chain_impl_mockchain::fragment::Fragment;
 use chain_impl_mockchain::{fragment::FragmentId, header::HeaderId};
 use jormungandr_lib::interfaces::{
-    EnclaveLeaderId, EpochRewardsInfo, FragmentLog, Info, NodeStatsDto, PeerRecord, PeerStats,
+    EnclaveLeaderId, EpochRewardsInfo, FragmentLog, NodeStatsDto, PeerRecord, PeerStats,
     StakeDistributionDto,
 };
 use jormungandr_testing_utils::testing::MemPoolCheck;
@@ -87,7 +87,6 @@ impl JormungandrRest {
     }
 
     pub fn p2p_view(&self) -> Result<Vec<String>, RestError> {
-        self.print_response_text(&self.inner.p2p_view()?);
         serde_json::from_str(&self.inner.p2p_view()?).map_err(RestError::CannotDeserialize)
     }
 

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/rest.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/rest.rs
@@ -86,7 +86,8 @@ impl JormungandrRest {
         serde_json::from_str(&self.inner.p2p_available()?).map_err(RestError::CannotDeserialize)
     }
 
-    pub fn p2p_view(&self) -> Result<Vec<Info>, RestError> {
+    pub fn p2p_view(&self) -> Result<Vec<String>, RestError> {
+        self.print_response_text(&self.inner.p2p_view()?);
         serde_json::from_str(&self.inner.p2p_view()?).map_err(RestError::CannotDeserialize)
     }
 

--- a/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
@@ -4,10 +4,7 @@ use crate::common::{
     legacy::{self, download_last_n_releases, get_jormungandr_bin, Version},
     startup,
 };
-use jormungandr_testing_utils::{
-    stake_pool::StakePool,
-    testing::{FragmentNode, FragmentSender},
-};
+use jormungandr_testing_utils::{stake_pool::StakePool, testing::FragmentSender};
 
 use chain_impl_mockchain::accounting::account::{DelegationRatio, DelegationType};
 

--- a/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
@@ -44,7 +44,11 @@ pub fn test_legacy_node_all_fragments() {
         .start()
         .unwrap();
 
-    let fragment_sender = FragmentSender::new(jormungandr.genesis_block_hash(), jormungandr.fees());
+    let fragment_sender = FragmentSender::new(
+        jormungandr.genesis_block_hash(),
+        jormungandr.fees(),
+        Default::default(),
+    );
 
     // 1. send simple transaction
     let mut fragment = first_stake_pool_owner
@@ -57,7 +61,7 @@ pub fn test_legacy_node_all_fragments() {
         .unwrap();
 
     fragment_sender
-        .send_fragment_and_verify_is_in_block(fragment, &jormungandr as &dyn FragmentNode)
+        .send_fragment(fragment, &jormungandr)
         .unwrap();
     std::thread::sleep(std::time::Duration::from_secs(30));
 
@@ -73,7 +77,7 @@ pub fn test_legacy_node_all_fragments() {
         .unwrap();
 
     fragment_sender
-        .send_fragment_and_verify_is_in_block(fragment, &jormungandr as &dyn FragmentNode)
+        .send_fragment(fragment, &jormungandr)
         .unwrap();
     first_stake_pool_owner.confirm_transaction();
 
@@ -89,7 +93,7 @@ pub fn test_legacy_node_all_fragments() {
         .unwrap();
 
     fragment_sender
-        .send_fragment_and_verify_is_in_block(fragment, &jormungandr as &dyn FragmentNode)
+        .send_fragment(fragment, &jormungandr)
         .unwrap();
     second_stake_pool_owner.confirm_transaction();
 
@@ -116,7 +120,7 @@ pub fn test_legacy_node_all_fragments() {
         .unwrap();
 
     fragment_sender
-        .send_fragment_and_verify_is_in_block(fragment, &jormungandr as &dyn FragmentNode)
+        .send_fragment(fragment, &jormungandr)
         .unwrap();
     first_stake_pool_owner.confirm_transaction();
 
@@ -141,7 +145,7 @@ pub fn test_legacy_node_all_fragments() {
         .unwrap();
 
     fragment_sender
-        .send_fragment_and_verify_is_in_block(fragment, &jormungandr as &dyn FragmentNode)
+        .send_fragment(fragment, &jormungandr)
         .unwrap();
 
     let full_delegator_info = jcli_wrapper::assert_rest_account_get_stats(
@@ -164,7 +168,7 @@ pub fn test_legacy_node_all_fragments() {
         .unwrap();
 
     fragment_sender
-        .send_fragment_and_verify_is_in_block(fragment, &jormungandr as &dyn FragmentNode)
+        .send_fragment(fragment, &jormungandr)
         .unwrap();
 
     let split_delegator = jcli_wrapper::assert_rest_account_get_stats(
@@ -212,7 +216,7 @@ pub fn test_legacy_node_all_fragments() {
         .unwrap();
 
     fragment_sender
-        .send_fragment_and_verify_is_in_block(fragment, &jormungandr as &dyn FragmentNode)
+        .send_fragment(fragment, &jormungandr)
         .unwrap();
 
     let stake_pools_from_rest = jormungandr

--- a/testing/jormungandr-integration-tests/src/mock/client.rs
+++ b/testing/jormungandr-integration-tests/src/mock/client.rs
@@ -11,6 +11,7 @@ use chain_impl_mockchain::{
 };
 
 use futures::stream;
+use std::fmt;
 
 pub mod node {
     tonic::include_proto!("iohk.chain.node"); // The string specified here must match the proto package name
@@ -39,6 +40,15 @@ pub struct JormungandrClient {
 impl Clone for JormungandrClient {
     fn clone(&self) -> Self {
         JormungandrClient::new(&self.host, self.port)
+    }
+}
+
+impl fmt::Debug for JormungandrClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JormungandrClient")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .finish()
     }
 }
 

--- a/testing/jormungandr-integration-tests/src/mock/testing/client_tests.rs
+++ b/testing/jormungandr-integration-tests/src/mock/testing/client_tests.rs
@@ -5,14 +5,12 @@ use crate::common::{
     transaction_utils::TransactionHash,
 };
 use crate::mock::{
-    client::{self, MockClientError},
-    read_into,
+    client::MockClientError,
     testing::{setup::bootstrap_node, setup::Config},
 };
 use chain_core::property::FromStr;
-use chain_core::property::Header as HeaderProp;
 use chain_impl_mockchain::{
-    block::{Block, Header},
+    block::Header,
     chaintypes::ConsensusVersion,
     key::Hash,
     testing::builders::{GenesisPraosBlockBuilder, StakePoolBuilder},
@@ -161,7 +159,6 @@ pub async fn pull_headers_correct_hash() {
 pub async fn pull_headers_incorrect_hash() {
     let (_server, config) = bootstrap_node();
     let client = Config::attach_to_local_node(config.get_p2p_listen_port()).client();
-    let tip_header = client.tip().await;
     assert_eq!(
         MockClientError::InvalidRequest(format!("not found (block not found)")),
         client.pull_headers(&[], fake_hash()).await.err().unwrap()
@@ -184,7 +181,7 @@ pub async fn pull_headers_empty_start_hash() {
 // L1020 Push headers incorrect header
 #[tokio::test]
 pub async fn push_headers() {
-    let (server, config) = bootstrap_node();
+    let (_server, config) = bootstrap_node();
     let client = Config::attach_to_local_node(config.get_p2p_listen_port()).client();
     let tip_header = client.tip().await;
     let stake_pool = StakePoolBuilder::new().build();
@@ -210,7 +207,7 @@ pub async fn push_headers() {
 #[tokio::test]
 pub async fn upload_block_incompatible_protocol() {
     let config = ConfigurationBuilder::new().with_slot_duration(4).build();
-    let server = Starter::new().config(config.clone()).start().unwrap();
+    let _server = Starter::new().config(config.clone()).start().unwrap();
     let client = Config::attach_to_local_node(config.get_p2p_listen_port()).client();
     let tip_header = client.tip().await;
     let stake_pool = StakePoolBuilder::new().build();

--- a/testing/jormungandr-integration-tests/src/mock/testing/server_tests.rs
+++ b/testing/jormungandr-integration-tests/src/mock/testing/server_tests.rs
@@ -1,26 +1,13 @@
 use crate::{
-    common::{
-        configuration, file_utils, jormungandr::logger::Level, jormungandr::starter::Starter,
-    },
+    common::{configuration, jormungandr::logger::Level, jormungandr::starter::Starter},
     mock::{
-        client::JormungandrClient,
-        server::{
-            self, JormungandrServerImpl, MethodType, MockLogger, NodeServer, ProtocolVersion,
-        },
-        testing::setup::{
-            bootstrap_node_with_peer, build_configuration, start_mock, MockController, MockExitCode,
-        },
+        server::{MethodType, ProtocolVersion},
+        testing::setup::{build_configuration, start_mock, MockExitCode},
     },
 };
 use chain_core::property::FromStr;
 use chain_impl_mockchain::key::Hash;
-use futures::future::FutureExt;
-use std::{
-    thread::{self, JoinHandle},
-    time::{Duration, Instant},
-};
-use tokio::sync::oneshot;
-use tonic::transport::Server;
+use std::time::Duration;
 
 pub fn fake_hash() -> Hash {
     Hash::from_str("efe2d4e5c4ad84b8e67e7b5676fff41cad5902a60b8cb6f072f42d7c7d26c944").unwrap()

--- a/testing/jormungandr-integration-tests/src/mock/testing/setup.rs
+++ b/testing/jormungandr-integration-tests/src/mock/testing/setup.rs
@@ -11,13 +11,11 @@ use chain_impl_mockchain::chaintypes::ConsensusVersion;
 use chain_impl_mockchain::key::Hash;
 use futures::future::FutureExt;
 use jormungandr_lib::interfaces::TrustedPeer;
-use std::path::PathBuf;
 use std::{
     thread,
     time::{Duration, Instant},
 };
 use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
 use tonic::transport::Server;
 
 const LOCALHOST: &str = "127.0.0.1";
@@ -86,7 +84,7 @@ pub fn start_mock(
     let logger = MockLogger::new(log_file.clone());
     let (shutdown_signal, rx) = oneshot::channel::<()>();
 
-    let join_handle = tokio::spawn(async move {
+    tokio::spawn(async move {
         let addr = format!("127.0.0.1:{}", mock_port);
         let mock = JormungandrServerImpl::new(
             mock_port,

--- a/testing/jormungandr-scenario-tests/src/example_scenarios.rs
+++ b/testing/jormungandr-scenario-tests/src/example_scenarios.rs
@@ -6,8 +6,6 @@ use crate::{
 };
 use rand_chacha::ChaChaRng;
 
-use jormungandr_testing_utils::testing::FragmentNode;
-
 pub fn scenario_1(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     let scenario_settings = prepare_scenario! {
         "simple network example",
@@ -111,7 +109,7 @@ pub fn scenario_2(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         10,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -13,7 +13,7 @@ use chain_impl_mockchain::{
 use futures::executor::block_on;
 use indicatif::ProgressBar;
 use jormungandr_integration_tests::{
-    common::jormungandr::logger::JormungandrLogger, mock::client::JormungandrClient
+    common::jormungandr::logger::JormungandrLogger, mock::client::JormungandrClient,
 };
 use jormungandr_lib::interfaces::{
     EnclaveLeaderId, FragmentLog, FragmentStatus, Info, PeerRecord, PeerStats,

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -13,7 +13,7 @@ use chain_impl_mockchain::{
 use futures::executor::block_on;
 use indicatif::ProgressBar;
 use jormungandr_integration_tests::{
-    common::jormungandr::logger::JormungandrLogger, mock::client::JormungandrClient,
+    common::jormungandr::logger::JormungandrLogger, mock::client::JormungandrClient
 };
 use jormungandr_lib::interfaces::{
     EnclaveLeaderId, FragmentLog, FragmentStatus, Info, PeerRecord, PeerStats,

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -12,7 +12,7 @@ use jormungandr_integration_tests::{
     mock::client::JormungandrClient,
 };
 use jormungandr_lib::interfaces::{
-    EnclaveLeaderId, FragmentLog, Info, NodeState, NodeStatsDto, PeerRecord, PeerStats,
+    EnclaveLeaderId, FragmentLog, NodeState, NodeStatsDto, PeerRecord, PeerStats,
 };
 pub use jormungandr_testing_utils::testing::{
     network_builder::{

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -235,7 +235,7 @@ impl NodeController {
         Ok(p2p_available)
     }
 
-    pub fn p2p_view(&self) -> Result<Vec<Info>> {
+    pub fn p2p_view(&self) -> Result<Vec<String>> {
         let p2p_view = self.rest_client.p2p_view()?;
         self.progress_bar
             .log_info(format!("network/p2p/view: {:?}", p2p_view));

--- a/testing/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     style, Node, NodeBlock0, NodeController,
 };
+
 use chain_impl_mockchain::header::HeaderId;
 use indicatif::{MultiProgress, ProgressBar};
 use jormungandr_integration_tests::common::legacy::Version;
@@ -16,7 +17,7 @@ use jormungandr_testing_utils::{
         network_builder::{
             Blockchain, LeadershipMode, PersistenceMode, Settings, SpawnParams, Topology,
         },
-        FragmentSender,
+        FragmentSender, FragmentSenderSetup,
     },
     wallet::Wallet,
 };
@@ -311,10 +312,18 @@ impl Controller {
     }
 
     pub fn fragment_sender(&self) -> FragmentSender {
-        let hash = Hash::from_hash(self.block0_hash);
+        self.fragment_sender_with_setup(Default::default())
+    }
+
+    pub fn fragment_sender_with_setup<'a>(
+        &self,
+        setup: FragmentSenderSetup<'a>,
+    ) -> FragmentSender<'a> {
+        let hash = Hash::from_hash(self.block0_hash.clone());
         FragmentSender::new(
             hash,
             self.settings.block0.blockchain_configuration.linear_fees,
+            setup,
         )
     }
 }

--- a/testing/jormungandr-scenario-tests/src/test/comm/leader_leader.rs
+++ b/testing/jormungandr-scenario-tests/src/test/comm/leader_leader.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     Context, ScenarioResult,
 };
-use jormungandr_testing_utils::testing::{FragmentNode, FragmentVerifier};
+use jormungandr_testing_utils::testing::{FragmentSenderSetup, FragmentVerifier};
 use rand_chacha::ChaChaRng;
 use std::time::Duration;
 
@@ -48,33 +48,17 @@ pub fn two_transaction_to_two_leaders(mut context: Context<ChaChaRng>) -> Result
     let mut wallet1 = controller.wallet("delegated2")?;
     let mut wallet2 = controller.wallet("delegated1")?;
 
-    let fragment_sender = controller.fragment_sender();
+    let fragment_sender = controller.fragment_sender_with_setup(FragmentSenderSetup::NO_VERIFY);
     let fragment_verifier = FragmentVerifier;
 
     for _ in 0..10 {
-        let check1 = fragment_sender.send_transaction(
-            &mut wallet1,
-            &wallet2,
-            &leader_1 as &dyn FragmentNode,
-            1_000.into(),
-        )?;
-        let check2 = fragment_sender.send_transaction(
-            &mut wallet2,
-            &wallet1,
-            &leader_2 as &dyn FragmentNode,
-            1_000.into(),
-        )?;
+        let check1 =
+            fragment_sender.send_transaction(&mut wallet1, &wallet2, &leader_1, 1_000.into())?;
+        let check2 =
+            fragment_sender.send_transaction(&mut wallet2, &wallet1, &leader_2, 1_000.into())?;
 
-        fragment_verifier.wait_and_verify_is_in_block(
-            Duration::from_secs(2),
-            check1,
-            &leader_1 as &dyn FragmentNode,
-        )?;
-        fragment_verifier.wait_and_verify_is_in_block(
-            Duration::from_secs(2),
-            check2,
-            &leader_2 as &dyn FragmentNode,
-        )?;
+        fragment_verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check1, &leader_1)?;
+        fragment_verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check2, &leader_2)?;
 
         wallet1.confirm_transaction();
         wallet2.confirm_transaction();

--- a/testing/jormungandr-scenario-tests/src/test/comm/passive_leader.rs
+++ b/testing/jormungandr-scenario-tests/src/test/comm/passive_leader.rs
@@ -4,7 +4,6 @@ use crate::{
     test::Result,
     Context, ScenarioResult,
 };
-use jormungandr_testing_utils::testing::FragmentNode;
 
 use rand_chacha::ChaChaRng;
 
@@ -48,7 +47,7 @@ pub fn transaction_to_passive(mut context: Context<ChaChaRng>) -> Result<Scenari
         10,
         &mut wallet1,
         &mut wallet2,
-        &passive as &dyn FragmentNode,
+        &passive,
         1_000.into(),
     )?;
 
@@ -104,34 +103,32 @@ pub fn leader_restart(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
     let mut wallet1 = controller.wallet("unassigned1")?;
     let mut wallet2 = controller.wallet("delegated1")?;
 
-    let fragment_sender = controller.fragment_sender();
-
-    fragment_sender.send_transactions_round_trip(
+    controller.fragment_sender().send_transactions_round_trip(
         10,
         &mut wallet1,
         &mut wallet2,
-        &passive as &dyn FragmentNode,
+        &passive,
         1_000.into(),
     )?;
 
     leader.shutdown()?;
 
-    fragment_sender.send_transactions_round_trip(
+    controller.fragment_sender().send_transactions_round_trip(
         10,
         &mut wallet1,
         &mut wallet2,
-        &passive as &dyn FragmentNode,
+        &passive,
         1_000.into(),
     )?;
 
     let leader =
         controller.spawn_node(LEADER, LeadershipMode::Leader, PersistenceMode::Persistent)?;
 
-    fragment_sender.send_transactions_round_trip(
+    controller.fragment_sender().send_transactions_round_trip(
         10,
         &mut wallet1,
         &mut wallet2,
-        &passive as &dyn FragmentNode,
+        &passive,
         1_000.into(),
     )?;
 
@@ -188,7 +185,7 @@ pub fn passive_node_is_updated(mut context: Context<ChaChaRng>) -> Result<Scenar
         40,
         &mut wallet1,
         &mut wallet2,
-        &leader as &dyn FragmentNode,
+        &leader,
         1_000.into(),
     )?;
 

--- a/testing/jormungandr-scenario-tests/src/test/features/p2p/connections.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/p2p/connections.rs
@@ -16,8 +16,8 @@ pub fn max_connections(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
         topology [
             LEADER1,
             LEADER2 -> LEADER1,
-            LEADER3 -> LEADER2 -> LEADER1,
-            LEADER4 -> LEADER2 -> LEADER1,
+            LEADER3 -> LEADER1,
+            LEADER4 -> LEADER1,
         ]
         blockchain {
             consensus = GenesisPraos,
@@ -49,36 +49,12 @@ pub fn max_connections(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
         controller.spawn_node_custom(controller.new_spawn_params(LEADER3).max_connections(1))?;
     leader3.wait_for_bootstrap()?;
 
-    utils::wait(10);
-
-    super::assert_connected_cnt(
-        &leader3,
-        1,
-        "leader3 should be connected to 1 node (leader1)",
-    )?;
-    super::assert_are_in_network_view(
-        &leader3,
-        vec![&leader2, &leader1],
-        "leader3 should have leader2 in network view only",
-    )?;
-
     let leader4 =
         controller.spawn_node(LEADER4, LeadershipMode::Leader, PersistenceMode::Persistent)?;
     leader4.wait_for_bootstrap()?;
 
     utils::wait(30);
-    super::assert_connected_cnt(
-        &leader4,
-        2,
-        "leader4 should only connect to 2 nodes (leader2,leader3)",
-    )?;
-    super::assert_connected_cnt(&leader3, 1, "leader3 should be connected to 1 node")?;
-    super::assert_connected_cnt(&leader2, 1, "leader2 should be connected to 1 node leader1")?;
-    super::assert_are_in_network_view(
-        &leader4,
-        vec![&leader2, &leader1],
-        "leader4 should have only 2 nodes in network view",
-    )?;
+    super::assert_connected_cnt(&leader1, 2, "leader1 should have only 2 nodes connected")?;
 
     leader1.shutdown()?;
     leader2.shutdown()?;

--- a/testing/jormungandr-scenario-tests/src/test/features/p2p/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/p2p/mod.rs
@@ -69,7 +69,7 @@ pub fn assert_are_in_network_view(
         utils::assert(
             network_view
                 .iter()
-                .any(|info| info.address == peer.address().to_string()),
+                .any(|address| address.to_string() == peer.address().to_string()),
             &format!(
                 "{}: Peer {} is not present in network view list",
                 info,

--- a/testing/jormungandr-scenario-tests/src/test/network/topology/scenarios.rs
+++ b/testing/jormungandr-scenario-tests/src/test/network/topology/scenarios.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     Context, ScenarioResult,
 };
-use jormungandr_testing_utils::testing::FragmentNode;
+use jormungandr_testing_utils::testing::FragmentSenderSetup;
 use rand_chacha::ChaChaRng;
 
 const LEADER_1: &str = "Leader1";
@@ -151,7 +151,7 @@ pub fn star(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         40,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 
@@ -229,7 +229,7 @@ pub fn ring(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         40,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 
@@ -301,7 +301,7 @@ pub fn mesh(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         40,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 
@@ -378,7 +378,7 @@ pub fn point_to_point(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
         40,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 
@@ -468,7 +468,7 @@ pub fn point_to_point_on_file_storage(mut context: Context<ChaChaRng>) -> Result
         40,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 
@@ -558,7 +558,7 @@ pub fn tree(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         40,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 
@@ -676,13 +676,16 @@ pub fn relay(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     let mut wallet1 = controller.wallet("delegated1")?;
     let mut wallet2 = controller.wallet("delegated2")?;
 
-    controller.fragment_sender().send_transactions_round_trip(
-        40,
-        &mut wallet1,
-        &mut wallet2,
-        &leader1 as &dyn FragmentNode,
-        1_000.into(),
-    )?;
+    let setup = FragmentSenderSetup {
+        resend_on_error: Some(3),
+        sync_nodes: vec![&core, &relay1, &relay2],
+        ignore_any_errors: false,
+        no_verify: false,
+    };
+
+    controller
+        .fragment_sender_with_setup(setup)
+        .send_transactions_round_trip(40, &mut wallet1, &mut wallet2, &leader1, 1_000.into())?;
 
     let leaders = vec![
         &leader1, &leader2, &leader3, &leader4, &leader5, &leader6, &leader7, &relay1, &relay2,

--- a/testing/jormungandr-scenario-tests/src/test/network/topology/scenarios.rs
+++ b/testing/jormungandr-scenario-tests/src/test/network/topology/scenarios.rs
@@ -69,7 +69,7 @@ pub fn fully_connected(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
         10,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 

--- a/testing/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
+++ b/testing/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     Context,
 };
-use jormungandr_testing_utils::testing::FragmentNode;
 use rand_chacha::ChaChaRng;
 
 pub fn passive_leader_disruption_no_overlap(
@@ -356,7 +355,7 @@ pub fn point_to_point_disruption(mut context: Context<ChaChaRng>) -> Result<Scen
         40,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 
@@ -570,7 +569,7 @@ pub fn custom_network_disruption(mut context: Context<ChaChaRng>) -> Result<Scen
         2,
         &mut wallet1,
         &mut wallet3,
-        &leader2 as &dyn FragmentNode,
+        &leader2,
         1_000.into(),
     )?;
 
@@ -585,7 +584,7 @@ pub fn custom_network_disruption(mut context: Context<ChaChaRng>) -> Result<Scen
         2,
         &mut wallet1,
         &mut wallet3,
-        &leader3 as &dyn FragmentNode,
+        &leader3,
         1_000.into(),
     )?;
 
@@ -602,12 +601,12 @@ pub fn custom_network_disruption(mut context: Context<ChaChaRng>) -> Result<Scen
         2,
         &mut wallet1,
         &mut wallet3,
-        &passive as &dyn FragmentNode,
+        &passive,
         1_000.into(),
     )?;
 
     utils::measure_and_log_sync_time(
-        vec![&leader1, &leader2, &leader3, &leader4, &leader5, &passive],
+        vec![&leader1, &leader3, &leader4, &leader5, &passive],
         SyncWaitParams::nodes_restart(5).into(),
         "custom_network_disruption",
         MeasurementReportInterval::Standard,
@@ -617,7 +616,6 @@ pub fn custom_network_disruption(mut context: Context<ChaChaRng>) -> Result<Scen
     leader5.shutdown()?;
     leader4.shutdown()?;
     leader3.shutdown()?;
-    leader2.shutdown()?;
     leader1.shutdown()?;
     controller.finalize();
     Ok(ScenarioResult::passed())
@@ -690,7 +688,7 @@ pub fn mesh_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
         10,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 
@@ -701,7 +699,7 @@ pub fn mesh_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
         10,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 
@@ -711,7 +709,7 @@ pub fn mesh_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
         10,
         &mut wallet1,
         &mut wallet2,
-        &leader1 as &dyn FragmentNode,
+        &leader1,
         1_000.into(),
     )?;
 

--- a/testing/jormungandr-scenario-tests/src/test/non_functional/soak.rs
+++ b/testing/jormungandr-scenario-tests/src/test/non_functional/soak.rs
@@ -6,7 +6,7 @@ use crate::{
     test::Result,
     Context,
 };
-use jormungandr_testing_utils::testing::{FragmentNode, FragmentVerifier};
+use jormungandr_testing_utils::testing::FragmentVerifier;
 use rand_chacha::ChaChaRng;
 use std::time::{Duration, SystemTime};
 
@@ -106,84 +106,28 @@ pub fn relay_soak(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     let fragment_verifier = FragmentVerifier;
 
     loop {
-        let check1 = fragment_sender.send_transaction(
-            &mut wallet1,
-            &wallet2,
-            &leader1 as &dyn FragmentNode,
-            1_000.into(),
-        )?;
-        let check2 = fragment_sender.send_transaction(
-            &mut wallet2,
-            &wallet1,
-            &leader2 as &dyn FragmentNode,
-            1_000.into(),
-        )?;
-        let check3 = fragment_sender.send_transaction(
-            &mut wallet3,
-            &wallet4,
-            &leader3 as &dyn FragmentNode,
-            1_000.into(),
-        )?;
-        let check4 = fragment_sender.send_transaction(
-            &mut wallet4,
-            &wallet3,
-            &leader4 as &dyn FragmentNode,
-            1_000.into(),
-        )?;
-        let check5 = fragment_sender.send_transaction(
-            &mut wallet5,
-            &wallet6,
-            &leader5 as &dyn FragmentNode,
-            1_000.into(),
-        )?;
-        let check6 = fragment_sender.send_transaction(
-            &mut wallet6,
-            &wallet1,
-            &leader6 as &dyn FragmentNode,
-            1_000.into(),
-        )?;
-        let check7 = fragment_sender.send_transaction(
-            &mut wallet7,
-            &wallet6,
-            &leader7 as &dyn FragmentNode,
-            1_000.into(),
-        )?;
+        let check1 =
+            fragment_sender.send_transaction(&mut wallet1, &wallet2, &leader1, 1_000.into())?;
+        let check2 =
+            fragment_sender.send_transaction(&mut wallet2, &wallet1, &leader2, 1_000.into())?;
+        let check3 =
+            fragment_sender.send_transaction(&mut wallet3, &wallet4, &leader3, 1_000.into())?;
+        let check4 =
+            fragment_sender.send_transaction(&mut wallet4, &wallet3, &leader4, 1_000.into())?;
+        let check5 =
+            fragment_sender.send_transaction(&mut wallet5, &wallet6, &leader5, 1_000.into())?;
+        let check6 =
+            fragment_sender.send_transaction(&mut wallet6, &wallet1, &leader6, 1_000.into())?;
+        let check7 =
+            fragment_sender.send_transaction(&mut wallet7, &wallet6, &leader7, 1_000.into())?;
 
-        fragment_verifier.wait_and_verify_is_in_block(
-            Duration::from_secs(2),
-            check1,
-            &leader1 as &dyn FragmentNode,
-        )?;
-        fragment_verifier.wait_and_verify_is_in_block(
-            Duration::from_secs(2),
-            check2,
-            &leader2 as &dyn FragmentNode,
-        )?;
-        fragment_verifier.wait_and_verify_is_in_block(
-            Duration::from_secs(2),
-            check3,
-            &leader3 as &dyn FragmentNode,
-        )?;
-        fragment_verifier.wait_and_verify_is_in_block(
-            Duration::from_secs(2),
-            check4,
-            &leader4 as &dyn FragmentNode,
-        )?;
-        fragment_verifier.wait_and_verify_is_in_block(
-            Duration::from_secs(2),
-            check5,
-            &leader5 as &dyn FragmentNode,
-        )?;
-        fragment_verifier.wait_and_verify_is_in_block(
-            Duration::from_secs(2),
-            check6,
-            &leader6 as &dyn FragmentNode,
-        )?;
-        fragment_verifier.wait_and_verify_is_in_block(
-            Duration::from_secs(2),
-            check7,
-            &leader7 as &dyn FragmentNode,
-        )?;
+        fragment_verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check1, &leader1)?;
+        fragment_verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check2, &leader2)?;
+        fragment_verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check3, &leader3)?;
+        fragment_verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check4, &leader4)?;
+        fragment_verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check5, &leader5)?;
+        fragment_verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check6, &leader6)?;
+        fragment_verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check7, &leader7)?;
 
         wallet1.confirm_transaction();
         wallet2.confirm_transaction();

--- a/testing/jormungandr-testing-utils/src/testing/fragments/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/mod.rs
@@ -2,6 +2,7 @@ pub use self::{
     initial_certificates::{signed_delegation_cert, signed_stake_pool_cert},
     node::{FragmentNode, FragmentNodeError, MemPoolCheck},
     sender::{FragmentSender, FragmentSenderError},
+    setup::FragmentSenderSetup,
     transaction::transaction_to,
     verifier::{FragmentVerifier, FragmentVerifierError},
 };
@@ -24,6 +25,7 @@ use thiserror::Error;
 mod initial_certificates;
 mod node;
 mod sender;
+mod setup;
 mod transaction;
 mod verifier;
 

--- a/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
@@ -1,61 +1,59 @@
-use chain_impl_mockchain::{
-    fee::LinearFee,
-    fragment::{Fragment, FragmentId},
+use crate::{
+    testing::{
+        assure_node_in_sync,
+        fragments::node::{FragmentNode, MemPoolCheck},
+        FragmentSenderSetup, FragmentVerifier, SyncNode, SyncNodeError, SyncWaitParams,
+    },
+    wallet::Wallet,
 };
+use chain_impl_mockchain::{fee::LinearFee, fragment::Fragment};
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{FragmentStatus, Value},
 };
 
-use crate::{
-    testing::{
-        fragments::node::{FragmentNode, MemPoolCheck},
-        FragmentVerifier, FragmentVerifierError,
-    },
-    wallet::Wallet,
-};
-
-use std::{thread, time::Duration};
+use std::time::Duration;
 
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum FragmentSenderError {
-    #[error("fragment sent to node: {alias} is not in block '{status:?}'. logs: {logs}")]
+    #[error("fragment sent to node: {alias} is not in block due to  '{reason}'. logs: {logs}")]
     FragmentNotInBlock {
         alias: String,
-        status: FragmentStatus,
+        reason: String,
         logs: String,
     },
-    #[error("transaction already balanced")]
-    FragmentIsPendingForTooLong,
     #[error(
-        "fragment sent to node: {alias} is not in in fragment pool :({fragment_id}). logs: {logs}"
+        "Too many attempts failed ({attempts}) while trying to send fragment to node: {alias}"
     )]
-    FragmentNoInMemPoolLogs {
-        alias: String,
-        fragment_id: FragmentId,
-        logs: String,
-    },
+    TooManyAttemptsFailed { attempts: u8, alias: String },
     #[error("fragment verifier error")]
     FragmentVerifierError(#[from] super::FragmentVerifierError),
     #[error("cannot send fragment")]
     SendFragmentError(#[from] super::node::FragmentNodeError),
+    #[error("cannot sync node before sending fragment")]
+    SyncNodeError(#[from] crate::testing::SyncNodeError),
     #[error("wallet error")]
     WalletError(#[from] crate::wallet::WalletError),
 }
 
-pub struct FragmentSender {
+pub struct FragmentSender<'a> {
     block0_hash: Hash,
     fees: LinearFee,
+    setup: FragmentSenderSetup<'a>,
 }
 
-impl FragmentSender {
-    pub fn new(block0_hash: Hash, fees: LinearFee) -> Self {
-        Self { block0_hash, fees }
+impl<'a> FragmentSender<'a> {
+    pub fn new(block0_hash: Hash, fees: LinearFee, setup: FragmentSenderSetup<'a>) -> Self {
+        Self {
+            block0_hash,
+            fees,
+            setup,
+        }
     }
 
-    pub fn send_transaction<A: FragmentNode + ?Sized>(
+    pub fn send_transaction<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         to: &Wallet,
@@ -64,10 +62,10 @@ impl FragmentSender {
     ) -> Result<MemPoolCheck, FragmentSenderError> {
         let address = to.address();
         let fragment = from.transaction_to(&self.block0_hash, &self.fees, address, value)?;
-        Ok(via.send_fragment(fragment)?)
+        self.send_fragment(fragment, via)
     }
 
-    pub fn send_transactions_ignore_errors<A: FragmentNode + ?Sized>(
+    pub fn send_transactions<A: FragmentNode + SyncNode + Sized>(
         &self,
         n: u32,
         mut wallet1: &mut Wallet,
@@ -76,16 +74,12 @@ impl FragmentSender {
         value: Value,
     ) -> Result<(), FragmentSenderError> {
         for _ in 0..n {
-            let check = self.send_transaction(&mut wallet1, &wallet2, node, value);
-            if let Err(err) = check {
-                println!("ignoring error : {:?}", err);
-            }
-            thread::sleep(Duration::from_secs(1));
+            self.send_transaction(&mut wallet1, &wallet2, node, value)?;
         }
         Ok(())
     }
 
-    pub fn send_transactions_round_trip<A: FragmentNode + ?Sized>(
+    pub fn send_transactions_round_trip<A: FragmentNode + SyncNode + Sized>(
         &self,
         n: u32,
         mut wallet1: &mut Wallet,
@@ -93,26 +87,81 @@ impl FragmentSender {
         node: &A,
         value: Value,
     ) -> Result<(), FragmentSenderError> {
-        let verifier = FragmentVerifier;
-
         for _ in 0..n {
-            let check = self.send_transaction(&mut wallet1, &wallet2, node, value.clone())?;
-            verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check, node)?;
+            self.send_transaction(&mut wallet1, &wallet2, node, value.clone())?;
             wallet1.confirm_transaction();
-            let check = self.send_transaction(&mut wallet2, &wallet1, node, value.clone())?;
-            verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check, node)?;
+            self.send_transaction(&mut wallet2, &wallet1, node, value.clone())?;
             wallet2.confirm_transaction();
         }
         Ok(())
     }
 
-    pub fn send_fragment_and_verify_is_in_block<A: FragmentNode + ?Sized>(
+    fn verify<A: FragmentNode + SyncNode + Sized>(
+        &self,
+        check: &MemPoolCheck,
+        node: &A,
+    ) -> Result<(), FragmentSenderError> {
+        let verifier = FragmentVerifier;
+        match verifier.wait_fragment(Duration::from_secs(2), check.clone(), node)? {
+            FragmentStatus::Rejected { reason } => Err(FragmentSenderError::FragmentNotInBlock {
+                alias: FragmentNode::alias(node).to_string(),
+                reason: reason,
+                logs: FragmentNode::log_content(node),
+            }),
+            FragmentStatus::InABlock { .. } => Ok(()),
+            _ => unimplemented!(),
+        }
+    }
+
+    pub fn send_fragment<A: FragmentNode + SyncNode + Sized>(
         &self,
         fragment: Fragment,
         node: &A,
-    ) -> Result<(), FragmentVerifierError> {
-        let verifier = FragmentVerifier;
-        let check = node.send_fragment(fragment)?;
-        verifier.wait_and_verify_is_in_block(Duration::from_secs(2), check, node)
+    ) -> Result<MemPoolCheck, FragmentSenderError> {
+        self.wait_for_node_sync_if_enabled(node)
+            .map_err(|e| FragmentSenderError::SyncNodeError(e))?;
+        for _ in 0..self.setup.attempts_count() {
+            let check = node
+                .send_fragment(fragment.clone())
+                .map_err(|e| FragmentSenderError::SendFragmentError(e))?;
+            if self.setup.no_verify() {
+                return Ok(check);
+            }
+
+            if let Err(err) = self.verify(&check, node) {
+                if self.setup.ignore_any_errors() {
+                    println!("Ignoring error: {:?}", err);
+                    return Ok(check);
+                }
+                println!(
+                    "Error while sending fragment {:?}. Retrying if possible...",
+                    err
+                );
+                continue;
+            }
+            return Ok(check);
+        }
+
+        Err(FragmentSenderError::TooManyAttemptsFailed {
+            attempts: self.setup.attempts_count(),
+            alias: FragmentNode::alias(node).to_string(),
+        })
+    }
+
+    fn wait_for_node_sync_if_enabled<A: FragmentNode + SyncNode + Sized>(
+        &self,
+        node: &A,
+    ) -> Result<(), SyncNodeError> {
+        if self.setup.no_sync_nodes() {
+            return Ok(());
+        }
+
+        let nodes_length = (self.setup.sync_nodes().len() + 1) as u64;
+        assure_node_in_sync(
+            node,
+            self.setup.sync_nodes(),
+            SyncWaitParams::network_size(nodes_length, 2).into(),
+            "waiting for node to be in sync before sending transaction",
+        )
     }
 }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
@@ -1,0 +1,75 @@
+use crate::testing::SyncNode;
+
+pub struct FragmentSenderSetup<'a> {
+    pub resend_on_error: Option<u8>,
+    pub sync_nodes: Vec<&'a dyn SyncNode>,
+    pub ignore_any_errors: bool,
+    pub no_verify: bool,
+}
+
+impl<'a> FragmentSenderSetup<'a> {
+    pub const NO_VERIFY: FragmentSenderSetup<'a> = FragmentSenderSetup {
+        resend_on_error: None,
+        sync_nodes: vec![],
+        ignore_any_errors: false,
+        no_verify: true,
+    };
+
+    pub const RESEND_3_TIMES: FragmentSenderSetup<'a> = FragmentSenderSetup {
+        resend_on_error: Some(3),
+        sync_nodes: vec![],
+        ignore_any_errors: false,
+        no_verify: false,
+    };
+
+    pub fn resend_3_times_and_sync_with(sync_nodes: Vec<&'a dyn SyncNode>) -> Self {
+        Self {
+            resend_on_error: Some(3),
+            sync_nodes: sync_nodes,
+            ignore_any_errors: false,
+            no_verify: false,
+        }
+    }
+
+    pub fn new() -> Self {
+        Self {
+            resend_on_error: None,
+            sync_nodes: Vec::new(),
+            ignore_any_errors: false,
+            no_verify: false,
+        }
+    }
+
+    pub fn resend_on_error(&self) -> Option<u8> {
+        self.resend_on_error.clone()
+    }
+
+    pub fn sync_nodes(&self) -> Vec<&'a dyn SyncNode> {
+        self.sync_nodes.clone()
+    }
+
+    pub fn no_sync_nodes(&self) -> bool {
+        self.sync_nodes().len() == 0
+    }
+
+    pub fn ignore_any_errors(&self) -> bool {
+        self.ignore_any_errors
+    }
+
+    pub fn attempts_count(&self) -> u8 {
+        match self.resend_on_error {
+            Some(resend_counter) => resend_counter + 1,
+            None => 1,
+        }
+    }
+
+    pub fn no_verify(&self) -> bool {
+        self.no_verify
+    }
+}
+
+impl<'a> Default for FragmentSenderSetup<'a> {
+    fn default() -> FragmentSenderSetup<'a> {
+        FragmentSenderSetup::new()
+    }
+}

--- a/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
@@ -10,14 +10,14 @@ pub struct FragmentSenderSetup<'a> {
 impl<'a> FragmentSenderSetup<'a> {
     pub const NO_VERIFY: FragmentSenderSetup<'a> = FragmentSenderSetup {
         resend_on_error: None,
-        sync_nodes: vec![],
+        sync_nodes: Vec::new(),
         ignore_any_errors: false,
         no_verify: true,
     };
 
     pub const RESEND_3_TIMES: FragmentSenderSetup<'a> = FragmentSenderSetup {
         resend_on_error: Some(3),
-        sync_nodes: vec![],
+        sync_nodes: Vec::new(),
         ignore_any_errors: false,
         no_verify: false,
     };

--- a/testing/jormungandr-testing-utils/src/testing/fragments/verifier.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/verifier.rs
@@ -29,8 +29,8 @@ pub enum FragmentVerifierError {
         fragment_id: FragmentId,
         logs: String,
     },
-    #[error("fragment verifier error")]
-    FragmentVerifierError(#[from] FragmentNodeError),
+    #[error("fragment node error")]
+    FragmentNodeError(#[from] FragmentNodeError),
 }
 
 pub struct FragmentVerifier;

--- a/testing/jormungandr-testing-utils/src/testing/measurement/benchmark/speed_benchmark.rs
+++ b/testing/jormungandr-testing-utils/src/testing/measurement/benchmark/speed_benchmark.rs
@@ -70,6 +70,10 @@ impl SpeedBenchmarkRun {
             false
         }
     }
+
+    pub fn definition(&self) -> &SpeedBenchmarkDef {
+        &self.definition
+    }
 }
 
 pub struct SpeedBenchmarkFinish {

--- a/testing/jormungandr-testing-utils/src/testing/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/mod.rs
@@ -4,13 +4,14 @@ pub mod github;
 /// Module contains cross project test utils
 mod measurement;
 pub mod network_builder;
+mod sync;
 mod web;
 
 pub use archive::decompress;
 pub use fragments::{
     signed_delegation_cert, signed_stake_pool_cert, FragmentBuilder, FragmentBuilderError,
-    FragmentNode, FragmentNodeError, FragmentSender, FragmentSenderError, FragmentVerifier,
-    FragmentVerifierError, MemPoolCheck,
+    FragmentNode, FragmentNodeError, FragmentSender, FragmentSenderError, FragmentSenderSetup,
+    FragmentVerifier, FragmentVerifierError, MemPoolCheck,
 };
 pub use measurement::{
     benchmark_consumption, benchmark_efficiency, benchmark_endurance, benchmark_speed,
@@ -18,4 +19,5 @@ pub use measurement::{
     EnduranceBenchmarkDef, EnduranceBenchmarkFinish, EnduranceBenchmarkRun, ResourcesUsage, Speed,
     SpeedBenchmarkDef, SpeedBenchmarkFinish, SpeedBenchmarkRun, Thresholds, Timestamp,
 };
+pub use sync::{assure_node_in_sync, SyncNode, SyncNodeError, SyncWaitParams};
 pub use web::download_file;

--- a/testing/jormungandr-testing-utils/src/testing/sync/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/sync/mod.rs
@@ -1,0 +1,93 @@
+use chain_impl_mockchain::key::Hash;
+use std::{fmt, time::Duration};
+use thiserror::Error;
+
+use crate::testing::measurement::{benchmark_speed, Speed, Thresholds};
+
+mod wait;
+pub use wait::SyncWaitParams;
+
+pub trait SyncNode {
+    fn alias(&self) -> &str;
+    fn last_block_height(&self) -> u32;
+    fn log_stats(&self);
+    fn all_blocks_hashes(&self) -> Vec<Hash>;
+    fn log_content(&self) -> String;
+    fn get_lines_with_error_and_invalid(&self) -> Vec<String>;
+    fn is_running(&self) -> bool;
+}
+
+#[derive(Debug, Clone)]
+pub struct SyncNodeRecord {
+    pub alias: String,
+    pub block_height: u32,
+}
+
+impl fmt::Display for SyncNodeRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "({} -> {})", self.alias, self.block_height)
+    }
+}
+
+impl SyncNodeRecord {
+    pub fn new(alias: String, block_height: u32) -> Self {
+        Self {
+            alias,
+            block_height,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SyncNodeError {
+    #[error(
+        "Timeout exceeded '{timeout:?}'. Target node: {target_node}. Sync nodes: {sync_nodes:?}"
+    )]
+    TimeoutWhenSyncingTargetNode {
+        timeout: Duration,
+        target_node: SyncNodeRecord,
+        sync_nodes: Vec<SyncNodeRecord>,
+    },
+}
+
+pub fn assure_node_in_sync(
+    target_node: &dyn SyncNode,
+    other_nodes: Vec<&dyn SyncNode>,
+    sync_wait: Thresholds<Speed>,
+    info: &str,
+) -> Result<(), SyncNodeError> {
+    let benchmark = benchmark_speed(info.to_owned())
+        .with_thresholds(sync_wait)
+        .start();
+
+    while !benchmark.timeout_exceeded() {
+        let target_node_block_height = target_node.last_block_height();
+
+        let max_block_height: u32 = other_nodes
+            .iter()
+            .map(|node| node.last_block_height())
+            .max()
+            .expect("unable to retrieve block height from sync nodes");
+
+        if target_node_block_height >= max_block_height {
+            benchmark.stop();
+            return Ok(());
+        }
+    }
+
+    let other_nodes_records: Vec<SyncNodeRecord> = other_nodes
+        .iter()
+        .map(|x| SyncNodeRecord::new(x.alias().to_string(), x.last_block_height()))
+        .collect();
+
+    let target_node = SyncNodeRecord::new(
+        target_node.alias().to_string(),
+        target_node.last_block_height(),
+    );
+
+    Err(SyncNodeError::TimeoutWhenSyncingTargetNode {
+        target_node: target_node,
+        sync_nodes: other_nodes_records,
+        timeout: benchmark.definition().thresholds().unwrap().max().into(),
+    })
+}

--- a/testing/jormungandr-testing-utils/src/testing/sync/wait.rs
+++ b/testing/jormungandr-testing-utils/src/testing/sync/wait.rs
@@ -1,4 +1,4 @@
-use jormungandr_testing_utils::testing::{Speed, Thresholds};
+use crate::testing::{Speed, Thresholds};
 use std::time::Duration;
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Implemented resend mechanism for FragmentSender struct as well as optional node synchronization before sending fragments. Those features can stabilize private scenario tests which suffers from `Account with invalid signature` or forever pending fragment.
Added setup which can control fragment node behavoir