### PR TITLE
add the option to skip the bootstrap only when starting a new blockchain

### DIFF
--- a/doc/configuration/introduction.md
+++ b/doc/configuration/introduction.md
@@ -99,6 +99,12 @@ Note:
 
 ## Advanced
 
+### Seeding mode
+
+When starting a new blockchain you would want to set `seeding_mode: true` for your node. This will
+skip the bootstrap until the first block after `block0` is created. After that this setting will
+require a proper bootstrap like any other node without `skip_bootstrap: true`.
+
 ### Rewards report
 
 Starting the node `jormungandr` with the command line option `--rewards-report-all` will

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -659,6 +659,11 @@ where
         return Ok(true);
     }
 
+    if config.seeding_node && &branch.get_ref().await.hash() == blockchain.block0() {
+        warn!(logger, "this node is set into the seeding mode and its blockchain is empty; starting a new blockchain!");
+        return Ok(true);
+    }
+
     if config.trusted_peers.is_empty() {
         error!(
             logger,

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -43,6 +43,8 @@ pub struct Config {
 
     pub bootstrap_from_trusted_peers: Option<bool>,
     pub skip_bootstrap: Option<bool>,
+    #[serde(default)]
+    pub seeding_node: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -197,17 +197,29 @@ fn generate_network(
 ) -> Result<network::Configuration, Error> {
     use jormungandr_lib::multiaddr::{multiaddr_resolve_dns, multiaddr_to_socket_addr};
 
-    let (mut p2p, http_fetch_block0_service, skip_bootstrap, bootstrap_from_trusted_peers) =
-        if let Some(cfg) = config {
-            (
-                cfg.p2p.clone(),
-                cfg.http_fetch_block0_service.clone(),
-                cfg.skip_bootstrap.unwrap_or(false),
-                cfg.bootstrap_from_trusted_peers.unwrap_or(false),
-            )
-        } else {
-            (config::P2pConfig::default(), Vec::new(), false, false)
-        };
+    let (
+        mut p2p,
+        http_fetch_block0_service,
+        skip_bootstrap,
+        bootstrap_from_trusted_peers,
+        seeding_node,
+    ) = if let Some(cfg) = config {
+        (
+            cfg.p2p.clone(),
+            cfg.http_fetch_block0_service.clone(),
+            cfg.skip_bootstrap.unwrap_or(false),
+            cfg.bootstrap_from_trusted_peers.unwrap_or(false),
+            cfg.seeding_node,
+        )
+    } else {
+        (
+            config::P2pConfig::default(),
+            Vec::new(),
+            false,
+            false,
+            false,
+        )
+    };
 
     if p2p.trusted_peers.is_some() {
         if let Some(peers) = p2p.trusted_peers.as_mut() {
@@ -302,6 +314,7 @@ fn generate_network(
         http_fetch_block0_service,
         bootstrap_from_trusted_peers,
         skip_bootstrap,
+        seeding_node,
         legacy_node_id: Some(legacy_node_id),
     };
 

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -91,6 +91,11 @@ pub struct Configuration {
     /// Whether to skip bootstrap, not recommended in normal settings. useful to true for self-node
     pub skip_bootstrap: bool,
 
+    /// The current node is the first node in the blockchain. This will not bootstrap if there is only block0 in the
+    /// blockchain. Otherwise (more than one block and need to catch up) the node will continue to the usual bootstrap
+    /// process.
+    pub seeding_node: bool,
+
     pub http_fetch_block0_service: Vec<String>,
 
     /// A pre-0.9 node ID to put in "node-id-bin" metadata when subscribing


### PR DESCRIPTION
Now the recommended approach for starting the first node in a new
network is to set `seeding_mode: true`. This will skip the bootstrap on
the first run.