### PR TITLE
Add serialize deserialize quickcheck

### DIFF
--- a/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/mod.rs
@@ -174,5 +174,19 @@ mod test {
 
             TestResult::from_bool(block0_configuration == block0_configuration_dec)
         }
+
+        fn block0_configuration_to_serialize(block0_configuration: Block0Configuration) -> TestResult {
+            use chain_core::property::{Serialize as _, Deserialize as _};
+
+            let block = block0_configuration.to_block();
+
+            let bytes = block.serialize_as_vec().unwrap();
+            let reader = std::io::Cursor::new(&bytes);
+            let decoded = Block::deserialize(reader).unwrap();
+
+            let block0_configuration_dec = Block0Configuration::from_block(&decoded).unwrap();
+
+            TestResult::from_bool(block0_configuration == block0_configuration_dec)
+        }
     }
 }

--- a/jormungandr-lib/src/interfaces/tax_type.rs
+++ b/jormungandr-lib/src/interfaces/tax_type.rs
@@ -47,9 +47,13 @@ mod test {
         where
             G: Gen,
         {
+            let denom = u64::arbitrary(g) + 1;
+            let num = u64::arbitrary(g) % denom;
+
+            let ratio = Ratio::new_checked(num, denom).unwrap();
             TaxType {
                 fixed: Value::arbitrary(g),
-                ratio: Ratio::arbitrary(g),
+                ratio,
                 max_limit: NonZeroU64::new(Arbitrary::arbitrary(g)),
             }
         }


### PR DESCRIPTION
The Arbitrary for the TaxType in jormungandr-lib was invalid. Fortunatelly on the blockchain/production there's nothing invalid.