### PR TITLE
Further fix and improve release workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,17 +5,16 @@ on:
 name: Nightly Release
 
 jobs:
-  nightly_release:
+  create_release:
     name: Create nightly release
     if: ${{ github.repository_owner == 'input-output-hk' }}
     runs-on: ubuntu-latest
     outputs:
+      release_version: ${{ steps.version.outputs.version }}
       upload_url: ${{ steps.create_nightly.outputs.upload_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          submodules: true
 
       - name: Get version from jormungandr/Cargo.toml
         id: version
@@ -32,26 +31,24 @@ jobs:
           d = json.load(p.stdout)
           print('::set-output name=version::' + d['version'])
 
-      - name: Delete nightly with hub
+      - name: Delete the existing nightly release
         continue-on-error: true
         env:
-          GITHUB_USER: ${{ secrets.GITHUB_USER }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
         run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          bin/hub release delete nightly
+          hub release delete nightly
+          git push --delete origin refs/tags/nightly
 
       - name: Create Nightly
         id: create_nightly
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: nightly
-          release_name: ${{ steps.version.outputs.version }}
-          draft: false
-          prerelease: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          hub release create --prerelease --draft \
+            -m "Release ${{ steps.version.outputs.version }} (in progress)" \
+            -t $GITHUB_SHA nightly
+          upload_url=$(hub release show -f '%uA' nightly)
+          echo "::set-output name=upload_url::$upload_url"
 
   update_deps:
     name: Update dependencies
@@ -100,10 +97,10 @@ jobs:
         run: |
           rm -rf ~/.cargo/registry/src
 
-  release_assets:
-    name: Release assets
+  build_assets:
+    name: Build assets
     if: ${{ github.repository_owner == 'input-output-hk' }}
-    needs: [nightly_release, update_deps]
+    needs: [create_release, update_deps]
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
@@ -280,7 +277,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.nightly_release.outputs.upload_url }}
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ./${{ env.RELEASE_ARCHIVE }}
           asset_name: ${{ env.RELEASE_ARCHIVE }}
           asset_content_type: ${{ env.RELEASE_CONTENT_TYPE }}
+
+  publish_release:
+    name: Publish nightly release
+    if: ${{ github.repository_owner == 'input-output-hk' }}
+    needs: [create_release, build_assets]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          hub release edit --draft=false \
+            -m 'Release ${{ needs.create_release.outputs.release_version }}' \
+            nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_date: ${{ steps.version.outputs.date }}
-      release_version: ${{ steps.version.outputs.version }}
+      version: ${{ steps.version.outputs.version }}
       upload_url: ${{ steps.create_nightly.outputs.upload_url }}
     steps:
       - name: Checkout code
@@ -260,7 +260,7 @@ jobs:
       - name: Pack binaries (Unix)
         if: matrix.config.os != 'windows-latest'
         run: |
-          archive=jormungandr-${{ needs.create_release.outputs.release_version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz
+          archive=jormungandr-${{ needs.create_release.outputs.version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz
           tar -C ./target/${{ matrix.config.target }}/release -czvf $archive jormungandr jcli
           echo "::set-env name=RELEASE_ARCHIVE::$archive"
           echo "::set-env name=RELEASE_CONTENT_TYPE::application/gzip"
@@ -268,7 +268,7 @@ jobs:
       - name: Pack binaries (Windows)
         if: matrix.config.os == 'windows-latest'
         run: |
-          $archive = "jormungandr-${{ needs.create_release.outputs.release_version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip"
+          $archive = "jormungandr-${{ needs.create_release.outputs.version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip"
           $args = @{
             Path  = "./target/${{ matrix.config.target }}/release/jormungandr.exe",
                     "./target/${{ matrix.config.target }}/release/jcli.exe"
@@ -302,5 +302,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           hub release edit --draft=false \
-            -m 'Release ${{ needs.create_release.outputs.release_version }}' \
+            -m 'Release ${{ needs.create_release.outputs.version }}' \
             nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,23 +41,29 @@ jobs:
           print('::set-output name=date::' + date)
           print('::set-output name=version::' + version)
 
-      - name: Delete the existing nightly release
+      - name: Delete existing nightly releases
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          hub release delete nightly
-          git push --delete origin refs/tags/nightly
+          set +e
+          git ls-remote --tags --refs origin 'refs/tags/nightly*' |
+          cut -f 2 |
+          while read ref; do
+            hub release delete ${ref#refs/tags/}
+            git push --delete origin $ref
+          done
 
       - name: Create Nightly
         id: create_nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          release_tag=nightly.${{ steps.version.outputs.date }}
           hub release create --prerelease --draft \
             -m "Release ${{ steps.version.outputs.version }} (in progress)" \
-            -t $GITHUB_SHA nightly
-          upload_url=$(hub release show -f '%uA' nightly)
+            -t $GITHUB_SHA $release_tag
+          upload_url=$(hub release show -f '%uA' $release_tag)
           echo "::set-output name=upload_url::$upload_url"
 
   update_deps:
@@ -301,6 +307,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          release_tag=nightly.${{ needs.create_release.outputs.release_date }}
           hub release edit --draft=false \
             -m 'Release ${{ needs.create_release.outputs.version }}' \
-            nightly
+            $release_tag

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,13 +1,18 @@
 on:
   schedule:
     - cron: '0 3 * * *' # run at 3 AM UTC
+  push:
+    branches:
+      - 'ci/test/nightly'
 
 name: Nightly Release
 
 jobs:
   create_release:
     name: Create nightly release
-    if: ${{ github.repository_owner == 'input-output-hk' }}
+    if: >
+      github.repository_owner == 'input-output-hk'
+      || startsWith(github.event.head_commit.message, 'TEST CI:')
     runs-on: ubuntu-latest
     outputs:
       release_date: ${{ steps.version.outputs.date }}
@@ -68,7 +73,9 @@ jobs:
 
   update_deps:
     name: Update dependencies
-    if: ${{ github.repository_owner == 'input-output-hk' }}
+    if: >
+      github.repository_owner == 'input-output-hk'
+      || startsWith(github.event.head_commit.message, 'TEST CI:')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -115,7 +122,9 @@ jobs:
 
   build_assets:
     name: Build assets
-    if: ${{ github.repository_owner == 'input-output-hk' }}
+    if: >
+      github.repository_owner == 'input-output-hk'
+      || startsWith(github.event.head_commit.message, 'TEST CI:')
     needs: [create_release, update_deps]
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -296,7 +305,9 @@ jobs:
 
   publish_release:
     name: Publish nightly release
-    if: ${{ github.repository_owner == 'input-output-hk' }}
+    if: >
+      github.repository_owner == 'input-output-hk'
+      || startsWith(github.event.head_commit.message, 'TEST CI:')
     needs: [create_release, build_assets]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -220,10 +220,17 @@ jobs:
           rustflags = ["-C", "target-cpu=${{ matrix.target_cpu }}", "-C", "lto"]
           EOF
 
+      - if: ${{ matrix.cross }}
+        name: Create Cross.toml
+        shell: bash
+        run: |
+          cat > Cross.toml <<EOF
+          [build.env]
+          passthrough = ["DATE"]
+          EOF
+
       - name: Build jormungandr
         uses: actions-rs/cargo@v1
-        env:
-          DATE: ${{ env.DATE }}
         with:
           use-cross: ${{ matrix.cross }}
           command: build
@@ -238,8 +245,6 @@ jobs:
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
-        env:
-          DATE: ${{ env.DATE }}
         with:
           use-cross: ${{ matrix.cross }}
           command: build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,11 +17,20 @@ jobs:
         with:
           submodules: true
 
-      - name: Get version
+      - name: Get version from jormungandr/Cargo.toml
         id: version
+        shell: python
         run: |
-          export VERSION=`cat ./jormungandr/Cargo.toml | grep "version" | head -n 1 | awk '{print $3}' | cut -d "\"" -f 2 `
-          echo ::set-output name=version::$VERSION
+          from __future__ import print_function
+          import json
+          from subprocess import Popen, PIPE
+          p = Popen(
+            'cargo read-manifest --manifest-path jormungandr/Cargo.toml',
+            shell=True,
+            stdout=PIPE
+          )
+          d = json.load(p.stdout)
+          print('::set-output name=version::' + d['version'])
 
       - name: Delete nightly with hub
         continue-on-error: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,7 @@ jobs:
     if: ${{ github.repository_owner == 'input-output-hk' }}
     runs-on: ubuntu-latest
     outputs:
+      release_date: ${{ steps.version.outputs.date }}
       release_version: ${{ steps.version.outputs.version }}
       upload_url: ${{ steps.create_nightly.outputs.upload_url }}
     steps:
@@ -21,7 +22,8 @@ jobs:
         shell: python
         run: |
           from __future__ import print_function
-          import json
+          import json, re
+          from datetime import date
           from subprocess import Popen, PIPE
           p = Popen(
             'cargo read-manifest --manifest-path jormungandr/Cargo.toml',
@@ -29,7 +31,15 @@ jobs:
             stdout=PIPE
           )
           d = json.load(p.stdout)
-          print('::set-output name=version::' + d['version'])
+          date = date.today().strftime('%Y%m%d')
+          version = re.sub(
+            r'^(\d+\.\d+\.\d+)(-.*)?$',
+            r'\1-nightly.' + date,
+            d['version'],
+            count=1
+          )
+          print('::set-output name=date::' + date)
+          print('::set-output name=version::' + version)
 
       - name: Delete the existing nightly release
         continue-on-error: true
@@ -173,23 +183,10 @@ jobs:
           override: true
           default: true
 
-      - name: Get current date
-        run: |
-          export DATE=`date +'%Y%m%d'`;
-          echo ::set-env name=DATE::$DATE
-        shell: bash
-
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           submodules: true
-
-      - name: Get version
-        id: version
-        run: |
-          export VERSION=`cat ./jormungandr/Cargo.toml | grep "version" | head -n 1 | awk '{print $3}' | cut -d "\"" -f 2 `
-          echo ::set-output name=version::$VERSION
-        shell: bash
 
       # https://github.com/actions/runner/issues/498
       - if: ${{ runner.os == 'Windows' }}
@@ -231,6 +228,8 @@ jobs:
 
       - name: Build jormungandr
         uses: actions-rs/cargo@v1
+        env:
+          DATE: ${{ needs.create_release.outputs.release_date }}
         with:
           use-cross: ${{ matrix.cross }}
           command: build
@@ -245,6 +244,8 @@ jobs:
 
       - name: Build jcli
         uses: actions-rs/cargo@v1
+        env:
+          DATE: ${{ needs.create_release.outputs.release_date }}
         with:
           use-cross: ${{ matrix.cross }}
           command: build
@@ -259,7 +260,7 @@ jobs:
       - name: Pack binaries (Unix)
         if: matrix.config.os != 'windows-latest'
         run: |
-          archive=jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz
+          archive=jormungandr-${{ needs.create_release.outputs.release_version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz
           tar -C ./target/${{ matrix.config.target }}/release -czvf $archive jormungandr jcli
           echo "::set-env name=RELEASE_ARCHIVE::$archive"
           echo "::set-env name=RELEASE_CONTENT_TYPE::application/gzip"
@@ -267,7 +268,7 @@ jobs:
       - name: Pack binaries (Windows)
         if: matrix.config.os == 'windows-latest'
         run: |
-          $archive = "jormungandr-${{ steps.version.outputs.version }}.${{ env.DATE }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip"
+          $archive = "jormungandr-${{ needs.create_release.outputs.release_version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip"
           $args = @{
             Path  = "./target/${{ matrix.config.target }}/release/jormungandr.exe",
                     "./target/${{ matrix.config.target }}/release/jcli.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,23 +6,32 @@ on:
 name: Release
 
 jobs:
-  initial_release:
-    name: Create base release
+  create_release:
+    name: Create draft release
     if: ${{ github.repository_owner == 'input-output-hk' }}
     runs-on: ubuntu-latest
     outputs:
+      version: ${{ steps.version.outputs.version }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - name: Create Release
+      - name: Get version from tag name
+        id: version
+        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/v}"
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Create release
         id: create_release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+        run: |
+          release_tag=${GITHUB_REF#refs/tags/}
+          hub release create --draft \
+            -m "Release ${{ steps.version.outputs.version }} (in progress)" \
+            $release_tag
+          upload_url=$(hub release show -f '%uA' $release_tag)
+          echo "::set-output name=upload_url::$upload_url"
 
   update_deps:
     name: Update dependencies
@@ -71,10 +80,10 @@ jobs:
         run: |
           rm -rf ~/.cargo/registry/src
 
-  release_assets:
-    name: Release assets
+  build_assets:
+    name: Build assets
     if: ${{ github.repository_owner == 'input-output-hk' }}
-    needs: [initial_release, update_deps]
+    needs: [create_release, update_deps]
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
@@ -207,15 +216,10 @@ jobs:
             --release
             --target ${{ matrix.config.target }}
 
-      - name: Get tag version
-        id: get_version
-        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
-        shell: bash
-
       - name: Pack binaries (Unix)
         if: matrix.config.os != 'windows-latest'
         run: |
-          archive=jormungandr-${{ steps.get_version.outputs.version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz
+          archive=jormungandr-${{ needs.create_release.outputs.version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.tar.gz
           tar -C ./target/${{ matrix.config.target }}/release -czvf $archive jormungandr jcli
           echo "::set-env name=RELEASE_ARCHIVE::$archive"
           echo "::set-env name=RELEASE_CONTENT_TYPE::application/gzip"
@@ -223,7 +227,7 @@ jobs:
       - name: Pack binaries (Windows)
         if: matrix.config.os == 'windows-latest'
         run: |
-          $archive = "jormungandr-${{ steps.get_version.outputs.version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip"
+          $archive = "jormungandr-${{ needs.create_release.outputs.version }}-${{ matrix.config.target }}-${{ matrix.target_cpu }}.zip"
           $args = @{
             Path  = "./target/${{ matrix.config.target }}/release/jormungandr.exe",
                     "./target/${{ matrix.config.target }}/release/jcli.exe"
@@ -238,7 +242,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.initial_release.outputs.upload_url }}
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ./${{ env.RELEASE_ARCHIVE }}
           asset_name: ${{ env.RELEASE_ARCHIVE }}
           asset_content_type: ${{ env.RELEASE_CONTENT_TYPE }}
+
+  publish_release:
+    name: Publish release
+    if: ${{ github.repository_owner == 'input-output-hk' }}
+    needs: [create_release, build_assets]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_tag=${GITHUB_REF#refs/tags/}
+          hub release edit --draft=false \
+            -m 'Release ${{ needs.create_release.outputs.version }}' \
+            $release_tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,9 @@ name: Release
 jobs:
   create_release:
     name: Create draft release
-    if: ${{ github.repository_owner == 'input-output-hk' }}
+    if: >
+      github.repository_owner == 'input-output-hk'
+      || startsWith(github.event.head_commit.message, 'TEST CI:')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -35,7 +37,9 @@ jobs:
 
   update_deps:
     name: Update dependencies
-    if: ${{ github.repository_owner == 'input-output-hk' }}
+    if: >
+      github.repository_owner == 'input-output-hk'
+      || startsWith(github.event.head_commit.message, 'TEST CI:')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -82,7 +86,9 @@ jobs:
 
   build_assets:
     name: Build assets
-    if: ${{ github.repository_owner == 'input-output-hk' }}
+    if: >
+      github.repository_owner == 'input-output-hk'
+      || startsWith(github.event.head_commit.message, 'TEST CI:')
     needs: [create_release, update_deps]
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -249,7 +255,9 @@ jobs:
 
   publish_release:
     name: Publish release
-    if: ${{ github.repository_owner == 'input-output-hk' }}
+    if: >
+      github.repository_owner == 'input-output-hk'
+      || startsWith(github.event.head_commit.message, 'TEST CI:')
     needs: [create_release, build_assets]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Create the releases in two phases: draft while no assets are ready, then publish with assets.
- The release mail, sent on publish, now lists all assets, not only the source tarballs.
- Post the new `nightly.YYYYMMDD` tag to which the nightly release is attached, delete all previous
  tags with their associated releases.
- Consistent naming of releases: suffix with date for nightly, `v` prefix stripped for regular.
- Make sure the `DATE` environment variable is passed to cross builds using `Cross.toml`.