### PR TITLE
Don't use --all flag with cargo fmt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,18 +96,12 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init --depth=1
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          name: Restore cargo registry index from cache
-          keys:
-            - cargo-index-v1-{{ checksum ".circleci/crates.io-index.head" }}
       - run:
           name: Print version information
-          command: cargo fmt -- --version
+          command: rustfmt --version
       - run:
           name: Check rustfmt
-          command: cargo fmt --all -- --check
+          command: cargo fmt -- --check
 
   test_debug:
     executor: rust-stable
@@ -188,9 +182,7 @@ workflows:
   test_all:
     jobs:
       - cargo_fetch
-      - rustfmt:
-          requires:
-            - cargo_fetch
+      - rustfmt
       - cargo_audit:
           requires:
             - cargo_fetch


### PR DESCRIPTION
It adds nothing useful: `cargo fmt` checks all legitimate workspace members, and for chain-deps we have a CI workflow in its own reposotiry.
Moreover, the `--all` flag slows down the test run. Per suggestion in
https://github.com/rust-lang/rustfmt/issues/4247#issuecomment-641484560