### PR TITLE
Log received fragments

### DIFF
--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -39,6 +39,7 @@ impl Pool {
         mut fragments: Vec<Fragment>,
         logger: Logger,
     ) -> Result<usize, ()> {
+        debug!(logger, "received {} fragments", fragments.len(); "origin" => ?origin);
         fragments.retain(is_fragment_valid);
         if fragments.is_empty() {
             return Ok(0);

--- a/jormungandr/src/network/subscription.rs
+++ b/jormungandr/src/network/subscription.rs
@@ -304,6 +304,7 @@ impl Sink<net_data::Fragment> for FragmentProcessor {
             );
             e
         })?;
+        debug!(self.logger, "received fragment"; "hash" => %fragment.hash());
         self.buffered_fragments.push(fragment);
         Ok(())
     }


### PR DESCRIPTION
Add log statements in network and fragment tasks, tracking fragments as they are received.