### PR TITLE
CI: check out recursively in create_release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          submodules: 'true'
 
       - id: release_info
         name: Get release information


### PR DESCRIPTION
Needed so that jortestkit submodule code is present when the cargo manifest is read.
Fixes a regression in release workflow.