### PR TITLE
Use the same legacy node ID in gossip as in subs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,9 +2293,9 @@ checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
 
 [[package]]
 name = "poldercast"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad74b4f644e23d1faf58fca06eed184db0efef1e7da9fc46b9f168d8b18e01f0"
+checksum = "b3908d6ede3d7ab33a989f1c46bd7ba38474d715563d1ab66676fe26cdaaee3e"
 dependencies = [
  "cid",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
  "cfg-if",
  "cryptoxide",
  "curve25519-dalek",
- "digest 0.8.1",
+ "digest 0.9.0",
  "ed25519-bip32",
  "ed25519-dalek",
  "generic-array 0.14.1",
@@ -742,6 +742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.1",
 ]
 
 [[package]]

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -34,7 +34,7 @@ jormungandr-lib = { path = "../jormungandr-lib" }
 lazy_static = "1.4"
 linked-hash-map = "0.5"
 pin-utils = "0.1.0"
-poldercast = "0.13.1"
+poldercast = "0.13.3"
 r2d2 = "0.8"
 rand = "0.7"
 rand_chacha = "0.2.2"

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -14,6 +14,7 @@ use futures::future::BoxFuture;
 use futures::prelude::*;
 use futures::ready;
 
+use std::convert::TryInto;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -27,7 +28,7 @@ use std::task::{Context, Poll};
 pub fn connect(state: ConnectionState, channels: Channels) -> (ConnectHandle, ConnectFuture) {
     let (sender, receiver) = oneshot::channel();
     let peer = state.peer();
-    let legacy_node_id = state.global.legacy_node_id;
+    let legacy_node_id = state.global.config.legacy_node_id;
     let logger = state.logger.clone();
     let cf = async move {
         let mut grpc_client = if let Some(node_id) = legacy_node_id {

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -14,7 +14,6 @@ mod service;
 mod subscription;
 
 use self::convert::Encode;
-use chain_network::grpc::legacy;
 use jormungandr_lib::multiaddr::multiaddr_to_socket_addr;
 
 use futures::{future, prelude::*};
@@ -133,7 +132,6 @@ pub struct GlobalState {
     topology: P2pTopology,
     peers: Peers,
     logger: Logger,
-    legacy_node_id: Option<legacy::NodeId>,
 }
 
 pub type GlobalStateR = Arc<GlobalState>;
@@ -150,13 +148,7 @@ impl GlobalState {
 
         let mut rng_seed = [0; 32];
         rand::thread_rng().fill(&mut rng_seed);
-        let mut prng = ChaChaRng::from_seed(rng_seed);
-
-        let legacy_node_id = if config.generate_legacy_node_id {
-            Some(legacy::NodeId::generate(&mut prng).unwrap())
-        } else {
-            None
-        };
+        let prng = ChaChaRng::from_seed(rng_seed);
 
         let topology = P2pTopology::new(
             &config,
@@ -171,7 +163,6 @@ impl GlobalState {
             topology,
             peers,
             logger,
-            legacy_node_id,
         }
     }
 

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -404,6 +404,9 @@ async fn start_gossiping(state: GlobalStateR, channels: Channels) {
                 .map(|tp| {
                     let mut builder = poldercast::NodeProfileBuilder::new();
                     builder.address(tp.address.clone());
+                    if let Some(id) = tp.legacy_node_id {
+                        builder.id(id);
+                    }
                     builder.build()
                 })
                 .map(p2p::Gossip::from)

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -104,7 +104,7 @@ pub struct P2pConfig {
     ///
     /// TODO: To remove once we can afford a breaking change in the config
     #[serde(default, skip)]
-    pub public_id: Option<Id>,
+    pub public_id: Option<poldercast::Id>,
 
     /// the rendezvous points for the peer to connect to in order to initiate
     /// the p2p discovery from.
@@ -189,40 +189,7 @@ pub struct TrustedPeer {
     //
     // TODO: to remove once we can afford having a config breaking change
     #[serde(skip, default)]
-    pub id: Option<Id>,
-}
-
-// Lifted from poldercast 0.11 for backward compatibility
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Id([u8; ID_LEN]);
-
-const ID_LEN: usize = 24;
-
-impl Id {
-    fn zero() -> Self {
-        Id([0; ID_LEN])
-    }
-}
-
-impl FromStr for Id {
-    type Err = hex::FromHexError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut v = Self::zero();
-        hex::decode_to_slice(s, &mut v.0)?;
-        Ok(v)
-    }
-}
-
-impl AsRef<[u8]> for Id {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-impl fmt::Debug for Id {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Id").field(&hex::encode(self)).finish()
-    }
+    pub id: Option<poldercast::Id>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -305,7 +272,7 @@ impl std::str::FromStr for TrustedPeer {
         };
 
         let optional_id = if let Some(id) = split.next() {
-            let id = id.parse::<Id>().map_err(|e| e.to_string())?;
+            let id = id.parse::<poldercast::Id>().map_err(|e| e.to_string())?;
             Some(id)
         } else {
             None

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -248,6 +248,9 @@ fn generate_network(
         profile.address(address);
     }
 
+    let legacy_node_id = poldercast::Id::generate(rand::thread_rng());
+    profile.id(legacy_node_id);
+
     for (topic, interest_level) in p2p
         .topics_of_interest
         .unwrap_or(config::default_interests())
@@ -298,7 +301,7 @@ fn generate_network(
         http_fetch_block0_service,
         bootstrap_from_trusted_peers,
         skip_bootstrap,
-        generate_legacy_node_id: true,
+        legacy_node_id: Some(legacy_node_id),
     };
 
     if network.max_inbound_connections > network.max_connections {

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -100,12 +100,14 @@ pub struct Configuration {
 #[derive(Clone)]
 pub struct TrustedPeer {
     pub address: poldercast::Address,
+    pub legacy_node_id: Option<poldercast::Id>,
 }
 
 impl From<super::config::TrustedPeer> for TrustedPeer {
     fn from(tp: super::config::TrustedPeer) -> Self {
         TrustedPeer {
             address: tp.address,
+            legacy_node_id: tp.id,
         }
     }
 }

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -93,8 +93,8 @@ pub struct Configuration {
 
     pub http_fetch_block0_service: Vec<String>,
 
-    /// Whether to use pre-0.9 "node-id-bin" metadata when subscribing
-    pub generate_legacy_node_id: bool,
+    /// A pre-0.9 node ID to put in "node-id-bin" metadata when subscribing
+    pub legacy_node_id: Option<poldercast::Id>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
It's confusing when we start posing as different nodes in gossip and subscriptions.
Also, correctly gossip about legacy nodes, whose IDs should be put into the configuration again.