### PR TITLE
Make jcli private vote tools more idiomatic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -422,11 +422,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chain-addr"
 version = "0.1.0"
 dependencies = [
  "bech32",
- "cfg-if",
+ "cfg-if 1.0.0",
  "chain-core",
  "chain-crypto",
  "cryptoxide",
@@ -445,7 +451,7 @@ name = "chain-crypto"
 version = "0.1.0"
 dependencies = [
  "bech32",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cryptoxide",
  "curve25519-dalek",
  "digest 0.9.0",
@@ -465,7 +471,7 @@ name = "chain-impl-mockchain"
 version = "0.1.0"
 dependencies = [
  "cardano-legacy-address",
- "cfg-if",
+ "cfg-if 1.0.0",
  "chain-addr",
  "chain-core",
  "chain-crypto",
@@ -494,7 +500,7 @@ dependencies = [
  "async-trait",
  "chain-crypto",
  "futures 0.3.6",
- "pin-project 0.4.23",
+ "pin-project 1.0.0",
  "prost",
  "rand_core 0.5.1",
  "thiserror",
@@ -528,7 +534,7 @@ dependencies = [
 name = "chain-time"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "chain-core",
  "chain-ser",
 ]
@@ -664,7 +670,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -695,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
@@ -718,7 +724,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
@@ -729,7 +735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
@@ -859,7 +865,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -947,7 +953,7 @@ version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1004,7 +1010,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -1022,7 +1028,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -1225,7 +1231,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -2032,7 +2038,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -2119,7 +2125,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -2238,7 +2244,7 @@ version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
 ]
@@ -2251,7 +2257,7 @@ checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -2264,7 +2270,7 @@ checksum = "85db2feff6bf70ebc3a4793191517d5f0331100a2f10f9bf93b5e5214f32b7b7"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
 ]
 
@@ -2403,7 +2409,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
@@ -2418,7 +2424,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
  "libc",
@@ -3329,7 +3335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3360,7 +3366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3527,7 +3533,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -3626,7 +3632,7 @@ version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2983daff11a197c7c406b130579bc362177aa54cf2cc1f34d6ac88fccaa6a5e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "doc-comment",
  "libc",
  "ntapi",
@@ -3641,7 +3647,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35d086fd10743c3d963d6eec65f932b5a4afbe948931eaf7ae81f5d6cb555ae"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "doc-comment",
  "libc",
  "ntapi",
@@ -3696,7 +3702,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
@@ -4205,7 +4211,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log 0.4.11",
  "tracing-attributes",
  "tracing-core",
@@ -4348,7 +4354,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
 ]
 
@@ -4442,7 +4448,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f79da5ff07bafd68a6822107bc37d194fc6c80ca4ae1cbdd66437e7a2b0e7e"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "platforms",
 ]
 
@@ -4529,7 +4535,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -4556,7 +4562,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.33"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
 name = "arc-swap"
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -153,12 +153,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.51"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -196,7 +196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a0b511f881feae65eb88a002da86c4346f2fc09135ac0934d420ef79cc7ee1"
 dependencies = [
  "error-chain",
- "futures 0.1.30",
+ "futures 0.1.29",
  "tokio-codec",
  "tokio-io",
  "tokio-process",
@@ -411,9 +411,9 @@ checksum = "2b6cda8a789815488ee290d106bc97dba47785dae73d63576fc42c126912a451"
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
 
 [[package]]
 name = "cfg-if"
@@ -422,17 +422,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "chain-addr"
 version = "0.1.0"
 dependencies = [
  "bech32",
- "cfg-if 1.0.0",
+ "cfg-if",
  "chain-core",
  "chain-crypto",
  "cryptoxide",
@@ -451,7 +445,7 @@ name = "chain-crypto"
 version = "0.1.0"
 dependencies = [
  "bech32",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cryptoxide",
  "curve25519-dalek",
  "digest 0.9.0",
@@ -471,7 +465,7 @@ name = "chain-impl-mockchain"
 version = "0.1.0"
 dependencies = [
  "cardano-legacy-address",
- "cfg-if 1.0.0",
+ "cfg-if",
  "chain-addr",
  "chain-core",
  "chain-crypto",
@@ -500,7 +494,7 @@ dependencies = [
  "async-trait",
  "chain-crypto",
  "futures 0.3.6",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "prost",
  "rand_core 0.5.1",
  "thiserror",
@@ -534,23 +528,21 @@ dependencies = [
 name = "chain-time"
 version = "0.1.0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "chain-core",
  "chain-ser",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
 dependencies = [
- "libc",
  "num-integer",
  "num-traits",
  "serde",
  "time",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -663,7 +655,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -694,7 +686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if 0.1.10",
+ "cfg-if",
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
@@ -717,7 +709,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -728,7 +720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if 0.1.10",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -858,7 +850,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "dirs-sys",
 ]
 
@@ -905,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -919,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "encode_unicode"
@@ -935,7 +927,7 @@ version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -992,7 +984,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -1010,7 +1002,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -1071,9 +1063,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.1.30"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
+checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
@@ -1163,7 +1155,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1213,7 +1205,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1363,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 
 [[package]]
 name = "headers"
@@ -1403,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -1444,12 +1436,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
-name = "httpdate"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
 name = "humantime"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,9 +1443,9 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -1469,10 +1455,10 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "socket2",
+ "time",
  "tokio",
  "tower-service",
  "tracing",
@@ -1535,7 +1521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown 0.9.1",
+ "hashbrown 0.9.0",
  "serde",
 ]
 
@@ -1562,12 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
-dependencies = [
- "cfg-if 0.1.10",
-]
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
 name = "integer-encoding"
@@ -1861,7 +1844,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-json",
- "sysinfo 0.15.3",
+ "sysinfo 0.15.2",
  "tar",
  "thiserror",
  "tokio",
@@ -1888,7 +1871,7 @@ dependencies = [
  "dialoguer",
  "flate2",
  "fs_extra",
- "futures 0.1.30",
+ "futures 0.1.29",
  "hex",
  "humantime",
  "indicatif",
@@ -2028,7 +2011,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2076,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -2101,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
 dependencies = [
  "adler",
  "autocfg 1.0.1",
@@ -2115,7 +2098,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -2234,7 +2217,7 @@ version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "winapi 0.3.9",
 ]
@@ -2247,7 +2230,7 @@ checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "void",
 ]
@@ -2260,7 +2243,7 @@ checksum = "85db2feff6bf70ebc3a4793191517d5f0331100a2f10f9bf93b5e5214f32b7b7"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
 ]
 
@@ -2388,7 +2371,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
@@ -2403,7 +2386,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cloudabi 0.1.0",
  "instant",
  "libc",
@@ -2517,11 +2500,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.23",
 ]
 
 [[package]]
@@ -2535,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2557,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.10"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
+checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 
 [[package]]
 name = "pin-utils"
@@ -2964,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
+checksum = "cfd016f0c045ad38b5251be2c9c0ab806917f82da4d36b2a327e5166adad9270"
 dependencies = [
  "autocfg 1.0.1",
  "crossbeam-deque",
@@ -2976,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
+checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -3115,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustc_version"
@@ -3314,7 +3297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3345,7 +3328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3512,7 +3495,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -3536,9 +3519,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "6cc388d94ffabf39b5ed5fadddc40147cb21e605f53db6f8f36a625d27489ac5"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3547,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -3560,15 +3543,15 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.19.5"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89a286a7e3b5720b9a477b23253bc50debac207c8d21505f8e70b36792f11b5"
+checksum = "3924a58d165da3b7b2922c667ab0673c7b5fd52b5c19ea3442747bcb3cd15abe"
 
 [[package]]
 name = "strum_macros"
-version = "0.19.4"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
+checksum = "2d2ab682ecdcae7f5f45ae85cd7c1e6c8e68ea42c8a612d47fedf831c037146a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3611,7 +3594,7 @@ version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2983daff11a197c7c406b130579bc362177aa54cf2cc1f34d6ac88fccaa6a5e1"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "doc-comment",
  "libc",
  "ntapi",
@@ -3622,11 +3605,11 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.15.3"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67330cbee3b2a819e3365a773f05e884a136603687f812bf24db5b6c3d76b696"
+checksum = "e35d086fd10743c3d963d6eec65f932b5a4afbe948931eaf7ae81f5d6cb555ae"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "doc-comment",
  "libc",
  "ntapi",
@@ -3681,7 +3664,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
@@ -3824,7 +3807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "tokio-io",
 ]
 
@@ -3835,7 +3818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -3845,7 +3828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "log 0.4.11",
 ]
 
@@ -3867,7 +3850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382d90f43fa31caebe5d3bc6cfd854963394fff3b8cb59d5146607aaae7e7e43"
 dependencies = [
  "crossbeam-queue",
- "futures 0.1.30",
+ "futures 0.1.29",
  "lazy_static",
  "libc",
  "log 0.4.11",
@@ -3886,7 +3869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "futures 0.1.29",
  "lazy_static",
  "log 0.4.11",
  "mio",
@@ -3916,7 +3899,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c34c6e548f101053321cba3da7cbb87a610b85555884c41b07da2eb91aff12"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.29",
  "libc",
  "mio",
  "mio-uds",
@@ -3934,7 +3917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 dependencies = [
  "fnv",
- "futures 0.1.30",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -3945,7 +3928,7 @@ checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
  "futures-util",
  "log 0.4.11",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tokio",
  "tungstenite",
 ]
@@ -3980,7 +3963,7 @@ dependencies = [
  "http-body",
  "hyper",
  "percent-encoding 2.1.0",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "prost",
  "prost-derive",
  "tokio",
@@ -4033,7 +4016,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "rand 0.7.3",
  "slab",
  "tokio",
@@ -4053,7 +4036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4067,7 +4050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tower-service",
 ]
 
@@ -4084,7 +4067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tokio",
  "tower-layer",
  "tower-load",
@@ -4099,7 +4082,7 @@ checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
 dependencies = [
  "futures-core",
  "log 0.4.11",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tokio",
  "tower-discover",
  "tower-service",
@@ -4112,7 +4095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tower-layer",
  "tower-service",
 ]
@@ -4148,7 +4131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4166,7 +4149,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4180,19 +4163,18 @@ checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tower-service",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "log 0.4.11",
- "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -4210,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
 dependencies = [
  "lazy_static",
 ]
@@ -4223,7 +4205,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "tracing",
 ]
 
@@ -4334,7 +4316,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
 ]
 
@@ -4428,7 +4410,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f79da5ff07bafd68a6822107bc37d194fc6c80ca4ae1cbdd66437e7a2b0e7e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "platforms",
 ]
 
@@ -4483,7 +4465,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "multipart",
- "pin-project 0.4.27",
+ "pin-project 0.4.23",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -4515,7 +4497,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -4542,7 +4524,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chain-vote"
+version = "0.1.0"
+dependencies = [
+ "cryptoxide",
+ "eccoxide",
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +885,17 @@ name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
+name = "eccoxide"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd94430d57f1f931d2b1e8e8a2267547a5fca34218d9289c8bf306da433d7afc"
+dependencies = [
+ "lazy_static",
+ "num-bigint",
+ "num-traits",
+]
 
 [[package]]
 name = "ed25519"
@@ -1613,6 +1633,7 @@ dependencies = [
  "chain-crypto",
  "chain-impl-mockchain",
  "chain-time",
+ "chain-vote",
  "clap",
  "ed25519-bip32",
  "gtmpl",
@@ -2260,6 +2281,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -28,6 +28,7 @@ chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 chain-addr      = { path = "../chain-deps/chain-addr" }
 chain-crypto    = { path = "../chain-deps/chain-crypto" }
 chain-time    = { path = "../chain-deps/chain-time" }
+chain-vote = { path = "../chain-deps/chain-vote", features = ["p256k1"] }
 jormungandr-lib = { path = "../jormungandr-lib" }
 gtmpl = "0.5.6"
 openapiv3 = "0.3.2"

--- a/jcli/src/jcli_app/mod.rs
+++ b/jcli/src/jcli_app/mod.rs
@@ -6,6 +6,7 @@ mod debug;
 mod key;
 mod rest;
 mod transaction;
+mod vote;
 
 pub mod utils;
 
@@ -52,6 +53,8 @@ pub enum JCliCommand {
     AutoCompletion(auto_completion::AutoCompletion),
     /// Utilities that perform specialized tasks
     Utils(utils::Utils),
+    /// Vote related operations
+    Votes(vote::Vote),
 }
 
 impl JCli {
@@ -83,6 +86,7 @@ impl JCliCommand {
             Certificate(certificate) => certificate.exec()?,
             AutoCompletion(auto_completion) => auto_completion.exec::<Self>()?,
             Utils(utils) => utils.exec()?,
+            Votes(vote) => vote.exec()?,
         };
         Ok(())
     }

--- a/jcli/src/jcli_app/utils/mod.rs
+++ b/jcli/src/jcli_app/utils/mod.rs
@@ -5,6 +5,7 @@ pub mod host_addr;
 pub mod io;
 pub mod key_parser;
 pub mod open_api_verifier;
+pub mod output_file;
 pub mod output_format;
 pub mod rest_api;
 

--- a/jcli/src/jcli_app/utils/output_file.rs
+++ b/jcli/src/jcli_app/utils/output_file.rs
@@ -1,0 +1,32 @@
+use crate::jcli_app::utils::io;
+
+use structopt::StructOpt;
+
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid output file path '{path}'")]
+    CannotOpen {
+        #[source]
+        cause: std::io::Error,
+        path: PathBuf,
+    },
+}
+
+#[derive(StructOpt, Debug)]
+pub struct OutputFile {
+    /// output the key to the given file or to stdout if not provided
+    #[structopt(name = "OUTPUT_FILE")]
+    output: Option<PathBuf>,
+}
+
+impl OutputFile {
+    pub fn open(&self) -> Result<impl Write, Error> {
+        io::open_file_write(&self.output).map_err(|cause| Error::CannotOpen {
+            cause,
+            path: self.output.clone().unwrap_or_default(),
+        })
+    }
+}

--- a/jcli/src/jcli_app/vote/committee/communication_key.rs
+++ b/jcli/src/jcli_app/vote/committee/communication_key.rs
@@ -1,4 +1,4 @@
-use super::{Error, OutputFile, Seed};
+use crate::jcli_app::vote::{Error, OutputFile, Seed};
 use chain_vote::MemberCommunicationKey;
 use rand::rngs::OsRng;
 use rand_chacha::rand_core::SeedableRng;
@@ -37,7 +37,7 @@ pub struct ToPublic {
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
-pub enum CommitteeCommunicationKey {
+pub enum CommunicationKey {
     /// generate a private key
     Generate(Generate),
     /// get the public key out of a given private key
@@ -76,11 +76,11 @@ impl ToPublic {
     }
 }
 
-impl CommitteeCommunicationKey {
+impl CommunicationKey {
     pub fn exec(self) -> Result<(), super::Error> {
         match self {
-            CommitteeCommunicationKey::Generate(args) => args.exec(),
-            CommitteeCommunicationKey::ToPublic(args) => args.exec(),
+            CommunicationKey::Generate(args) => args.exec(),
+            CommunicationKey::ToPublic(args) => args.exec(),
         }
     }
 }

--- a/jcli/src/jcli_app/vote/committee/member_key.rs
+++ b/jcli/src/jcli_app/vote/committee/member_key.rs
@@ -1,4 +1,4 @@
-use super::{Error, OutputFile, Seed};
+use crate::jcli_app::vote::{Error, OutputFile, Seed};
 use chain_vote::gargamel::PublicKey;
 use chain_vote::{MemberCommunicationPublicKey, MemberState};
 use rand::rngs::OsRng;
@@ -41,18 +41,6 @@ pub struct Generate {
     output_file: OutputFile,
 }
 
-fn parse_member_communication_key(key: &str) -> Result<MemberCommunicationPublicKey, Error> {
-    let raw_key = hex::decode(key)?;
-    let pk = PublicKey::from_bytes(&raw_key).ok_or(Error::InvalidPublicKey)?;
-    Ok(MemberCommunicationPublicKey::from_public_key(pk))
-}
-
-fn parse_crs(crs: &str) -> Result<chain_vote::CRS, Error> {
-    let bytes = hex::decode(crs)?;
-
-    chain_vote::CRS::from_bytes(&bytes).ok_or(Error::InvalidCrs)
-}
-
 #[derive(StructOpt)]
 pub struct ToPublic {
     /// the source private key to extract the public key from
@@ -68,7 +56,7 @@ pub struct ToPublic {
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
-pub enum CommitteeMemberKey {
+pub enum MemberKey {
     /// generate a private key
     Generate(Generate),
     /// get the public key out of a given private key
@@ -132,15 +120,27 @@ impl ToPublic {
     }
 }
 
-impl CommitteeMemberKey {
+impl MemberKey {
     pub fn exec(self) -> Result<(), super::Error> {
         match self {
-            CommitteeMemberKey::Generate(args) => args.exec(),
-            CommitteeMemberKey::ToPublic(args) => args.exec(),
+            MemberKey::Generate(args) => args.exec(),
+            MemberKey::ToPublic(args) => args.exec(),
         }
     }
 }
 
 fn read_hex<P: AsRef<Path>>(path: &Option<P>) -> Result<Vec<u8>, Error> {
     hex::decode(crate::jcli_app::utils::io::read_line(path)?).map_err(Into::into)
+}
+
+fn parse_member_communication_key(key: &str) -> Result<MemberCommunicationPublicKey, Error> {
+    let raw_key = hex::decode(key)?;
+    let pk = PublicKey::from_bytes(&raw_key).ok_or(Error::InvalidPublicKey)?;
+    Ok(MemberCommunicationPublicKey::from_public_key(pk))
+}
+
+fn parse_crs(crs: &str) -> Result<chain_vote::CRS, Error> {
+    let bytes = hex::decode(crs)?;
+
+    chain_vote::CRS::from_bytes(&bytes).ok_or(Error::InvalidCrs)
 }

--- a/jcli/src/jcli_app/vote/committee/mod.rs
+++ b/jcli/src/jcli_app/vote/committee/mod.rs
@@ -1,0 +1,23 @@
+mod communication_key;
+mod member_key;
+
+use super::Error;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub enum Committee {
+    /// generate a private key
+    CommunicationKey(communication_key::CommunicationKey),
+    /// get the public key out of a given private key
+    MemberKey(member_key::MemberKey),
+}
+
+impl Committee {
+    pub fn exec(self) -> Result<(), super::Error> {
+        match self {
+            Committee::CommunicationKey(args) => args.exec(),
+            Committee::MemberKey(args) => args.exec(),
+        }
+    }
+}

--- a/jcli/src/jcli_app/vote/committee_communication_key.rs
+++ b/jcli/src/jcli_app/vote/committee_communication_key.rs
@@ -1,0 +1,90 @@
+use super::{Error, OutputFile, Seed};
+use chain_vote::MemberCommunicationKey;
+use rand::rngs::OsRng;
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct Generate {
+    #[structopt(flatten)]
+    output_file: OutputFile,
+
+    /// optional seed to generate the key, for the same entropy the same key
+    /// will be generated (32 bytes in hexadecimal). This seed will be fed to
+    /// ChaChaRNG and allow pseudo random key generation. Do not use if you
+    /// are not sure.
+    #[structopt(long = "seed", short = "s", name = "SEED", parse(try_from_str))]
+    seed: Option<Seed>,
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ToPublic {
+    /// the source private key to extract the public key from
+    ///
+    /// if no value passed, the private key will be read from the
+    /// standard input
+    #[structopt(long = "input")]
+    input_key: Option<PathBuf>,
+
+    #[structopt(flatten)]
+    output_file: OutputFile,
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub enum CommitteeCommunicationKey {
+    /// generate a private key
+    Generate(Generate),
+    /// get the public key out of a given private key
+    ToPublic(ToPublic),
+}
+
+impl Generate {
+    fn exec(self) -> Result<(), Error> {
+        let mut rng = if let Some(seed) = self.seed {
+            ChaCha20Rng::from_seed(seed.0)
+        } else {
+            ChaCha20Rng::from_rng(OsRng)?
+        };
+
+        let key = MemberCommunicationKey::new(&mut rng);
+
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", hex::encode(key.to_bytes()))?;
+        Ok(())
+    }
+}
+
+impl ToPublic {
+    fn exec(self) -> Result<(), Error> {
+        let bytes = read_hex(&self.input_key)?;
+
+        let key =
+            chain_vote::gargamel::SecretKey::from_bytes(&bytes).ok_or(Error::InvalidSecretKey)?;
+
+        let kp = chain_vote::gargamel::Keypair::from_secretkey(key);
+
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", hex::encode(kp.public_key.to_bytes()))?;
+
+        Ok(())
+    }
+}
+
+impl CommitteeCommunicationKey {
+    pub fn exec(self) -> Result<(), super::Error> {
+        match self {
+            CommitteeCommunicationKey::Generate(args) => args.exec(),
+            CommitteeCommunicationKey::ToPublic(args) => args.exec(),
+        }
+    }
+}
+
+fn read_hex<P: AsRef<Path>>(path: &Option<P>) -> Result<Vec<u8>, Error> {
+    hex::decode(crate::jcli_app::utils::io::read_line(path)?).map_err(Into::into)
+}

--- a/jcli/src/jcli_app/vote/committee_member_key.rs
+++ b/jcli/src/jcli_app/vote/committee_member_key.rs
@@ -1,0 +1,146 @@
+use super::{Error, OutputFile, Seed};
+use chain_vote::gargamel::PublicKey;
+use chain_vote::{MemberCommunicationPublicKey, MemberState};
+use rand::rngs::OsRng;
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use std::{
+    convert::TryInto,
+    io::Write,
+    path::{Path, PathBuf},
+};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+pub struct Generate {
+    /// optional seed to generate the key, for the same entropy the same key
+    /// will be generated (32 bytes in hexadecimal). This seed will be fed to
+    /// ChaChaRNG and allow pseudo random key generation. Do not use if you
+    /// are not sure.
+    #[structopt(long = "seed", short = "s", name = "SEED", parse(try_from_str))]
+    seed: Option<Seed>,
+
+    /// the committee member index (my)
+    index: u64,
+
+    /// the common reference string
+    #[structopt(parse(try_from_str = parse_crs))]
+    crs: chain_vote::CRS,
+
+    threshold: usize,
+
+    #[structopt(
+        long = "communication_keys",
+        short = "c",
+        name = "COMMUNICATION_KEYS",
+        parse(try_from_str = parse_member_communication_key)
+    )]
+    communication_keys: Vec<MemberCommunicationPublicKey>,
+
+    #[structopt(flatten)]
+    output_file: OutputFile,
+}
+
+fn parse_member_communication_key(key: &str) -> Result<MemberCommunicationPublicKey, Error> {
+    let raw_key = hex::decode(key)?;
+    let pk = PublicKey::from_bytes(&raw_key).ok_or(Error::InvalidPublicKey)?;
+    Ok(MemberCommunicationPublicKey::from_public_key(pk))
+}
+
+fn parse_crs(crs: &str) -> Result<chain_vote::CRS, Error> {
+    let bytes = hex::decode(crs)?;
+
+    chain_vote::CRS::from_bytes(&bytes).ok_or(Error::InvalidCrs)
+}
+
+#[derive(StructOpt)]
+pub struct ToPublic {
+    /// the source private key to extract the public key from
+    ///
+    /// if no value passed, the private key will be read from the
+    /// standard input
+    #[structopt(long = "input")]
+    input_key: Option<PathBuf>,
+
+    #[structopt(flatten)]
+    output_file: OutputFile,
+}
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub enum CommitteeMemberKey {
+    /// generate a private key
+    Generate(Generate),
+    /// get the public key out of a given private key
+    ToPublic(ToPublic),
+}
+
+impl Generate {
+    fn exec(self) -> Result<(), Error> {
+        let mut rng = if let Some(seed) = self.seed {
+            ChaCha20Rng::from_seed(seed.0)
+        } else {
+            ChaCha20Rng::from_rng(OsRng)?
+        };
+
+        if self.communication_keys.is_empty() {
+            return Err(Error::EmptyCommittee);
+        }
+
+        // this things are asserted in MemberState::new, but it's better to not
+        // panic here
+        let n = self.communication_keys.len();
+        if self.threshold == 0 || self.threshold > n {
+            return Err(Error::InvalidThreshold {
+                threshold: self.threshold,
+                committee_members: n,
+            });
+        }
+        if self.index as usize >= n {
+            return Err(Error::InvalidCommitteMemberIndex);
+        }
+
+        let ms = MemberState::new(
+            &mut rng,
+            self.threshold,
+            &self.crs,
+            &self.communication_keys,
+            self.index.try_into().unwrap(),
+        );
+
+        let key = ms.secret_key();
+
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", hex::encode(key.to_bytes()))?;
+        Ok(())
+    }
+}
+
+impl ToPublic {
+    fn exec(self) -> Result<(), Error> {
+        let key = read_hex(&self.input_key)?;
+
+        let key =
+            chain_vote::gargamel::SecretKey::from_bytes(&key).ok_or(Error::InvalidSecretKey)?;
+
+        let pk = chain_vote::gargamel::Keypair::from_secretkey(key).public_key;
+
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", hex::encode(pk.to_bytes()))?;
+
+        Ok(())
+    }
+}
+
+impl CommitteeMemberKey {
+    pub fn exec(self) -> Result<(), super::Error> {
+        match self {
+            CommitteeMemberKey::Generate(args) => args.exec(),
+            CommitteeMemberKey::ToPublic(args) => args.exec(),
+        }
+    }
+}
+
+fn read_hex<P: AsRef<Path>>(path: &Option<P>) -> Result<Vec<u8>, Error> {
+    hex::decode(crate::jcli_app::utils::io::read_line(path)?).map_err(Into::into)
+}

--- a/jcli/src/jcli_app/vote/common_reference_string.rs
+++ b/jcli/src/jcli_app/vote/common_reference_string.rs
@@ -1,0 +1,51 @@
+use super::{Error, OutputFile, Seed};
+use rand::rngs::OsRng;
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use std::io::Write;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct Generate {
+    #[structopt(flatten)]
+    output_file: OutputFile,
+
+    /// optional seed to generate the key, for the same entropy the same key
+    /// will be generated (32 bytes in hexadecimal). This seed will be fed to
+    /// ChaChaRNG and allow pseudo random key generation. Do not use if you
+    /// are not sure.
+    #[structopt(long = "seed", short = "s", name = "SEED", parse(try_from_str))]
+    seed: Option<Seed>,
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub enum CRS {
+    /// generate the common reference string
+    Generate(Generate),
+}
+
+impl Generate {
+    fn exec(self) -> Result<(), Error> {
+        let mut rng = if let Some(seed) = self.seed {
+            ChaCha20Rng::from_seed(seed.0)
+        } else {
+            ChaCha20Rng::from_rng(OsRng)?
+        };
+
+        let crs = chain_vote::CRS::random(&mut rng);
+
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", hex::encode(crs.to_bytes().as_ref()))?;
+
+        Ok(())
+    }
+}
+
+impl CRS {
+    pub fn exec(self) -> Result<(), super::Error> {
+        match self {
+            CRS::Generate(args) => args.exec(),
+        }
+    }
+}

--- a/jcli/src/jcli_app/vote/encrypting_vote_key.rs
+++ b/jcli/src/jcli_app/vote/encrypting_vote_key.rs
@@ -1,13 +1,30 @@
-use super::Error;
+use crate::jcli_app::vote::{Error, OutputFile};
+use std::io::Write as _;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub struct EncryptingVoteKey {
     #[structopt(
-        parse(try_from_str = parse_member_key)
+        parse(try_from_str = parse_member_key),
+        required = true,
+        short = "m",
+        long = "member-keys"
     )]
     member_keys: Vec<chain_vote::committee::MemberPublicKey>,
+
+    #[structopt(flatten)]
+    output_file: OutputFile,
+}
+
+impl EncryptingVoteKey {
+    pub fn exec(&self) -> Result<(), Error> {
+        let election_public_key =
+            chain_vote::EncryptingVoteKey::from_participants(&self.member_keys);
+
+        let mut output = self.output_file.open()?;
+        writeln!(output, "{}", hex::encode(election_public_key.to_bytes())).map_err(Error::from)
+    }
 }
 
 fn parse_member_key(key: &str) -> Result<chain_vote::committee::MemberPublicKey, Error> {
@@ -17,18 +34,4 @@ fn parse_member_key(key: &str) -> Result<chain_vote::committee::MemberPublicKey,
             chain_vote::gargamel::PublicKey::from_bytes(&raw_key).ok_or(Error::InvalidPublicKey)
         })
         .map(chain_vote::committee::MemberPublicKey::from_public_key)
-}
-
-impl EncryptingVoteKey {
-    pub fn exec(&self) -> Result<(), Error> {
-        if self.member_keys.is_empty() {
-            Err(Error::EncryptingVoteKeyFromEmpty)
-        } else {
-            let election_public_key =
-                chain_vote::EncryptingVoteKey::from_participants(&self.member_keys);
-
-            println!("{}", hex::encode(election_public_key.to_bytes()));
-            Ok(())
-        }
-    }
 }

--- a/jcli/src/jcli_app/vote/encrypting_vote_key.rs
+++ b/jcli/src/jcli_app/vote/encrypting_vote_key.rs
@@ -8,8 +8,8 @@ pub struct EncryptingVoteKey {
     #[structopt(
         parse(try_from_str = parse_member_key),
         required = true,
-        short = "m",
-        long = "member-keys"
+        short = "k",
+        long = "keys"
     )]
     member_keys: Vec<chain_vote::committee::MemberPublicKey>,
 

--- a/jcli/src/jcli_app/vote/encrypting_vote_key.rs
+++ b/jcli/src/jcli_app/vote/encrypting_vote_key.rs
@@ -1,10 +1,9 @@
 use super::Error;
-use chain_vote::EncryptingVoteKey;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
-pub struct MakeEncryptingVoteKey {
+pub struct EncryptingVoteKey {
     #[structopt(
         parse(try_from_str = parse_member_key)
     )]
@@ -20,12 +19,13 @@ fn parse_member_key(key: &str) -> Result<chain_vote::committee::MemberPublicKey,
         .map(chain_vote::committee::MemberPublicKey::from_public_key)
 }
 
-impl MakeEncryptingVoteKey {
+impl EncryptingVoteKey {
     pub fn exec(&self) -> Result<(), Error> {
         if self.member_keys.is_empty() {
             Err(Error::EncryptingVoteKeyFromEmpty)
         } else {
-            let election_public_key = EncryptingVoteKey::from_participants(&self.member_keys);
+            let election_public_key =
+                chain_vote::EncryptingVoteKey::from_participants(&self.member_keys);
 
             println!("{}", hex::encode(election_public_key.to_bytes()));
             Ok(())

--- a/jcli/src/jcli_app/vote/encrypting_vote_key.rs
+++ b/jcli/src/jcli_app/vote/encrypting_vote_key.rs
@@ -33,5 +33,5 @@ fn parse_member_key(key: &str) -> Result<chain_vote::committee::MemberPublicKey,
         .and_then(|raw_key| {
             chain_vote::gargamel::PublicKey::from_bytes(&raw_key).ok_or(Error::InvalidPublicKey)
         })
-        .map(chain_vote::committee::MemberPublicKey::from_public_key)
+        .map(chain_vote::committee::MemberPublicKey::from)
 }

--- a/jcli/src/jcli_app/vote/encrypting_vote_key.rs
+++ b/jcli/src/jcli_app/vote/encrypting_vote_key.rs
@@ -1,0 +1,34 @@
+use super::Error;
+use chain_vote::EncryptingVoteKey;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub struct MakeEncryptingVoteKey {
+    #[structopt(
+        parse(try_from_str = parse_member_key)
+    )]
+    member_keys: Vec<chain_vote::committee::MemberPublicKey>,
+}
+
+fn parse_member_key(key: &str) -> Result<chain_vote::committee::MemberPublicKey, Error> {
+    hex::decode(key)
+        .map_err(Error::from)
+        .and_then(|raw_key| {
+            chain_vote::gargamel::PublicKey::from_bytes(&raw_key).ok_or(Error::InvalidPublicKey)
+        })
+        .map(chain_vote::committee::MemberPublicKey::from_public_key)
+}
+
+impl MakeEncryptingVoteKey {
+    pub fn exec(&self) -> Result<(), Error> {
+        if self.member_keys.is_empty() {
+            Err(Error::EncryptingVoteKeyFromEmpty)
+        } else {
+            let election_public_key = EncryptingVoteKey::from_participants(&self.member_keys);
+
+            println!("{}", hex::encode(election_public_key.to_bytes()));
+            Ok(())
+        }
+    }
+}

--- a/jcli/src/jcli_app/vote/mod.rs
+++ b/jcli/src/jcli_app/vote/mod.rs
@@ -1,0 +1,103 @@
+mod committee_communication_key;
+mod committee_member_key;
+mod common_reference_string;
+mod encrypting_vote_key;
+
+use structopt::StructOpt;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("I/O error")]
+    Io(#[from] std::io::Error),
+    #[error("invalid Hexadecimal")]
+    Hex(#[from] hex::FromHexError),
+    #[error("error while using random source")]
+    Rand(#[from] rand::Error),
+    #[error("invalid seed length, expected 32 bytes but received {seed_len}")]
+    InvalidSeed { seed_len: usize },
+    #[error("invalid output file path '{path}'")]
+    InvalidOutput {
+        #[source]
+        source: std::io::Error,
+        path: std::path::PathBuf,
+    },
+    #[error("invalid public key")]
+    InvalidPublicKey,
+    #[error("invalid secret key")]
+    InvalidSecretKey,
+    #[error("invalid common reference string")]
+    InvalidCrs,
+    #[error("must provide at least one member key to build encrypting vote key")]
+    EncryptingVoteKeyFromEmpty,
+    #[error("expected at least one committee key")]
+    EmptyCommittee,
+    #[error("threshold should be in range (0..{committee_members:?}] and is {threshold:?}")]
+    InvalidThreshold {
+        threshold: usize,
+        committee_members: usize,
+    },
+    #[error("invalid committee member index")]
+    InvalidCommitteMemberIndex,
+}
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub enum Vote {
+    /// Build a commitee communication key
+    CommitteeCommunicationKey(committee_communication_key::CommitteeCommunicationKey),
+    /// Build a committee member key
+    CommitteeMemberKey(committee_member_key::CommitteeMemberKey),
+    /// Build an encryption vote key
+    MakeEncryptingVoteKey(encrypting_vote_key::MakeEncryptingVoteKey),
+    /// Build an encryption vote key
+    CRS(common_reference_string::CRS),
+}
+
+impl Vote {
+    pub fn exec(self) -> Result<(), Error> {
+        match self {
+            Vote::CommitteeCommunicationKey(cmd) => cmd.exec(),
+            Vote::CommitteeMemberKey(cmd) => cmd.exec(),
+            Vote::MakeEncryptingVoteKey(cmd) => cmd.exec(),
+            Vote::CRS(cmd) => cmd.exec(),
+        }
+    }
+}
+
+// FIXME: Duplicated with key.rs
+#[derive(Debug)]
+struct Seed([u8; 32]);
+impl std::str::FromStr for Seed {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let vec = hex::decode(s)?;
+        if vec.len() != 32 {
+            return Err(Error::InvalidSeed {
+                seed_len: vec.len(),
+            });
+        }
+        let mut bytes = [0; 32];
+        bytes.copy_from_slice(&vec);
+        Ok(Seed(bytes))
+    }
+}
+
+// FIXME: Duplicated with key.rs
+#[derive(StructOpt, Debug)]
+struct OutputFile {
+    /// output the key to the given file or to stdout if not provided
+    #[structopt(name = "OUTPUT_FILE")]
+    output: Option<std::path::PathBuf>,
+}
+
+impl OutputFile {
+    fn open(&self) -> Result<impl std::io::Write, Error> {
+        crate::jcli_app::utils::io::open_file_write(&self.output).map_err(|source| {
+            Error::InvalidOutput {
+                source,
+                path: self.output.clone().unwrap_or_default(),
+            }
+        })
+    }
+}

--- a/jcli/src/jcli_app/vote/mod.rs
+++ b/jcli/src/jcli_app/vote/mod.rs
@@ -1,5 +1,4 @@
-mod committee_communication_key;
-mod committee_member_key;
+mod committee;
 mod common_reference_string;
 mod encrypting_vote_key;
 
@@ -44,10 +43,8 @@ pub enum Error {
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub enum Vote {
-    /// Build a commitee communication key
-    CommitteeCommunicationKey(committee_communication_key::CommitteeCommunicationKey),
-    /// Build a committee member key
-    CommitteeMemberKey(committee_member_key::CommitteeMemberKey),
+    // Committee commands
+    Committee(committee::Committee),
     /// Build an encryption vote key
     EncryptingVoteKey(encrypting_vote_key::EncryptingVoteKey),
     /// Build an encryption vote key
@@ -57,8 +54,7 @@ pub enum Vote {
 impl Vote {
     pub fn exec(self) -> Result<(), Error> {
         match self {
-            Vote::CommitteeCommunicationKey(cmd) => cmd.exec(),
-            Vote::CommitteeMemberKey(cmd) => cmd.exec(),
+            Vote::Committee(cmd) => cmd.exec(),
             Vote::EncryptingVoteKey(cmd) => cmd.exec(),
             Vote::CRS(cmd) => cmd.exec(),
         }

--- a/jcli/src/jcli_app/vote/mod.rs
+++ b/jcli/src/jcli_app/vote/mod.rs
@@ -27,8 +27,6 @@ pub enum Error {
     InvalidSecretKey,
     #[error("invalid common reference string")]
     InvalidCrs,
-    #[error("must provide at least one member key to build encrypting vote key")]
-    EncryptingVoteKeyFromEmpty,
     #[error("expected at least one committee key")]
     EmptyCommittee,
     #[error("threshold should be in range (0..{committee_members:?}] and is {threshold:?}")]

--- a/jcli/src/jcli_app/vote/mod.rs
+++ b/jcli/src/jcli_app/vote/mod.rs
@@ -27,8 +27,6 @@ pub enum Error {
     InvalidSecretKey,
     #[error("invalid common reference string")]
     InvalidCrs,
-    #[error("expected at least one committee key")]
-    EmptyCommittee,
     #[error("threshold should be in range (0..{committee_members:?}] and is {threshold:?}")]
     InvalidThreshold {
         threshold: usize,

--- a/jcli/src/jcli_app/vote/mod.rs
+++ b/jcli/src/jcli_app/vote/mod.rs
@@ -49,7 +49,7 @@ pub enum Vote {
     /// Build a committee member key
     CommitteeMemberKey(committee_member_key::CommitteeMemberKey),
     /// Build an encryption vote key
-    MakeEncryptingVoteKey(encrypting_vote_key::MakeEncryptingVoteKey),
+    EncryptingVoteKey(encrypting_vote_key::EncryptingVoteKey),
     /// Build an encryption vote key
     CRS(common_reference_string::CRS),
 }
@@ -59,7 +59,7 @@ impl Vote {
         match self {
             Vote::CommitteeCommunicationKey(cmd) => cmd.exec(),
             Vote::CommitteeMemberKey(cmd) => cmd.exec(),
-            Vote::MakeEncryptingVoteKey(cmd) => cmd.exec(),
+            Vote::EncryptingVoteKey(cmd) => cmd.exec(),
             Vote::CRS(cmd) => cmd.exec(),
         }
     }


### PR DESCRIPTION
 ## Improve jcli private vote tools consistency

needs: https://github.com/input-output-hk/chain-libs/pull/469
Probably will need some reconciliation with #2591 (in the errors, mostly)
This is actually based on #2554, but the git story was a bit confusing when I tried to rebase, and I rewrote almost everything so I just separated it.  

### About 
Rework the vote key generation commands to be more like the rest of the
jcli commands.
Also split the common reference string generation

#### Still missing:
 - Tests
 - A bit more polishing (particularly the errors may be too redundant, and some of the arguments may need naming)
 - Documentation

### Example (with 2 members) (updated)
```sh
jcli votes committee communication-key generate ck1.prv
jcli votes committee communication-key generate ck2.prv

cat ck1.prv | jcli votes committee communication-key to-public > ck1.pub
cat ck2.prv | jcli votes committee communication-key to-public > ck2.pub

jcli votes crs generate > crs

jcli votes committee member-key generate -i 0 --crs $(cat crs) -t 2 -k $(cat ck1.pub) $(cat ck2.pub) -- mk1.prv
jcli votes committee member-key generate -i 1 --crs $(cat crs) -t 2 -k $(cat ck1.pub) $(cat ck2.pub) -- mk2.prv

cat mk1.prv | jcli votes committee member-key to-public > mk1.pub
cat mk2.prv | jcli votes committee member-key to-public > mk2.pub

jcli votes encrypting-vote-key --keys $(cat mk1.pub) $(cat mk2.pub) -- encrypting-vote-key
```