### PR TITLE
add scenario tests build during circle ci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,10 @@ commands:
           command: |
             cargo build --workspace --tests << parameters.mode >> << parameters.cargo_behavior >>
       - run:
+          name: Build scenario tests
+          command: |
+            cargo build -p jormungandr-scenario-tests --bin jormungandr-scenario-tests << parameters.mode >> << parameters.cargo_behavior >>
+      - run:
           name: Run tests
           environment:
             RUST_BACKTRACE: 1


### PR DESCRIPTION
In our circle ci workflow there is one missing test project to build: jormungandr-scenario-tests. Adding required test step