### PR TITLE
Actively refresh cargo index cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,18 +96,12 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init --depth=1
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          name: Restore cargo registry index from cache
-          keys:
-            - cargo-index-v1-{{ checksum ".circleci/crates.io-index.head" }}
       - run:
           name: Print version information
-          command: cargo fmt -- --version
+          command: rustfmt --version
       - run:
           name: Check rustfmt
-          command: cargo fmt --all -- --check
+          command: cargo fmt -- --check
 
   test_debug:
     executor: rust-stable
@@ -188,9 +182,7 @@ workflows:
   test_all:
     jobs:
       - cargo_fetch
-      - rustfmt:
-          requires:
-            - cargo_fetch
+      - rustfmt
       - cargo_audit:
           requires:
             - cargo_fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: Fetch dependencies and update cargo registry index
           command: |
-            cargo fetch --locked
+            cargo fetch
             git -C /usr/local/cargo/registry/index/github.com-1ecc6299db9ec823 \
                 show-ref -s refs/remotes/origin/master |
               tee .circleci/crates.io-index.head


### PR DESCRIPTION
Use of the `--locked` option with `cargo fetch` caused the index to be stuck at an old checkout that's sufficient for this `Cargo.lock`, increasing resync times. Better to save the fresh index every time.