### PR TITLE
test which version is displayed

### DIFF
--- a/testing/jormungandr-integration-tests/src/bin/explorer_load.rs
+++ b/testing/jormungandr-integration-tests/src/bin/explorer_load.rs
@@ -63,6 +63,7 @@ impl ExplorerLoadCommand {
             std::time::Duration::from_secs(self.duration),
             self.pace,
             self.build_monitor(),
+            0,
         );
         let stats = jortestkit::load::start_sync(request_gen, config, "Explorer load test");
         if self.measure {

--- a/testing/jormungandr-integration-tests/src/non_functional/explorer.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/explorer.rs
@@ -152,6 +152,7 @@ pub fn explorer_load_test() {
         std::time::Duration::from_secs(60),
         100,
         Monitor::Progress(100),
+        0,
     );
     let stats = jortestkit::load::start_sync(request_gen, config, "Explorer load test");
     assert!((stats.calculate_passrate() as u32) > 95);

--- a/testing/jormungandr-testing-utils/src/testing/node/legacy/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/legacy/mod.rs
@@ -38,6 +38,7 @@ pub fn get_jormungandr_bin(release: &Release, temp_dir: &impl PathChild) -> Path
         .get_asset_for_current_os_by_version(release.version())
         .unwrap()
         .unwrap();
+
     let url = Url::parse(&asset.download_url()).expect("cannot parse url");
     let file_name = url
         .path_segments()

--- a/testing/jormungandr-testing-utils/src/testing/node/legacy/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/legacy/mod.rs
@@ -34,6 +34,9 @@ pub fn download_last_n_releases(n: u32) -> Vec<Release> {
 
 pub fn get_jormungandr_bin(release: &Release, temp_dir: &impl PathChild) -> PathBuf {
     let github_api = GitHubApi::new();
+    println!("{:?}", os_info::get());
+    println!("{}", release.version());
+
     let asset = github_api
         .get_asset_for_current_os_by_version(release.version())
         .unwrap()

--- a/testing/jormungandr-testing-utils/src/testing/node/legacy/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/legacy/mod.rs
@@ -34,9 +34,6 @@ pub fn download_last_n_releases(n: u32) -> Vec<Release> {
 
 pub fn get_jormungandr_bin(release: &Release, temp_dir: &impl PathChild) -> PathBuf {
     let github_api = GitHubApi::new();
-    println!("{:?}", os_info::get());
-    println!("{:?}", release);
-
     let asset = github_api
         .get_asset_for_current_os_by_version(release.version())
         .unwrap()

--- a/testing/jormungandr-testing-utils/src/testing/node/legacy/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/legacy/mod.rs
@@ -35,7 +35,7 @@ pub fn download_last_n_releases(n: u32) -> Vec<Release> {
 pub fn get_jormungandr_bin(release: &Release, temp_dir: &impl PathChild) -> PathBuf {
     let github_api = GitHubApi::new();
     println!("{:?}", os_info::get());
-    println!("{}", release.version());
+    println!("{:?}", release);
 
     let asset = github_api
         .get_asset_for_current_os_by_version(release.version())


### PR DESCRIPTION
Somehow on beta release legacy_node_all_fagments_tests is failing due to some obscured enum issue. While i'm planning to explore it further, this provides easy and quick fix for mentioned problem