### PR TITLE
[Test] change way features are organized

### DIFF
--- a/testing/jormungandr-integration-tests/src/non_functional/mod.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/mod.rs
@@ -1,30 +1,35 @@
-#![cfg(feature = "sanity-non-functional")]
-
+#[cfg(feature = "sanity-non-functional")]
 pub mod compatibility;
 /*
  Explorer soak test. Run node for ~15 minutes and verify explorer is in sync with node rest
 */
+#[cfg(feature = "sanity-non-functional")]
 pub mod explorer;
 /*
  Sanity performance tests. Quick tests to check overall node performance.
  Run some transaction for ~15 minutes or specified no of transactions (100)
 */
+#[cfg(feature = "sanity-non-functional")]
 pub mod sanity;
 /*
 Long running test for self node (48 h)
 */
+#[cfg(feature = "soak-non-functional")]
 pub mod soak;
 
 /*
   Quick load test for rest api
 */
+#[cfg(feature = "sanity-non-functional")]
 pub mod rest;
 
 /*
 Long running test for dumping rewards each epoch
 */
+#[cfg(feature = "sanity-non-functional")]
 pub mod rewards;
 
+#[cfg(feature = "sanity-non-functional")]
 pub mod fragment;
 
 use crate::common::{

--- a/testing/jormungandr-integration-tests/src/non_functional/soak.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/soak.rs
@@ -6,7 +6,6 @@ use jormungandr_testing_utils::testing::{benchmark_consumption, benchmark_endura
 use jortestkit::process::Wait;
 use std::time::Duration;
 
-#[cfg(feature = "soak-non-functional")]
 #[test]
 pub fn test_blocks_are_being_created_for_48_hours() {
     let jcli: JCli = Default::default();


### PR DESCRIPTION
separate `soak-non-functional`  from  `sanity-non-functional` features in integration tests