### PR TITLE
CI Matrix: Reloaded

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,7 @@ jobs:
           echo ::set-output name=version::$VERSION
 
       - name: Delete nightly with hub
+        continue-on-error: true
         env:
           GITHUB_USER: ${{ secrets.GITHUB_USER }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -213,7 +213,15 @@ jobs:
         with:
           use-cross: ${{ matrix.cross }}
           command: rustc
-          args: --manifest-path jormungandr/Cargo.toml --verbose --locked --release --target ${{ matrix.config.target }} --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.target_cpu }} -C lto
+          args: |
+            --manifest-path jormungandr/Cargo.toml
+            --bin jormungandr
+            --no-default-features
+            --verbose
+            --locked
+            --release
+            --target ${{ matrix.config.target }}
+            -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
@@ -222,7 +230,14 @@ jobs:
         with:
           use-cross: ${{ matrix.cross }}
           command: rustc
-          args: --manifest-path jcli/Cargo.toml --verbose --locked --release --target ${{ matrix.config.target }} --bin jcli -- -C target-cpu=${{ matrix.target_cpu }} -C lto
+          args: |
+            --manifest-path jcli/Cargo.toml
+            --bin jcli
+            --verbose
+            --locked
+            --release
+            --target ${{ matrix.config.target }}
+            -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Pack binaries (Unix)
         if: matrix.config.os != 'windows-latest'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -168,13 +168,6 @@ jobs:
           override: true
           default: true
 
-      - name: Downgrade cross
-        uses: actions-rs/cargo@v1
-        if: ${{ matrix.cross }}
-        with:
-          command: install
-          args: --version 0.1.16 cross
-
       - name: Get current date
         run: |
           export DATE=`date +'%Y%m%d'`;

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -220,7 +220,7 @@ jobs:
         with:
           use-cross: ${{ matrix.cross }}
           command: rustc
-          args: --manifest-path jormungandr/Cargo.toml --locked --release --target ${{ matrix.config.target }} --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.target_cpu }} -C lto
+          args: --manifest-path jormungandr/Cargo.toml --verbose --locked --release --target ${{ matrix.config.target }} --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
@@ -229,7 +229,7 @@ jobs:
         with:
           use-cross: ${{ matrix.cross }}
           command: rustc
-          args: --manifest-path jcli/Cargo.toml --locked --release --target ${{ matrix.config.target }} --bin jcli -- -C target-cpu=${{ matrix.target_cpu }} -C lto
+          args: --manifest-path jcli/Cargo.toml --verbose --locked --release --target ${{ matrix.config.target }} --bin jcli -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Pack binaries (Unix)
         if: matrix.config.os != 'windows-latest'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,35 +47,75 @@ jobs:
       matrix:
         config:
           # Linux
-          - {os: ubuntu-latest, toolchain: stable, target: x86_64-unknown-linux-gnu, target_cpu: generic, cross: false}
-          - {os: ubuntu-latest, toolchain: stable, target: x86_64-unknown-linux-gnu, target_cpu: broadwell, cross: false}
-          - {os: ubuntu-latest, toolchain: stable, target: aarch64-unknown-linux-gnu, target_cpu: generic, cross: true}
-          - {os: ubuntu-latest, toolchain: stable, target: arm-unknown-linux-gnueabi, target_cpu: generic, cross: true}
-          - {os: ubuntu-latest, toolchain: stable, target: armv7-unknown-linux-gnueabihf, target_cpu: generic, cross: true}
-          - {os: ubuntu-latest, toolchain: stable,  target: x86_64-unknown-linux-musl, target_cpu: generic, cross: true}
-          - {os: ubuntu-latest, toolchain: stable,  target: x86_64-unknown-linux-musl, target_cpu: broadwell, cross: true}
-          - {os: ubuntu-latest, toolchain: stable, target: aarch64-linux-android, target_cpu: generic, cross: true}
-          # - {os: ubuntu-latest, toolchain: stable, target: mips64el-unknown-linux-gnuabi64, target_cpu: generic, cross: true}
-          # - {os: ubuntu-latest, toolchain: stable, target: powerpc64le-unknown-linux-gnu, target_cpu: generic, cross: true}
+          - {os: ubuntu-latest, target: x86_64-unknown-linux-gnu}
           # Macos
-          - {os: macos-latest, toolchain: stable, target: x86_64-apple-darwin, target_cpu: generic, cross: false}
-          - {os: macos-latest, toolchain: stable, target: x86_64-apple-darwin, target_cpu: broadwell, cross: false}
+          - {os: macos-latest, target: x86_64-apple-darwin}
+        target_cpu: [generic, broadwell]
+        toolchain: [stable]
+        cross: [false]
+        include:
           # Windows
-          - {os: windows-latest, toolchain: stable-x86_64-pc-windows-gnu, target: x86_64-pc-windows-gnu, target_cpu: generic, cross: false}
-          - {os: windows-latest, toolchain: stable-x86_64-pc-windows-msvc, target: x86_64-pc-windows-msvc, target_cpu: generic, cross: false}
-          - {os: windows-latest, toolchain: stable-x86_64-pc-windows-gnu, target: x86_64-pc-windows-gnu, target_cpu: broadwell, cross: false}
-          - {os: windows-latest, toolchain: stable-x86_64-pc-windows-msvc, target: x86_64-pc-windows-msvc, target_cpu: broadwell, cross: false}
+          - config: {os: windows-latest, target: x86_64-pc-windows-gnu}
+            target_cpu: generic
+            toolchain: stable-x86_64-pc-windows-gnu
+            cross: false
+          - config: {os: windows-latest, target: x86_64-pc-windows-gnu}
+            target_cpu: broadwell
+            toolchain: stable-x86_64-pc-windows-gnu
+            cross: false
+          - config: {os: windows-latest, target: x86_64-pc-windows-msvc}
+            target_cpu: generic
+            toolchain: stable-x86_64-pc-windows-msvc
+            cross: false
+          - config: {os: windows-latest, target: x86_64-pc-windows-msvc}
+            target_cpu: broadwell
+            toolchain: stable-x86_64-pc-windows-msvc
+            cross: false
+          # Cross targets
+          - config: {os: ubuntu-latest, target: aarch64-unknown-linux-gnu}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest, target: arm-unknown-linux-gnueabi}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest,  target: x86_64-unknown-linux-musl}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest,  target: x86_64-unknown-linux-musl}
+            target_cpu: broadwell
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest, target: aarch64-linux-android}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          # - config: {os: ubuntu-latest, target: mips64el-unknown-linux-gnuabi64}
+          #   target_cpu: generic
+          #   toolchain: stable
+          #   cross: true
+          # - config: {os: ubuntu-latest, target: powerpc64le-unknown-linux-gnu}
+          #   target_cpu: generic
+          #   toolchain: stable
+          #   cross: true
+
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.config.toolchain }}
+          toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.config.target }}
           override: true
           default: true
 
       - name: Downgrade cross
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.config.cross }}
+        if: ${{ matrix.cross }}
         with:
           command: install
           args: --version 0.1.16 cross
@@ -103,26 +143,26 @@ jobs:
         env:
           DATE: ${{ env.DATE }}
         with:
-          use-cross: ${{ matrix.config.cross }}
+          use-cross: ${{ matrix.cross }}
           command: rustc
-          args:  --manifest-path jormungandr/Cargo.toml --release --target ${{ matrix.config.target }} --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.config.target_cpu }} -C lto
+          args:  --manifest-path jormungandr/Cargo.toml --release --target ${{ matrix.config.target }} --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
         env:
           DATE: ${{ env.DATE }}
         with:
-          use-cross: ${{ matrix.config.cross }}
+          use-cross: ${{ matrix.cross }}
           command: rustc
-          args: --manifest-path jcli/Cargo.toml --release --target ${{ matrix.config.target }} --bin jcli -- -C target-cpu=${{ matrix.config.target_cpu }} -C lto
+          args: --manifest-path jcli/Cargo.toml --release --target ${{ matrix.config.target }} --bin jcli -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Pack binaries if unix
         if: matrix.config.os != 'windows-latest'
-        run: tar -C ./target/${{ matrix.config.target }}/release -czvf jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}.tar.gz jormungandr jcli
+        run: tar -C ./target/${{ matrix.config.target }}/release -czvf jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz jormungandr jcli
 
       - name: Pack binaries if windows
         if: matrix.config.os == 'windows-latest'
-        run: compress-archive ./target/${{ matrix.config.target }}/release/jormungandr.exe, ./target/${{ matrix.config.target }}/release/jcli.exe jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}.zip
+        run: compress-archive ./target/${{ matrix.config.target }}/release/jormungandr.exe, ./target/${{ matrix.config.target }}/release/jcli.exe jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip
 
       - name: Upload binaries to nightly release
         uses: svenstaro/upload-release-action@v1-release

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Install hub
-        uses: geertvdc/setup-hub@master
-
       - name: Get version
         id: version
         run: |
@@ -31,8 +28,10 @@ jobs:
         env:
           GITHUB_USER: ${{ secrets.GITHUB_USER }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          hub release delete nightly
+          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+          bin/hub release delete nightly
 
       - name: Create Nightly
         id: create_nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,7 @@ name: Nightly Release
 jobs:
   nightly_release:
     name: Create nightly release
+    if: ${{ github.repository_owner == 'input-output-hk' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -42,6 +43,7 @@ jobs:
 
   release_assets:
     name: Release assets
+    if: ${{ github.repository_owner == 'input-output-hk' }}
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,9 @@ jobs:
       upload_url: ${{ steps.create_nightly.outputs.upload_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Install hub
         uses: geertvdc/setup-hub@master
@@ -133,7 +135,7 @@ jobs:
         shell: bash
 
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           submodules: true
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,8 @@ jobs:
     name: Create nightly release
     if: ${{ github.repository_owner == 'input-output-hk' }}
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_nightly.outputs.upload_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -160,20 +162,33 @@ jobs:
           command: rustc
           args: --manifest-path jcli/Cargo.toml --release --target ${{ matrix.config.target }} --bin jcli -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
-      - name: Pack binaries if unix
+      - name: Pack binaries (Unix)
         if: matrix.config.os != 'windows-latest'
-        run: tar -C ./target/${{ matrix.config.target }}/release -czvf jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz jormungandr jcli
+        run: |
+          archive=jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz
+          tar -C ./target/${{ matrix.config.target }}/release -czvf $archive jormungandr jcli
+          echo "::set-env name=RELEASE_ARCHIVE::$archive"
+          echo "::set-env name=RELEASE_CONTENT_TYPE::application/gzip"
 
-      - name: Pack binaries if windows
+      - name: Pack binaries (Windows)
         if: matrix.config.os == 'windows-latest'
-        run: compress-archive ./target/${{ matrix.config.target }}/release/jormungandr.exe, ./target/${{ matrix.config.target }}/release/jcli.exe jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip
+        run: |
+          $archive = "jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip"
+          $args = @{
+            Path  = "./target/${{ matrix.config.target }}/release/jormungandr.exe",
+                    "./target/${{ matrix.config.target }}/release/jcli.exe"
+            DestinationPath = $archive
+          }
+          Compress-Archive @args
+          echo "::set-env name=RELEASE_ARCHIVE::$archive"
+          echo "::set-env name=RELEASE_CONTENT_TYPE::application/zip"
 
       - name: Upload binaries to nightly release
-        uses: svenstaro/upload-release-action@v1-release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}.*
-          asset_name: jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}
-          tag: nightly
-          file_glob: true
-          overwrite: true
+          upload_url: ${{ needs.nightly_release.outputs.upload_url }}
+          asset_path: ./${{ env.RELEASE_ARCHIVE }}
+          asset_name: ${{ env.RELEASE_ARCHIVE }}
+          asset_content_type: ${{ env.RELEASE_CONTENT_TYPE }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,10 +45,57 @@ jobs:
           draft: false
           prerelease: true
 
+  update_deps:
+    name: Update dependencies
+    if: ${{ github.repository_owner == 'input-output-hk' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - id: cargo-registry
+        name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+      - if: ${{ steps.cargo-registry.outputs.cache-hit != 'true' }}
+        id: ls-crates-io-index
+        name: Get head commit hash of crates.io registry index
+        continue-on-error: true
+        shell: bash
+        run: |
+          commit=$(
+            git ls-remote --heads https://github.com/rust-lang/crates.io-index.git master |
+            cut -f 1
+          )
+          echo "::set-output name=head::$commit"
+      - if: ${{ steps.cargo-registry.outputs.cache-hit != 'true' }}
+        name: Cache cargo registry index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry/index
+          key: cargo-index-${{ steps.ls-crates-io-index.outputs.head }}
+          restore-keys: |
+            cargo-index-
+
+      - if: ${{ steps.cargo-registry.outputs.cache-hit != 'true' }}
+        name: Fetch dependencies
+        run: cargo fetch --locked
+
+      - if: ${{ steps.cargo-registry.outputs.cache-hit != 'true' }}
+        name: Prune unpacked sources of dependency crates from cache
+        shell: bash
+        run: |
+          rm -rf ~/.cargo/registry/src
+
   release_assets:
     name: Release assets
-    needs: nightly_release
     if: ${{ github.repository_owner == 'input-output-hk' }}
+    needs: [nightly_release, update_deps]
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
@@ -146,6 +193,26 @@ jobs:
           echo ::set-output name=version::$VERSION
         shell: bash
 
+      # https://github.com/actions/runner/issues/498
+      - if: ${{ runner.os == 'Windows' }}
+        name: Fix up Cargo.lock hash
+        shell: powershell
+        run: |
+          ((Get-Content Cargo.lock) -join "`n") + "`n" |
+          Set-Content -NoNewline Cargo.lock
+
+      # https://github.com/actions/virtual-environments/issues/895
+      # https://github.com/actions/virtual-environments/issues/936
+      - if: ${{ runner.os == 'Windows' }}
+        name: Clean up cargo registry files
+        run: rm -r -fo $env:UserProfile\.cargo\registry
+
+      - name: Restore cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry-${{ hashFiles('Cargo.lock') }}
+
       - name: Build jormungandr
         uses: actions-rs/cargo@v1
         env:
@@ -153,7 +220,7 @@ jobs:
         with:
           use-cross: ${{ matrix.cross }}
           command: rustc
-          args:  --manifest-path jormungandr/Cargo.toml --release --target ${{ matrix.config.target }} --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.target_cpu }} -C lto
+          args: --manifest-path jormungandr/Cargo.toml --locked --release --target ${{ matrix.config.target }} --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
@@ -162,7 +229,7 @@ jobs:
         with:
           use-cross: ${{ matrix.cross }}
           command: rustc
-          args: --manifest-path jcli/Cargo.toml --release --target ${{ matrix.config.target }} --bin jcli -- -C target-cpu=${{ matrix.target_cpu }} -C lto
+          args: --manifest-path jcli/Cargo.toml --locked --release --target ${{ matrix.config.target }} --bin jcli -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Pack binaries (Unix)
         if: matrix.config.os != 'windows-latest'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,7 @@ jobs:
 
   release_assets:
     name: Release assets
+    needs: nightly_release
     if: ${{ github.repository_owner == 'input-output-hk' }}
     runs-on: ${{ matrix.config.os }}
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,10 @@ name: Release
 jobs:
   initial_release:
     name: Create base release
+    if: ${{ github.repository_owner == 'input-output-hk' }}
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Create Release
         id: create_release
@@ -21,86 +24,214 @@ jobs:
           draft: false
           prerelease: false
 
+  update_deps:
+    name: Update dependencies
+    if: ${{ github.repository_owner == 'input-output-hk' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - id: cargo-registry
+        name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+      - if: ${{ steps.cargo-registry.outputs.cache-hit != 'true' }}
+        id: ls-crates-io-index
+        name: Get head commit hash of crates.io registry index
+        continue-on-error: true
+        shell: bash
+        run: |
+          commit=$(
+            git ls-remote --heads https://github.com/rust-lang/crates.io-index.git master |
+            cut -f 1
+          )
+          echo "::set-output name=head::$commit"
+      - if: ${{ steps.cargo-registry.outputs.cache-hit != 'true' }}
+        name: Cache cargo registry index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry/index
+          key: cargo-index-${{ steps.ls-crates-io-index.outputs.head }}
+          restore-keys: |
+            cargo-index-
+
+      - if: ${{ steps.cargo-registry.outputs.cache-hit != 'true' }}
+        name: Fetch dependencies
+        run: cargo fetch --locked
+
+      - if: ${{ steps.cargo-registry.outputs.cache-hit != 'true' }}
+        name: Prune unpacked sources of dependency crates from cache
+        shell: bash
+        run: |
+          rm -rf ~/.cargo/registry/src
+
   release_assets:
     name: Release assets
-    needs: initial_release
+    if: ${{ github.repository_owner == 'input-output-hk' }}
+    needs: [initial_release, update_deps]
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
         config:
           # Linux
-          - {os: ubuntu-latest, toolchain: stable, target: x86_64-unknown-linux-gnu, target_cpu: generic, cross: false}
-          - {os: ubuntu-latest, toolchain: stable, target: x86_64-unknown-linux-gnu, target_cpu: broadwell, cross: false}
-          - {os: ubuntu-latest, toolchain: stable, target: aarch64-unknown-linux-gnu, target_cpu: generic, cross: true}
-          - {os: ubuntu-latest, toolchain: stable, target: arm-unknown-linux-gnueabi, target_cpu: generic, cross: true}
-          - {os: ubuntu-latest, toolchain: stable, target: armv7-unknown-linux-gnueabihf, target_cpu: generic, cross: true}
-          # - {os: ubuntu-latest, toolchain: stable, target: mips64el-unknown-linux-gnuabi64, target_cpu: generic, cross: true}
-          # - {os: ubuntu-latest, toolchain: stable, target: powerpc64le-unknown-linux-gnu, target_cpu: generic, cross: true}
-          - {os: ubuntu-latest, toolchain: stable,  target: x86_64-unknown-linux-musl, target_cpu: generic, cross: true}
-          - {os: ubuntu-latest, toolchain: stable,  target: x86_64-unknown-linux-musl, target_cpu: broadwell, cross: true}
-          - {os: ubuntu-latest, toolchain: stable, target: aarch64-linux-android, target_cpu: generic, cross: true}
+          - {os: ubuntu-latest, target: x86_64-unknown-linux-gnu}
           # Macos
-          - {os: macos-latest, toolchain: stable, target: x86_64-apple-darwin, target_cpu: generic, cross: false}
-          - {os: macos-latest, toolchain: stable, target: x86_64-apple-darwin, target_cpu: broadwell, cross: false}
+          - {os: macos-latest, target: x86_64-apple-darwin}
+        target_cpu: [generic, broadwell]
+        toolchain: [stable]
+        cross: [false]
+        include:
           # Windows
-          - {os: windows-latest, toolchain: stable-x86_64-pc-windows-gnu, target: x86_64-pc-windows-gnu, target_cpu: generic, cross: false}
-          - {os: windows-latest, toolchain: stable-x86_64-pc-windows-msvc, target: x86_64-pc-windows-msvc, target_cpu: generic, cross: false}
-          - {os: windows-latest, toolchain: stable-x86_64-pc-windows-gnu, target: x86_64-pc-windows-gnu, target_cpu: broadwell, cross: false}
-          - {os: windows-latest, toolchain: stable-x86_64-pc-windows-msvc, target: x86_64-pc-windows-msvc, target_cpu: broadwell, cross: false}
+          - config: {os: windows-latest, target: x86_64-pc-windows-gnu}
+            target_cpu: generic
+            toolchain: stable-x86_64-pc-windows-gnu
+            cross: false
+          - config: {os: windows-latest, target: x86_64-pc-windows-gnu}
+            target_cpu: broadwell
+            toolchain: stable-x86_64-pc-windows-gnu
+            cross: false
+          - config: {os: windows-latest, target: x86_64-pc-windows-msvc}
+            target_cpu: generic
+            toolchain: stable-x86_64-pc-windows-msvc
+            cross: false
+          - config: {os: windows-latest, target: x86_64-pc-windows-msvc}
+            target_cpu: broadwell
+            toolchain: stable-x86_64-pc-windows-msvc
+            cross: false
+          # Cross targets
+          - config: {os: ubuntu-latest, target: aarch64-unknown-linux-gnu}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest, target: arm-unknown-linux-gnueabi}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest,  target: x86_64-unknown-linux-musl}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest,  target: x86_64-unknown-linux-musl}
+            target_cpu: broadwell
+            toolchain: stable
+            cross: true
+          - config: {os: ubuntu-latest, target: aarch64-linux-android}
+            target_cpu: generic
+            toolchain: stable
+            cross: true
+          # - config: {os: ubuntu-latest, target: mips64el-unknown-linux-gnuabi64}
+          #   target_cpu: generic
+          #   toolchain: stable
+          #   cross: true
+          # - config: {os: ubuntu-latest, target: powerpc64le-unknown-linux-gnu}
+          #   target_cpu: generic
+          #   toolchain: stable
+          #   cross: true
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.config.toolchain }}
+          toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.config.target }}
           override: true
           default: true
 
-      - name: Downgrade cross
-        uses: actions-rs/cargo@v1
-        if: ${{ matrix.config.cross }}
-        with:
-          command: install
-          args: --version 0.1.16 cross
-
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           submodules: true
+
+      # https://github.com/actions/runner/issues/498
+      - if: ${{ runner.os == 'Windows' }}
+        name: Fix up Cargo.lock hash
+        shell: powershell
+        run: |
+          ((Get-Content Cargo.lock) -join "`n") + "`n" |
+          Set-Content -NoNewline Cargo.lock
+
+      # https://github.com/actions/virtual-environments/issues/895
+      # https://github.com/actions/virtual-environments/issues/936
+      - if: ${{ runner.os == 'Windows' }}
+        name: Clean up cargo registry files
+        run: rm -r -fo $env:UserProfile\.cargo\registry
+
+      - name: Restore cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry-${{ hashFiles('Cargo.lock') }}
 
       - name: Build jormungandr
         uses: actions-rs/cargo@v1
         with:
-          use-cross: ${{ matrix.config.cross }}
+          use-cross: ${{ matrix.cross }}
           command: rustc
-          args: --manifest-path jormungandr/Cargo.toml --release --target ${{ matrix.config.target }} --bin jormungandr --no-default-features -- -C target-cpu=${{ matrix.config.target_cpu }} -C lto
+          args: |
+            --manifest-path jormungandr/Cargo.toml
+            --bin jormungandr
+            --no-default-features
+            --verbose
+            --locked
+            --release
+            --target ${{ matrix.config.target }}
+            -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
         with:
-          use-cross: ${{ matrix.config.cross }}
+          use-cross: ${{ matrix.cross }}
           command: rustc
-          args: --manifest-path jcli/Cargo.toml --release --target ${{ matrix.config.target }} --bin jcli -- -C target-cpu=${{ matrix.config.target_cpu }} -C lto
+          args: |
+            --manifest-path jcli/Cargo.toml
+            --bin jcli
+            --verbose
+            --locked
+            --release
+            --target ${{ matrix.config.target }}
+            -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Get tag version
         id: get_version
-        run: echo ::set-output name=VERSION::``${GITHUB_REF#refs/tags/}``
+        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
         shell: bash
 
-      - name: Pack binaries if unix
+      - name: Pack binaries (Unix)
         if: matrix.config.os != 'windows-latest'
-        run: tar -C ./target/${{ matrix.config.target }}/release -czvf jormungandr-${{ steps.get_version.outputs.VERSION }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}.tar.gz jormungandr jcli
+        run: |
+          archive=jormungandr-${{ steps.get_version.outputs.version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz
+          tar -C ./target/${{ matrix.config.target }}/release -czvf $archive jormungandr jcli
+          echo "::set-env name=RELEASE_ARCHIVE::$archive"
+          echo "::set-env name=RELEASE_CONTENT_TYPE::application/gzip"
 
-      - name: Pack binaries if windows
+      - name: Pack binaries (Windows)
         if: matrix.config.os == 'windows-latest'
-        run: compress-archive ./target/${{ matrix.config.target }}/release/jormungandr.exe, ./target/${{ matrix.config.target }}/release/jcli.exe jormungandr-${{ steps.get_version.outputs.VERSION }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}.zip
+        run: |
+          $archive = "jormungandr-${{ steps.get_version.outputs.version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip"
+          $args = @{
+            Path  = "./target/${{ matrix.config.target }}/release/jormungandr.exe",
+                    "./target/${{ matrix.config.target }}/release/jcli.exe"
+            DestinationPath = $archive
+          }
+          Compress-Archive @args
+          echo "::set-env name=RELEASE_ARCHIVE::$archive"
+          echo "::set-env name=RELEASE_CONTENT_TYPE::application/zip"
 
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v1-release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: jormungandr-${{ steps.get_version.outputs.VERSION }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}.*
-          asset_name: jormungandr-${{ steps.get_version.outputs.VERSION }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}
-          tag: ${{ github.ref }}
-          file_glob: true
-          overwrite: true
+          upload_url: ${{ needs.initial_release.outputs.upload_url }}
+          asset_path: ./${{ env.RELEASE_ARCHIVE }}
+          asset_name: ${{ env.RELEASE_ARCHIVE }}
+          asset_content_type: ${{ env.RELEASE_CONTENT_TYPE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
 
   release_assets:
     name: Release assets
+    needs: initial_release
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,22 +591,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
-
-[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,21 +882,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1277,19 +1246,6 @@ dependencies = [
  "tokio 0.2.21",
  "tokio-rustls 0.13.1",
  "webpki",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
-dependencies = [
- "bytes 0.5.4",
- "hyper",
- "native-tls",
- "tokio 0.2.21",
- "tokio-tls",
 ]
 
 [[package]]
@@ -1978,24 +1934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
-dependencies = [
- "lazy_static",
- "libc",
- "log 0.4.8",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,39 +2048,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "lazy_static",
- "libc",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7410fef80af8ac071d4f63755c0ab89ac3df0fd1ea91f1d1f37cf5cec4395990"
-dependencies = [
- "autocfg 1.0.0",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2836,13 +2741,11 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "js-sys",
  "lazy_static",
  "log 0.4.8",
  "mime 0.3.16",
  "mime_guess 2.0.3",
- "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
  "rustls 0.17.0",
@@ -2851,7 +2754,6 @@ dependencies = [
  "serde_urlencoded",
  "tokio 0.2.21",
  "tokio-rustls 0.13.1",
- "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2966,16 +2868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,29 +2896,6 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3787,16 +3656,6 @@ dependencies = [
  "futures 0.1.29",
  "slab",
  "tokio-executor",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio 0.2.21",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byte-tools"
@@ -329,12 +329,13 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.8+1.0.8"
+version = "0.1.9+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038"
+checksum = "ad3b39a260062fca31f7b0b12f207e8f2590a67d32ec7d59c20484b07ea7285e"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -530,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "clear_on_drop"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
+checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
 dependencies = [
  "cc",
 ]
@@ -661,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+checksum = "ab6bffe714b6bb07e42f201352c34f51fefd355ace793f9e638ebd52d23f98d2"
 dependencies = [
  "cfg-if",
  "crossbeam-utils 0.7.2",
@@ -704,9 +705,9 @@ checksum = "da24927b5b899890bcb29205436c957b7892ec3a3fbffce81d710b9611e77778"
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
  "byteorder",
  "digest 0.8.1",
@@ -1240,9 +1241,9 @@ checksum = "b9b6c53306532d3c8e8087b44e6580e10db51a023cf9b433cea2ac38066b92da"
 
 [[package]]
 name = "hyper"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
+checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
  "bytes 0.5.4",
  "futures-channel",
@@ -1254,8 +1255,8 @@ dependencies = [
  "httparse",
  "itoa",
  "log 0.4.8",
- "net2",
  "pin-project",
+ "socket2",
  "time",
  "tokio 0.2.21",
  "tower-service",
@@ -1304,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128b9e89d15a3faa642ee164c998fd4fae3d89d054463cddb2c25a7baad3a352"
+checksum = "22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "globset",
@@ -1326,9 +1327,9 @@ version = "0.1.0"
 
 [[package]]
 name = "indexmap"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg 1.0.0",
  "serde",
@@ -1631,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.39"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
+checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1753,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.4.5"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e488db3a9e108382265a30764f43cfc87517322e5d04ae0603b32a33461dca3"
+checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
 dependencies = [
  "hashbrown",
 ]
@@ -2305,18 +2306,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
+checksum = "ba3a1acf4a3e70849f8a673497ef984f043f95d2d8252dcdf74d54e6a1e47e8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
+checksum = "194e88048b71a3e02eb4ee36a6995fed9b8236c11a7bb9f7247a9d9835b3f265"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2325,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
+checksum = "9df32da11d84f3a7d70205549562966279adb900e080fad3dccd8e64afccf0ad"
 
 [[package]]
 name = "pin-utils"
@@ -2349,9 +2350,9 @@ checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
 name = "podio"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
+checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
 
 [[package]]
 name = "poldercast"
@@ -2361,7 +2362,7 @@ checksum = "ad74b4f644e23d1faf58fca06eed184db0efef1e7da9fc46b9f168d8b18e01f0"
 dependencies = [
  "cid",
  "hex",
- "lru 0.4.5",
+ "lru 0.4.3",
  "multiaddr",
  "rand 0.7.3",
  "rayon",
@@ -2444,9 +2445,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid",
 ]
@@ -2761,7 +2762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 dependencies = [
  "crossbeam-deque",
- "crossbeam-queue 0.2.1",
+ "crossbeam-queue 0.2.2",
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
@@ -2945,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safemem"
@@ -3352,15 +3353,15 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
+checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.27"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef781e621ee763a2a40721a8861ec519cb76966aee03bb5d00adb6a31dc1c1de"
+checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3380,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf74492539712b190e4b3234cf6a4a026812e880fe45e8001807cc0044a7f21"
+checksum = "5b796215da5a4b2a1a5db53ee55866c13b74a89acd259ab762eb10e28e937cb5"
 dependencies = [
  "cfg-if",
  "doc-comment",
@@ -3766,7 +3767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
  "crossbeam-deque",
- "crossbeam-queue 0.2.1",
+ "crossbeam-queue 0.2.2",
  "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
@@ -4080,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c6b59d116d218cb2d990eb06b77b64043e0268ef7323aae63d8b30ae462923"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
 dependencies = [
  "cfg-if",
  "log 0.4.8",
@@ -4299,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+checksum = "55d1e41d56121e07f1e223db0a4def204e45c85425f6a16d462fd07c8d10d74c"
 
 [[package]]
 name = "vec_map"
@@ -4393,9 +4394,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
+checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
 dependencies = [
  "cfg-if",
  "serde",
@@ -4405,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
+checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4420,9 +4421,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
+checksum = "64487204d863f109eb77e8462189d111f27cb5712cc9fdb3461297a76963a2f6"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4432,9 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
+checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4442,9 +4443,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
+checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4455,15 +4456,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
+checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
 
 [[package]]
 name = "web-sys"
-version = "0.3.39"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
+checksum = "7b72fe77fd39e4bd3eaa4412fd299a0be6b3dfe9d2597e2f1c20beb968f41d17"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4471,9 +4472,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef"
+checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
 dependencies = [
  "ring",
  "untrusted",

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -41,18 +41,10 @@ version = "2.33"
 default-features = false
 features = [ "suggestions", "color", "wrap_help" ]
 
-[target.'cfg(not(target_os = "android"))'.dependencies.reqwest]
+[dependencies.reqwest]
 version = "0.10.6"
 default-features = false
 features = ["blocking", "rustls-tls"]
-
-# rustls-native-certs required by rustls-tls does not support Android, so build
-# with OpenSSL.
-# TODO rustls-tls should work on Android when https://github.com/seanmonstar/reqwest/pull/862
-# is merged and released.
-[target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.10.4"
-features = ["blocking"]
 
 [dev-dependencies]
 assert_fs = "1.0"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -60,17 +60,10 @@ warp = { version = "0.2.3", features = ["tls"] }
 pin-project = "0.4"
 multiaddr = "0.3.1"
 
-[target.'cfg(not(target_os = "android"))'.dependencies.reqwest]
+[dependencies.reqwest]
 version = "0.10.6"
 default-features = false
 features = ["rustls-tls"]
-
-# rustls-native-certs required by rustls-tls does not support Android, so build
-# with OpenSSL.
-# TODO rustls-tls should work on Android when https://github.com/seanmonstar/reqwest/pull/862
-# is merged and released.
-[target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.10.4"
 
 [dev-dependencies]
 rand_core = "0.5"

--- a/testing/jormungandr-integration-tests/Cargo.toml
+++ b/testing/jormungandr-integration-tests/Cargo.toml
@@ -38,18 +38,10 @@ thiserror = "1.0"
 url = "2.1.1"
 yaml-rust = "0.4.4"
 
-[target.'cfg(not(target_os = "android"))'.dependencies.reqwest]
+[dependencies.reqwest]
 version = "0.10.6"
 default-features = false
 features = ["blocking", "json", "rustls-tls"]
-
-# rustls-native-certs required by rustls-tls does not support Android, so build
-# with OpenSSL.
-# TODO rustls-tls should work on Android when https://github.com/seanmonstar/reqwest/pull/862
-# is merged and released.
-[target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.10.4"
-features = ["blocking", "json"]
 
 [features]
 testnet = []

--- a/testing/jormungandr-scenario-tests/Cargo.toml
+++ b/testing/jormungandr-scenario-tests/Cargo.toml
@@ -38,15 +38,7 @@ yaml-rust = "0.4.4"
 indicatif = "0.14"
 lazy_static = "1"
 
-[target.'cfg(not(target_os = "android"))'.dependencies.reqwest]
+[dependencies.reqwest]
 version = "0.10.6"
 default-features = false
 features = ["blocking", "rustls-tls"]
-
-# rustls-native-certs required by rustls-tls does not support Android, so build
-# with OpenSSL.
-# TODO rustls-tls should work on Android when https://github.com/seanmonstar/reqwest/pull/862
-# is merged and released.
-[target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.10.4"
-features = ["blocking"]

--- a/testing/jormungandr-testing-utils/Cargo.toml
+++ b/testing/jormungandr-testing-utils/Cargo.toml
@@ -32,18 +32,10 @@ flate2 = "1.0.14"
 tar = "0.4"
 hex = "0.4"
 
-[target.'cfg(not(target_os = "android"))'.dependencies.reqwest]
+[dependencies.reqwest]
 version = "0.10.6"
 default-features = false
 features = ["blocking", "rustls-tls"]
-
-# rustls-native-certs required by rustls-tls does not support Android, so build
-# with OpenSSL.
-# TODO rustls-tls should work on Android when https://github.com/seanmonstar/reqwest/pull/862
-# is merged and released.
-[target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.10.4"
-features = ["blocking"]
 
 [features]
 default = []


### PR DESCRIPTION
I meant to fix #2310, but then I got a little carried away:

- Factor out repetitive parameters from the CI build matrix.
- Disable nightly runs on forked repositories.
- Remove the cross workarounds and the last vestiges of OpenSSL from our dependency graph.
- Add caching of cargo dependencies.
- Use `actions/checkout@v2`
- Replace third party actions with the official GitHub action and the official GitHub script.

(P.S. I know that the Matrix sequels were crap, just wanted to give this PR a cool name)