### PR TITLE
add a new, bare module, that uses `sled` for the persistent storage of settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1095,15 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -3125,6 +3144,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings"
+version = "0.1.0"
+dependencies = [
+ "sled",
+ "thiserror",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3236,22 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "sled"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2aed3832b6d0c828efe6bcb6c309a18cf487dffc5cc0787da2ce140f0fb0ce"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils 0.7.2",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log 0.4.8",
+ "parking_lot 0.11.0",
+]
 
 [[package]]
 name = "slog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "jormungandr-lib",
   "jormungandr",
   "jcli",
+  "modules/settings",
   "testing/jormungandr-testing-utils",
   "testing/jormungandr-integration-tests",
   "testing/jormungandr-scenario-tests",

--- a/modules/settings/Cargo.toml
+++ b/modules/settings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "settings"
+version = "0.1.0"
+authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sled = "0.34"
+thiserror = "1.0"

--- a/modules/settings/README.md
+++ b/modules/settings/README.md
@@ -1,0 +1,8 @@
+# Settings interfaces for the jormungandr node
+
+Exposes only the APIs of how to update or get the settings of the node.
+The content is very much opinionated already. We expects the keys and the
+value to be `String`.
+
+Underlying, it uses `sled`. Though, except for the constructor itself
+the API hides entirely what's going on in the backend.

--- a/modules/settings/src/lib.rs
+++ b/modules/settings/src/lib.rs
@@ -1,0 +1,171 @@
+use sled::Tree;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use thiserror::Error;
+
+/// the root domain of the settings.
+#[derive(Clone)]
+pub struct Settings {
+    inner: Domain,
+}
+
+/// The settings domain. This object allows keeping track of the
+/// encapsulation of the settings parameters and also to keep
+/// separated the different operations on different domains
+///
+/// For example, the network module will only be interested about
+/// the network settings.
+#[derive(Clone)]
+pub struct Domain {
+    inner: Tree,
+    domain: String,
+}
+
+/// Subscriber for events that occurs in within the associated Domain.
+///
+/// Implements both synchronous subscriber (`Iterator`) and asynchronous
+/// subscriber (`Future`).
+pub struct Subscriber(sled::Subscriber);
+
+#[derive(Debug, Clone)]
+pub struct Event;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("{source}")]
+    Storage {
+        #[from]
+        source: sled::Error,
+    },
+}
+
+impl Domain {
+    fn new<S>(inner: Tree, domain: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            inner,
+            domain: domain.into(),
+        }
+    }
+
+    fn key<K>(&self, key: K) -> String
+    where
+        K: std::fmt::Display,
+    {
+        format!("{}.{}", self.domain(), key)
+    }
+
+    /// Get the domain full name
+    pub fn domain(&self) -> &str {
+        self.domain.as_str()
+    }
+
+    /// create a subdomain off the given domain
+    ///
+    /// # panics
+    ///
+    /// This function will panic if the given domain is empty
+    ///
+    pub fn sub_domain<S>(&self, domain: S) -> Self
+    where
+        S: AsRef<str>,
+    {
+        assert!(!domain.as_ref().is_empty(), "Domain cannot be empty");
+        Self::new(self.inner.clone(), self.key(domain.as_ref()))
+    }
+
+    /// get the value associated to the given key (if any) within the
+    /// current Domain.
+    ///
+    pub fn get<K>(&self, key: K) -> Result<Option<String>, Error>
+    where
+        K: std::fmt::Display,
+    {
+        let key = self.key(key);
+        let res = self.inner.get(key)?;
+
+        if let Some(res) = res {
+            let prev = String::from_utf8_lossy(res.as_ref()).into_owned();
+            Ok(Some(prev))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// insert a new key/value or replace the existing one with the new value.
+    ///
+    /// If it was a replace, the previous value is returned. Otherwise new value
+    /// will return `None`.
+    pub fn insert<K, V>(&self, key: K, value: V) -> Result<Option<String>, Error>
+    where
+        K: std::fmt::Display,
+        V: AsRef<str>,
+    {
+        let key = self.key(key);
+        let res = self.inner.insert(key, value.as_ref())?;
+
+        if let Some(prev) = res {
+            let prev = String::from_utf8_lossy(prev.as_ref()).into_owned();
+            Ok(Some(prev))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// subscribe to changes in this domain
+    ///
+    /// any changes in this domain or any of its subdomain will
+    /// raise an Event.
+    pub fn subscribe(&self) -> Subscriber {
+        Subscriber(self.inner.watch_prefix(&self.domain))
+    }
+}
+
+impl Settings {
+    /// create a new settings in within the given `sled`'s Tree.
+    pub fn new(inner: Tree) -> Self {
+        Self {
+            inner: Domain::new(inner, String::new()),
+        }
+    }
+
+    /// create a settings domain
+    ///
+    /// # panics
+    ///
+    /// This function will panic if the domain name is empty
+    pub fn domain<D>(&self, domain: D) -> Domain
+    where
+        D: AsRef<str>,
+    {
+        assert!(!domain.as_ref().is_empty(), "Domain cannot be empty");
+        self.inner.sub_domain(domain)
+    }
+}
+
+impl Iterator for Subscriber {
+    type Item = Event;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|_| Event)
+    }
+}
+
+impl Future for Subscriber {
+    type Output = Option<Event>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let pinned = Pin::new(&mut self.get_mut().0);
+
+        match Future::poll(pinned, cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(_)) => Poll::Ready(Some(Event)),
+        }
+    }
+}


### PR DESCRIPTION
Moving toward a set of modules like this will allow us to isolate the different components of each modules from each others. But also to be able to update the internals without suffering upon more complex major migration in the future.