### PR TITLE
Consistently use optimization flags when building releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -209,9 +209,10 @@ jobs:
         uses: actions-rs/cargo@v1
         env:
           DATE: ${{ env.DATE }}
+          RUSTFLAGS: -C target-cpu=${{ matrix.target_cpu }} -C lto
         with:
           use-cross: ${{ matrix.cross }}
-          command: rustc
+          command: build
           args: |
             --manifest-path jormungandr/Cargo.toml
             --bin jormungandr
@@ -220,15 +221,15 @@ jobs:
             --locked
             --release
             --target ${{ matrix.config.target }}
-            -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
         env:
           DATE: ${{ env.DATE }}
+          RUSTFLAGS: -C target-cpu=${{ matrix.target_cpu }} -C lto
         with:
           use-cross: ${{ matrix.cross }}
-          command: rustc
+          command: build
           args: |
             --manifest-path jcli/Cargo.toml
             --bin jcli
@@ -236,7 +237,6 @@ jobs:
             --locked
             --release
             --target ${{ matrix.config.target }}
-            -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Pack binaries (Unix)
         if: matrix.config.os != 'windows-latest'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -205,11 +205,19 @@ jobs:
           path: ~/.cargo/registry
           key: cargo-registry-${{ hashFiles('Cargo.lock') }}
 
+      - name: Create .cargo/config.toml
+        shell: bash
+        run: |
+          mkdir .cargo
+          cat > .cargo/config.toml <<EOF
+          [target.${{ matrix.config.target }}]
+          rustflags = ["-C", "target-cpu=${{ matrix.target_cpu }}", "-C", "lto"]
+          EOF
+
       - name: Build jormungandr
         uses: actions-rs/cargo@v1
         env:
           DATE: ${{ env.DATE }}
-          RUSTFLAGS: -C target-cpu=${{ matrix.target_cpu }} -C lto
         with:
           use-cross: ${{ matrix.cross }}
           command: build
@@ -226,7 +234,6 @@ jobs:
         uses: actions-rs/cargo@v1
         env:
           DATE: ${{ env.DATE }}
-          RUSTFLAGS: -C target-cpu=${{ matrix.target_cpu }} -C lto
         with:
           use-cross: ${{ matrix.cross }}
           command: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,10 +171,17 @@ jobs:
           path: ~/.cargo/registry
           key: cargo-registry-${{ hashFiles('Cargo.lock') }}
 
+      - name: Create .cargo/config.toml
+        shell: bash
+        run: |
+          mkdir .cargo
+          cat > .cargo/config.toml <<EOF
+          [target.${{ matrix.config.target }}]
+          rustflags = ["-C", "target-cpu=${{ matrix.target_cpu }}", "-C", "lto"]
+          EOF
+
       - name: Build jormungandr
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: -C target-cpu=${{ matrix.target_cpu }} -C lto
         with:
           use-cross: ${{ matrix.cross }}
           command: build
@@ -189,8 +196,6 @@ jobs:
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: -C target-cpu=${{ matrix.target_cpu }} -C lto
         with:
           use-cross: ${{ matrix.cross }}
           command: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,9 +173,11 @@ jobs:
 
       - name: Build jormungandr
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -C target-cpu=${{ matrix.target_cpu }} -C lto
         with:
           use-cross: ${{ matrix.cross }}
-          command: rustc
+          command: build
           args: |
             --manifest-path jormungandr/Cargo.toml
             --bin jormungandr
@@ -184,13 +186,14 @@ jobs:
             --locked
             --release
             --target ${{ matrix.config.target }}
-            -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -C target-cpu=${{ matrix.target_cpu }} -C lto
         with:
           use-cross: ${{ matrix.cross }}
-          command: rustc
+          command: build
           args: |
             --manifest-path jcli/Cargo.toml
             --bin jcli
@@ -198,7 +201,6 @@ jobs:
             --locked
             --release
             --target ${{ matrix.config.target }}
-            -- -C target-cpu=${{ matrix.target_cpu }} -C lto
 
       - name: Get tag version
         id: get_version


### PR DESCRIPTION
`cargo rustc` only applies the compiler flags passed as arguments to the end target build.
Use `cargo build` and override the target compiler flags via `.cargo/config.toml`, this way the flags get down to dependency library compilations and LTO can be applied across the board.
This has a dramatic impact on the executable sizes.