### PR TITLE
Fix error reporting in streaming replies

### DIFF
--- a/jormungandr/src/network/client/mod.rs
+++ b/jormungandr/src/network/client/mod.rs
@@ -200,6 +200,13 @@ impl Client {
             })?;
         } else {
             match client_box.as_mut().poll_flush(cx) {
+                Poll::Pending => {
+                    // Ignoring possible Pending return here: due to the following
+                    // ready!() invocation, this function cannot return Continue
+                    // while no progress has been made.
+                    Ok(())
+                }
+                Poll::Ready(Ok(())) => Ok(()),
                 Poll::Ready(Err(e)) => {
                     error!(
                         self.logger,
@@ -208,13 +215,6 @@ impl Client {
                     );
                     Err(())
                 }
-                Poll::Pending => {
-                    // Ignoring possible Pending return here: due to the following
-                    // ready!() invocation, this function cannot return Continue
-                    // while no progress has been made.
-                    Ok(())
-                }
-                _ => Ok(()),
             }?;
         }
 

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -114,30 +114,33 @@ impl BlockService for NodeService {
     ) -> Result<Self::PullBlocksToTipStream, Error> {
         let from = from.decode()?;
         let logger = self.logger().new(o!("request" => "PullBlocksToTip"));
-        let (handle, stream) =
+        let (handle, future) =
             intercom::stream_reply(buffer_sizes::outbound::BLOCKS, logger.clone());
         let client_box = self.channels.client_box.clone();
         send_message(client_box, ClientMsg::PullBlocksToTip(from, handle), logger).await?;
+        let stream = future.await?;
         Ok(convert::response_stream(stream))
     }
 
     async fn get_blocks(&self, ids: BlockIds) -> Result<Self::GetBlocksStream, Error> {
         let ids = ids.decode()?;
         let logger = self.logger().new(o!("request" => "GetBlocks"));
-        let (handle, stream) =
+        let (handle, future) =
             intercom::stream_reply(buffer_sizes::outbound::BLOCKS, logger.clone());
         let client_box = self.channels.client_box.clone();
         send_message(client_box, ClientMsg::GetBlocks(ids, handle), logger).await?;
+        let stream = future.await?;
         Ok(convert::response_stream(stream))
     }
 
     async fn get_headers(&self, ids: BlockIds) -> Result<Self::GetHeadersStream, Error> {
         let ids = ids.decode()?;
         let logger = self.logger().new(o!("request" => "GetHeaders"));
-        let (handle, stream) =
+        let (handle, future) =
             intercom::stream_reply(buffer_sizes::outbound::HEADERS, logger.clone());
         let client_box = self.channels.client_box.clone();
         send_message(client_box, ClientMsg::GetHeaders(ids, handle), logger).await?;
+        let stream = future.await?;
         Ok(convert::response_stream(stream))
     }
 
@@ -149,7 +152,7 @@ impl BlockService for NodeService {
         let from = from.decode()?;
         let to = to.decode()?;
         let logger = self.logger().new(o!("request" => "PullHeaders"));
-        let (handle, stream) =
+        let (handle, future) =
             intercom::stream_reply(buffer_sizes::outbound::HEADERS, logger.clone());
         let client_box = self.channels.client_box.clone();
         send_message(
@@ -158,6 +161,7 @@ impl BlockService for NodeService {
             logger,
         )
         .await?;
+        let stream = future.await?;
         Ok(convert::response_stream(stream))
     }
 


### PR DESCRIPTION
<p>Our handling of outbound streams has been lacking in error
reporting: when handling of a stream request or solicitation
was rejected due to, say, wrong parameters, the error was sent
in the stream. With upload streams, it now means the error cannot
be propagated to the server in the client streaming request,
resulting in a request with an empty outbound stream.
With server streaming responses, we haven't been doing the right thing
either: instead of sending a proper error response, we sent an OK in the
headers, then an error in the trailers.</p>

Rework `intercom::stream_reply` to return a future, which provides the missing error reporting stage.

Opportunistically, clean up the pump code in `blockchain::storage`.