### PR TITLE
Legacy scenario test fix

### DIFF
--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -370,8 +370,8 @@ async fn handle_propagation_msg(msg: PropagateMsg, state: GlobalStateR, channels
     if let Err(unreached_nodes) = propagate_res {
         debug!(
             state.logger(),
-            "will try to connect to {} of the peers not immediately reachable for propagation",
-            unreached_nodes.len(),
+            "will try to connect to the peers not immediately reachable for propagation: {:?}",
+            unreached_nodes,
         );
         for node in unreached_nodes {
             let mut options = p2p::comm::ConnectOptions::default();

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -562,6 +562,7 @@ impl Peers {
         nodes: Vec<Address>,
         header: Header,
     ) -> Result<(), Vec<Address>> {
+        debug!(self.logger, "propagating block to {:?}", nodes);
         self.propagate_with(nodes, move |status| match status {
             CommStatus::Established(comms) => comms.try_send_block_announcement(header.clone()),
             CommStatus::Connecting(comms) => {
@@ -577,10 +578,7 @@ impl Peers {
         nodes: Vec<Address>,
         fragment: Fragment,
     ) -> Result<(), Vec<Address>> {
-        debug!(
-            self.logger,
-            "propagating fragment";
-        );
+        debug!(self.logger, "propagating fragment to {:?}", nodes);
         self.propagate_with(nodes, move |status| match status {
             CommStatus::Established(comms) => comms.try_send_fragment(fragment.clone()),
             CommStatus::Connecting(comms) => {

--- a/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
@@ -114,7 +114,7 @@ impl LegacyNodeConfigConverter {
                 max_inbound_connections: None,
                 max_connections: None,
                 topics_of_interest: source.p2p.topics_of_interest.clone(),
-                allow_private_addresses: false,
+                allow_private_addresses: source.p2p.allow_private_addresses,
                 policy: source.p2p.policy.clone(),
                 layers: None,
             },


### PR DESCRIPTION
Make sure the `p2p.allow_private_addresses` setting is copied from the test settings to legacy node configuration.