### PR TITLE
[Tests] shorten resource result string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
+name = "bytesize"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
+
+[[package]]
 name = "bzip2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1597,7 @@ name = "jormungandr-testing-utils"
 version = "0.1.0"
 dependencies = [
  "bech32",
+ "bytesize",
  "cardano-legacy-address",
  "chain-addr",
  "chain-core",

--- a/testing/jormungandr-testing-utils/Cargo.toml
+++ b/testing/jormungandr-testing-utils/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 bech32 = "0.7"
+bytesize = "1.0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain", features = [ "property-test-api" ] }

--- a/testing/jormungandr-testing-utils/src/testing/measurement/marker/resources_usage.rs
+++ b/testing/jormungandr-testing-utils/src/testing/measurement/marker/resources_usage.rs
@@ -1,3 +1,4 @@
+use bytesize::ByteSize;
 use std::{cmp::Ordering, fmt};
 
 #[derive(Clone, Debug)]
@@ -47,10 +48,13 @@ impl Ord for ResourcesUsage {
 
 impl fmt::Display for ResourcesUsage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let memory_usage = ByteSize::kib(self.memory_usage.into()).to_string();
+        let virtual_memory_usage = ByteSize::kib(self.virtual_memory_usage.into()).to_string();
+
         write!(
             f,
-            "Usage(CPU: {:.1} %. Memory: {:.1}. Virtual memory: {:.1})",
-            self.cpu_usage, self.memory_usage, self.virtual_memory_usage
+            "(CPU: {:.1} %. Mem: {}. V_Mem: {})",
+            self.cpu_usage, memory_usage, virtual_memory_usage
         )
     }
 }


### PR DESCRIPTION
Changed node resources usage from long to short representation

from: `Usage(CPU: 0 %. Memory: 15328. Virtual memory: 576012288)`
to: `(CPU: 0 %. Mem: 39.1 MB. V_Mem: 460 MB)`