### PR TITLE
Vote tally and plan status

### DIFF
--- a/jcli/src/jcli_app/certificate/mod.rs
+++ b/jcli/src/jcli_app/certificate/mod.rs
@@ -19,7 +19,9 @@ mod new_vote_plan;
 mod sign;
 mod weighted_pool_ids;
 
-pub(crate) use self::sign::{pool_owner_sign, stake_delegation_account_binding_sign};
+pub(crate) use self::sign::{
+    committee_vote_tally_sign, pool_owner_sign, stake_delegation_account_binding_sign,
+};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -209,6 +211,7 @@ fn read_cert_or_signed_cert(input: Option<&Path>) -> Result<interfaces::Certific
                 SignedCertificate::PoolUpdate(pu, _) => Certificate::PoolUpdate(pu),
                 SignedCertificate::VotePlan(vp, _) => Certificate::VotePlan(vp),
                 SignedCertificate::VoteCast(vp, _) => Certificate::VoteCast(vp),
+                SignedCertificate::VoteTally(vt, _) => Certificate::VoteTally(vt),
             };
 
             Ok(interfaces::Certificate(cert))

--- a/jormungandr-lib/src/crypto/hash.rs
+++ b/jormungandr-lib/src/crypto/hash.rs
@@ -111,6 +111,12 @@ impl<T> From<DigestOf<Blake2b256, T>> for Hash {
     }
 }
 
+impl<T> From<Hash> for DigestOf<Blake2b256, T> {
+    fn from(h: Hash) -> Self {
+        DigestOf::from(h.0)
+    }
+}
+
 impl From<Hash> for [u8; 32] {
     fn from(hash: Hash) -> [u8; 32] {
         hash.0.into()

--- a/jormungandr-lib/src/interfaces/account_identifier.rs
+++ b/jormungandr-lib/src/interfaces/account_identifier.rs
@@ -94,6 +94,16 @@ impl From<AccountIdentifier> for transaction::AccountIdentifier {
     }
 }
 
+impl From<transaction::UnspecifiedAccountIdentifier> for AccountIdentifier {
+    fn from(t: transaction::UnspecifiedAccountIdentifier) -> Self {
+        Self(
+            t.to_single_account()
+                .map(transaction::AccountIdentifier::Single)
+                .unwrap_or_else(|| transaction::AccountIdentifier::Multi(t.to_multi_account())),
+        )
+    }
+}
+
 /* ------------------- Serde ----------------------------------------------- */
 
 impl Serialize for AccountIdentifier {

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
@@ -75,8 +75,11 @@ pub fn try_initials_vec_from_messages<'a>(
             Fragment::VotePlan(tx) => {
                 let tx = tx.as_slice();
                 let cert = tx.payload().into_payload();
-                let auth = tx.payload_auth().into_payload_auth();
-                let cert = certificate::SignedCertificate::VotePlan(cert, auth);
+                // the pattern match here is to make sure we are actually expecting the `()`
+                // and that if it changes the compiler will detect it and tell us about the
+                // change so we are reminded of a breaking change
+                let () = tx.payload_auth().into_payload_auth();
+                let cert = certificate::SignedCertificate::VotePlan(cert, ());
                 inits.push(Initial::Cert(cert.into()))
             }
             _ => return Err(Error::Block0MessageUnexpected),

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
@@ -187,6 +187,7 @@ fn pack_certificate_in_empty_tx_fragment(cert: &SignedCertificate) -> Fragment {
         }
         certificate::SignedCertificate::VotePlan(c, a) => Fragment::VotePlan(empty_auth_tx(c, a)),
         certificate::SignedCertificate::VoteCast(c, a) => Fragment::VoteCast(empty_auth_tx(c, a)),
+        certificate::SignedCertificate::VoteTally(c, a) => Fragment::VoteTally(empty_auth_tx(c, a)),
     }
 }
 

--- a/jormungandr-lib/src/interfaces/certificate.rs
+++ b/jormungandr-lib/src/interfaces/certificate.rs
@@ -50,6 +50,9 @@ impl SignedCertificate {
             certificate::SignedCertificate::VoteCast(c, _) => {
                 Certificate(certificate::Certificate::VoteCast(c))
             }
+            certificate::SignedCertificate::VoteTally(c, _) => {
+                Certificate(certificate::Certificate::VoteTally(c))
+            }
         }
     }
 }
@@ -84,6 +87,10 @@ impl property::Serialize for Certificate {
             }
             certificate::Certificate::VoteCast(c) => {
                 writer.write_all(&[7])?;
+                writer.write_all(c.serialize().as_slice())?;
+            }
+            certificate::Certificate::VoteTally(c) => {
+                writer.write_all(&[8])?;
                 writer.write_all(c.serialize().as_slice())?;
             }
         };
@@ -126,6 +133,10 @@ impl Readable for Certificate {
                 let cert = certificate::VoteCast::read(buf)?;
                 Ok(Certificate(certificate::Certificate::VoteCast(cert)))
             }
+            8 => {
+                let cert = certificate::VoteTally::read(buf)?;
+                Ok(Certificate(certificate::Certificate::VoteTally(cert)))
+            }
             t => Err(ReadError::UnknownTag(t as u32)),
         }
     }
@@ -166,6 +177,11 @@ impl property::Serialize for SignedCertificate {
             certificate::SignedCertificate::VoteCast(c, ()) => {
                 writer.write_all(&[7])?;
                 writer.write_all(c.serialize().as_slice())?;
+            }
+            certificate::SignedCertificate::VoteTally(c, a) => {
+                writer.write_all(&[8])?;
+                writer.write_all(c.serialize().as_slice())?;
+                writer.write_all(a.serialize_in(ByteBuilder::new()).finalize().as_slice())?;
             }
         };
         Ok(())

--- a/jormungandr-lib/src/interfaces/mod.rs
+++ b/jormungandr-lib/src/interfaces/mod.rs
@@ -61,4 +61,6 @@ pub use self::transaction_output::TransactionOutput;
 pub use self::transaction_witness::TransactionWitness;
 pub use self::utxo_info::{UTxOInfo, UTxOOutputInfo};
 pub use self::value::{Value, ValueDef};
-pub use self::vote::{VotePlanSerializableHelper, VotePlanWithId};
+pub use self::vote::{
+    Payload, PayloadTypeDef, Tally, TallyResult, VotePlanStatus, VoteProposalStatus,
+};

--- a/jormungandr-lib/src/interfaces/vote/mod.rs
+++ b/jormungandr-lib/src/interfaces/vote/mod.rs
@@ -1,157 +1,117 @@
-use crate::{crypto::hash::Hash, interfaces::blockdate::BlockDateDef};
+use crate::{
+    crypto::hash::Hash,
+    interfaces::{account_identifier::AccountIdentifier, blockdate::BlockDateDef},
+};
+use chain_impl_mockchain::{
+    header::BlockDate,
+    vote::{self, PayloadType},
+};
 use core::ops::Range;
-use serde::{ser::SerializeSeq, Serialize, Serializer};
+use serde::Serialize;
+use std::collections::HashMap;
 
-#[derive(Serialize)]
-pub struct VoteOptions {
-    range: Range<u8>,
-}
-
-fn get_proposal_hash(proposal: &chain_impl_mockchain::certificate::Proposal) -> Hash {
-    Hash::from(proposal.external_id().clone())
-}
-
-fn get_proposal_vote_options(
-    proposal: &chain_impl_mockchain::certificate::Proposal,
-) -> VoteOptions {
-    VoteOptions {
-        range: proposal.options().choice_range().clone(),
-    }
-}
-
-#[derive(Serialize)]
-#[serde(remote = "chain_impl_mockchain::certificate::Proposal")]
-pub struct Proposal {
-    #[serde(getter = "get_proposal_hash")]
-    pub external_id: Hash,
-    #[serde(getter = "get_proposal_vote_options")]
-    pub options: VoteOptions,
-}
-
-#[derive(Serialize)]
-pub struct ProposalSerializableHelper<'a>(
-    #[serde(with = "Proposal")] pub &'a chain_impl_mockchain::certificate::Proposal,
-);
-
-#[derive(Serialize)]
-#[serde(remote = "chain_impl_mockchain::vote::PayloadType")]
+#[derive(
+    Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, serde::Deserialize,
+)]
+#[serde(remote = "PayloadType")]
 pub enum PayloadTypeDef {
     Public,
 }
 
-fn serialize_proposals<S>(
-    proposals: &chain_impl_mockchain::certificate::Proposals,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let mut seq = serializer.serialize_seq(Some(proposals.len()))?;
-    for e in proposals.iter() {
-        seq.serialize_element(&ProposalSerializableHelper(e))?;
-    }
-    seq.end()
-}
-
 #[derive(Serialize)]
-#[serde(remote = "chain_impl_mockchain::certificate::VotePlan")]
-pub struct VotePlan {
-    #[serde(
-        with = "BlockDateDef",
-        getter = "chain_impl_mockchain::certificate::VotePlan::vote_start"
-    )]
-    pub vote_start: chain_impl_mockchain::block::BlockDate,
-
-    #[serde(
-        with = "BlockDateDef",
-        getter = "chain_impl_mockchain::certificate::VotePlan::vote_end"
-    )]
-    pub vote_end: chain_impl_mockchain::block::BlockDate,
-
-    #[serde(
-        with = "BlockDateDef",
-        getter = "chain_impl_mockchain::certificate::VotePlan::committee_end"
-    )]
-    pub committee_end: chain_impl_mockchain::block::BlockDate,
-
-    #[serde(
-        with = "PayloadTypeDef",
-        getter = "chain_impl_mockchain::certificate::VotePlan::payload_type"
-    )]
-    pub payload_type: chain_impl_mockchain::vote::PayloadType,
-
-    #[serde(
-        serialize_with = "serialize_proposals",
-        getter = "chain_impl_mockchain::certificate::VotePlan::proposals"
-    )]
-    pub proposals: chain_impl_mockchain::certificate::Proposals,
-}
-
-#[derive(Serialize)]
-pub struct VotePlanSerializableHelper(
-    #[serde(with = "VotePlan")] chain_impl_mockchain::certificate::VotePlan,
-);
-
-impl VotePlanSerializableHelper {
-    pub fn new(vote_plan: chain_impl_mockchain::certificate::VotePlan) -> Self {
-        Self(vote_plan)
-    }
-}
-
-#[derive(Serialize)]
-pub struct VotePlanWithId {
-    pub voteplan_id: Hash,
-
-    #[serde(with = "BlockDateDef")]
-    pub vote_start: chain_impl_mockchain::block::BlockDate,
-
-    #[serde(with = "BlockDateDef")]
-    pub vote_end: chain_impl_mockchain::block::BlockDate,
-
-    #[serde(with = "BlockDateDef")]
-    pub committee_end: chain_impl_mockchain::block::BlockDate,
-
+pub struct VotePlanStatus {
+    pub id: Hash,
     #[serde(with = "PayloadTypeDef")]
-    pub payload_type: chain_impl_mockchain::vote::PayloadType,
-
-    #[serde(serialize_with = "serialize_proposals_index")]
-    pub proposals: chain_impl_mockchain::certificate::Proposals,
+    pub payload: PayloadType,
+    #[serde(with = "BlockDateDef")]
+    pub vote_start: BlockDate,
+    #[serde(with = "BlockDateDef")]
+    pub vote_end: BlockDate,
+    #[serde(with = "BlockDateDef")]
+    pub committee_end: BlockDate,
+    pub proposals: Vec<VoteProposalStatus>,
 }
 
-impl VotePlanWithId {
-    pub fn new(vote_plan: &chain_impl_mockchain::certificate::VotePlan) -> VotePlanWithId {
-        VotePlanWithId {
-            voteplan_id: Hash::from(vote_plan.to_id()),
-            vote_start: vote_plan.vote_start(),
-            vote_end: vote_plan.vote_end(),
-            committee_end: vote_plan.committee_end(),
-            payload_type: vote_plan.payload_type(),
-            proposals: vote_plan.proposals().clone(),
+#[derive(Serialize)]
+pub enum Tally {
+    Public { result: TallyResult },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TallyResult {
+    results: Vec<u64>,
+
+    options: Range<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub enum Payload {
+    Public { choice: u8 },
+}
+
+#[derive(Serialize)]
+pub struct VoteProposalStatus {
+    pub index: u8,
+    pub proposal_id: Hash,
+    pub options: Range<u8>,
+    pub tally: Option<Tally>,
+    pub votes: HashMap<AccountIdentifier, Payload>,
+}
+
+impl From<vote::Payload> for Payload {
+    fn from(this: vote::Payload) -> Self {
+        match this {
+            vote::Payload::Public { choice } => Self::Public {
+                choice: choice.as_byte(),
+            },
         }
     }
 }
 
-#[derive(Serialize)]
-pub struct ProposalWithIndex {
-    pub external_id: Hash,
-    pub options: VoteOptions,
-    pub index: u8,
+impl From<vote::TallyResult> for TallyResult {
+    fn from(this: vote::TallyResult) -> Self {
+        Self {
+            results: this.results().iter().map(|v| (*v).into()).collect(),
+            options: this.options().choice_range().clone(),
+        }
+    }
 }
 
-fn serialize_proposals_index<S>(
-    proposals: &chain_impl_mockchain::certificate::Proposals,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let mut seq = serializer.serialize_seq(Some(proposals.len()))?;
-    for (i, e) in proposals.iter().enumerate() {
-        seq.serialize_element(&ProposalWithIndex {
-            external_id: get_proposal_hash(e),
-            options: get_proposal_vote_options(e),
-            index: i as u8,
-        })?;
+impl From<vote::Tally> for Tally {
+    fn from(this: vote::Tally) -> Self {
+        match this {
+            vote::Tally::Public { result } => Tally::Public {
+                result: result.into(),
+            },
+        }
     }
-    seq.end()
+}
+
+impl From<vote::VoteProposalStatus> for VoteProposalStatus {
+    fn from(this: vote::VoteProposalStatus) -> Self {
+        Self {
+            index: this.index,
+            proposal_id: this.proposal_id.into(),
+            options: this.options.choice_range().clone(),
+            tally: this.tally.map(|t| t.into()),
+            votes: this
+                .votes
+                .iter()
+                .map(|(k, p)| (k.clone().into(), p.clone().into()))
+                .collect(),
+        }
+    }
+}
+
+impl From<vote::VotePlanStatus> for VotePlanStatus {
+    fn from(this: vote::VotePlanStatus) -> Self {
+        Self {
+            id: this.id.into(),
+            vote_start: this.vote_start,
+            vote_end: this.vote_end,
+            committee_end: this.committee_end,
+            payload: this.payload,
+            proposals: this.proposals.into_iter().map(|p| p.into()).collect(),
+        }
+    }
 }

--- a/jormungandr/src/blockchain/reference.rs
+++ b/jormungandr/src/blockchain/reference.rs
@@ -2,7 +2,7 @@ use crate::blockcfg::{
     BlockDate, ChainLength, EpochRewardsInfo, Header, HeaderHash, Leadership, Ledger,
     LedgerParameters,
 };
-use chain_impl_mockchain::{certificate::VotePlan, multiverse};
+use chain_impl_mockchain::{multiverse, vote::VotePlanStatus};
 use chain_time::{
     era::{EpochPosition, EpochSlotOffset},
     Epoch, Slot, TimeFrame,
@@ -164,7 +164,7 @@ impl Ref {
     ///
     /// this includes, votes to be voted on, on going votes, votes to be resolved and votes
     /// to result into a change on the ledger
-    pub fn active_vote_plans(&self) -> Vec<VotePlan> {
+    pub fn active_vote_plans(&self) -> Vec<VotePlanStatus> {
         self.ledger.state().active_vote_plans()
     }
 }

--- a/jormungandr/src/explorer/graphql/certificates.rs
+++ b/jormungandr/src/explorer/graphql/certificates.rs
@@ -16,6 +16,7 @@ pub enum Certificate {
     PoolUpdate(PoolUpdate),
     VotePlan(VotePlan),
     VoteCast(VoteCast),
+    VoteTally(VoteTally),
 }
 
 pub struct StakeDelegation(certificate::StakeDelegation);
@@ -33,6 +34,8 @@ pub struct VotePlan(certificate::VotePlan);
 
 pub struct VoteCast(certificate::VoteCast);
 
+pub struct VoteTally(certificate::VoteTally);
+
 graphql_union!(Certificate: Context |&self| {
     // the left hand side of the `instance_resolvers` match-like pub structure is the one
     // that's used to match in the graphql query with the `__typename` field
@@ -44,6 +47,7 @@ graphql_union!(Certificate: Context |&self| {
         &PoolRetirement => match *self { Certificate::PoolRetirement(ref c) => Some(c), _ => None},
         &VotePlan => match *self { Certificate::VotePlan(ref c) => Some(c), _ => None},
         &VoteCast => match *self { Certificate::VoteCast(ref c) => Some(c), _ => None},
+        &VoteTally => match *self { Certificate::VoteTally(ref c) => Some(c), _ => None},
     }
 });
 
@@ -245,6 +249,15 @@ impl VoteCast {
     }
 }
 
+#[juniper::object(
+    Context = Context,
+)]
+impl VoteTally {
+    pub fn vote_plan(&self) -> VotePlanId {
+        self.0.id().clone().into()
+    }
+}
+
 /*------------------------------*/
 /*------- Conversions ---------*/
 /*----------------------------*/
@@ -270,6 +283,7 @@ impl TryFrom<chain_impl_mockchain::certificate::Certificate> for Certificate {
             certificate::Certificate::PoolUpdate(c) => Ok(Certificate::PoolUpdate(PoolUpdate(c))),
             certificate::Certificate::VotePlan(c) => Ok(Certificate::VotePlan(VotePlan(c))),
             certificate::Certificate::VoteCast(c) => Ok(Certificate::VoteCast(VoteCast(c))),
+            certificate::Certificate::VoteTally(c) => Ok(Certificate::VoteTally(VoteTally(c))),
         }
     }
 }

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -108,6 +108,7 @@ fn is_fragment_valid(fragment: &Fragment) -> bool {
         Fragment::UpdateVote(_) => false,     // TODO: enable when ready
         Fragment::VotePlan(ref tx) => is_transaction_valid(tx),
         Fragment::VoteCast(ref tx) => is_transaction_valid(tx),
+        Fragment::VoteTally(ref tx) => is_transaction_valid(tx),
     }
 }
 

--- a/jormungandr/src/rest/v0/logic.rs
+++ b/jormungandr/src/rest/v0/logic.rs
@@ -34,7 +34,7 @@ use jormungandr_lib::{
         AccountState, EnclaveLeaderId, EpochRewardsInfo, FragmentLog, FragmentOrigin,
         LeadershipLog, NodeStats, NodeStatsDto, PeerStats, Rewards as StakePoolRewards,
         SettingsDto, StakeDistribution, StakeDistributionDto, StakePoolStats, TaxTypeSerde,
-        TransactionOutput, VotePlanWithId,
+        TransactionOutput, VotePlanStatus,
     },
     time::SystemTime,
 };
@@ -636,14 +636,14 @@ pub async fn get_committees(context: &Context) -> Result<Vec<String>, Error> {
         .collect())
 }
 
-pub async fn get_active_vote_plans(context: &Context) -> Result<Vec<VotePlanWithId>, Error> {
+pub async fn get_active_vote_plans(context: &Context) -> Result<Vec<VotePlanStatus>, Error> {
     let vp = context
         .blockchain_tip()?
         .get_ref()
         .await
         .active_vote_plans()
-        .iter()
-        .map(|vote_plan| VotePlanWithId::new(vote_plan))
+        .into_iter()
+        .map(VotePlanStatus::from)
         .collect();
     Ok(vp)
 }

--- a/jormungandr/src/rest/v0/logic.rs
+++ b/jormungandr/src/rest/v0/logic.rs
@@ -192,6 +192,7 @@ async fn create_stats(context: &Context) -> Result<Option<NodeStats>, Error> {
                 Fragment::PoolUpdate(tx) => totals(tx),
                 Fragment::VotePlan(tx) => totals(tx),
                 Fragment::VoteCast(tx) => totals(tx),
+                Fragment::VoteTally(tx) => totals(tx),
                 Fragment::Initial(_)
                 | Fragment::OldUtxoDeclaration(_)
                 | Fragment::UpdateProposal(_)

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
@@ -548,7 +548,7 @@ where
     fn verify_is_up(&self) -> Result<(), StartupError> {
         let start = Instant::now();
         let log_file_path = self.params.log_file_path();
-        let logger = JormungandrLogger::new(log_file_path.clone());
+        let logger = JormungandrLogger::new(log_file_path);
         loop {
             if start.elapsed() > self.starter.timeout {
                 return Err(StartupError::Timeout {

--- a/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -196,7 +196,7 @@ pub fn test_genesis_decode_bijection() {
 
     let right_hash = jcli_wrapper::assert_genesis_hash(block0_after.path());
 
-    assert_eq!(params.genesis_block_hash().clone(), right_hash);
+    assert_eq!(params.genesis_block_hash(), right_hash);
 }
 
 #[test]

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/input.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/input.rs
@@ -1,4 +1,4 @@
-use crate::common::jcli_wrapper::jcli_transaction_wrapper::JCLITransactionWrapper;
+use crate::common::{file_utils, jcli_wrapper::jcli_transaction_wrapper::JCLITransactionWrapper};
 use jormungandr_lib::crypto::hash::Hash;
 
 lazy_static! {

--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
@@ -26,7 +26,7 @@ pub fn test_jormungandr_passive_node_starts_successfully() {
     passive_dir.create_dir_all().unwrap();
     let passive_config = ConfigurationBuilder::new()
         .with_trusted_peers(vec![jormungandr_leader.to_trusted_peer()])
-        .with_block_hash(leader_config.genesis_block_hash().clone())
+        .with_block_hash(leader_config.genesis_block_hash())
         .build(&passive_dir);
 
     let jormungandr_passive = Starter::new()

--- a/testing/jormungandr-integration-tests/src/jormungandr/vit/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/vit/mod.rs
@@ -57,7 +57,7 @@ pub fn test_get_initial_vote_plan() {
     assert!(vote_plans.len() == 1);
 
     let vote_plan = vote_plans.get(0).unwrap();
-    let actual_vote_plan_id = vote_plan["voteplan_id"].as_str().unwrap().to_string();
+    let actual_vote_plan_id = vote_plan["id"].as_str().unwrap().to_string();
 
     assert_eq!(actual_vote_plan_id, expected_vote_plan.to_id().to_string());
 }

--- a/testing/jormungandr-integration-tests/src/networking/communication.rs
+++ b/testing/jormungandr-integration-tests/src/networking/communication.rs
@@ -34,7 +34,7 @@ pub fn two_nodes_communication() {
     trusted_node_dir.create_dir_all().unwrap();
     let trusted_node_config = ConfigurationBuilder::new()
         .with_trusted_peers(vec![leader_jormungandr.to_trusted_peer()])
-        .with_block_hash(leader_config.genesis_block_hash().clone())
+        .with_block_hash(leader_config.genesis_block_hash())
         .build(&trusted_node_dir);
 
     let trusted_jormungandr = Starter::new()

--- a/testing/jormungandr-testing-utils/src/testing/sync/measure.rs
+++ b/testing/jormungandr-testing-utils/src/testing/sync/measure.rs
@@ -81,7 +81,7 @@ pub fn measure_fragment_propagation_speed<A: FragmentNode + Sized + Send>(
             let leader_index_usize = (leader_id - 1) as usize;
             let leader: &A = leaders.get(leader_index_usize).unwrap();
             let fragment_logs = leader.fragment_logs().unwrap();
-            let alias = FragmentNode::alias(leader).clone();
+            let alias = FragmentNode::alias(leader);
             report_node_stats
                 .do_if_interval_reached(|| println!("Node: {} -> {:?}", alias, fragment_logs));
 


### PR DESCRIPTION
To `jcli`:

* this add the vote plan tally for public tally, auth with the committee key

To `jormungandr`:

* [ ] on the REST: it changes the active vote plan details (the openapi doc needsupdated);
* on the GraphQL it adds the VoteTall certificate, though it is note very useful and it would be better to have the plan status instead
* the blockchain will automatically do the tally if the tally has a public payload

depends on input-output-hk/chain-libs#404