### PR TITLE
[Test] Explorer passive node

### DIFF
--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -19,7 +19,7 @@ pub use jormungandr_testing_utils::testing::{
     },
     node::{
         grpc::{client::MockClientError, JormungandrClient},
-        uri_from_socket_addr, JormungandrLogger, JormungandrRest, RestError,
+        uri_from_socket_addr, Explorer, JormungandrLogger, JormungandrRest, RestError,
     },
     FragmentNode, MemPoolCheck, NamedProcess,
 };
@@ -199,6 +199,10 @@ impl NodeController {
 
     pub fn as_named_process(&self) -> NamedProcess {
         NamedProcess::new(self.alias().to_string(), self.process_id as usize)
+    }
+
+    pub fn explorer(&self) -> Explorer {
+        Explorer::new(self.settings.config.rest.listen.clone().to_string())
     }
 
     fn get(&self, path: &str) -> Result<reqwest::blocking::Response> {

--- a/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
@@ -15,7 +15,8 @@ use crate::{
         comm::leader_leader::*,
         comm::passive_leader::*,
         features::{
-            leader_promotion::*, leadership_log::leader_restart_preserves_leadership_log, p2p::*,
+            explorer::passive_node_explorer, leader_promotion::*,
+            leadership_log::leader_restart_preserves_leadership_log, p2p::*,
         },
         legacy,
         network::real::real_network,
@@ -334,6 +335,12 @@ fn scenarios_repository() -> Vec<Scenario> {
         "max_connections",
         max_connections,
         vec![Tag::Short, Tag::Unstable],
+    ));
+
+    repository.push(Scenario::new(
+        "passive_node_explorer",
+        passive_node_explorer,
+        vec![Tag::Short],
     ));
 
     repository.push(Scenario::new(

--- a/testing/jormungandr-scenario-tests/src/test/features/explorer.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/explorer.rs
@@ -1,0 +1,95 @@
+use crate::{
+    node::NodeController,
+    node::{LeadershipMode, PersistenceMode},
+    test::{utils, Result},
+    Context, ScenarioResult,
+};
+use jormungandr_lib::interfaces::Explorer;
+use rand_chacha::ChaChaRng;
+const LEADER_1: &str = "Leader_1";
+const LEADER_2: &str = "Leader_2";
+const LEADER_3: &str = "Leader_3";
+const PASSIVE: &str = "Passive";
+
+pub fn passive_node_explorer(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let scenario_settings = prepare_scenario! {
+        "Passive node with explorer",
+        &mut context,
+        topology [
+            LEADER_1,
+            LEADER_2 -> LEADER_1,
+            LEADER_3 -> LEADER_1,
+            PASSIVE -> LEADER_1,LEADER_2,LEADER_3
+        ]
+        blockchain {
+            consensus = GenesisPraos,
+            number_of_slots_per_epoch = 60,
+            slot_duration = 1,
+            leaders = [ LEADER_1 ],
+            initials = [
+                account "alice" with   500_000_000,
+                account "bob" with  2_000_000_000 delegates to LEADER_1,
+                account "clarice" with  2_000_000_000 delegates to LEADER_2,
+            ],
+        }
+    };
+
+    let mut controller = scenario_settings.build(context)?;
+
+    let leader_1 =
+        controller.spawn_node(LEADER_1, LeadershipMode::Leader, PersistenceMode::InMemory)?;
+    leader_1.wait_for_bootstrap()?;
+
+    controller.monitor_nodes();
+
+    let leader_2 =
+        controller.spawn_node(LEADER_2, LeadershipMode::Leader, PersistenceMode::InMemory)?;
+    leader_2.wait_for_bootstrap()?;
+
+    let leader_3 =
+        controller.spawn_node(LEADER_3, LeadershipMode::Leader, PersistenceMode::InMemory)?;
+    leader_3.wait_for_bootstrap()?;
+
+    let passive = controller.spawn_node_custom(
+        controller
+            .new_spawn_params(PASSIVE)
+            .passive()
+            .in_memory()
+            .explorer(Explorer { enabled: true }),
+    )?;
+    passive.wait_for_bootstrap()?;
+
+    let mut alice = controller.wallet("alice")?;
+    let mut bob = controller.wallet("bob")?;
+
+    let mem_pool_check = controller.fragment_sender().send_transaction(
+        &mut alice,
+        &mut bob,
+        &leader_1,
+        1_000.into(),
+    )?;
+
+    // give some time to update explorer
+    jortestkit::process::sleep(10);
+
+    let transaction_id = passive
+        .explorer()
+        .transaction((*mem_pool_check.fragment_id()).into())?
+        .data
+        .unwrap()
+        .transaction
+        .id;
+    utils::assert_equals(
+        &transaction_id,
+        &mem_pool_check.fragment_id().to_string(),
+        "Wrong transaction id in explorer",
+    )?;
+
+    leader_1.shutdown()?;
+    leader_2.shutdown()?;
+    leader_3.shutdown()?;
+    passive.shutdown()?;
+
+    controller.finalize();
+    Ok(ScenarioResult::passed())
+}

--- a/testing/jormungandr-scenario-tests/src/test/features/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/mod.rs
@@ -1,3 +1,4 @@
+pub mod explorer;
 pub mod leader_promotion;
 pub mod leadership_log;
 pub mod p2p;

--- a/testing/jormungandr-scenario-tests/src/test/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/mod.rs
@@ -20,6 +20,7 @@ error_chain! {
         FragmentVerifier(jormungandr_testing_utils::testing::FragmentVerifierError);
         VerificationFailed(jormungandr_testing_utils::testing::VerificationError);
         MonitorResourcesError(jormungandr_testing_utils::testing::ConsumptionBenchmarkError);
+        ExplorerError(jormungandr_testing_utils::testing::node::ExplorerError);
     }
 
     links {


### PR DESCRIPTION
Added new test with 4 nodes (3 leaders and 1 passive with explorer). Test verifies if explorer deployed with passive node will receive transaction