### PR TITLE
Tune gRPC connections

### DIFF
--- a/jormungandr/src/network/grpc/client.rs
+++ b/jormungandr/src/network/grpc/client.rs
@@ -1,7 +1,7 @@
 use crate::{
     blockcfg::{Block, HeaderHash},
-    network::concurrency_limits,
     network::convert::Decode,
+    network::{concurrency_limits, keepalive_durations},
     settings::start::network::{Peer, Protocol},
 };
 use chain_network::data as net_data;
@@ -49,6 +49,8 @@ async fn connect_internal(peer: &Peer, builder: Builder) -> Result<Client, Conne
     assert!(peer.protocol == Protocol::Grpc);
     let endpoint = destination_endpoint(peer.connection)
         .concurrency_limit(concurrency_limits::CLIENT_REQUESTS)
+        .tcp_keepalive(Some(keepalive_durations::TCP))
+        .http2_keep_alive_interval(keepalive_durations::HTTP2)
         .timeout(peer.timeout);
     builder.connect(endpoint).await
 }

--- a/jormungandr/src/network/grpc/server.rs
+++ b/jormungandr/src/network/grpc/server.rs
@@ -1,5 +1,6 @@
 use super::super::{
-    concurrency_limits, service::NodeService, Channels, GlobalStateR, ListenError, TCP_KEEPALIVE,
+    concurrency_limits, keepalive_durations, service::NodeService, Channels, GlobalStateR,
+    ListenError,
 };
 use crate::settings::start::network::Listen;
 use chain_network::grpc;
@@ -27,7 +28,7 @@ pub async fn run_listen_socket(
 
     Server::builder()
         .concurrency_limit_per_connection(concurrency_limits::SERVER_REQUESTS)
-        .tcp_keepalive(Some(TCP_KEEPALIVE))
+        .tcp_keepalive(Some(keepalive_durations::TCP))
         .add_service(service)
         .serve(sockaddr)
         .await

--- a/jormungandr/src/network/grpc/server.rs
+++ b/jormungandr/src/network/grpc/server.rs
@@ -1,4 +1,4 @@
-use super::super::{service::NodeService, Channels, GlobalStateR, ListenError};
+use super::super::{concurrency_limits, service::NodeService, Channels, GlobalStateR, ListenError};
 use crate::settings::start::network::Listen;
 use chain_network::grpc;
 
@@ -24,6 +24,7 @@ pub async fn run_listen_socket(
     let service = builder.build(NodeService::new(channels, state));
 
     Server::builder()
+        .concurrency_limit_per_connection(concurrency_limits::SERVER_REQUESTS)
         .add_service(service)
         .serve(sockaddr)
         .await

--- a/jormungandr/src/network/grpc/server.rs
+++ b/jormungandr/src/network/grpc/server.rs
@@ -1,4 +1,6 @@
-use super::super::{concurrency_limits, service::NodeService, Channels, GlobalStateR, ListenError};
+use super::super::{
+    concurrency_limits, service::NodeService, Channels, GlobalStateR, ListenError, TCP_KEEPALIVE,
+};
 use crate::settings::start::network::Listen;
 use chain_network::grpc;
 
@@ -25,6 +27,7 @@ pub async fn run_listen_socket(
 
     Server::builder()
         .concurrency_limit_per_connection(concurrency_limits::SERVER_REQUESTS)
+        .tcp_keepalive(Some(TCP_KEEPALIVE))
         .add_service(service)
         .serve(sockaddr)
         .await

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -59,8 +59,15 @@ mod concurrency_limits {
     pub const SERVER_REQUESTS: usize = 256;
 }
 
-// TCP level keepalive duration for connections
-const TCP_KEEPALIVE: Duration = Duration::from_secs(60);
+mod keepalive_durations {
+    use std::time::Duration;
+
+    // TCP level keepalive duration for client and server connections
+    pub const TCP: Duration = Duration::from_secs(60);
+
+    // HTTP/2 keepalive for client connections
+    pub const HTTP2: Duration = Duration::from_secs(120);
+}
 
 use self::client::ConnectError;
 use self::p2p::{comm::Peers, P2pTopology};

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -54,6 +54,9 @@ mod buffer_sizes {
 mod concurrency_limits {
     // How many concurrent requests are permitted per client connection
     pub const CLIENT_REQUESTS: usize = 256;
+
+    // How many concurrent requests are permitted per server connection
+    pub const SERVER_REQUESTS: usize = 256;
 }
 
 use self::client::ConnectError;

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -59,6 +59,9 @@ mod concurrency_limits {
     pub const SERVER_REQUESTS: usize = 256;
 }
 
+// TCP level keepalive duration for connections
+const TCP_KEEPALIVE: Duration = Duration::from_secs(60);
+
 use self::client::ConnectError;
 use self::p2p::{comm::Peers, P2pTopology};
 use crate::blockcfg::{Block, HeaderHash};


### PR DESCRIPTION
Add tunings that were missing from gRPC P2P connections:
- Per-connection limits for requests on the server side;
- TCP level keepalives;
- HTTP/2 level keepalives on the client side.