### PR TITLE
[Tests] Public id revert

### DIFF
--- a/jormungandr-lib/src/interfaces/config/node.rs
+++ b/jormungandr-lib/src/interfaces/config/node.rs
@@ -16,7 +16,8 @@ pub struct Rest {
 pub struct P2p {
     /// The public address to which other peers may connect to
     pub public_address: poldercast::Address,
-
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_id: Option<poldercast::Id>,
     /// the rendezvous points for the peer to connect to in order to initiate
     /// the p2p discovery from.
     pub trusted_peers: Vec<TrustedPeer>,
@@ -97,6 +98,8 @@ pub struct PreferredListConfig {
 #[serde(deny_unknown_fields)]
 pub struct TrustedPeer {
     pub address: poldercast::Address,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<poldercast::Id>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -116,6 +119,7 @@ impl P2p {
     pub fn make_trusted_peer_setting(&self) -> TrustedPeer {
         TrustedPeer {
             address: self.get_listen_address(),
+            id: self.public_id.clone(),
         }
     }
 

--- a/testing/jormungandr-integration-tests/src/common/configuration/node_config_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/configuration/node_config_builder.rs
@@ -62,6 +62,7 @@ impl NodeConfigBuilder {
                     quarantine_whitelist: None,
                 }),
                 layers: None,
+                public_id: None,
             },
             mempool: Some(Mempool::default()),
             explorer: Explorer { enabled: false },

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -220,6 +220,11 @@ impl ConfigurationBuilder {
     pub fn build(&self, temp_dir: &impl PathChild) -> JormungandrParams<NodeConfig> {
         let mut node_config = self.node_config_builder.build();
 
+        //remove id from trusted peers
+        for trusted_peer in node_config.p2p.trusted_peers.iter_mut() {
+            trusted_peer.id = None;
+        }
+
         let default_log_file = || temp_dir.child("node.log").path().to_path_buf();
 
         let log_file_path = match (&node_config.log, self.configure_default_log) {

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -134,6 +134,7 @@ impl JormungandrProcess {
     pub fn to_trusted_peer(&self) -> TrustedPeer {
         TrustedPeer {
             address: self.p2p_public_address.clone(),
+            id: None,
         }
     }
 

--- a/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/legacy/configuration_builder.rs
@@ -12,7 +12,7 @@ pub enum LegacyConfigConverterError {
     UnsupportedVersion(Version),
 }
 
-pub fn version_0_8_19() -> Version {
+pub const fn version_0_8_19() -> Version {
     Version::new(0, 8, 19)
 }
 
@@ -95,9 +95,19 @@ impl LegacyNodeConfigConverter {
             .p2p
             .trusted_peers
             .iter()
-            .map(|peer| TrustedPeer {
-                id: Some(Self::generate_legacy_poldercast_id(&mut rng)),
-                address: peer.address.clone(),
+            .map(|peer| {
+                let id = {
+                    if let Some(id) = peer.id {
+                        id.to_string()
+                    } else {
+                        Self::generate_legacy_poldercast_id(&mut rng)
+                    }
+                };
+
+                TrustedPeer {
+                    id: Some(id),
+                    address: peer.address.clone(),
+                }
             })
             .collect();
 
@@ -117,6 +127,7 @@ impl LegacyNodeConfigConverter {
                 allow_private_addresses: source.p2p.allow_private_addresses,
                 policy: source.p2p.policy.clone(),
                 layers: None,
+                public_id: None,
             },
             mempool: source.mempool.clone(),
             explorer: source.explorer.clone(),

--- a/testing/jormungandr-integration-tests/src/common/network/controller.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/controller.rs
@@ -125,6 +125,10 @@ impl Controller {
         let mut config = node_setting.config().clone();
         spawn_params.override_settings(&mut config);
 
+        for peer in config.p2p.trusted_peers.iter_mut() {
+            peer.id = None;
+        }
+
         let log_file_path = dir.child("node.log").path().to_path_buf();
         config.log = Some(Log(vec![LogEntry {
             format: "json".into(),
@@ -136,7 +140,6 @@ impl Controller {
             let path_to_storage = dir.child("storage").path().into();
             config.storage = Some(path_to_storage);
         }
-
         dir.create_dir_all()?;
 
         let config_file = dir.child("node_config.yaml");

--- a/testing/jormungandr-integration-tests/src/mock/testing/setup.rs
+++ b/testing/jormungandr-integration-tests/src/mock/testing/setup.rs
@@ -63,6 +63,7 @@ impl Fixture {
             address: format!("/ip4/{}/tcp/{}", LOCALHOST, mock_port)
                 .parse()
                 .unwrap(),
+            id: None,
         };
 
         ConfigurationBuilder::new()

--- a/testing/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -298,6 +298,11 @@ impl Controller {
         let mut node_setting_overriden = node_setting.clone();
         params.override_settings(&mut node_setting_overriden.config);
 
+        // remove all id from trusted peers for current version
+        for trusted_peer in node_setting_overriden.config.p2p.trusted_peers.iter_mut() {
+            trusted_peer.id = None;
+        }
+
         let block0_setting = match params.get_leadership_mode() {
             LeadershipMode::Leader => NodeBlock0::File(self.block0_file.as_path().into()),
             LeadershipMode::Passive => NodeBlock0::Hash(self.block0_hash),

--- a/testing/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -223,6 +223,7 @@ impl Prepare for P2p {
             topics_of_interest: Some(TopicsOfInterest::prepare(context)),
             policy: Some(Policy::prepare(context)),
             layers: None,
+            public_id: None,
         }
     }
 }

--- a/testing/jormungandr-scenario-tests/src/test/legacy/fragment_propagation.rs
+++ b/testing/jormungandr-scenario-tests/src/test/legacy/fragment_propagation.rs
@@ -114,49 +114,6 @@ pub fn current_node_legacy_fragment_propagation(
 
     send_all_fragment_types(&mut controller, &passive, Some(version));
 
-    let leader_stake_pool = controller.stake_pool(LEADER).unwrap();
-    let david_stake_pool = StakePool::new(&david);
-
-    let sender = controller.fragment_sender();
-
-    sender
-        .send_transaction(&mut alice, &bob, &passive, 10.into())
-        .expect("send transaction failed");
-    sender
-        .send_pool_registration(&mut david, &david_stake_pool, &passive)
-        .expect("send pool registration");
-    sender
-        .send_owner_delegation(&mut david, &david_stake_pool, &passive)
-        .expect("send owner delegation");
-    sender
-        .send_full_delegation(&mut bob, &leader_stake_pool, &passive)
-        .expect("send full delegation failed");
-
-    let distribution: Vec<(&StakePool, u8)> = vec![(&leader_stake_pool, 1), (&david_stake_pool, 1)];
-    sender
-        .send_split_delegation(&mut bob, &distribution, &passive)
-        .expect("send split delegation failed");
-
-    let mut david_and_clarice_stake_pool = david_stake_pool.clone();
-    david_and_clarice_stake_pool
-        .info_mut()
-        .owners
-        .push(clarice.identifier().into_public_key());
-
-    if version != version_0_8_19() {
-        sender
-            .send_pool_update(
-                &mut david,
-                &david_stake_pool,
-                &david_and_clarice_stake_pool,
-                &passive,
-            )
-            .expect("send update stake pool failed");
-    }
-    sender
-        .send_pool_retire(&mut david, &david_stake_pool, &passive)
-        .expect("send pool retire failed");
-
     leader.shutdown()?;
     passive.shutdown()?;
 

--- a/testing/jormungandr-testing-utils/src/legacy/config/node.rs
+++ b/testing/jormungandr-testing-utils/src/legacy/config/node.rs
@@ -8,6 +8,9 @@ pub struct P2p {
     /// The public address to which other peers may connect to
     pub public_address: poldercast::Address,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_id: Option<poldercast::Id>,
+
     /// the rendezvous points for the peer to connect to in order to initiate
     /// the p2p discovery from.
     pub trusted_peers: Vec<TrustedPeer>,

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/spawn_params.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/spawn_params.rs
@@ -21,7 +21,7 @@ pub struct SpawnParams {
     pub max_connections: Option<u32>,
     pub max_inbound_connections: Option<u32>,
     pub alias: String,
-    pub node_id: Option<poldercast::Address>,
+    pub public_address: Option<poldercast::Address>,
     pub version: Option<Version>,
     pub bootstrap_from_peers: Option<bool>,
     pub skip_bootstrap: Option<bool>,
@@ -38,7 +38,7 @@ impl SpawnParams {
             alias: alias.to_owned(),
             leadership_mode: LeadershipMode::Leader,
             persistence_mode: PersistenceMode::Persistent,
-            node_id: None,
+            public_address: None,
             trusted_peers: None,
             listen_address: None,
             max_connections: None,
@@ -80,8 +80,8 @@ impl SpawnParams {
         self
     }
 
-    pub fn node_id(&mut self, node_id: poldercast::Address) -> &mut Self {
-        self.node_id = Some(node_id);
+    pub fn public_address(&mut self, public_address: poldercast::Address) -> &mut Self {
+        self.public_address = Some(public_address);
         self
     }
 
@@ -186,8 +186,8 @@ impl SpawnParams {
             node_config.p2p.policy = Some(policy.clone());
         }
 
-        if let Some(node_id) = &self.node_id {
-            node_config.p2p.public_address = node_id.clone();
+        if let Some(public_address) = &self.public_address {
+            node_config.p2p.public_address = public_address.clone();
         }
 
         if let Some(max_inbound_connections) = &self.max_inbound_connections {


### PR DESCRIPTION
Quick and not very elegant way to bring back public_id into test framework again.
Implemented new behavior which assign public_id  only for trusted peers, as well as remove `id`  from trusted peer if node those not support it