### PR TITLE
Disable double logging in staging tests

### DIFF
--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -584,11 +584,7 @@ impl LegacyNode {
             cause: e,
         })?;
 
-        command.arguments(&[
-            "--config",
-            &config_file.display().to_string(),
-            "--log-level=warn",
-        ]);
+        command.arguments(&["--config", &config_file.display().to_string()]);
 
         match block0 {
             NodeBlock0::File(path) => {

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -573,11 +573,7 @@ impl Node {
             cause: e,
         })?;
 
-        command.arguments(&[
-            "--config",
-            &config_file.display().to_string(),
-            "--log-level=warn",
-        ]);
+        command.arguments(&["--config", &config_file.display().to_string()]);
 
         match block0 {
             NodeBlock0::File(path) => {


### PR DESCRIPTION
Unfortunately, passing `--log-level` on the command line currently results in another log backend being instanciated, in addition to the one configured in `config.yaml`.
Both of them are set up to log to standard output/error.