### PR TITLE
Update ring & restore release for PowerPC and MIPS

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,9 +55,8 @@ jobs:
           - {os: ubuntu-latest, toolchain: stable,  target: x86_64-unknown-linux-musl, target_cpu: generic, cross: true}
           - {os: ubuntu-latest, toolchain: stable,  target: x86_64-unknown-linux-musl, target_cpu: broadwell, cross: true}
           - {os: ubuntu-latest, toolchain: stable, target: aarch64-linux-android, target_cpu: generic, cross: true}
-          # mips and powerpc are not compitble with ring v0.16.10, so they are disabled for now
-#          - {os: ubuntu-latest, target: mips64el-unknown-linux-gnuabi64, cross: true}
-#          - {os: ubuntu-latest, target: powerpc64le-unknown-linux-gnu, cross: true}
+          - {os: ubuntu-latest, target: mips64el-unknown-linux-gnuabi64, cross: true}
+          - {os: ubuntu-latest, target: powerpc64le-unknown-linux-gnu, cross: true}
           # Macos
           - {os: macos-latest, toolchain: stable, target: x86_64-apple-darwin, target_cpu: generic, cross: false}
           - {os: macos-latest, toolchain: stable, target: x86_64-apple-darwin, target_cpu: broadwell, cross: false}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,8 @@ jobs:
           - {os: ubuntu-latest, toolchain: stable, target: aarch64-unknown-linux-gnu, target_cpu: generic, cross: true}
           - {os: ubuntu-latest, toolchain: stable, target: arm-unknown-linux-gnueabi, target_cpu: generic, cross: true}
           - {os: ubuntu-latest, toolchain: stable, target: armv7-unknown-linux-gnueabihf, target_cpu: generic, cross: true}
-          # mips and powerpc are not compitble with ring v0.16.10, so they are disabled for now
-#          - {os: ubuntu-latest, target: mips64el-unknown-linux-gnuabi64, cross: true}
-#          - {os: ubuntu-latest, target: powerpc64le-unknown-linux-gnu, cross: true}
+          - {os: ubuntu-latest, target: mips64el-unknown-linux-gnuabi64, cross: true}
+          - {os: ubuntu-latest, target: powerpc64le-unknown-linux-gnu, cross: true}
           - {os: ubuntu-latest, toolchain: stable,  target: x86_64-unknown-linux-musl, target_cpu: generic, cross: true}
           - {os: ubuntu-latest, toolchain: stable,  target: x86_64-unknown-linux-musl, target_cpu: broadwell, cross: true}
           - {os: ubuntu-latest, toolchain: stable, target: aarch64-linux-android, target_cpu: generic, cross: true}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.13"
+version = "0.16.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
+checksum = "06b3fefa4f12272808f809a0af618501fdaba41a58963c5fb72238ab0be09603"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
The latest `ring` should support MIPS and PowerPC targets.

https://github.com/briansmith/ring/issues/104