### PR TITLE
Add vote plan proposal certificates to explorer

### DIFF
--- a/jormungandr/src/explorer/graphql/certificates.rs
+++ b/jormungandr/src/explorer/graphql/certificates.rs
@@ -1,0 +1,257 @@
+use super::error::ErrorKind;
+use chain_impl_mockchain::certificate;
+use juniper::graphql_union;
+use std::convert::TryFrom;
+
+use super::scalars::{PoolId, PublicKey, TimeOffsetSeconds, VotePlanId};
+use super::{Address, BlockDate, Context, ExplorerAddress, Pool, Proposal, TaxType};
+use juniper::FieldResult;
+
+// interface for grouping certificates as a graphl union
+pub enum Certificate {
+    StakeDelegation(StakeDelegation),
+    OwnerStakeDelegation(OwnerStakeDelegation),
+    PoolRegistration(PoolRegistration),
+    PoolRetirement(PoolRetirement),
+    PoolUpdate(PoolUpdate),
+    VotePlan(VotePlan),
+    VoteCast(VoteCast),
+}
+
+pub struct StakeDelegation(certificate::StakeDelegation);
+
+pub struct PoolRegistration(certificate::PoolRegistration);
+
+pub struct OwnerStakeDelegation(certificate::OwnerStakeDelegation);
+
+/// Retirement info for a pool
+pub struct PoolRetirement(certificate::PoolRetirement);
+
+pub struct PoolUpdate(certificate::PoolUpdate);
+
+graphql_union!(Certificate: Context |&self| {
+    // the left hand side of the `instance_resolvers` match-like pub structure is the one
+    // that's used to match in the graphql query with the `__typename` field
+    instance_resolvers: |_| {
+        &StakeDelegation => match *self { Certificate::StakeDelegation(ref c) => Some(c), _ => None },
+        &OwnerStakeDelegation => match *self { Certificate::OwnerStakeDelegation(ref c) => Some(c), _ => None },
+        &PoolRegistration => match *self { Certificate::PoolRegistration(ref c) => Some(c), _ => None },
+        &PoolUpdate => match *self { Certificate::PoolUpdate(ref c) => Some(c), _ => None},
+        &PoolRetirement => match *self { Certificate::PoolRetirement(ref c) => Some(c), _ => None},
+        &VotePlan => match *self { Certificate::VotePlan(ref c) => Some(c), _ => None},
+        &VoteCast => match *self { Certificate::VoteCast(ref c) => Some(c), _ => None},
+    }
+});
+
+#[juniper::object(
+    Context = Context,
+)]
+impl StakeDelegation {
+    // FIXME: Maybe a new Account type would be better?
+    pub fn account(&self, context: &Context) -> FieldResult<Address> {
+        let discrimination = context.db.blockchain_config.discrimination;
+        self.0
+            .account_id
+            .to_single_account()
+            .ok_or_else(||
+                // TODO: Multisig address?
+                ErrorKind::Unimplemented.into())
+            .map(|single| {
+                chain_addr::Address(discrimination, chain_addr::Kind::Account(single.into()))
+            })
+            .map(|addr| Address::from(&ExplorerAddress::New(addr)))
+    }
+
+    pub fn pools(&self, context: &Context) -> Vec<Pool> {
+        use chain_impl_mockchain::account::DelegationType;
+        use std::iter::FromIterator as _;
+
+        match self.0.get_delegation_type() {
+            DelegationType::NonDelegated => vec![],
+            DelegationType::Full(id) => vec![Pool::from_valid_id(id.clone())],
+            DelegationType::Ratio(delegation_ratio) => Vec::from_iter(
+                delegation_ratio
+                    .pools()
+                    .iter()
+                    .cloned()
+                    .map(|(p, _)| Pool::from_valid_id(p)),
+            ),
+        }
+    }
+}
+
+#[juniper::object(
+    Context = Context,
+)]
+impl PoolRegistration {
+    pub fn pool(&self, context: &Context) -> Pool {
+        Pool::from_valid_id(self.0.to_id())
+    }
+
+    /// Beginning of validity for this pool, this is used
+    /// to keep track of the period of the expected key and the expiry
+    pub fn start_validity(&self) -> TimeOffsetSeconds {
+        self.0.start_validity.into()
+    }
+
+    /// Management threshold for owners, this need to be <= #owners and > 0
+    pub fn management_threshold(&self) -> i32 {
+        // XXX: u8 fits in i32, but maybe some kind of custom scalar is better?
+        self.0.management_threshold().into()
+    }
+
+    /// Owners of this pool
+    pub fn owners(&self) -> Vec<PublicKey> {
+        self.0.owners.iter().map(PublicKey::from).collect()
+    }
+
+    pub fn operators(&self) -> Vec<PublicKey> {
+        self.0.operators.iter().map(PublicKey::from).collect()
+    }
+
+    pub fn rewards(&self) -> TaxType {
+        TaxType(self.0.rewards)
+    }
+
+    /// Reward account
+    pub fn reward_account(&self, context: &Context) -> Option<Address> {
+        use chain_impl_mockchain::transaction::AccountIdentifier;
+        let discrimination = context.db.blockchain_config.discrimination;
+
+        // FIXME: Move this transformation to a point earlier
+
+        self.0
+            .reward_account
+            .clone()
+            .map(|acc_id| match acc_id {
+                AccountIdentifier::Single(d) => ExplorerAddress::New(chain_addr::Address(
+                    discrimination,
+                    chain_addr::Kind::Account(d.into()),
+                )),
+                AccountIdentifier::Multi(d) => {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&d.as_ref()[0..32]);
+                    ExplorerAddress::New(chain_addr::Address(
+                        discrimination,
+                        chain_addr::Kind::Multisig(bytes),
+                    ))
+                }
+            })
+            .map(|explorer_address| Address {
+                id: explorer_address,
+            })
+    }
+
+    // Genesis Praos keys
+    // pub keys: GenesisPraosLeader,
+}
+
+#[juniper::object(
+    Context = Context,
+)]
+impl OwnerStakeDelegation {
+    fn pools(&self) -> Vec<Pool> {
+        use chain_impl_mockchain::account::DelegationType;
+        use std::iter::FromIterator as _;
+
+        match self.0.get_delegation_type() {
+            DelegationType::NonDelegated => vec![],
+            DelegationType::Full(id) => vec![Pool::from_valid_id(id.clone())],
+            DelegationType::Ratio(delegation_ratio) => Vec::from_iter(
+                delegation_ratio
+                    .pools()
+                    .iter()
+                    .cloned()
+                    .map(|(p, _)| Pool::from_valid_id(p)),
+            ),
+        }
+    }
+}
+
+#[juniper::object(
+    Context = Context,
+)]
+impl PoolRetirement {
+    pub fn pool_id(&self) -> PoolId {
+        PoolId(format!("{}", self.0.pool_id))
+    }
+
+    pub fn retirement_time(&self) -> TimeOffsetSeconds {
+        self.0.retirement_time.into()
+    }
+}
+
+#[juniper::object(
+    Context = Context,
+)]
+impl PoolUpdate {
+    pub fn pool_id(&self) -> PoolId {
+        PoolId(format!("{}", self.0.pool_id))
+    }
+
+    pub fn start_validity(&self) -> TimeOffsetSeconds {
+        self.0.new_pool_reg.start_validity.into()
+    }
+
+    // TODO: Previous keys?
+    // TODO: Updated keys?
+}
+
+/*------------------------------*/
+/*------- Conversions ---------*/
+/*----------------------------*/
+
+impl TryFrom<chain_impl_mockchain::certificate::Certificate> for Certificate {
+    type Error = super::error::Error;
+    fn try_from(
+        original: chain_impl_mockchain::certificate::Certificate,
+    ) -> Result<Certificate, Self::Error> {
+        match original {
+            certificate::Certificate::StakeDelegation(c) => {
+                Ok(Certificate::StakeDelegation(StakeDelegation(c)))
+            }
+            certificate::Certificate::OwnerStakeDelegation(c) => {
+                Ok(Certificate::OwnerStakeDelegation(OwnerStakeDelegation(c)))
+            }
+            certificate::Certificate::PoolRegistration(c) => {
+                Ok(Certificate::PoolRegistration(PoolRegistration(c)))
+            }
+            certificate::Certificate::PoolRetirement(c) => {
+                Ok(Certificate::PoolRetirement(PoolRetirement(c)))
+            }
+            certificate::Certificate::PoolUpdate(c) => Ok(Certificate::PoolUpdate(PoolUpdate(c))),
+            certificate::Certificate::VotePlan(c) => Ok(Certificate::VotePlan(VotePlan(c))),
+            certificate::Certificate::VoteCast(c) => Ok(Certificate::VoteCast(VoteCast(c))),
+        }
+    }
+}
+
+impl From<certificate::StakeDelegation> for StakeDelegation {
+    fn from(delegation: certificate::StakeDelegation) -> StakeDelegation {
+        StakeDelegation(delegation)
+    }
+}
+
+impl From<certificate::OwnerStakeDelegation> for OwnerStakeDelegation {
+    fn from(owner_stake_delegation: certificate::OwnerStakeDelegation) -> OwnerStakeDelegation {
+        OwnerStakeDelegation(owner_stake_delegation)
+    }
+}
+
+impl From<certificate::PoolRegistration> for PoolRegistration {
+    fn from(registration: certificate::PoolRegistration) -> PoolRegistration {
+        PoolRegistration(registration)
+    }
+}
+
+impl From<certificate::PoolRetirement> for PoolRetirement {
+    fn from(pool_retirement: certificate::PoolRetirement) -> PoolRetirement {
+        PoolRetirement(pool_retirement)
+    }
+}
+
+impl From<certificate::PoolUpdate> for PoolUpdate {
+    fn from(pool_update: certificate::PoolUpdate) -> PoolUpdate {
+        PoolUpdate(pool_update)
+    }
+}

--- a/jormungandr/src/explorer/graphql/certificates.rs
+++ b/jormungandr/src/explorer/graphql/certificates.rs
@@ -29,6 +29,10 @@ pub struct PoolRetirement(certificate::PoolRetirement);
 
 pub struct PoolUpdate(certificate::PoolUpdate);
 
+pub struct VotePlan(certificate::VotePlan);
+
+pub struct VoteCast(certificate::VoteCast);
+
 graphql_union!(Certificate: Context |&self| {
     // the left hand side of the `instance_resolvers` match-like pub structure is the one
     // that's used to match in the graphql query with the `__typename` field
@@ -197,6 +201,46 @@ impl PoolUpdate {
     // TODO: Updated keys?
 }
 
+#[juniper::object(
+    Context = Context,
+)]
+impl VotePlan {
+    /// the vote start validity
+    pub fn vote_start(&self) -> BlockDate {
+        self.0.vote_start().into()
+    }
+
+    /// the duration within which it is possible to vote for one of the proposals
+    /// of this voting plan.
+    pub fn vote_end(&self) -> BlockDate {
+        self.0.vote_end().into()
+    }
+
+    /// the committee duration is the time allocated to the committee to open
+    /// the ballots and publish the results on chain
+    pub fn committee_end(&self) -> BlockDate {
+        self.0.committee_end().into()
+    }
+
+    /// the proposals to vote for
+    pub fn proposals(&self) -> Vec<Proposal> {
+        self.0.proposals().iter().cloned().map(Proposal).collect()
+    }
+}
+
+#[juniper::object(
+    Context = Context,
+)]
+impl VoteCast {
+    pub fn vote_plan(&self) -> VotePlanId {
+        self.0.vote_plan().clone().into()
+    }
+
+    pub fn proposal_index(&self) -> i32 {
+        self.0.proposal_index() as i32
+    }
+}
+
 /*------------------------------*/
 /*------- Conversions ---------*/
 /*----------------------------*/
@@ -253,5 +297,17 @@ impl From<certificate::PoolRetirement> for PoolRetirement {
 impl From<certificate::PoolUpdate> for PoolUpdate {
     fn from(pool_update: certificate::PoolUpdate) -> PoolUpdate {
         PoolUpdate(pool_update)
+    }
+}
+
+impl From<certificate::VotePlan> for VotePlan {
+    fn from(vote_plan: certificate::VotePlan) -> VotePlan {
+        VotePlan(vote_plan)
+    }
+}
+
+impl From<certificate::VoteCast> for VoteCast {
+    fn from(vote_cast: certificate::VoteCast) -> VoteCast {
+        VoteCast(vote_cast)
     }
 }

--- a/jormungandr/src/explorer/graphql/connections.rs
+++ b/jormungandr/src/explorer/graphql/connections.rs
@@ -158,7 +158,7 @@ pub trait Edge {
     type Node;
     fn new(node: Self::Node, cursor: IndexCursor) -> Self;
 
-    fn cursor<'a>(&'a self) -> &'a IndexCursor;
+    fn cursor(&self) -> &IndexCursor;
 }
 
 pub struct ValidatedPaginationArguments<I> {
@@ -239,7 +239,7 @@ where
         let end_cursor = edges
             .last()
             .map(|e| e.cursor().clone())
-            .or(start_cursor.clone());
+            .or_else(|| start_cursor.clone());
 
         Ok(Connection {
             edges,
@@ -289,7 +289,7 @@ impl Edge for BlockEdge {
         }
     }
 
-    fn cursor<'a>(&'a self) -> &'a IndexCursor {
+    fn cursor(&self) -> &IndexCursor {
         &self.cursor
     }
 }
@@ -300,7 +300,7 @@ impl Edge for PoolEdge {
         PoolEdge { node, cursor }
     }
 
-    fn cursor<'a>(&'a self) -> &'a IndexCursor {
+    fn cursor(&self) -> &IndexCursor {
         &self.cursor
     }
 }

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -520,11 +520,16 @@ impl Ratio {
     }
 }
 
+pub struct Proposal(certificate::Proposal);
 
 #[juniper::object(
     Context = Context,
 )]
+impl Proposal {
+    pub fn external_id(&self) -> ExternalProposalId {
+        ExternalProposalId(self.0.external_id().to_string())
     }
+    // TODO: options
 }
 
 #[derive(Clone)]

--- a/jormungandr/src/explorer/graphql/scalars.rs
+++ b/jormungandr/src/explorer/graphql/scalars.rs
@@ -2,7 +2,6 @@ use super::error::ErrorKind;
 use crate::blockcfg;
 use chain_crypto::bech32::Bech32;
 use chain_impl_mockchain::value;
-
 use juniper::{ParseScalarResult, ParseScalarValue};
 use std::convert::{TryFrom, TryInto};
 

--- a/jormungandr/src/explorer/graphql/scalars.rs
+++ b/jormungandr/src/explorer/graphql/scalars.rs
@@ -40,6 +40,12 @@ pub struct TimeOffsetSeconds(pub String);
 #[derive(juniper::GraphQLScalarValue)]
 pub struct NonZero(pub String);
 
+#[derive(juniper::GraphQLScalarValue)]
+pub struct VotePlanId(pub String);
+
+#[derive(juniper::GraphQLScalarValue)]
+pub struct ExternalProposalId(pub String);
+
 // u32 should be enough to count blocks and transactions (the only two cases for now)
 #[derive(Clone)]
 pub struct IndexCursor(pub u64);
@@ -143,6 +149,12 @@ impl From<u64> for PoolCount {
 impl From<u32> for IndexCursor {
     fn from(number: u32) -> IndexCursor {
         IndexCursor(number.into())
+    }
+}
+
+impl From<chain_impl_mockchain::certificate::VotePlanId> for VotePlanId {
+    fn from(id: chain_impl_mockchain::certificate::VotePlanId) -> VotePlanId {
+        VotePlanId(id.to_string())
     }
 }
 

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -113,84 +113,95 @@ impl ExplorerBlock {
             HashMap::<FragmentId, ExplorerTransaction>::new(),
             |mut current_block_txs, (offset, fragment)| {
                 let fragment_id = fragment.id();
+                let offset: u32 = offset.try_into().unwrap();
                 let metx = match fragment {
                     Fragment::Transaction(tx) => {
                         let tx = tx.as_slice();
                         Some(ExplorerTransaction::from(
+                            &context,
                             &fragment_id,
                             &tx,
-                            discrimination,
-                            prev_transactions,
-                            prev_blocks,
                             None,
-                            offset.try_into().unwrap(),
+                            offset,
                             &current_block_txs,
                         ))
                     }
                     Fragment::OwnerStakeDelegation(tx) => {
                         let tx = tx.as_slice();
                         Some(ExplorerTransaction::from(
+                            &context,
                             &fragment_id,
                             &tx,
-                            discrimination,
-                            prev_transactions,
-                            prev_blocks,
                             Some(Certificate::OwnerStakeDelegation(
                                 tx.payload().into_payload(),
                             )),
-                            offset.try_into().unwrap(),
+                            offset,
                             &current_block_txs,
                         ))
                     }
                     Fragment::StakeDelegation(tx) => {
                         let tx = tx.as_slice();
                         Some(ExplorerTransaction::from(
+                            &context,
                             &fragment_id,
                             &tx,
-                            discrimination,
-                            prev_transactions,
-                            prev_blocks,
                             Some(Certificate::StakeDelegation(tx.payload().into_payload())),
-                            offset.try_into().unwrap(),
+                            offset,
                             &current_block_txs,
                         ))
                     }
                     Fragment::PoolRegistration(tx) => {
                         let tx = tx.as_slice();
                         Some(ExplorerTransaction::from(
+                            &context,
                             &fragment_id,
                             &tx,
-                            discrimination,
-                            prev_transactions,
-                            prev_blocks,
                             Some(Certificate::PoolRegistration(tx.payload().into_payload())),
-                            offset.try_into().unwrap(),
+                            offset,
                             &current_block_txs,
                         ))
                     }
                     Fragment::PoolRetirement(tx) => {
                         let tx = tx.as_slice();
                         Some(ExplorerTransaction::from(
+                            &context,
                             &fragment_id,
                             &tx,
-                            discrimination,
-                            prev_transactions,
-                            prev_blocks,
                             Some(Certificate::PoolRetirement(tx.payload().into_payload())),
-                            offset.try_into().unwrap(),
+                            offset,
                             &current_block_txs,
                         ))
                     }
                     Fragment::PoolUpdate(tx) => {
                         let tx = tx.as_slice();
                         Some(ExplorerTransaction::from(
+                            &context,
                             &fragment_id,
                             &tx,
-                            discrimination,
-                            prev_transactions,
-                            prev_blocks,
                             Some(Certificate::PoolUpdate(tx.payload().into_payload())),
-                            offset.try_into().unwrap(),
+                            offset,
+                            &current_block_txs,
+                        ))
+                    }
+                    Fragment::VotePlan(tx) => {
+                        let tx = tx.as_slice();
+                        Some(ExplorerTransaction::from(
+                            &context,
+                            &fragment_id,
+                            &tx,
+                            Some(Certificate::VotePlan(tx.payload().into_payload())),
+                            offset,
+                            &current_block_txs,
+                        ))
+                    }
+                    Fragment::VoteCast(tx) => {
+                        let tx = tx.as_slice();
+                        Some(ExplorerTransaction::from(
+                            &context,
+                            &fragment_id,
+                            &tx,
+                            Some(Certificate::VoteCast(tx.payload().into_payload())),
+                            offset,
                             &current_block_txs,
                         ))
                     }
@@ -208,7 +219,7 @@ impl ExplorerBlock {
                             inputs: vec![],
                             outputs,
                             certificate: None,
-                            offset_in_block: offset.try_into().unwrap(),
+                            offset_in_block: offset,
                         })
                     }
                     _ => None,

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -154,9 +154,11 @@ impl ExplorerDB {
 
         let block = ExplorerBlock::resolve_from(
             &block0,
-            blockchain_config.discrimination,
-            &Transactions::new(),
-            &Blocks::new(),
+            indexing::ExplorerBlockBuildingContext {
+                discrimination: blockchain_config.discrimination,
+                prev_transactions: &Transactions::new(),
+                prev_blocks: &Blocks::new(),
+            },
         );
 
         let blocks = apply_block_to_blocks(Blocks::new(), &block)?;
@@ -243,8 +245,14 @@ impl ExplorerDB {
             stake_pool_blocks,
         } = previous_state.state().clone();
 
-        let explorer_block =
-            ExplorerBlock::resolve_from(&block, discrimination, &transactions, &blocks);
+        let explorer_block = ExplorerBlock::resolve_from(
+            &block,
+            indexing::ExplorerBlockBuildingContext {
+                discrimination,
+                prev_transactions: &transactions,
+                prev_blocks: &blocks,
+            },
+        );
         let (stake_pool_data, stake_pool_blocks) =
             apply_block_to_stake_pools(stake_pool_data, stake_pool_blocks, &explorer_block);
 

--- a/jormungandr/src/explorer/persistent_sequence.rs
+++ b/jormungandr/src/explorer/persistent_sequence.rs
@@ -33,3 +33,9 @@ impl<T> PersistentSequence<T> {
         self.len
     }
 }
+
+impl<T> Default for PersistentSequence<T> {
+    fn default() -> Self {
+        PersistentSequence::new()
+    }
+}


### PR DESCRIPTION
- Apply a bunch of clippy feedback to the explorer modules. Mostly clone on copy types and function calls in `or` instead of `or_else` kind of stuff.
- Add `VotePlan` and `VoteCast` as members of the graphql `Certificate` union.
- Move all the certificate code to it's own file/submodule to organize things a bit more (making the diff big), I think it's better that way, but I could move those changes to a separate PR if preferred.

This allows querying for the fields when asking for the certificate in a transaction, but there is no extra indexing for things like querying all the proposals, etc. I'm not sure what querys do we want to support.

#### In the graphql schema (only the additions)
```graphql
union Certificate = StakeDelegation | OwnerStakeDelegation | PoolRegistration | PoolUpdate | PoolRetirement | VotePlan | VoteCast

type VoteCast {
  votePlan: VotePlanId!
  proposalIndex: Int!
}

type VotePlan {
  """the vote start validity"""
  voteStart: BlockDate!

  """
  the duration within which it is possible to vote for one of the proposals
  of this voting plan.
  """
  voteEnd: BlockDate!

  """
  the committee duration is the time allocated to the committee to open
  the ballots and publish the results on chain
  """
  committeeEnd: BlockDate!

  """the proposals to vote for"""
  proposals: [Proposal!]!
}

scalar VotePlanId

```