### PR TITLE
[Tests] Private scenario network fixes pack

### DIFF
--- a/testing/jormungandr-scenario-tests/src/main.rs
+++ b/testing/jormungandr-scenario-tests/src/main.rs
@@ -71,6 +71,8 @@ struct CommandArgs {
 fn main() {
     let command_args = CommandArgs::from_args();
 
+    std::env::set_var("RUST_BACKTRACE", "full");
+
     let jormungandr = prepare_command(command_args.jormungandr);
     let jcli = prepare_command(command_args.jcli);
     let progress_bar_mode = command_args.progress_bar_mode;

--- a/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
@@ -110,6 +110,7 @@ impl ScenariosRepository {
         let scenario_to_run = scenario.method();
 
         println!("Running '{}' scenario", scenario.name());
+
         let result = std::panic::catch_unwind(|| scenario_to_run(context.clone().derive()));
         let scenario_result = ScenarioResult::from_result(result);
         println!("Scenario '{}' {}", scenario.name(), scenario_result);
@@ -138,7 +139,7 @@ fn scenarios_repository() -> Vec<Scenario> {
     repository.push(Scenario::new(
         "leader_restart",
         leader_restart,
-        vec![Tag::Short],
+        vec![Tag::Short, Tag::Unstable],
     ));
     repository.push(Scenario::new(
         "passive_node_is_updated",
@@ -193,7 +194,7 @@ fn scenarios_repository() -> Vec<Scenario> {
     repository.push(Scenario::new(
         "custom_network_disruption",
         custom_network_disruption,
-        vec![Tag::Short, Tag::Unstable],
+        vec![Tag::Short],
     ));
 
     repository.push(Scenario::new(
@@ -273,7 +274,7 @@ fn scenarios_repository() -> Vec<Scenario> {
     repository.push(Scenario::new(
         "max_connections",
         max_connections,
-        vec![Tag::Short, Tag::Unstable],
+        vec![Tag::Short],
     ));
 
     repository.push(Scenario::new("real_network", real_network, vec![Tag::Long]));

--- a/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
@@ -105,7 +105,7 @@ impl<'a> FragmentSender<'a> {
         match verifier.wait_fragment(Duration::from_secs(2), check.clone(), node)? {
             FragmentStatus::Rejected { reason } => Err(FragmentSenderError::FragmentNotInBlock {
                 alias: FragmentNode::alias(node).to_string(),
-                reason: reason,
+                reason,
                 logs: FragmentNode::log_content(node),
             }),
             FragmentStatus::InABlock { .. } => Ok(()),

--- a/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
@@ -11,7 +11,7 @@ impl<'a> FragmentSenderSetup<'a> {
     pub const NO_VERIFY: FragmentSenderSetup<'a> = FragmentSenderSetup {
         resend_on_error: None,
         sync_nodes: Vec::new(),
-        ignore_any_errors: false,
+        ignore_any_errors: true,
         no_verify: true,
     };
 
@@ -25,7 +25,7 @@ impl<'a> FragmentSenderSetup<'a> {
     pub fn resend_3_times_and_sync_with(sync_nodes: Vec<&'a dyn SyncNode>) -> Self {
         Self {
             resend_on_error: Some(3),
-            sync_nodes: sync_nodes,
+            sync_nodes,
             ignore_any_errors: false,
             no_verify: false,
         }


### PR DESCRIPTION
Moved `max_connection` and `custom_network_disruption` tests.
Print error back-trace on panic.
more fault tolerant sender in `leader restart` test  