### PR TITLE
separate out the blockchain module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "blockchain"
+version = "0.1.0"
+dependencies = [
+ "chain-impl-mockchain",
+ "chain-time",
+ "lru 0.5.3",
+ "thiserror",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "jormungandr",
   "jcli",
   "modules/settings",
+  "modules/blockchain",
   "testing/jormungandr-testing-utils",
   "testing/jormungandr-integration-tests",
   "testing/jormungandr-scenario-tests",

--- a/modules/blockchain/Cargo.toml
+++ b/modules/blockchain/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "blockchain"
+version = "0.1.0"
+authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
+edition = "2018"
+
+[dependencies]
+chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain" }
+chain-time           = { path = "../../chain-deps/chain-time"}
+thiserror = "1.0.20"
+lru       = "0.5.3"

--- a/modules/blockchain/README.md
+++ b/modules/blockchain/README.md
@@ -1,0 +1,5 @@
+# blockchain management
+
+This module provides all the necessary tooling to follow a blockchain. It
+also maintains multiple branches that can be used to quickly transition from
+one fork to another.

--- a/modules/blockchain/src/block0.rs
+++ b/modules/blockchain/src/block0.rs
@@ -1,0 +1,56 @@
+use chain_impl_mockchain::{
+    block::Block,
+    config::{self, ConfigParam},
+    fragment::{ConfigParams, Fragment},
+};
+use std::time::{Duration, SystemTime};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Block0Error {
+    #[error("Block0 Initial settings: {0}")]
+    CannotParseEntity(#[from] config::Error),
+    #[error("Block0 is invalid or malformed: {0}")]
+    Malformed(#[from] Block0Malformed),
+}
+
+#[derive(Debug, Error)]
+pub enum Block0Malformed {
+    #[error("missing its initial settings")]
+    NoInitialSettings,
+    #[error("missing `block0-start' value in the block0")]
+    NoStartTime,
+    #[error("missing `discrimination' value in the block0")]
+    NoDiscrimination,
+    #[error("missing `slot_duration' value in the block0")]
+    NoSlotDuration,
+    #[error("missing `slots_per_epoch' value in the block0")]
+    NoSlotsPerEpoch,
+}
+
+pub fn slot_duration(block0: &Block) -> Result<Duration, Block0Error> {
+    for config in initial(block0)?.iter() {
+        if let ConfigParam::SlotDuration(duration) = config {
+            return Ok(Duration::from_secs(*duration as u64));
+        }
+    }
+    Err(Block0Malformed::NoSlotDuration.into())
+}
+
+pub fn start_time(block0: &Block) -> Result<SystemTime, Block0Error> {
+    for config in initial(block0)?.iter() {
+        if let ConfigParam::Block0Date(date) = config {
+            return Ok(SystemTime::UNIX_EPOCH + Duration::from_secs(date.0));
+        }
+    }
+    Err(Block0Malformed::NoStartTime.into())
+}
+
+fn initial(block0: &Block) -> Result<&ConfigParams, Block0Malformed> {
+    for fragment in block0.fragments() {
+        if let Fragment::Initial(init) = fragment {
+            return Ok(&init);
+        }
+    }
+    Err(Block0Malformed::NoInitialSettings)
+}

--- a/modules/blockchain/src/blockchain.rs
+++ b/modules/blockchain/src/blockchain.rs
@@ -1,0 +1,107 @@
+use crate::{Error, Reference, Selection};
+use chain_impl_mockchain::{block::Block, header::HeaderId, ledger::RewardsInfoParameters};
+use std::sync::Arc;
+
+pub struct Blockchain {
+    tip: Arc<Reference>,
+    heads: lru::LruCache<HeaderId, Arc<Reference>>,
+    cache: lru::LruCache<HeaderId, Arc<Reference>>,
+}
+
+/// configuration entries for the blockchain parameters
+#[derive(Debug, Copy, Clone)]
+pub struct Configuration {
+    pub heads_capacity: usize,
+    pub cache_capacity: usize,
+    pub rewards_info_params: RewardsInfoParameters,
+}
+
+pub enum Event {
+    Added {
+        new_branch: bool,
+        new_tip: bool,
+        epoch_transition: bool,
+        new_reference: Arc<Reference>,
+    },
+    MissingParent {
+        parent: HeaderId,
+    },
+}
+
+impl Blockchain {
+    /// start a blockchain with the given block as starting point
+    pub fn new(configuration: &Configuration, block0: Arc<Reference>) -> Self {
+        let mut blockchain = Self {
+            tip: Arc::clone(&block0),
+            heads: lru::LruCache::new(configuration.heads_capacity),
+            cache: lru::LruCache::new(configuration.cache_capacity),
+        };
+
+        blockchain.heads.put(block0.hash(), Arc::clone(&block0));
+        blockchain.cache.put(block0.hash(), block0);
+
+        blockchain
+    }
+
+    pub fn tip(&self) -> Arc<Reference> {
+        Arc::clone(&self.tip)
+    }
+
+    pub fn put(&mut self, block: &Block) -> Result<Event, Error> {
+        let parent_hash = block.header.block_parent_hash();
+        if let Some(parent) = self.heads.get(&parent_hash).cloned() {
+            // refresh the parent in the `cache` LRU
+            self.cache.put(parent_hash, Arc::clone(&parent));
+            let new_reference = Reference::chain(Arc::clone(&parent), block)?;
+            let new_reference = Arc::new(new_reference);
+            let epoch_transition = parent.block_date().epoch < new_reference.block_date().epoch;
+
+            Ok(self.put_head(new_reference, false, epoch_transition))
+        } else if let Some(parent) = self.cache.get(&parent_hash).cloned() {
+            let new_reference = Reference::chain(Arc::clone(&parent), block)?;
+            let new_reference = Arc::new(new_reference);
+            let epoch_transition = parent.block_date().epoch < new_reference.block_date().epoch;
+
+            Ok(self.put_head(new_reference, true, epoch_transition))
+        } else {
+            Ok(Event::MissingParent {
+                parent: block.header.hash(),
+            })
+        }
+    }
+
+    fn put_head(
+        &mut self,
+        reference: Arc<Reference>,
+        new_branch: bool,
+        epoch_transition: bool,
+    ) -> Event {
+        self.heads.put(reference.hash(), Arc::clone(&reference));
+        self.cache.put(reference.hash(), Arc::clone(&reference));
+
+        let new_tip = match self.tip.select(&reference) {
+            Selection::PreferCurrent => false,
+            Selection::PreferCandidate => {
+                self.tip = Arc::clone(&reference);
+                true
+            }
+        };
+
+        Event::Added {
+            new_tip,
+            new_branch,
+            epoch_transition,
+            new_reference: reference,
+        }
+    }
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Self {
+            heads_capacity: 1024,
+            cache_capacity: 1024 * 1024 * 1024,
+            rewards_info_params: RewardsInfoParameters::default(),
+        }
+    }
+}

--- a/modules/blockchain/src/blockchain.rs
+++ b/modules/blockchain/src/blockchain.rs
@@ -47,6 +47,15 @@ impl Blockchain {
         Arc::clone(&self.tip)
     }
 
+    /// get an iterator for all the branches currently being considered by
+    /// the `Blockchain`.
+    ///
+    /// The `tip` is already included in the list too and it may be that
+    /// the some branches in the list are no longer `Head` only.
+    pub fn branches(&self) -> lru::Iter<'_, HeaderId, Arc<Reference>> {
+        self.heads.iter()
+    }
+
     pub fn put(&mut self, block: &Block) -> Result<Event, Error> {
         let parent_hash = block.header.block_parent_hash();
         if let Some(parent) = self.heads.get(&parent_hash).cloned() {

--- a/modules/blockchain/src/blockchain.rs
+++ b/modules/blockchain/src/blockchain.rs
@@ -80,7 +80,14 @@ impl Blockchain {
         self.cache.put(reference.hash(), Arc::clone(&reference));
 
         let new_tip = match self.tip.select(&reference) {
-            Selection::PreferCurrent => false,
+            Selection::PreferCurrent => {
+                // we prefer the current tip, so refresh it in the cache so
+                // it is properly cached and we don't get cache miss in
+                // future `put`.
+                self.heads.put(self.tip.hash(), Arc::clone(&self.tip));
+                self.cache.put(self.tip.hash(), Arc::clone(&self.tip));
+                false
+            }
             Selection::PreferCandidate => {
                 self.tip = Arc::clone(&reference);
                 true

--- a/modules/blockchain/src/checkpoints.rs
+++ b/modules/blockchain/src/checkpoints.rs
@@ -1,0 +1,71 @@
+use crate::Reference;
+use chain_impl_mockchain::header::HeaderId;
+use std::ops::Deref;
+
+/// different checkpoints in time of the blockchain
+///
+/// This is useful to build a list of header ids that can be used to hint
+/// the network or the storage about other blocks relevant for streaming
+/// blocks.
+///
+/// the list is ordered from most recent to most ancient. It starts with
+/// the given reference and its parent hash, then the hash of the previous epoch
+/// then iterate epoch after epoch. Leaving increasingly larger holes between epoch
+///
+/// `hash -> parent hash -> epoch N -> N-1 -> N-3 -> N-7 -> N-15 -> N-31 ...`
+#[derive(Debug, PartialEq, Eq)]
+pub struct Checkpoints(Box<[HeaderId]>);
+
+impl Checkpoints {
+    pub fn new(from: &Reference) -> Self {
+        let mut checkpoints = vec![from.hash(), from.block_parent_hash()];
+        let mut cursor = from;
+
+        let mut to_skip = 0;
+        let mut skipped = 0;
+        while let Some(prev) = cursor.previous_epoch_state() {
+            cursor = prev.as_ref();
+            if cursor.hash() == from.block_parent_hash() {
+                // ignore the case where the block's parent is also the last block
+                // of the previous epoch
+                continue;
+            }
+
+            if skipped >= to_skip {
+                checkpoints.push(cursor.hash());
+                to_skip = 1 + to_skip * 2;
+                skipped = 0;
+            } else {
+                skipped += 1;
+            }
+        }
+
+        Self(checkpoints.into())
+    }
+
+    pub fn iter(&self) -> ::std::slice::Iter<HeaderId> {
+        self.0.iter()
+    }
+}
+
+impl AsRef<[HeaderId]> for Checkpoints {
+    fn as_ref(&self) -> &[HeaderId] {
+        self.0.as_ref()
+    }
+}
+
+impl Deref for Checkpoints {
+    type Target = [HeaderId];
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<'a> IntoIterator for &'a Checkpoints {
+    type Item = &'a HeaderId;
+    type IntoIter = ::std::slice::Iter<'a, HeaderId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}

--- a/modules/blockchain/src/epoch_info.rs
+++ b/modules/blockchain/src/epoch_info.rs
@@ -33,7 +33,7 @@ pub struct EpochInfo {
 
 #[derive(Debug, Error)]
 pub enum EpochInfoError {
-    #[error("Cannot needed informations from the block0")]
+    #[error("Cannot needed information from the block0")]
     InvalidBlock0(
         #[source]
         #[from]

--- a/modules/blockchain/src/epoch_info.rs
+++ b/modules/blockchain/src/epoch_info.rs
@@ -1,0 +1,139 @@
+use crate::block0;
+use chain_impl_mockchain::{
+    block::Block,
+    header::BlockDate,
+    header::Header,
+    leadership::{self, Leadership, Verification},
+    ledger::{EpochRewardsInfo, Ledger, LedgerParameters},
+};
+use chain_time::{
+    era::{EpochPosition, EpochSlotOffset},
+    Epoch, Slot, TimeFrame,
+};
+use std::time::SystemTime;
+use thiserror::Error;
+
+pub struct EpochInfo {
+    /// the time frame applicable in the current branch of the blockchain
+    time_frame: TimeFrame,
+    /// the leadership used to validate the current header's leader
+    ///
+    /// this object will be shared between different Ref of the same epoch
+    epoch_leadership_schedule: Leadership,
+
+    /// pointer to the current ledger parameters
+    ///
+    /// The object will be shared between different Ref of the same epoch
+    epoch_ledger_parameters: LedgerParameters,
+
+    /// If present, this is the rewards info distributed at the beginning of
+    /// the epoch. Useful to follow up on the reward distribution history
+    epoch_rewards_info: Option<EpochRewardsInfo>,
+}
+
+#[derive(Debug, Error)]
+pub enum EpochInfoError {
+    #[error("Cannot needed informations from the block0")]
+    InvalidBlock0(
+        #[source]
+        #[from]
+        block0::Block0Error,
+    ),
+
+    #[error("Block Header's verification failed")]
+    HeaderVerification {
+        #[source]
+        #[from]
+        source: leadership::Error,
+    },
+}
+
+impl EpochInfo {
+    pub(crate) fn new(block0: &Block, ledger: &Ledger) -> Result<Self, EpochInfoError> {
+        let epoch = block0.header.block_date().epoch;
+        let time_frame = {
+            let start_time = block0::start_time(block0)?;
+            let slot_duration = block0::slot_duration(block0)?;
+
+            TimeFrame::new(
+                chain_time::Timeline::new(start_time),
+                chain_time::SlotDuration::from_secs(slot_duration.as_secs() as u32),
+            )
+        };
+
+        let epoch_leadership_schedule = Leadership::new(epoch, ledger);
+        let epoch_ledger_parameters = epoch_leadership_schedule.ledger_parameters().clone();
+        let epoch_rewards_info = None;
+
+        Ok(Self {
+            time_frame,
+            epoch_leadership_schedule,
+            epoch_ledger_parameters,
+            epoch_rewards_info,
+        })
+    }
+
+    pub(crate) fn chain(
+        &self,
+        leadership: Leadership,
+        epoch_rewards_info: Option<EpochRewardsInfo>,
+    ) -> Self {
+        Self {
+            time_frame: self.time_frame.clone(),
+            epoch_ledger_parameters: leadership.ledger_parameters().clone(),
+            epoch_leadership_schedule: leadership,
+            epoch_rewards_info,
+        }
+    }
+
+    pub fn check_header(&self, header: &Header) -> Result<(), EpochInfoError> {
+        match self.epoch_leadership_schedule.verify(header) {
+            Verification::Failure(error) => {
+                Err(EpochInfoError::HeaderVerification { source: error })
+            }
+            Verification::Success => Ok(()),
+        }
+    }
+
+    pub fn epoch(&self) -> u32 {
+        self.epoch_leadership_schedule.epoch()
+    }
+
+    /// get the slot for the given BlockDate
+    ///
+    /// Having this available allows for better handling of the time scheduled
+    /// of the given date.
+    pub fn slot_of(&self, date: BlockDate) -> Slot {
+        let epoch = Epoch(date.epoch);
+        let slot = EpochSlotOffset(date.slot_id);
+
+        let pos = EpochPosition { epoch, slot };
+
+        self.epoch_leadership_schedule.era().from_era_to_slot(pos)
+    }
+
+    /// get the system time scheduled for the given block date
+    ///
+    /// This function returns `None` if the block date is not
+    /// within the time frame of this EpochInfo (i.e. the time
+    /// frame has changed)
+    pub fn time_of(&self, date: BlockDate) -> Option<SystemTime> {
+        let slot = self.slot_of(date);
+
+        self.time_frame.slot_to_systemtime(slot)
+    }
+
+    pub fn epoch_leadership_schedule(&self) -> &Leadership {
+        &self.epoch_leadership_schedule
+    }
+
+    pub fn epoch_ledger_parameters(&self) -> &LedgerParameters {
+        &self.epoch_ledger_parameters
+    }
+
+    /// access the rewards info that were distributed at the end of the previous epoch
+    /// (and that are accessible/visible from this epoch only).
+    pub fn epoch_rewards_info(&self) -> Option<&EpochRewardsInfo> {
+        self.epoch_rewards_info.as_ref()
+    }
+}

--- a/modules/blockchain/src/lib.rs
+++ b/modules/blockchain/src/lib.rs
@@ -1,3 +1,59 @@
+/*!
+# Blockchain management module
+
+this module provides a high level API to manage the blockchain and the different
+state it may be. Allowing tracking different branches and to be able to make simple
+informed decisions as to what is the tip of the blockchain or what is a valid block.
+
+## Reference
+
+the `Reference` holds the state information at the given block. It can be used to
+know the blockdate, the chainlength etc... but it also links to the epoch information
+such as the current leadership schedule: this is core to validate a block.
+
+From a `Reference` it is possible to `chain` a `Block`. This means creating a new
+reference with a derive state from the previous `Reference`. This operation will
+do all the necessary verifications.
+
+## EpochInfo
+
+The `EpochInfo` is the data tied to a given Epoch: the TimeFrame, the stake
+distribution, the leadership schedule, the ledger parameters (fees, etc...).
+When chaining a `Block` with a `Reference`, if an epoch transition occurs,
+a new `EpochInfo` will be constructed for the new epoch.
+
+## Selection between 2 branches
+
+In some consensus, it may be that there are multiple competing blocks for the
+same slot in the blockchain. It is possible to use `select` to compare the
+2 different `Reference`.
+
+## Checkpoints
+
+From any reference, it is possible to build `Checkpoints`. These is a list
+of header ID (block's header hash) that are selected arbitrarily from the
+given `Reference`. They can be used to send to the network or storage as
+hints of where to start from when requiring a stream of blocks from one of
+the header ID in the Checkpoints.
+
+# The Blockchain manager
+
+the `Blockchain` is a simple collection object that will keep track of the
+different branches and blocks as well as the Tip of the blockchain. It will
+garbage collect the `Reference` that are not used to prevent keeping too
+much non needed data in memory.
+
+When adding a new block, the blockchain will lookup for the best option
+regarding branch management. It will first look for an existing branch
+to continue it or will create a new branch if required.
+
+If the block is added successfully, the `Event::Added` will be returned.
+It contains the details as to what and how it was added. A new branch
+may have been created, it may even be the new tip. It will also tell if an
+epoch transition occurs: that way the application may notify the different
+module with the appropriate data.
+*/
+
 pub(crate) mod block0;
 mod blockchain;
 mod checkpoints;

--- a/modules/blockchain/src/lib.rs
+++ b/modules/blockchain/src/lib.rs
@@ -1,0 +1,12 @@
+pub(crate) mod block0;
+mod blockchain;
+mod checkpoints;
+mod epoch_info;
+mod reference;
+
+pub use self::{
+    blockchain::{Blockchain, Configuration, Event},
+    checkpoints::Checkpoints,
+    epoch_info::{EpochInfo, EpochInfoError},
+    reference::{Error, Reference, Selection},
+};

--- a/modules/blockchain/src/reference.rs
+++ b/modules/blockchain/src/reference.rs
@@ -1,0 +1,365 @@
+use crate::{EpochInfo, EpochInfoError};
+use chain_impl_mockchain::{
+    block::Block,
+    chaintypes::ConsensusVersion,
+    header::{BlockDate, ChainLength, Epoch, Header, HeaderId},
+    leadership::Leadership,
+    ledger::{self, Ledger, RewardsInfoParameters},
+};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+use thiserror::Error;
+
+pub struct Reference {
+    /// the ledger at the state of the left by applying the current block
+    /// and all the previous blocks before that.
+    ledger: Ledger,
+
+    /// keeping the block's header here to save some lookup time in the storage
+    /// it contains all needed to retrieve the block from the storage (the HeaderId)
+    /// but also all the metadata associated to the block (parent, date, depth...).
+    ///
+    header: Header,
+
+    /// the block's epoch info
+    epoch_info: Arc<EpochInfo>,
+
+    /// last `Ref`. Every time there is a transition this value will be filled with
+    /// the parent `Ref`. Otherwise it will be copied from `Ref` to `Ref`.
+    ///
+    previous_epoch_state: Option<Arc<Reference>>,
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("The block could not apply successfully")]
+    Ledger {
+        #[source]
+        #[from]
+        source: ledger::Error,
+    },
+
+    #[error("The block's epoch validity failed to successfully apply")]
+    EpochInfo {
+        #[source]
+        #[from]
+        source: EpochInfoError,
+    },
+
+    #[error("Block's parent ({current}) does not match the block reference ({current})")]
+    NotTheParentBlock {
+        expected: HeaderId,
+        current: HeaderId,
+    },
+
+    #[error("The block's chain length ({current}) is not the expected value ({expected})")]
+    InvalidChainLength {
+        expected: ChainLength,
+        current: ChainLength,
+    },
+
+    #[error(
+        "The block's date ({current}) is not increasing compared to the parent's block ({parent})"
+    )]
+    InvalidBlockDate {
+        parent: BlockDate,
+        current: BlockDate,
+    },
+}
+
+pub enum Selection {
+    PreferCurrent,
+    PreferCandidate,
+}
+
+impl Reference {
+    /// create a new block reference with the given block0
+    ///
+    /// This will mark the beginning of a new blockchain as there is no expected parents
+    /// before this block. Thought he block_parent_hash may refer to a block hash from
+    /// another blockchain or may have a specific meaning
+    pub fn new(block0: &Block) -> Result<Self, Error> {
+        let header = block0.header.clone();
+        let ledger = Ledger::new(header.hash(), block0.contents.iter_slice())?;
+        let epoch_info = Arc::new(EpochInfo::new(block0, &ledger)?);
+        let previous_epoch_state = None;
+
+        Ok(Self {
+            header,
+            ledger,
+            epoch_info,
+            previous_epoch_state,
+        })
+    }
+
+    /// approximate a common ancestor between the given References
+    ///
+    /// This will lead to a common ancestor within the epoch boundary
+    /// as this is the only References that may be kept.
+    ///
+    /// There is only 2 reasons for this function to return None:
+    ///
+    /// 1. the 2 blocks are from different blockchain;
+    /// 2. one of the blocks are from the first epoch
+    pub fn approximate_common_ancestor(self: &Arc<Self>, other: &Arc<Self>) -> Option<Arc<Self>> {
+        let mut index1 = self;
+        let mut index2 = other;
+
+        if index1.hash() == index2.block_parent_hash() {
+            return Some(index1.clone());
+        }
+        if index1.block_parent_hash() == index2.hash() {
+            return Some(index2.clone());
+        }
+        loop {
+            if index1.hash() == index2.hash() {
+                return Some(index1.clone());
+            }
+
+            if index1.chain_length() < index2.chain_length() {
+                if let Some(prev) = index2.previous_epoch_state.as_ref() {
+                    index2 = prev;
+                    continue;
+                } else {
+                    return None;
+                }
+            } else if let Some(prev) = index1.previous_epoch_state.as_ref() {
+                index1 = prev;
+                continue;
+            } else {
+                return None;
+            }
+        }
+    }
+
+    /// compare the current Reference with the candidate one
+    ///
+    pub fn select(self: &Arc<Self>, candidate: &Arc<Self>) -> Selection {
+        let epoch_stability_depth = self
+            .epoch_info
+            .epoch_ledger_parameters()
+            .epoch_stability_depth;
+
+        if candidate.elapsed().is_err() {
+            Selection::PreferCurrent
+        } else if self.chain_length() < candidate.chain_length() {
+            if let Some(common) = self.approximate_common_ancestor(candidate) {
+                let common_chain_length = common.chain_length();
+                if let Some(ancestor) = candidate.chain_length().nth_ancestor(epoch_stability_depth)
+                {
+                    if common_chain_length > ancestor {
+                        Selection::PreferCurrent
+                    } else {
+                        Selection::PreferCandidate
+                    }
+                } else {
+                    Selection::PreferCandidate
+                }
+            } else {
+                Selection::PreferCurrent
+            }
+        } else {
+            Selection::PreferCurrent
+        }
+    }
+
+    /// chain a new block, expecting the new block to be a child of the given block
+    ///
+    /// This function will also perform all the necessary checks to make sure this
+    /// block is valid within the initial context (parent hash, chain length, ledger
+    /// and block signatures)
+    pub fn chain(self: Arc<Self>, block: &Block) -> Result<Self, Error> {
+        self.check_child(block)?;
+        self.check_chain_length(block)?;
+        self.check_block_date(block)?;
+
+        let transition_state = Self::chain_epoch_info(Arc::clone(&self), block)?;
+        let metadata = block.header.to_content_eval_context();
+
+        transition_state.epoch_info.check_header(&block.header)?;
+
+        let ledger = transition_state.ledger().apply_block(
+            transition_state.epoch_info.epoch_ledger_parameters(),
+            &block.contents,
+            &metadata,
+        )?;
+
+        Ok(Self {
+            ledger,
+            header: block.header.clone(),
+            epoch_info: transition_state.epoch_info.clone(),
+            previous_epoch_state: Some(self),
+        })
+    }
+
+    /// once we suppose the end of an epoch as come, we can compute the
+    /// missing steps to finalize the epoch: apply the protocol changes
+    /// and distribute the rewards
+    pub fn epoch_transition(&self) -> Result<Self, Error> {
+        // 1. apply protocol changes
+        let ledger = self.ledger.apply_protocol_changes()?;
+        // 2. distribute rewards
+        let ledger = if let Some(distribution) = self
+            .epoch_info
+            .epoch_leadership_schedule()
+            .stake_distribution()
+        {
+            let (ledger, _rewards) = ledger.distribute_rewards(
+                distribution,
+                self.epoch_info.epoch_ledger_parameters(),
+                RewardsInfoParameters::default(),
+            )?;
+            ledger
+        } else {
+            ledger
+        };
+
+        Ok(Self {
+            ledger,
+            header: self.header.clone(),
+            epoch_info: self.epoch_info.clone(),
+            previous_epoch_state: self.previous_epoch_state.clone(),
+        })
+    }
+
+    /// compute a new epoch info from the given Reference for the given Epoch
+    ///
+    /// We are not performing any checks here, merely generating a new Leadership
+    /// object of the given state.
+    pub fn new_epoch_info(&self, epoch: Epoch) -> Result<Arc<EpochInfo>, Error> {
+        // 3. prepare the leader schedule
+        let leadership = if self.ledger.consensus_version() == ConsensusVersion::GenesisPraos {
+            if let Some(previous_state) = self.previous_epoch_state.as_ref() {
+                Leadership::new(epoch, previous_state.ledger())
+            } else {
+                Leadership::new(epoch, &self.ledger)
+            }
+        } else {
+            Leadership::new(epoch, &self.ledger)
+        };
+
+        Ok(Arc::new(self.epoch_info.chain(leadership, None)))
+    }
+
+    fn chain_epoch_info(self: Arc<Self>, block: &Block) -> Result<Arc<Self>, Error> {
+        let epoch = block.header.block_date().epoch;
+
+        if self.block_date().epoch < epoch {
+            let transition = self.epoch_transition()?;
+            let epoch_info = transition.new_epoch_info(epoch)?;
+
+            let previous_epoch_state = self.previous_epoch_state.clone();
+
+            Ok(Arc::new(Self {
+                ledger: transition.ledger,
+                header: transition.header,
+                epoch_info,
+                previous_epoch_state,
+            }))
+        } else {
+            Ok(self)
+        }
+    }
+
+    fn check_child(&self, block: &Block) -> Result<(), Error> {
+        if self.hash() != block.header.block_parent_hash() {
+            Err(Error::NotTheParentBlock {
+                expected: self.hash(),
+                current: block.header.block_parent_hash(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn check_chain_length(&self, block: &Block) -> Result<(), Error> {
+        if self.chain_length().increase() != block.header.chain_length() {
+            Err(Error::InvalidChainLength {
+                expected: self.chain_length().increase(),
+                current: block.header.chain_length(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn check_block_date(&self, block: &Block) -> Result<(), Error> {
+        if self.block_date() >= block.header.block_date() {
+            Err(Error::InvalidBlockDate {
+                parent: self.block_date(),
+                current: block.header.block_date(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// retrieve the header hash of the `Ref`
+    pub fn hash(&self) -> HeaderId {
+        self.header.hash()
+    }
+
+    /// access the reference's parent hash
+    pub fn block_parent_hash(&self) -> HeaderId {
+        self.header().block_parent_hash()
+    }
+
+    /// retrieve the block date of the `Ref`
+    pub fn block_date(&self) -> BlockDate {
+        self.header().block_date()
+    }
+
+    /// retrieve the chain length, the number of blocks created
+    /// between the block0 and this block. This is useful to compare
+    /// the density of 2 branches.
+    pub fn chain_length(&self) -> ChainLength {
+        self.header().chain_length()
+    }
+
+    /// access the `Header` of the block pointed by this `Ref`
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    pub fn ledger(&self) -> &Ledger {
+        &self.ledger
+    }
+
+    /// retrieve the block's epoch info
+    pub fn epoch_info(&self) -> Arc<EpochInfo> {
+        Arc::clone(&self.epoch_info)
+    }
+
+    /// get the time the block was schedule for
+    ///
+    /// # panics
+    ///
+    /// This function will panic is the block does not coincide with the epoch's time era.
+    /// This should not happen by construct as the `Reference` has been constructed and
+    /// validated already.
+    ///
+    pub fn time(&self) -> SystemTime {
+        if let Some(time) = self.epoch_info.time_of(self.header.block_date()) {
+            time
+        } else {
+            // This error should not occur as the Reference
+            // should have been constructed in the given epoch info only
+            // if the block date existed in the epoch's time frame.
+            panic!("The Reference has been constructed with an invalid block date on the epoch's time frame")
+        }
+    }
+
+    /// retrieve the number of seconds since this block was schedule
+    ///
+    /// If the block was schedule in the future, the function will return
+    /// an error.
+    pub fn elapsed(&self) -> Result<Duration, std::time::SystemTimeError> {
+        SystemTime::now().duration_since(self.time())
+    }
+
+    pub(crate) fn previous_epoch_state(&self) -> Option<&Arc<Self>> {
+        self.previous_epoch_state.as_ref()
+    }
+}


### PR DESCRIPTION
separate the blockchain module entirely from the Jörmungandr node. One of the main difference with the current implementation of the Jörmungandr's blockchain management is that this version is much simpler design, yet more flexible. There is not tie to the storage and instead when trying to put a new block in the blockchain's state, if the parent state is missing from the local cache then the appropriate event is returned for the application level to handle this case.

- [x] document how the block reference works
- [x] document how the different forks are kept in a LRU cache