### PR TITLE
CircleCI: Limit the doctest threads to 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,9 @@ commands:
             RUST_BACKTRACE: 1
             CARGO_BUILD_JOBS: 1
           command: |
-            cargo test --workspace --doc << parameters.mode >> << parameters.cargo_behavior >>
+            cargo test --workspace --doc \
+              << parameters.mode >> << parameters.cargo_behavior >> \
+              -- --test-threads=1
 
 workflows:
   version: 2


### PR DESCRIPTION
Some linker processes still run out of memory.