### PR TITLE
[Tests] added some delays in recovery tests

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -97,7 +97,7 @@ pub fn test_node_recovers_from_node_restart() {
     let snapshot_before = take_snapshot(&account_receiver, &jormungandr, new_utxo.clone());
     jormungandr.stop();
 
-    std::thread::sleep(std::time::Duration::from_secs(5));
+    std::thread::sleep(std::time::Duration::from_secs(1));
 
     let jormungandr = Starter::new()
         .config(config)
@@ -105,7 +105,7 @@ pub fn test_node_recovers_from_node_restart() {
         .start()
         .unwrap();
 
-    std::thread::sleep(std::time::Duration::from_secs(5));
+    std::thread::sleep(std::time::Duration::from_secs(1));
     let snapshot_after = take_snapshot(&account_receiver, &jormungandr, new_utxo);
 
     assert_eq!(
@@ -143,13 +143,13 @@ pub fn test_node_recovers_kill_signal() {
     );
     let snapshot_before = take_snapshot(&account_receiver, &jormungandr, new_utxo.clone());
     jormungandr.stop();
-    std::thread::sleep(std::time::Duration::from_secs(5));
+    std::thread::sleep(std::time::Duration::from_secs(1));
     let jormungandr = Starter::new()
         .config(config)
         .role(Role::Leader)
         .start()
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_secs(5));
+    std::thread::sleep(std::time::Duration::from_secs(1));
     let snapshot_after = take_snapshot(&account_receiver, &jormungandr, new_utxo);
 
     assert_eq!(

--- a/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -96,11 +96,16 @@ pub fn test_node_recovers_from_node_restart() {
     );
     let snapshot_before = take_snapshot(&account_receiver, &jormungandr, new_utxo.clone());
     jormungandr.stop();
+
+    std::thread::sleep(std::time::Duration::from_secs(5));
+
     let jormungandr = Starter::new()
         .config(config)
         .role(Role::Leader)
         .start()
         .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_secs(5));
     let snapshot_after = take_snapshot(&account_receiver, &jormungandr, new_utxo);
 
     assert_eq!(
@@ -138,11 +143,13 @@ pub fn test_node_recovers_kill_signal() {
     );
     let snapshot_before = take_snapshot(&account_receiver, &jormungandr, new_utxo.clone());
     jormungandr.stop();
+    std::thread::sleep(std::time::Duration::from_secs(5));
     let jormungandr = Starter::new()
         .config(config)
         .role(Role::Passive)
         .start()
         .unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(5));
     let snapshot_after = take_snapshot(&account_receiver, &jormungandr, new_utxo);
 
     assert_eq!(

--- a/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -146,7 +146,7 @@ pub fn test_node_recovers_kill_signal() {
     std::thread::sleep(std::time::Duration::from_secs(5));
     let jormungandr = Starter::new()
         .config(config)
-        .role(Role::Passive)
+        .role(Role::Leader)
         .start()
         .unwrap();
     std::thread::sleep(std::time::Duration::from_secs(5));


### PR DESCRIPTION
This PR is an attempt to fix test issues observed during two test runs:

- test_node_recovers_from_node_restart
- test_node_recovers_kill_signal

Tests failures occurs once per 20 runs, so it's very challenging to catch the problem.
Issue with data: #2592