### PR TITLE
Modules block creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,11 +1814,12 @@ dependencies = [
 name = "kms"
 version = "0.1.0"
 dependencies = [
- "chain-crypto",
+ "blockchain",
  "chain-impl-mockchain",
  "hex",
  "rand 0.7.3",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,7 +1819,6 @@ dependencies = [
  "hex",
  "rand 0.7.3",
  "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -1827,6 +1826,19 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leadership"
+version = "0.1.0"
+dependencies = [
+ "blockchain",
+ "chain-impl-mockchain",
+ "chain-time",
+ "clock",
+ "kms",
+ "lru 0.5.3",
+ "thiserror",
+]
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,8 +1238,18 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
- "ahash",
+ "ahash 0.2.18",
  "autocfg 0.1.7",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+dependencies = [
+ "ahash 0.3.8",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -1915,7 +1931,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.6.3",
 ]
 
 [[package]]
@@ -1924,7 +1940,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35c456c123957de3a220cd03786e0d86aa542a88b46029973b542f426da6ef34"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.6.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
+dependencies = [
+ "hashbrown 0.8.1",
 ]
 
 [[package]]
@@ -1967,6 +1992,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
  "autocfg 1.0.0",
+]
+
+[[package]]
+name = "mempool"
+version = "0.1.0"
+dependencies = [
+ "chain-impl-mockchain",
+ "chain-ser",
+ "lru 0.6.0",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,6 +1811,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kms"
+version = "0.1.0"
+dependencies = [
+ "chain-crypto",
+ "chain-impl-mockchain",
+ "hex",
+ "rand 0.7.3",
+ "thiserror",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "clock"
+version = "0.1.0"
+dependencies = [
+ "chain-time",
+ "tokio",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "modules/blockchain",
   "modules/clock",
   "modules/kms",
+  "modules/mempool",
   "modules/leadership",
   "testing/jormungandr-testing-utils",
   "testing/jormungandr-integration-tests",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "modules/blockchain",
   "modules/clock",
   "modules/kms",
+  "modules/leadership",
   "testing/jormungandr-testing-utils",
   "testing/jormungandr-integration-tests",
   "testing/jormungandr-scenario-tests",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "modules/settings",
   "modules/blockchain",
   "modules/clock",
+  "modules/kms",
   "testing/jormungandr-testing-utils",
   "testing/jormungandr-integration-tests",
   "testing/jormungandr-scenario-tests",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "jcli",
   "modules/settings",
   "modules/blockchain",
+  "modules/clock",
   "testing/jormungandr-testing-utils",
   "testing/jormungandr-integration-tests",
   "testing/jormungandr-scenario-tests",

--- a/modules/blockchain/src/epoch_info.rs
+++ b/modules/blockchain/src/epoch_info.rs
@@ -8,7 +8,7 @@ use chain_impl_mockchain::{
 };
 use chain_time::{
     era::{EpochPosition, EpochSlotOffset},
-    Epoch, Slot, TimeFrame,
+    Epoch, Slot, TimeEra, TimeFrame,
 };
 use std::time::SystemTime;
 use thiserror::Error;
@@ -84,6 +84,14 @@ impl EpochInfo {
             epoch_leadership_schedule: leadership,
             epoch_rewards_info,
         }
+    }
+
+    pub fn time_frame(&self) -> TimeFrame {
+        self.time_frame.clone()
+    }
+
+    pub fn time_era(&self) -> TimeEra {
+        self.epoch_leadership_schedule.era().clone()
     }
 
     pub fn check_header(&self, header: &Header) -> Result<(), EpochInfoError> {

--- a/modules/clock/Cargo.toml
+++ b/modules/clock/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "clock"
+version = "0.1.0"
+authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
+edition = "2018"
+
+[dependencies]
+chain-time           = { path = "../../chain-deps/chain-time"}
+tokio = { version = "0.2.22", default-features = false, features = ["time"] }

--- a/modules/clock/src/lib.rs
+++ b/modules/clock/src/lib.rs
@@ -1,0 +1,102 @@
+use chain_time::{
+    era::{Epoch, EpochPosition, EpochSlotOffset},
+    Slot, TimeEra, TimeFrame,
+};
+use std::time::{Duration, SystemTime};
+
+/// define a `Clock` object, responsible for managing all that is time related
+///
+/// A Clock is only valid within a given TimeFrame and TimeEra.
+/// The TimeFrame defines the relation between the blockchain and the time, the
+/// Era defines how the blockchain time is split into epochs
+pub struct Clock {
+    frame: TimeFrame,
+    era: TimeEra,
+}
+
+impl Clock {
+    pub fn new(frame: TimeFrame, era: TimeEra) -> Self {
+        Self { frame, era }
+    }
+
+    #[inline]
+    pub fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+
+    #[inline]
+    pub fn slot_duration(&self) -> Duration {
+        Duration::from_secs(self.frame.slot_duration())
+    }
+
+    #[inline]
+    pub fn slots_per_epoch(&self) -> usize {
+        self.era.slots_per_epoch() as usize
+    }
+
+    #[inline]
+    fn current_slot(&self) -> Option<Slot> {
+        self.frame.slot_at(&self.now())
+    }
+
+    #[inline]
+    fn next_slot(&self) -> Option<Slot> {
+        let current: u64 = self.current_slot()?.into();
+        let next = current + 1;
+        Some(next.into())
+    }
+
+    /// get the current epoch position (epoch number and offset within this epoch)
+    ///
+    #[inline]
+    pub fn current_epoch_position(&self) -> Option<EpochPosition> {
+        let slot = self.current_slot()?;
+
+        self.era.from_slot_to_era(slot)
+    }
+
+    /// get the next epoch position (epoch number and offset within this epoch)
+    #[inline]
+    pub fn next_epoch_position(&self) -> Option<EpochPosition> {
+        let slot = self.next_slot()?;
+        self.era.from_slot_to_era(slot)
+    }
+
+    /// get the system time to the next Epoch
+    #[inline]
+    pub fn next_epoch(&self) -> Option<EpochPosition> {
+        let current = self.current_epoch_position()?;
+        Some(EpochPosition {
+            epoch: Epoch(current.epoch.0 + 1),
+            slot: EpochSlotOffset(0),
+        })
+    }
+
+    /// get the system time to the next Epoch
+    #[inline]
+    pub fn next_epoch_time(&self) -> Option<SystemTime> {
+        let next_epoch = self.next_epoch()?;
+        let slot = self.era.from_era_to_slot(next_epoch);
+        self.frame.slot_to_systemtime(slot)
+    }
+
+    /// synchronously await for the next slot to start
+    ///
+    /// This function will block the current thread until the next slot is starting
+    pub fn tick(&self) -> Option<()> {
+        let dur = self.frame.slot_at_precise(&self.now())?.offset;
+
+        std::thread::sleep(dur);
+        Some(())
+    }
+
+    /// same as the `tick` function, but asynchronous (tokio::time)
+    ///
+    pub async fn tick_async(&self) -> Option<()> {
+        let duration = self.frame.slot_at_precise(&self.now())?.offset;
+
+        tokio::time::delay_for(duration).await;
+
+        Some(())
+    }
+}

--- a/modules/clock/src/lib.rs
+++ b/modules/clock/src/lib.rs
@@ -19,6 +19,11 @@ impl Clock {
         Self { frame, era }
     }
 
+    /// returns the current system time in the given clock.
+    ///
+    /// TODO: for testing purpose, it would be interesting to be able to
+    ///       mock/update/configure the clock in a way the time can run
+    ///       at different pace for testing and simulation
     #[inline]
     pub fn now(&self) -> SystemTime {
         SystemTime::now()

--- a/modules/kms/Cargo.toml
+++ b/modules/kms/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chain-crypto         = { path = "../../chain-deps/chain-crypto"}
 chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain" }
+blockchain = { path = "../blockchain" }
 thiserror = "1.0.20"
 hex = "0.4.2"
 rand = "0.7"

--- a/modules/kms/Cargo.toml
+++ b/modules/kms/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "kms"
+version = "0.1.0"
+authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chain-crypto         = { path = "../../chain-deps/chain-crypto"}
+chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain" }
+thiserror = "1.0.20"
+hex = "0.4.2"
+rand = "0.7"

--- a/modules/kms/src/id.rs
+++ b/modules/kms/src/id.rs
@@ -1,0 +1,74 @@
+use rand::RngCore;
+use std::{
+    fmt::{self, Debug, Display},
+    str::FromStr,
+};
+
+/// unique identifier for an identity in with the KMS
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Hash)]
+pub struct Id {
+    raw: [u8; 32],
+}
+
+impl Id {
+    /// create a new ID with the given raw bytes
+    pub const fn new(raw: [u8; 32]) -> Self {
+        Self { raw }
+    }
+
+    const fn zero() -> Self {
+        Self::new([0; 32])
+    }
+
+    /// generate a random Id with the `thread_rng`
+    pub fn generate() -> Self {
+        let mut rng = rand::thread_rng();
+        Self::generate_with(&mut rng)
+    }
+
+    /// generate a Random Id with the given Random number generator
+    pub fn generate_with<RNG>(rng: &mut RNG) -> Self
+    where
+        RNG: RngCore,
+    {
+        let mut id = Id::zero();
+        rng.fill_bytes(&mut id.raw);
+        id
+    }
+}
+
+impl From<[u8; 32]> for Id {
+    fn from(raw: [u8; 32]) -> Self {
+        Self::new(raw)
+    }
+}
+
+impl Into<[u8; 32]> for Id {
+    fn into(self) -> [u8; 32] {
+        self.raw
+    }
+}
+
+impl Debug for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Id")
+            .field("raw", &hex::encode(&self.raw))
+            .finish()
+    }
+}
+
+impl Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&hex::encode(&self.raw), f)
+    }
+}
+
+impl FromStr for Id {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut id = Id::zero();
+        hex::decode_to_slice(s, &mut id.raw)?;
+        Ok(id)
+    }
+}

--- a/modules/kms/src/lib.rs
+++ b/modules/kms/src/lib.rs
@@ -1,0 +1,82 @@
+mod id;
+mod manager;
+mod query;
+
+use std::collections::HashMap;
+use thiserror::Error;
+
+pub mod managers;
+pub use self::{
+    id::Id,
+    manager::{KeyManager, ManagerError},
+    query::{Query, Schedule},
+};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Cannot register the key manager")]
+    CannotRegister {
+        #[source]
+        reason: ManagerError,
+    },
+    #[error("Cannot un-register the key manager {id}")]
+    CannotUnRegister {
+        id: Id,
+        #[source]
+        reason: ManagerError,
+    },
+    #[error("Cannot query the key manager {id}")]
+    CannotQuery {
+        id: Id,
+        #[source]
+        reason: ManagerError,
+    },
+}
+
+#[derive(Default)]
+pub struct KMS {
+    keys: HashMap<Id, KeyManager>,
+}
+
+impl KMS {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn contains(&self, id: &Id) -> bool {
+        self.keys.contains_key(id)
+    }
+
+    pub fn register(&mut self, id: Id, mut manager: KeyManager) -> Result<Id, Error> {
+        manager
+            .register()
+            .map_err(|reason| Error::CannotRegister { reason })?;
+        self.keys.insert(id, manager);
+        Ok(id)
+    }
+
+    pub fn un_register(&mut self, id: Id) -> Result<(), Error> {
+        if let Some(mut manager) = self.keys.remove(&id) {
+            manager
+                .un_register()
+                .map_err(|reason| Error::CannotUnRegister { id, reason })?;
+        }
+        Ok(())
+    }
+
+    /// list all the ID present in the KMS
+    // TODO: wrap the Keys iterator to an IdIter type. so we don't expose internals
+    pub fn ids(&self) -> std::collections::hash_map::Keys<'_, Id, KeyManager> {
+        self.keys.keys()
+    }
+
+    pub fn query(&mut self, id: Id, query: Query) -> Result<(), Error> {
+        if let Some(manager) = self.keys.get_mut(&id) {
+            manager
+                .query(query)
+                .map_err(|reason| Error::CannotQuery { id, reason })?;
+        }
+
+        Ok(())
+    }
+}

--- a/modules/kms/src/lib.rs
+++ b/modules/kms/src/lib.rs
@@ -70,6 +70,9 @@ impl KMS {
         self.keys.keys()
     }
 
+    /// this function will not block, however it is possible the action
+    /// queried takes some times to respond asynchronously.
+    ///
     pub fn query(&mut self, id: Id, query: Query) -> Result<(), Error> {
         if let Some(manager) = self.keys.get_mut(&id) {
             manager

--- a/modules/kms/src/manager.rs
+++ b/modules/kms/src/manager.rs
@@ -1,0 +1,32 @@
+use crate::{managers, Query};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ManagerError {}
+
+pub enum KeyManager {
+    InMemory(managers::InMemory),
+}
+
+impl KeyManager {
+    pub(crate) fn register(&mut self) -> Result<(), ManagerError> {
+        match self {
+            Self::InMemory(_in_memory) => Ok(()),
+        }
+    }
+
+    pub(crate) fn un_register(&mut self) -> Result<(), ManagerError> {
+        match self {
+            Self::InMemory(_in_memory) => Ok(()),
+        }
+    }
+
+    pub(crate) fn query(&mut self, query: Query) -> Result<(), ManagerError> {
+        match self {
+            Self::InMemory(in_memory) => {
+                in_memory.query(query);
+                Ok(())
+            }
+        }
+    }
+}

--- a/modules/kms/src/manager.rs
+++ b/modules/kms/src/manager.rs
@@ -4,24 +4,48 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum ManagerError {}
 
-pub enum KeyManager {
+pub struct KeyManager {
+    inner: Inner,
+}
+
+enum Inner {
     InMemory(managers::InMemory),
 }
 
 impl KeyManager {
-    pub(crate) fn register(&mut self) -> Result<(), ManagerError> {
-        match self {
-            Self::InMemory(_in_memory) => Ok(()),
+    pub fn in_memory(in_memory: managers::InMemory) -> Self {
+        Self {
+            inner: Inner::InMemory(in_memory),
         }
+    }
+
+    pub(crate) fn register(&mut self) -> Result<(), ManagerError> {
+        self.inner.register()
     }
 
     pub(crate) fn un_register(&mut self) -> Result<(), ManagerError> {
+        self.inner.un_register()
+    }
+
+    pub(crate) fn query(&mut self, query: Query) -> Result<(), ManagerError> {
+        self.inner.query(query)
+    }
+}
+
+impl Inner {
+    fn register(&mut self) -> Result<(), ManagerError> {
         match self {
             Self::InMemory(_in_memory) => Ok(()),
         }
     }
 
-    pub(crate) fn query(&mut self, query: Query) -> Result<(), ManagerError> {
+    fn un_register(&mut self) -> Result<(), ManagerError> {
+        match self {
+            Self::InMemory(_in_memory) => Ok(()),
+        }
+    }
+
+    fn query(&mut self, query: Query) -> Result<(), ManagerError> {
         match self {
             Self::InMemory(in_memory) => {
                 in_memory.query(query);

--- a/modules/kms/src/managers/in_memory.rs
+++ b/modules/kms/src/managers/in_memory.rs
@@ -1,0 +1,89 @@
+use crate::{Query, Schedule};
+use chain_impl_mockchain::header::{
+    HeaderBft, HeaderBftBuilder, HeaderGenesisPraos, HeaderGenesisPraosBuilder,
+    HeaderSetConsensusSignature, SlotId,
+};
+use chain_impl_mockchain::leadership::{Leader, LeaderOutput, Leadership};
+use std::sync::Arc;
+
+pub struct InMemory(Leader);
+
+impl InMemory {
+    pub fn new(leader: Leader) -> Self {
+        Self(leader)
+    }
+
+    pub(crate) fn query(&mut self, query: Query) {
+        match query {
+            Query::SignBft {
+                header_builder,
+                reply,
+            } => self.sign_bft(header_builder, reply),
+            Query::SignGenesisPraos {
+                header_builder,
+                reply,
+            } => self.sign_genesis_praos(header_builder, reply),
+            Query::Schedules {
+                from,
+                length,
+                leadership,
+                reply,
+            } => self.schedule(from, length, leadership, reply),
+        }
+    }
+
+    fn schedule(
+        &self,
+        from: SlotId,
+        length: usize,
+        leadership: Arc<Leadership>,
+        reply: Box<dyn FnOnce(Vec<Schedule>)>,
+    ) {
+        let mut schedules = Vec::with_capacity(std::cmp::min(128, length));
+        for slot_id in from..(from + length as u32) {
+            let date = leadership.date_at_slot(slot_id);
+            match leadership.is_leader_for_date(&self.0, date) {
+                Ok(LeaderOutput::None) => continue,
+                Ok(output) => {
+                    let schedule = Schedule { output, slot_id };
+                    schedules.push(schedule);
+                }
+                Err(_) => {
+                    // For now silently ignore errors
+                }
+            }
+        }
+
+        reply(schedules)
+    }
+
+    fn sign_bft(
+        &self,
+        header_builder: HeaderBftBuilder<HeaderSetConsensusSignature>,
+        reply: Box<dyn FnOnce(Option<HeaderBft>)>,
+    ) {
+        let s = if let Some(bft_leader) = &self.0.bft_leader {
+            let data = header_builder.get_authenticated_data();
+            let signature = bft_leader.sig_key.sign_slice(data);
+            Some(header_builder.set_signature(signature.into()))
+        } else {
+            None
+        };
+        reply(s)
+    }
+
+    fn sign_genesis_praos(
+        &mut self,
+        header_builder: HeaderGenesisPraosBuilder<HeaderSetConsensusSignature>,
+        reply: Box<dyn FnOnce(Option<HeaderGenesisPraos>)>,
+    ) {
+        let s = if let Some(genesis_leader) = &self.0.genesis_leader {
+            let data = header_builder.get_authenticated_data();
+            let signature = genesis_leader.sig_key.sign_slice(data);
+            Some(header_builder.set_signature(signature.into()))
+        } else {
+            None
+        };
+        reply(s)
+    }
+}

--- a/modules/kms/src/managers/in_memory.rs
+++ b/modules/kms/src/managers/in_memory.rs
@@ -1,16 +1,17 @@
 use crate::{Query, Schedule};
+use blockchain::EpochInfo;
 use chain_impl_mockchain::header::{
     HeaderBft, HeaderBftBuilder, HeaderGenesisPraos, HeaderGenesisPraosBuilder,
     HeaderSetConsensusSignature, SlotId,
 };
-use chain_impl_mockchain::leadership::{Leader, LeaderOutput, Leadership};
-use std::sync::Arc;
+use chain_impl_mockchain::leadership::{Leader, LeaderOutput};
+use std::sync::{Arc, Mutex};
 
-pub struct InMemory(Leader);
+pub struct InMemory(Arc<Mutex<Leader>>);
 
 impl InMemory {
     pub fn new(leader: Leader) -> Self {
-        Self(leader)
+        Self(Arc::new(Mutex::new(leader)))
     }
 
     pub(crate) fn query(&mut self, query: Query) {
@@ -26,64 +27,88 @@ impl InMemory {
             Query::Schedules {
                 from,
                 length,
-                leadership,
+                epoch_info,
                 reply,
-            } => self.schedule(from, length, leadership, reply),
+            } => self.schedule(from, length, epoch_info, reply),
         }
     }
 
+    /// calling this function may be a bit intensive, so instead it will
+    /// call the result
     fn schedule(
         &self,
         from: SlotId,
         length: usize,
-        leadership: Arc<Leadership>,
-        reply: Box<dyn FnOnce(Vec<Schedule>)>,
+        epoch_info: Arc<EpochInfo>,
+        reply: Box<dyn FnOnce(Vec<Schedule>) + Send + 'static>,
     ) {
-        let mut schedules = Vec::with_capacity(std::cmp::min(128, length));
-        for slot_id in from..(from + length as u32) {
-            let date = leadership.date_at_slot(slot_id);
-            match leadership.is_leader_for_date(&self.0, date) {
-                Ok(LeaderOutput::None) => continue,
-                Ok(output) => {
-                    let schedule = Schedule { output, slot_id };
-                    schedules.push(schedule);
-                }
-                Err(_) => {
-                    // For now silently ignore errors
+        let inner = self.0.clone();
+        std::thread::spawn(move || {
+            let leader = inner.lock().ok()?;
+            let mut schedules = Vec::with_capacity(std::cmp::min(128, length));
+            for slot_id in from..(from + length as u32) {
+                let date = epoch_info.epoch_leadership_schedule().date_at_slot(slot_id);
+                match epoch_info
+                    .epoch_leadership_schedule()
+                    .is_leader_for_date(&leader, date)
+                {
+                    Ok(LeaderOutput::None) => continue,
+                    Ok(output) => {
+                        let schedule = Schedule { output, date };
+                        schedules.push(schedule);
+                    }
+                    Err(_) => {
+                        // For now silently ignore errors
+                    }
                 }
             }
-        }
 
-        reply(schedules)
+            reply(schedules);
+            Some(())
+        });
     }
 
     fn sign_bft(
         &self,
         header_builder: HeaderBftBuilder<HeaderSetConsensusSignature>,
-        reply: Box<dyn FnOnce(Option<HeaderBft>)>,
+        reply: Box<dyn FnOnce(Option<HeaderBft>) + Send + 'static>,
     ) {
-        let s = if let Some(bft_leader) = &self.0.bft_leader {
-            let data = header_builder.get_authenticated_data();
-            let signature = bft_leader.sig_key.sign_slice(data);
-            Some(header_builder.set_signature(signature.into()))
-        } else {
-            None
-        };
-        reply(s)
+        let inner = self.0.clone();
+        std::thread::spawn(move || {
+            if let Ok(inner) = inner.lock() {
+                let s = if let Some(bft_leader) = &inner.bft_leader {
+                    let data = header_builder.get_authenticated_data();
+                    let signature = bft_leader.sig_key.sign_slice(data);
+                    Some(header_builder.set_signature(signature.into()))
+                } else {
+                    None
+                };
+                reply(s)
+            } else {
+                reply(None)
+            }
+        });
     }
 
     fn sign_genesis_praos(
         &mut self,
         header_builder: HeaderGenesisPraosBuilder<HeaderSetConsensusSignature>,
-        reply: Box<dyn FnOnce(Option<HeaderGenesisPraos>)>,
+        reply: Box<dyn FnOnce(Option<HeaderGenesisPraos>) + Send + 'static>,
     ) {
-        let s = if let Some(genesis_leader) = &self.0.genesis_leader {
-            let data = header_builder.get_authenticated_data();
-            let signature = genesis_leader.sig_key.sign_slice(data);
-            Some(header_builder.set_signature(signature.into()))
-        } else {
-            None
-        };
-        reply(s)
+        let inner = self.0.clone();
+        std::thread::spawn(move || {
+            if let Ok(inner) = inner.lock() {
+                let s = if let Some(genesis_leader) = &inner.genesis_leader {
+                    let data = header_builder.get_authenticated_data();
+                    let signature = genesis_leader.sig_key.sign_slice(data);
+                    Some(header_builder.set_signature(signature.into()))
+                } else {
+                    None
+                };
+                reply(s)
+            } else {
+                reply(None)
+            }
+        });
     }
 }

--- a/modules/kms/src/managers/mod.rs
+++ b/modules/kms/src/managers/mod.rs
@@ -1,0 +1,3 @@
+mod in_memory;
+
+pub use self::in_memory::InMemory;

--- a/modules/kms/src/query.rs
+++ b/modules/kms/src/query.rs
@@ -1,0 +1,30 @@
+use chain_impl_mockchain::{
+    header::{
+        HeaderBft, HeaderBftBuilder, HeaderGenesisPraos, HeaderGenesisPraosBuilder,
+        HeaderSetConsensusSignature, SlotId,
+    },
+    leadership::{LeaderOutput, Leadership},
+};
+use std::sync::Arc;
+
+pub struct Schedule {
+    pub slot_id: SlotId,
+    pub output: LeaderOutput,
+}
+
+pub enum Query {
+    SignBft {
+        header_builder: HeaderBftBuilder<HeaderSetConsensusSignature>,
+        reply: Box<dyn FnOnce(Option<HeaderBft>)>,
+    },
+    SignGenesisPraos {
+        header_builder: HeaderGenesisPraosBuilder<HeaderSetConsensusSignature>,
+        reply: Box<dyn FnOnce(Option<HeaderGenesisPraos>)>,
+    },
+    Schedules {
+        from: SlotId,
+        length: usize,
+        leadership: Arc<Leadership>,
+        reply: Box<dyn FnOnce(Vec<Schedule>)>,
+    },
+}

--- a/modules/kms/src/query.rs
+++ b/modules/kms/src/query.rs
@@ -1,30 +1,31 @@
+use blockchain::EpochInfo;
 use chain_impl_mockchain::{
     header::{
-        HeaderBft, HeaderBftBuilder, HeaderGenesisPraos, HeaderGenesisPraosBuilder,
+        BlockDate, HeaderBft, HeaderBftBuilder, HeaderGenesisPraos, HeaderGenesisPraosBuilder,
         HeaderSetConsensusSignature, SlotId,
     },
-    leadership::{LeaderOutput, Leadership},
+    leadership::LeaderOutput,
 };
 use std::sync::Arc;
 
 pub struct Schedule {
-    pub slot_id: SlotId,
+    pub date: BlockDate,
     pub output: LeaderOutput,
 }
 
 pub enum Query {
     SignBft {
         header_builder: HeaderBftBuilder<HeaderSetConsensusSignature>,
-        reply: Box<dyn FnOnce(Option<HeaderBft>)>,
+        reply: Box<dyn FnOnce(Option<HeaderBft>) + Send + 'static>,
     },
     SignGenesisPraos {
         header_builder: HeaderGenesisPraosBuilder<HeaderSetConsensusSignature>,
-        reply: Box<dyn FnOnce(Option<HeaderGenesisPraos>)>,
+        reply: Box<dyn FnOnce(Option<HeaderGenesisPraos>) + Send + 'static>,
     },
     Schedules {
         from: SlotId,
         length: usize,
-        leadership: Arc<Leadership>,
-        reply: Box<dyn FnOnce(Vec<Schedule>)>,
+        epoch_info: Arc<EpochInfo>,
+        reply: Box<dyn FnOnce(Vec<Schedule>) + Send + 'static>,
     },
 }

--- a/modules/leadership/Cargo.toml
+++ b/modules/leadership/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "leadership"
+version = "0.1.0"
+authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
+edition = "2018"
+
+[dependencies]
+chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain" }
+chain-time           = { path = "../../chain-deps/chain-time"}
+
+clock      = { path = "../clock" }
+kms        = { path = "../kms" }
+blockchain = { path = "../blockchain" }
+
+thiserror = "1.0.20"
+lru       = "0.5.3"

--- a/modules/leadership/src/lib.rs
+++ b/modules/leadership/src/lib.rs
@@ -1,0 +1,88 @@
+use chain_impl_mockchain::header::BlockDate;
+use kms::{Id, Schedule};
+use std::collections::{BTreeMap, HashMap};
+
+const EXPLORATORY_LENGTH: usize = 20;
+
+/// the leadership plan for the given leader ID
+pub struct LeadershipPlan {
+    id: Id,
+    query_counter: usize,
+    schedules: BTreeMap<BlockDate, Schedule>,
+}
+
+#[derive(Default)]
+pub struct Leadership {
+    plans: HashMap<Id, LeadershipPlan>,
+}
+
+impl Leadership {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn ids(&self) -> impl ExactSizeIterator<Item = &Id> {
+        self.plans.keys()
+    }
+
+    pub fn register(&mut self, id: Id) -> Option<LeadershipPlan> {
+        self.plans.insert(id, LeadershipPlan::new(id))
+    }
+
+    pub fn un_register(&mut self, id: &Id) -> Option<LeadershipPlan> {
+        self.plans.remove(id)
+    }
+}
+
+impl LeadershipPlan {
+    pub fn new(id: Id) -> Self {
+        Self {
+            id,
+            query_counter: 0,
+            schedules: BTreeMap::new(),
+        }
+    }
+
+    pub fn id(&self) -> &Id {
+        &self.id
+    }
+
+    /// clear all the schedules
+    pub fn clear(&mut self) {
+        self.schedules.clear()
+    }
+
+    /// add a schedule to this leader
+    pub fn schedule(&mut self, schedule: Schedule) {
+        let date = schedule.date;
+
+        self.schedules.insert(date, schedule);
+    }
+
+    /// unschedule a given schedule
+    pub fn unschedule(&mut self, schedule: &BlockDate) -> Option<Schedule> {
+        self.schedules.remove(schedule)
+    }
+
+    /// peek the next schedule (if any)
+    pub fn next_schedule(&self) -> Option<&Schedule> {
+        self.schedules.values().next()
+    }
+
+    /// peek the last schedule (if any at all)
+    pub fn last_schedule(&self) -> Option<&Schedule> {
+        self.schedules.values().next_back()
+    }
+
+    /// pop the next schedule
+    pub fn pop_next_schedule(&mut self) -> Option<Schedule> {
+        let schedule = self.next_schedule()?.date;
+
+        self.unschedule(&schedule)
+    }
+
+    pub fn advice_schedule_exploration_length(&mut self) -> usize {
+        self.query_counter += 1;
+        self.query_counter * EXPLORATORY_LENGTH
+    }
+}

--- a/modules/mempool/Cargo.toml
+++ b/modules/mempool/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mempool"
+version = "0.1.0"
+authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
+edition = "2018"
+
+[dependencies]
+chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain" }
+chain-ser = { path = "../../chain-deps/chain-ser" }
+lru = "0.6"
+thiserror = "1.0.20"

--- a/modules/mempool/src/lib.rs
+++ b/modules/mempool/src/lib.rs
@@ -1,0 +1,254 @@
+use chain_impl_mockchain::{
+    fragment::{Fragment, FragmentId, FragmentRaw},
+    transaction::Transaction,
+    value::{Value, ValueError},
+};
+use chain_ser::mempack::ReadError;
+use std::collections::{BTreeMap, HashMap};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Fragment has invalid structure")]
+    InvalidStructure {
+        #[source]
+        #[from]
+        source: ReadError,
+    },
+
+    #[error("this kind of fragment are not authorized through the mempool")]
+    NotAuthorizedFragment,
+
+    #[error("The transaction is not properly balanced")]
+    NotProperlyBalanced {
+        #[source]
+        #[from]
+        source: ValueError,
+    },
+}
+
+struct Entry {
+    fragment: FragmentRaw,
+    score: u64,
+    previous: *mut Entry,
+    next: *mut Entry,
+}
+
+pub struct Mempool {
+    by_hash: HashMap<FragmentId, Box<Entry>>,
+    by_fee: BTreeMap<u64, HashMap<FragmentId, *mut Entry>>,
+    by_size: BTreeMap<usize, HashMap<FragmentId, *mut Entry>>,
+    head: *mut Entry,
+    tail: *mut Entry,
+    cap: usize,
+}
+
+impl Mempool {
+    const DEFAULT_CAPACITY: usize = 10_000;
+
+    pub fn new(cap: usize) -> Self {
+        Self {
+            cap,
+            by_hash: HashMap::new(),
+            by_fee: BTreeMap::new(),
+            by_size: BTreeMap::new(),
+            head: std::ptr::null_mut(),
+            tail: std::ptr::null_mut(),
+        }
+    }
+
+    pub fn contains(&self, fragment_id: &FragmentId) -> bool {
+        self.by_hash.contains_key(fragment_id)
+    }
+
+    /// add the given fragment, return the fragment that was already in
+    /// if the capacity is reached. The removed fragment will be the oldest
+    /// added fragment of the pool
+    ///
+    /// if the fragment is already in the mempool, nothing is done
+    pub fn push(&mut self, fragment: FragmentRaw) -> Result<Option<FragmentId>, Error> {
+        let entry = Entry::new(fragment)?;
+        let id = entry.id();
+
+        if self.contains(&id) {
+            return Ok(None);
+        }
+
+        let oldest = if self.len() == self.capacity() {
+            self.pop_oldest()
+        } else {
+            None
+        };
+
+        let score = entry.score;
+        let size = entry.fragment.size_bytes_plus_size();
+        let mut entry = Box::new(entry);
+        let ptr: *mut Entry = &mut *entry;
+
+        self.by_hash.insert(id, entry);
+        self.by_fee.entry(score).or_default().insert(id, ptr);
+        self.by_size.entry(size).or_default().insert(id, ptr);
+
+        self.attach(ptr);
+
+        Ok(oldest)
+    }
+
+    fn pop_oldest(&mut self) -> Option<FragmentId> {
+        if let Some(tail) = unsafe { self.tail.as_mut() } {
+            let id = tail.id();
+            let score = tail.score;
+            let size = tail.fragment.size_bytes_plus_size();
+
+            self.by_fee.entry(score).and_modify(|e| {
+                e.remove(&id);
+            });
+            self.by_size.entry(size).and_modify(|e| {
+                e.remove(&id);
+            });
+            let ptr = self
+                .by_hash
+                .remove(&id)
+                .expect("the entry is definitely in the hashmap");
+
+            self.tail = tail.previous;
+            tail.detach();
+
+            std::mem::drop(ptr);
+
+            Some(id)
+        } else {
+            None
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_hash.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_hash.is_empty()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.cap
+    }
+
+    /// refresh the capacity of the Mempool
+    ///
+    /// If some fragments are removed because of this, their `FragmentId` will
+    /// be returned so events can be associated to that.
+    ///
+    pub fn resize(&mut self, size: usize) -> Vec<FragmentId> {
+        // create the Vec with the initial capacity for the detected number
+        // of entry to remove from the Mempool due to resizing
+        // if the num to remove is 0 then nothing is changed.
+
+        let mut left_to_remove = self.cap.wrapping_sub(size);
+        let mut removed = Vec::with_capacity(left_to_remove);
+
+        while left_to_remove > 0 {
+            if let Some(id) = self.pop_oldest() {
+                removed.push(id);
+            } else {
+                break;
+            }
+            left_to_remove -= 1;
+        }
+
+        removed
+    }
+
+    fn attach(&mut self, entry: *mut Entry) {
+        unsafe {
+            (*entry).next = self.head;
+        }
+        if let Some(ptr) = unsafe { self.head.as_mut() } {
+            ptr.previous = entry;
+        } else {
+            self.tail = entry;
+        }
+
+        self.head = entry;
+    }
+}
+
+impl Default for Mempool {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_CAPACITY)
+    }
+}
+
+impl Entry {
+    fn new(fragment: FragmentRaw) -> Result<Self, Error> {
+        let decoded = Fragment::from_raw(&fragment)?;
+        check(&decoded)?;
+
+        Ok(Self {
+            fragment,
+            score: score(&decoded)?,
+            next: std::ptr::null_mut(),
+            previous: std::ptr::null_mut(),
+        })
+    }
+
+    fn id(&self) -> FragmentId {
+        self.fragment.id()
+    }
+
+    fn detach(&mut self) {
+        if let Some(previous) = unsafe { self.previous.as_mut() } {
+            previous.next = self.next;
+        }
+        if let Some(next) = unsafe { self.next.as_mut() } {
+            next.previous = self.previous;
+        }
+    }
+}
+
+fn check(fragment: &Fragment) -> Result<(), Error> {
+    let reject_not_authorized = Err(Error::NotAuthorizedFragment);
+
+    match fragment {
+        Fragment::Initial(_) => reject_not_authorized,
+        Fragment::OldUtxoDeclaration(_) => reject_not_authorized,
+        Fragment::UpdateProposal(_) => reject_not_authorized,
+        Fragment::UpdateVote(_) => reject_not_authorized,
+        Fragment::Transaction(_t) => Ok(()),
+        Fragment::OwnerStakeDelegation(_t) => Ok(()),
+        Fragment::StakeDelegation(_t) => Ok(()),
+        Fragment::PoolRegistration(_t) => Ok(()),
+        Fragment::PoolRetirement(_t) => (Ok(())),
+        Fragment::PoolUpdate(_t) => Ok(()),
+        Fragment::VotePlan(_t) => Ok(()),
+        Fragment::VoteCast(_t) => Ok(()),
+        Fragment::VoteTally(_t) => Ok(()),
+    }
+}
+
+fn fee<P>(t: &Transaction<P>) -> Result<Value, Error> {
+    let input = t.total_input()?;
+    let output = t.total_output()?;
+
+    Ok(output.checked_sub(input)?)
+}
+
+fn score(fragment: &Fragment) -> Result<u64, Error> {
+    let fee = match fragment {
+        Fragment::Initial(_) => 0,
+        Fragment::OldUtxoDeclaration(_) => 0,
+        Fragment::UpdateProposal(_) => 0,
+        Fragment::UpdateVote(_) => 0,
+        Fragment::Transaction(t) => fee(t)?.0,
+        Fragment::OwnerStakeDelegation(t) => fee(t)?.0,
+        Fragment::StakeDelegation(t) => fee(t)?.0,
+        Fragment::PoolRegistration(t) => fee(t)?.0,
+        Fragment::PoolRetirement(t) => fee(t)?.0,
+        Fragment::PoolUpdate(t) => fee(t)?.0,
+        Fragment::VotePlan(t) => fee(t)?.0,
+        Fragment::VoteCast(t) => fee(t)?.0,
+        Fragment::VoteTally(t) => fee(t)?.0,
+    };
+
+    Ok(fee)
+}


### PR DESCRIPTION
Introduce 3 new modules to expose the APIs needed for the block scheduling:

* `clock`: handy module to do all that is time management with the appropriate `tick` functions (one sync, and one async) to await for the next block schedule;
* the `kms`: to keep the keys in a separate module. Here the difference with Jörmungandr legacy's enclave is that the keys are to work in isolation from the block creation module. I.e. we can have keys in the KMS that are not used for the leadership here yet.
* the `leadership`: it is rather incomplete for now, but the idea is to have the necessary tooling for the management of "calendar" (LeadershipPlan in the code) for any new Leadership's Id (the Id used in the `kms`). It also provides a way to define how much forward in the future we want to plan to "discover" block creation. This will allow to know how much forward ti is worth to lookup, knowing that the further we will the longer it may take to explore all the schedules.

Missing:

- [ ] actually creating blocks, this is going to be yet another module from the `leadership` because it will be tied to the `mempool`. This will define how to create blocks (to prepare them for block creation)