### PR TITLE
pass embed-bitcode=yes for LTO builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
           mkdir .cargo
           cat > .cargo/config.toml <<EOF
           [target.${{ matrix.config.target }}]
-          rustflags = ["-C", "target-cpu=${{ matrix.target_cpu }}", "-C", "lto"]
+          rustflags = ["-C", "target-cpu=${{ matrix.target_cpu }}", "-C", "lto", "-C", "embed-bitcode=yes"]
           EOF
 
       - if: ${{ matrix.cross }}


### PR DESCRIPTION
On Rust toolchain starting from version 1.45 the default is
embed-bitcode=no which conflicts with LTO. This commit overrides the
default setting.