### PR TITLE
Inject legacy "node-id-bin" metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "futures 0.3.5",
  "pin-project",
  "prost",
+ "rand_core 0.5.1",
  "thiserror",
  "tonic",
  "tonic-build",

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -22,7 +22,6 @@ use crate::{
     blockcfg::{HeaderHash, Leader},
     blockchain::Blockchain,
     diagnostic::Diagnostic,
-    network::p2p::P2pTopology,
     secure::enclave::Enclave,
     settings::start::Settings,
     utils::{async_msg, task::Services},
@@ -105,13 +104,6 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
     let leadership_logs =
         leadership::Logs::new(bootstrapped_node.settings.leadership.logs_capacity);
 
-    let topology = P2pTopology::new(
-        &bootstrapped_node.settings.network,
-        bootstrapped_node
-            .logger
-            .new(o!(log::KEY_TASK => "poldercast")),
-    );
-
     let stats_counter = StatsCounter::default();
 
     {
@@ -188,7 +180,6 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
     let network_state = Arc::new(network::GlobalState::new(
         bootstrapped_node.block0_hash,
         bootstrapped_node.settings.network.clone(),
-        topology,
         stats_counter.clone(),
         bootstrapped_node
             .logger

--- a/jormungandr/src/network/grpc/mod.rs
+++ b/jormungandr/src/network/grpc/mod.rs
@@ -1,5 +1,7 @@
 pub(super) mod client;
 mod server;
 
-pub use self::client::{connect, fetch_block, Client, ConnectError, FetchBlockError};
+pub use self::client::{
+    connect, connect_legacy, fetch_block, Client, ConnectError, FetchBlockError,
+};
 pub use self::server::run_listen_socket;

--- a/jormungandr/src/network/p2p/layers/preferred_list.rs
+++ b/jormungandr/src/network/p2p/layers/preferred_list.rs
@@ -1,7 +1,6 @@
 pub use jormungandr_lib::interfaces::{PreferredListConfig, TrustedPeer};
 use poldercast::{Address, GossipsBuilder, Layer, NodeProfile, Nodes, ViewBuilder};
 use rand::seq::IteratorRandom;
-use rand::{Rng as _, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::collections::HashSet;
 
@@ -22,23 +21,12 @@ pub struct PreferredListLayer {
 }
 
 impl PreferredListLayer {
-    pub fn new(config: PreferredListConfig) -> Self {
-        let mut seed = [0; 32];
-
-        rand::thread_rng().fill(&mut seed);
+    pub fn new(config: PreferredListConfig, prng: ChaChaRng) -> Self {
         let addresses: Vec<Address> = config.peers.iter().map(|p| p.address.clone()).collect();
-        Self::new_with_seed(config.view_max.into(), addresses, seed)
-    }
-
-    fn new_with_seed(
-        view_max: usize,
-        peers: Vec<Address>,
-        seed: <ChaChaRng as SeedableRng>::Seed,
-    ) -> Self {
         Self {
-            view_max,
-            peers: peers.iter().cloned().collect(),
-            prng: ChaChaRng::from_seed(seed),
+            view_max: config.view_max.into(),
+            peers: addresses.into_iter().collect(),
+            prng,
         }
     }
 }

--- a/jormungandr/src/network/p2p/topology.rs
+++ b/jormungandr/src/network/p2p/topology.rs
@@ -11,6 +11,7 @@ use poldercast::{
     poldercast::{Cyclon, Rings, Vicinity},
     NodeProfile, PolicyReport, StrikeReason, Topology,
 };
+use rand_chacha::ChaChaRng;
 use slog::Logger;
 use tokio::sync::RwLock;
 
@@ -55,7 +56,7 @@ impl Builder {
         self
     }
 
-    fn set_custom_modules(mut self, config: &Configuration) -> Self {
+    fn set_custom_modules(mut self, config: &Configuration, rng: ChaChaRng) -> Self {
         if let Some(size) = config.max_unreachable_nodes_to_connect_per_event {
             self.topology
                 .add_layer(custom_layers::RandomDirectConnections::with_max_view_length(size));
@@ -66,6 +67,7 @@ impl Builder {
 
         self.topology.add_layer(PreferredListLayer::new(
             config.layers.preferred_list.clone(),
+            rng,
         ));
 
         self
@@ -79,10 +81,10 @@ impl Builder {
 }
 
 impl P2pTopology {
-    pub fn new(config: &Configuration, logger: Logger) -> Self {
+    pub fn new(config: &Configuration, logger: Logger, rng: ChaChaRng) -> Self {
         Builder::new(config.profile.clone(), logger)
             .set_poldercast_modules()
-            .set_custom_modules(&config)
+            .set_custom_modules(&config, rng)
             .set_policy(config.policy.clone())
             .build()
     }

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -297,6 +297,7 @@ fn generate_network(
         http_fetch_block0_service,
         bootstrap_from_trusted_peers,
         skip_bootstrap,
+        generate_legacy_node_id: true,
     };
 
     if network.max_inbound_connections > network.max_connections {

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -92,6 +92,9 @@ pub struct Configuration {
     pub skip_bootstrap: bool,
 
     pub http_fetch_block0_service: Vec<String>,
+
+    /// Whether to use pre-0.9 "node-id-bin" metadata when subscribing
+    pub generate_legacy_node_id: bool,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Now do it unconditionally, to later add support for an option that would disable it.

Also changed the initialization code to create and seed an RNG once and reuse it (or rather, pass it around because it was currently all that was needed).

Fixes #2301