### PR TITLE
Cut unneeded uses of bytes and the old futures 0.1/ tokio 0.2 stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,6 @@ version = "0.9.1"
 dependencies = [
  "assert_fs",
  "base64 0.12.3",
- "bytes 0.5.5",
  "chain-addr",
  "chain-core",
  "chain-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli",
 ]
@@ -14,6 +14,12 @@ name = "adler"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
+
+[[package]]
+name = "adler32"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
 name = "ahash"
@@ -26,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -39,7 +45,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -120,7 +126,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -137,13 +143,14 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
+checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
+ "miniz_oxide 0.3.7",
  "object",
  "rustc-demangle",
 ]
@@ -171,9 +178,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e223af0dc48c96d4f8342ec01a4974f139df863896b316681efd36742f22cc67"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bawawa"
@@ -196,9 +203,9 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 
 [[package]]
 name = "bincode"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
  "serde",
@@ -378,9 +385,9 @@ checksum = "2b6cda8a789815488ee290d106bc97dba47785dae73d63576fc42c126912a451"
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "77c1f1d60091c1b73e2b1f4560ab419204b178e625fa945ded7b660becd2bd46"
 
 [[package]]
 name = "cfg-if"
@@ -418,7 +425,7 @@ dependencies = [
  "digest 0.9.0",
  "ed25519-bip32",
  "ed25519-dalek",
- "generic-array 0.14.1",
+ "generic-array 0.14.2",
  "hex",
  "quickcheck",
  "rand_chacha 0.2.2",
@@ -578,7 +585,7 @@ dependencies = [
  "terminal_size",
  "termios",
  "unicode-width",
- "winapi 0.3.8",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -664,12 +671,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6bffe714b6bb07e42f201352c34f51fefd355ace793f9e638ebd52d23f98d2"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if",
  "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -779,7 +787,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.1",
+ "generic-array 0.14.2",
 ]
 
 [[package]]
@@ -794,14 +802,13 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
- "cfg-if",
  "libc",
  "redox_users",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -812,9 +819,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "ed25519-bip32"
@@ -905,7 +912,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -923,7 +930,7 @@ dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.0",
 ]
 
 [[package]]
@@ -1080,7 +1087,7 @@ dependencies = [
  "libc",
  "log 0.4.8",
  "rustc_version",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1103,11 +1110,12 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
+checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
 dependencies = [
  "typenum",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1189,7 +1197,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "slab",
- "tokio 0.2.21",
+ "tokio",
  "tokio-util",
 ]
 
@@ -1209,7 +1217,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
- "base64 0.12.2",
+ "base64 0.12.3",
  "bitflags",
  "bytes 0.5.5",
  "headers-core",
@@ -1239,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
+checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
 ]
@@ -1304,7 +1312,7 @@ dependencies = [
  "pin-project",
  "socket2",
  "time",
- "tokio 0.2.21",
+ "tokio",
  "tower-service",
  "want",
 ]
@@ -1320,7 +1328,7 @@ dependencies = [
  "hyper",
  "log 0.4.8",
  "rustls 0.17.0",
- "tokio 0.2.21",
+ "tokio",
  "tokio-rustls 0.13.1",
  "webpki",
 ]
@@ -1434,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jcli"
@@ -1525,7 +1533,7 @@ dependencies = [
  "slog-term",
  "structopt",
  "thiserror",
- "tokio 0.2.21",
+ "tokio",
  "tonic",
  "versionisator",
  "warp",
@@ -1536,7 +1544,7 @@ name = "jormungandr-integration-tests"
 version = "0.9.1"
 dependencies = [
  "assert_fs",
- "base64 0.12.2",
+ "base64 0.12.3",
  "bytes 0.5.5",
  "chain-addr",
  "chain-core",
@@ -1567,7 +1575,7 @@ dependencies = [
  "slog-json",
  "structopt",
  "thiserror",
- "tokio 0.2.21",
+ "tokio",
  "tonic",
  "tonic-build",
  "url",
@@ -1609,8 +1617,6 @@ name = "jormungandr-scenario-tests"
 version = "0.9.1"
 dependencies = [
  "assert_fs",
- "bawawa",
- "bytes 0.5.5",
  "chain-addr",
  "chain-core",
  "chain-crypto",
@@ -1640,7 +1646,6 @@ dependencies = [
  "slog",
  "structopt",
  "thiserror",
- "tokio 0.1.22",
  "yaml-rust",
 ]
 
@@ -1683,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
+checksum = "c4b9172132a62451e56142bff9afc91c8e4a4500aa5b847da36815b63bfda916"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1922,6 +1927,15 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
@@ -1950,14 +1964,14 @@ dependencies = [
 
 [[package]]
 name = "mio-named-pipes"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log 0.4.8",
  "mio",
- "miow 0.3.4",
- "winapi 0.3.8",
+ "miow 0.3.5",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1985,12 +1999,12 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dfdd1d51b2639a5abd17ed07005c3af05fb7a2a3b1a1d0d7af1000a520c1c7"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
  "socket2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2056,7 +2070,7 @@ checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2097,14 +2111,14 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg 1.0.0",
  "num-traits",
@@ -2112,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg 1.0.0",
 ]
@@ -2137,9 +2151,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
@@ -2172,7 +2186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cc1fe7b45f7e51f755195fd86b0483dbae30fdcf831a3254438d29118d12c4"
 dependencies = [
  "log 0.4.8",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2184,16 +2198,6 @@ dependencies = [
  "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
  "rustc_version",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -2219,21 +2223,7 @@ dependencies = [
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if",
- "cloudabi 0.0.3",
- "libc",
- "redox_syscall",
- "smallvec 1.4.0",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2248,7 +2238,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec 1.4.0",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2372,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df32da11d84f3a7d70205549562966279adb900e080fad3dccd8e64afccf0ad"
+checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 
 [[package]]
 name = "pin-utils"
@@ -2453,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -2466,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
+checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2485,9 +2475,9 @@ checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -2602,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
@@ -2630,7 +2620,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2649,7 +2639,7 @@ dependencies = [
  "rand_os",
  "rand_pcg 0.1.2",
  "rand_xorshift",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2745,7 +2735,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2759,7 +2749,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2792,10 +2782,11 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
 dependencies = [
+ "autocfg 1.0.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -2803,12 +2794,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
+checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
 dependencies = [
  "crossbeam-deque",
- "crossbeam-queue 0.2.2",
+ "crossbeam-queue 0.2.3",
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
@@ -2860,11 +2851,11 @@ checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2873,7 +2864,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 dependencies = [
- "base64 0.12.2",
+ "base64 0.12.3",
  "bytes 0.5.5",
  "encoding_rs",
  "futures-core",
@@ -2893,7 +2884,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.21",
+ "tokio",
  "tokio-rustls 0.13.1",
  "url",
  "wasm-bindgen",
@@ -2905,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.14"
+version = "0.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06b3fefa4f12272808f809a0af618501fdaba41a58963c5fb72238ab0be09603"
+checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
 dependencies = [
  "cc",
  "libc",
@@ -2915,7 +2906,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3010,11 +3001,11 @@ dependencies = [
 
 [[package]]
 name = "scheduled-thread-pool"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0988d7fdf88d5e5fcf5923a0f1e8ab345f3e98ab4bc6bc45a2d5ff7f7458fbf6"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
 ]
 
 [[package]]
@@ -3083,9 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",
@@ -3306,7 +3297,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3409,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b796215da5a4b2a1a5db53ee55866c13b74a89acd259ab762eb10e28e937cb5"
+checksum = "11c9e4fd26a5b1dfa0aceb8417d4825b65b49cf98b84a45b7af4007ad403e797"
 dependencies = [
  "cfg-if",
  "doc-comment",
@@ -3419,7 +3410,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3473,7 +3464,7 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3483,7 +3474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
  "dirs",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3493,7 +3484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3503,7 +3494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3561,7 +3552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3574,28 +3565,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "0.1.22"
+name = "tinyvec"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "mio",
- "num_cpus",
- "tokio-codec",
- "tokio-current-thread",
- "tokio-executor",
- "tokio-fs",
- "tokio-io",
- "tokio-reactor",
- "tokio-sync",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
- "tokio-udp",
- "tokio-uds",
-]
+checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tokio"
@@ -3618,7 +3591,7 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "tokio-macros",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3633,16 +3606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-current-thread"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
-dependencies = [
- "futures 0.1.29",
- "tokio-executor",
-]
-
-[[package]]
 name = "tokio-executor"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,17 +3613,6 @@ checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.29",
-]
-
-[[package]]
-name = "tokio-fs"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
-dependencies = [
- "futures 0.1.29",
- "tokio-io",
- "tokio-threadpool",
 ]
 
 [[package]]
@@ -3701,7 +3653,7 @@ dependencies = [
  "tokio-io",
  "tokio-reactor",
  "tokio-signal",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3731,7 +3683,7 @@ checksum = "3068d891551949b37681724d6b73666787cc63fa8e255c812a41d2513aff9775"
 dependencies = [
  "futures-core",
  "rustls 0.16.0",
- "tokio 0.2.21",
+ "tokio",
  "webpki",
 ]
 
@@ -3743,7 +3695,7 @@ checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
 dependencies = [
  "futures-core",
  "rustls 0.17.0",
- "tokio 0.2.21",
+ "tokio",
  "webpki",
 ]
 
@@ -3761,7 +3713,7 @@ dependencies = [
  "tokio-executor",
  "tokio-io",
  "tokio-reactor",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3775,49 +3727,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "iovec",
- "mio",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-threadpool"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-queue 0.2.2",
- "crossbeam-utils 0.7.2",
- "futures 0.1.29",
- "lazy_static",
- "log 0.4.8",
- "num_cpus",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-timer"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.29",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,41 +3735,8 @@ dependencies = [
  "futures 0.3.5",
  "log 0.4.8",
  "pin-project",
- "tokio 0.2.21",
+ "tokio",
  "tungstenite",
-]
-
-[[package]]
-name = "tokio-udp"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "log 0.4.8",
- "mio",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-uds"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5076db410d6fdc6523df7595447629099a1fdc47b3d9f896220780fa48faf798"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "iovec",
- "libc",
- "log 0.4.8",
- "mio",
- "mio-uds",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
 ]
 
 [[package]]
@@ -3874,7 +3750,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.21",
+ "tokio",
 ]
 
 [[package]]
@@ -3896,7 +3772,7 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
- "tokio 0.2.21",
+ "tokio",
  "tokio-util",
  "tower",
  "tower-balance",
@@ -3949,7 +3825,7 @@ dependencies = [
  "pin-project",
  "rand 0.7.3",
  "slab",
- "tokio 0.2.21",
+ "tokio",
  "tower-discover",
  "tower-layer",
  "tower-load",
@@ -3967,7 +3843,7 @@ checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
  "futures-core",
  "pin-project",
- "tokio 0.2.21",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3998,7 +3874,7 @@ checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
  "pin-project",
- "tokio 0.2.21",
+ "tokio",
  "tower-layer",
  "tower-load",
  "tower-service",
@@ -4013,7 +3889,7 @@ dependencies = [
  "futures-core",
  "log 0.4.8",
  "pin-project",
- "tokio 0.2.21",
+ "tokio",
  "tower-discover",
  "tower-service",
 ]
@@ -4036,7 +3912,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 dependencies = [
- "tokio 0.2.21",
+ "tokio",
  "tower-service",
 ]
 
@@ -4050,7 +3926,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "log 0.4.8",
- "tokio 0.2.21",
+ "tokio",
  "tower-service",
 ]
 
@@ -4062,7 +3938,7 @@ checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
  "futures-core",
  "pin-project",
- "tokio 0.2.21",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -4080,7 +3956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
  "pin-project",
- "tokio 0.2.21",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -4218,11 +4094,11 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
- "smallvec 1.4.0",
+ "tinyvec",
 ]
 
 [[package]]
@@ -4233,15 +4109,15 @@ checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "unix_socket"
@@ -4272,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "urlencoding"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed"
+checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
 
 [[package]]
 name = "utf-8"
@@ -4318,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d1e41d56121e07f1e223db0a4def204e45c85425f6a16d462fd07c8d10d74c"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec_map"
@@ -4363,7 +4239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
- "winapi 0.3.8",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -4397,7 +4273,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.21",
+ "tokio",
  "tokio-rustls 0.12.3",
  "tokio-tungstenite",
  "tower-service",
@@ -4412,9 +4288,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
+checksum = "6a634620115e4a229108b71bde263bb4220c483b3f07f5ba514ee8d15064c4c2"
 dependencies = [
  "cfg-if",
  "serde",
@@ -4424,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
+checksum = "3e53963b583d18a5aa3aaae4b4c1cb535218246131ba22a71f05b518098571df"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4439,9 +4315,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64487204d863f109eb77e8462189d111f27cb5712cc9fdb3461297a76963a2f6"
+checksum = "dba48d66049d2a6cc8488702e7259ab7afc9043ad0dc5448444f46f2a453b362"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4451,9 +4327,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
+checksum = "3fcfd5ef6eec85623b4c6e844293d4516470d8f19cd72d0d12246017eb9060b8"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4461,9 +4337,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
+checksum = "9adff9ee0e94b926ca81b57f57f86d5545cdcb1d259e21ec9bdd95b901754c75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4474,15 +4350,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
+checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
 
 [[package]]
 name = "web-sys"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b72fe77fd39e4bd3eaa4412fd299a0be6b3dfe9d2597e2f1c20beb968f41d17"
+checksum = "863539788676619aac1a23e2df3655e96b32b0e05eb72ca34ba045ad573c625d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4524,9 +4400,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -4550,7 +4426,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4565,7 +4441,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,12 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "bytesize"
@@ -1068,6 +1071,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
+dependencies = [
+ "cc",
+ "libc",
+ "log 0.4.8",
+ "rustc_version",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,7 +1180,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1195,7 +1211,7 @@ checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
  "base64 0.12.2",
  "bitflags",
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "headers-core",
  "http",
  "mime 0.3.16",
@@ -1242,7 +1258,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "fnv",
  "itoa",
 ]
@@ -1253,7 +1269,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "http",
 ]
 
@@ -1275,7 +1291,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1299,7 +1315,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "futures-util",
  "hyper",
  "log 0.4.8",
@@ -1370,7 +1386,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
 ]
 
 [[package]]
@@ -1429,7 +1445,6 @@ dependencies = [
  "assert_fs",
  "bech32",
  "bincode",
- "bytes 0.4.12",
  "chain-addr",
  "chain-core",
  "chain-crypto",
@@ -1465,7 +1480,7 @@ dependencies = [
  "async-trait",
  "bech32",
  "bincode",
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "cardano-legacy-address",
  "chain-addr",
  "chain-core",
@@ -1522,7 +1537,7 @@ version = "0.9.1"
 dependencies = [
  "assert_fs",
  "base64 0.12.2",
- "bytes 0.4.12",
+ "bytes 0.5.5",
  "chain-addr",
  "chain-core",
  "chain-crypto",
@@ -1595,7 +1610,7 @@ version = "0.9.1"
 dependencies = [
  "assert_fs",
  "bawawa",
- "bytes 0.4.12",
+ "bytes 0.5.5",
  "chain-addr",
  "chain-core",
  "chain-crypto",
@@ -1795,6 +1810,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "loom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls 0.1.2",
 ]
 
 [[package]]
@@ -2478,7 +2504,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "prost-derive",
 ]
 
@@ -2488,7 +2514,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "heck",
  "itertools 0.8.2",
  "log 0.4.8",
@@ -2519,7 +2545,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "prost",
 ]
 
@@ -2848,7 +2874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 dependencies = [
  "base64 0.12.2",
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2990,6 +3016,12 @@ checksum = "0988d7fdf88d5e5fcf5923a0f1e8ab345f3e98ab4bc6bc45a2d5ff7f7458fbf6"
 dependencies = [
  "parking_lot 0.10.2",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "scoped-tls"
@@ -3571,7 +3603,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "fnv",
  "futures-core",
  "iovec",
@@ -3837,7 +3869,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "futures-core",
  "futures-sink",
  "log 0.4.8",
@@ -3854,7 +3886,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.11.0",
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "futures-core",
  "futures-util",
  "http",
@@ -4127,7 +4159,7 @@ checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "http",
  "httparse",
  "input_buffer",
@@ -4351,7 +4383,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e95175b7a927258ecbb816bdada3cc469cb68593e7940b96a60f4af366a9970"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "futures 0.3.5",
  "headers",
  "http",
@@ -4361,7 +4393,7 @@ dependencies = [
  "mime_guess 2.0.3",
  "multipart",
  "pin-project",
- "scoped-tls",
+ "scoped-tls 1.0.0",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -22,7 +22,6 @@ bincode = "1.0.1"
 mime = "^0.3.7"
 structopt = "^0.3"
 bech32 = "0.7"
-bytes = "0.4"
 hex = "0.4.2"
 chain-core      = { path = "../chain-deps/chain-core" }
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }

--- a/jcli/src/jcli_app/rest/v0/message/mod.rs
+++ b/jcli/src/jcli_app/rest/v0/message/mod.rs
@@ -6,8 +6,6 @@ use chain_core::property::Deserialize;
 use chain_impl_mockchain::fragment::Fragment;
 use std::path::PathBuf;
 use structopt::StructOpt;
-extern crate bytes;
-use self::bytes::IntoBuf;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
@@ -64,8 +62,8 @@ fn get_logs(addr: HostAddr, debug: DebugFlag, output_format: OutputFormat) -> Re
 fn post_message(file: Option<PathBuf>, addr: HostAddr, debug: DebugFlag) -> Result<(), Error> {
     let msg_hex = io::read_line(&file)?;
     let msg_bin = hex::decode(&msg_hex)?;
-    let _fragment = Fragment::deserialize(msg_bin.as_slice().into_buf())
-        .map_err(Error::InputFragmentMalformed)?;
+    let _fragment =
+        Fragment::deserialize(msg_bin.as_slice()).map_err(Error::InputFragmentMalformed)?;
     let url = addr.with_segments(&["v0", "message"])?.into_url();
     let builder = reqwest::blocking::Client::new().post(url);
     let response = RestApiSender::new(builder, &debug)

--- a/testing/jormungandr-integration-tests/Cargo.toml
+++ b/testing/jormungandr-integration-tests/Cargo.toml
@@ -10,7 +10,7 @@ prost = "0.6"
 tokio = { version = "0.2", features = ["macros"] }
 futures      = "0.3.5"
 base64 = "0.12"
-bytes = "0.4"
+bytes = "0.5"
 hex = "0.4.2"
 chain-addr      = { path = "../../chain-deps/chain-addr" }
 chain-core      = { path = "../../chain-deps/chain-core" }

--- a/testing/jormungandr-integration-tests/Cargo.toml
+++ b/testing/jormungandr-integration-tests/Cargo.toml
@@ -10,7 +10,6 @@ prost = "0.6"
 tokio = { version = "0.2", features = ["macros"] }
 futures      = "0.3.5"
 base64 = "0.12"
-bytes = "0.5"
 hex = "0.4.2"
 chain-addr      = { path = "../../chain-deps/chain-addr" }
 chain-core      = { path = "../../chain-deps/chain-core" }

--- a/testing/jormungandr-scenario-tests/Cargo.toml
+++ b/testing/jormungandr-scenario-tests/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 slog = "2"
 bawawa = "0.1.5"
-bytes = "0.4"
+bytes = "0.5"
 custom_debug = "0.5"
 dialoguer = "0.6.2"
 error-chain = "0.12"

--- a/testing/jormungandr-scenario-tests/Cargo.toml
+++ b/testing/jormungandr-scenario-tests/Cargo.toml
@@ -8,12 +8,9 @@ edition = "2018"
 
 [dependencies]
 slog = "2"
-bawawa = "0.1.5"
-bytes = "0.5"
 custom_debug = "0.5"
 dialoguer = "0.6.2"
 error-chain = "0.12"
-tokio = "0.1"
 assert_fs = "1.0"
 chain-core           = { path = "../../chain-deps/chain-core" }
 chain-crypto         = { path = "../../chain-deps/chain-crypto", features = [ "property-test-api" ] }

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -36,7 +36,7 @@ use yaml_rust::{Yaml, YamlLoader};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -618,6 +618,8 @@ impl LegacyNode {
                 command.args(&["--genesis-block-hash", &hash.to_string()]);
             }
         }
+
+        command.stderr(Stdio::piped());
 
         let process = command.spawn().map_err(Error::CannotSpawnNode)?;
 

--- a/testing/jormungandr-scenario-tests/src/main.rs
+++ b/testing/jormungandr-scenario-tests/src/main.rs
@@ -93,8 +93,8 @@ fn main() {
 
     std::env::set_var("RUST_BACKTRACE", "full");
 
-    let jormungandr = prepare_command(command_args.jormungandr);
-    let jcli = prepare_command(command_args.jcli);
+    let jormungandr = prepare_command(&command_args.jormungandr);
+    let jcli = prepare_command(&command_args.jcli);
     let progress_bar_mode = command_args.progress_bar_mode;
     let seed = command_args
         .seed
@@ -154,9 +154,9 @@ fn introduction<R: rand_core::RngCore>(context: &Context<R>) {
 ###############################################################################
     "###,
         *style::icons::jormungandr,
-        style::binary.apply_to(context.jormungandr().to_string()),
+        style::binary.apply_to(context.jormungandr().to_string_lossy()),
         *style::icons::jcli,
-        style::binary.apply_to(context.jcli().to_string()),
+        style::binary.apply_to(context.jcli().to_string_lossy()),
         *style::icons::seed,
         style::seed.apply_to(context.seed()),
     )

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -24,16 +24,14 @@ pub use jormungandr_testing_utils::testing::{
     FragmentNode, MemPoolCheck, NamedProcess,
 };
 
-use bawawa::{Control, Process};
 use futures::executor::block_on;
 use indicatif::ProgressBar;
 use rand_core::RngCore;
-use tokio::prelude::*;
 
 use std::collections::HashMap;
-use std::io;
+use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::ExitStatus;
+use std::process::{Child, Command, ExitStatus};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -66,7 +64,7 @@ pub enum Error {
         cause: serde_yaml::Error,
     },
     #[error("cannot spawn the node")]
-    CannotSpawnNode(#[source] bawawa::Error),
+    CannotSpawnNode(#[source] io::Error),
     // FIXME: duplicate of GrpcError?
     #[error("invalid grpc call")]
     InvalidGrpcCall(#[source] MockClientError),
@@ -166,7 +164,7 @@ pub struct Node {
     #[allow(unused)]
     dir: PathBuf,
 
-    process: Process,
+    process: Child,
 
     progress_bar: ProgressBarController,
     node_settings: NodeSetting,
@@ -520,12 +518,12 @@ impl Node {
             settings: self.node_settings.clone(),
             status: self.status.clone(),
             progress_bar: self.progress_bar.clone(),
-            process_id: self.id(),
+            process_id: self.process.id(),
         }
     }
 
     pub fn spawn<R: RngCore>(
-        jormungandr: &bawawa::Command,
+        jormungandr: &Path,
         context: &Context<R>,
         progress_bar: ProgressBar,
         alias: &str,
@@ -534,7 +532,7 @@ impl Node {
         working_dir: &Path,
         peristence_mode: PersistenceMode,
     ) -> Result<Self> {
-        let mut command = jormungandr.clone();
+        let mut command = Command::new(jormungandr);
         let dir = working_dir.join(alias);
         std::fs::DirBuilder::new().recursive(true).create(&dir)?;
 
@@ -592,23 +590,22 @@ impl Node {
             cause: e,
         })?;
 
-        command.arguments(&["--config", &config_file.display().to_string()]);
+        command.arg("--config");
+        command.arg(&config_file);
 
         match block0 {
             NodeBlock0::File(path) => {
-                command.arguments(&[
-                    "--genesis-block",
-                    &path.display().to_string(),
-                    "--secret",
-                    &config_secret.display().to_string(),
-                ]);
+                command.arg("--genesis-block");
+                command.arg(&path);
+                command.arg("--secret");
+                command.arg(&config_secret);
             }
             NodeBlock0::Hash(hash) => {
-                command.arguments(&["--genesis-block-hash", &hash.to_string()]);
+                command.args(&["--genesis-block-hash", &hash.to_string()]);
             }
         }
 
-        let process = Process::spawn(command.clone()).map_err(Error::CannotSpawnNode)?;
+        let process = command.spawn().map_err(Error::CannotSpawnNode)?;
 
         let node = Node {
             alias: alias.clone().into(),
@@ -624,20 +621,36 @@ impl Node {
 
         node.progress_bar_start();
         node.progress_bar
-            .log_info(&format!("{} bootstrapping: {}", alias, command));
+            .log_info(&format!("{} bootstrapping: {:?}", alias, command));
         Ok(node)
     }
 
-    pub fn capture_logs(&mut self) -> impl Future<Item = (), Error = ()> {
-        let stderr = self.process.stderr().take().unwrap();
+    pub fn capture_logs(&mut self) {
+        let stderr = self.process.stderr.take().unwrap();
+        let reader = BufReader::new(stderr);
+        for line_result in reader.lines() {
+            let line = line_result.expect("failed to read a line from log output");
+            self.progress_bar.log_info(&line);
+        }
+    }
 
-        let stderr = tokio::codec::FramedRead::new(stderr, tokio::codec::LinesCodec::new());
-
-        let progress_bar = self.progress_bar.clone();
-
-        stderr
-            .for_each(move |line| future::ok(progress_bar.log_info(&line)))
-            .map_err(|err| unimplemented!("{}", err))
+    pub fn wait(&mut self) {
+        match self.process.wait() {
+            Err(err) => {
+                self.progress_bar.log_err(&err);
+                self.progress_bar_failure();
+                self.set_status(Status::Failure);
+            }
+            Ok(status) => {
+                if status.success() {
+                    self.progress_bar_success();
+                } else {
+                    self.progress_bar.log_err(&status);
+                    self.progress_bar_failure()
+                }
+                self.set_status(Status::Exit(status));
+            }
+        }
     }
 
     fn progress_bar_start(&self) {
@@ -730,46 +743,5 @@ impl std::ops::Deref for ProgressBarController {
     type Target = ProgressBar;
     fn deref(&self) -> &Self::Target {
         &self.progress_bar
-    }
-}
-
-impl Future for Node {
-    type Item = ();
-    type Error = ();
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.process.poll() {
-            Err(err) => {
-                self.progress_bar.log_err(&err);
-                self.progress_bar_failure();
-                self.set_status(Status::Failure);
-                Err(())
-            }
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Ok(Async::Ready(status)) => {
-                if status.success() {
-                    self.progress_bar_success();
-                } else {
-                    self.progress_bar.log_err(&status);
-                    self.progress_bar_failure()
-                }
-                self.set_status(Status::Exit(status));
-                Ok(Async::Ready(()))
-            }
-        }
-    }
-}
-
-impl Control for Node {
-    fn command(&self) -> &bawawa::Command {
-        &self.process.command()
-    }
-
-    fn id(&self) -> u32 {
-        self.process.id()
-    }
-
-    fn kill(&mut self) -> bawawa::Result<()> {
-        self.process.kill()
     }
 }

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -31,7 +31,7 @@ use rand_core::RngCore;
 use std::collections::HashMap;
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, ExitStatus};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -604,6 +604,8 @@ impl Node {
                 command.args(&["--genesis-block-hash", &hash.to_string()]);
             }
         }
+
+        command.stderr(Stdio::piped());
 
         let process = command.spawn().map_err(Error::CannotSpawnNode)?;
 

--- a/testing/jormungandr-scenario-tests/src/programs.rs
+++ b/testing/jormungandr-scenario-tests/src/programs.rs
@@ -1,40 +1,25 @@
-use bawawa::{Command, Program};
-use error_chain::ChainedError as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
-/// internal function to prepare a bawawa `Command` for `jormungandr` and `jcli`
+/// internal function to prepare an executable path name for `jormungandr` and `jcli`
 ///
 /// if the program could not be found in the $PATH or the current path then this
-/// function will print the error reported by `bawawa` and then will `panic!` so
-/// the tests are not executed.
-pub fn prepare_command(exe: PathBuf) -> Command {
-    let cmd = match Program::new(exe.display().to_string()) {
-        Ok(program) => Command::new(program),
-        Err(error) => {
-            eprintln!("{}", error.display_chain().to_string());
-            panic!(
-                "the program {} is necessary for the execution of the tests but could not be found",
-                exe.display(),
-            );
-        }
-    };
-
-    check_command_version(cmd.clone());
-
-    cmd
+/// function will panic so the tests are not executed.
+pub fn prepare_command(exe: impl Into<PathBuf>) -> PathBuf {
+    let exe = exe.into();
+    check_command_version(&exe);
+    exe
 }
 
-fn check_command_version(mut cmd: Command) {
-    use bawawa::Process;
-    use tokio::prelude::*;
+fn check_command_version(exe: &Path) {
+    let mut cmd = Command::new(exe);
+    cmd.arg("--version");
 
-    cmd.arguments(&["--version"]);
-
-    let exit_status = Process::spawn(cmd.clone()).unwrap().wait().unwrap();
+    let exit_status = cmd.spawn().unwrap().wait().unwrap();
 
     assert!(
         exit_status.success(),
-        "cannot execute the command successfully '{}'",
+        "cannot execute the command successfully: {:?}",
         cmd
     );
 }

--- a/testing/jormungandr-scenario-tests/src/scenario/context.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/context.rs
@@ -3,14 +3,10 @@ use assert_fs::prelude::*;
 use assert_fs::TempDir;
 use rand_chacha::ChaChaRng;
 use rand_core::RngCore;
-use std::{
-    net::SocketAddr,
-    path::{Path, PathBuf},
-    sync::{
-        atomic::{self, AtomicU16},
-        Arc,
-    },
-};
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{self, AtomicU16};
+use std::sync::Arc;
 
 use crate::scenario::ProgressBarMode;
 use jormungandr_testing_utils::testing::network_builder::{Random, Seed};
@@ -29,8 +25,8 @@ enum TestingDirectory {
 pub struct Context<RNG: RngCore + Sized = ChaChaRng> {
     rng: Random<RNG>,
 
-    jormungandr: bawawa::Command,
-    jcli: bawawa::Command,
+    jormungandr: PathBuf,
+    jcli: PathBuf,
 
     next_available_rest_port_number: Arc<AtomicU16>,
     next_available_grpc_port_number: Arc<AtomicU16>,
@@ -44,8 +40,8 @@ pub struct Context<RNG: RngCore + Sized = ChaChaRng> {
 impl Context<ChaChaRng> {
     pub fn new(
         seed: Seed,
-        jormungandr: bawawa::Command,
-        jcli: bawawa::Command,
+        jormungandr: PathBuf,
+        jcli: PathBuf,
         testing_directory: Option<PathBuf>,
         generate_documentation: bool,
         progress_bar_mode: ProgressBarMode,
@@ -82,8 +78,8 @@ impl Context<ChaChaRng> {
             rng,
             next_available_rest_port_number: Arc::clone(&self.next_available_rest_port_number),
             next_available_grpc_port_number: Arc::clone(&self.next_available_grpc_port_number),
-            jormungandr: self.jormungandr().clone(),
-            jcli: self.jcli().clone(),
+            jormungandr: self.jormungandr.clone(),
+            jcli: self.jcli.clone(),
             testing_directory: self.testing_directory.clone(),
             generate_documentation: self.generate_documentation,
             progress_bar_mode: self.progress_bar_mode,
@@ -97,7 +93,7 @@ impl Context<ChaChaRng> {
 }
 
 impl<RNG: RngCore> Context<RNG> {
-    pub fn jormungandr(&self) -> &bawawa::Command {
+    pub fn jormungandr(&self) -> &Path {
         &self.jormungandr
     }
 
@@ -107,7 +103,7 @@ impl<RNG: RngCore> Context<RNG> {
         child
     }
 
-    pub fn jcli(&self) -> &bawawa::Command {
+    pub fn jcli(&self) -> &Path {
         &self.jcli
     }
 


### PR DESCRIPTION
Mainly in `jormungandr-scenario-tests`; `jcli` and `jormungandr-integration-tests` had a `bytes` dependency that was unneeded too.

`bawawa` had to be let go.