### PR TITLE
Clippy warnings rush

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init --depth=1
-      - run: rustup component add clippy-preview
+      - run: rustup component add clippy
       - run:
           name: Print version information
           command: cargo clippy -- --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init --depth=1
+      - run: cargo install clippy
       - run:
           name: Print version information
           command: cargo clippy -- --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,6 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init --depth=1
-      - run: rustup component add clippy
       - run:
           name: Print version information
           command: cargo clippy -- --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
     environment:
       RUSTFLAGS: -D warnings
     steps:
+      - checkout
       - run: git submodule sync
       - run: git submodule update --init --depth=1
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init --depth=1
-      - run: cargo install clippy
+      - run: rustup component add clippy-preview
       - run:
           name: Print version information
           command: cargo clippy -- --version

--- a/jcli/src/jcli_app/utils/rest_api.rs
+++ b/jcli/src/jcli_app/utils/rest_api.rs
@@ -160,10 +160,7 @@ impl RestApiRequestBody {
     }
 
     pub fn has_body(&self) -> bool {
-        match self {
-            RestApiRequestBody::None => false,
-            _ => true,
-        }
+        !matches!(self, RestApiRequestBody::None)
     }
 }
 

--- a/jcli/src/jcli_app/vote/tally/decrypt_shares.rs
+++ b/jcli/src/jcli_app/vote/tally/decrypt_shares.rs
@@ -49,7 +49,7 @@ impl TallyDecryptWithAllShares {
             let mut shares = Vec::with_capacity(self.threshold);
             for _ in 0..self.threshold {
                 let mut buff = String::new();
-                &shares_file.read_line(&mut buff);
+                shares_file.read_line(&mut buff)?;
                 shares.push(
                     chain_vote::TallyDecryptShare::from_bytes(&base64::decode(buff)?)
                         .ok_or(Error::DecryptionShareRead)?,

--- a/jormungandr-lib/src/interfaces/config/node.rs
+++ b/jormungandr-lib/src/interfaces/config/node.rs
@@ -54,7 +54,7 @@ impl<'de> Deserialize<'de> for CorsOrigin {
                 write!(fmt, "an origin in format http[s]://example.com[:3000]",)
             }
 
-            fn visit_str<'a, E>(self, v: &'a str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -191,7 +191,7 @@ impl P2p {
     pub fn make_trusted_peer_setting(&self) -> TrustedPeer {
         TrustedPeer {
             address: self.get_listen_address(),
-            id: self.public_id.clone(),
+            id: self.public_id,
         }
     }
 

--- a/jormungandr-lib/src/interfaces/fragment_log.rs
+++ b/jormungandr-lib/src/interfaces/fragment_log.rs
@@ -47,20 +47,12 @@ impl FragmentStatus {
 
     #[inline]
     pub fn is_rejected(&self) -> bool {
-        if let FragmentStatus::Rejected { .. } = &self {
-            true
-        } else {
-            false
-        }
+        matches!(self, FragmentStatus::Rejected { .. })
     }
 
     #[inline]
     pub fn is_in_a_block(&self) -> bool {
-        if let FragmentStatus::InABlock { .. } = &self {
-            true
-        } else {
-            false
-        }
+        matches!(self, FragmentStatus::InABlock { .. })
     }
 }
 

--- a/jormungandr-lib/src/interfaces/vote.rs
+++ b/jormungandr-lib/src/interfaces/vote.rs
@@ -101,14 +101,13 @@ impl<'de> Deserialize<'de> for SerdeMemberPublicKey {
                 formatter.write_str("binary data for member public key")
             }
 
-            #[allow(clippy::or_fun_call)]
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                let pk = MemberPublicKey::from_bytes(v).ok_or(serde::de::Error::custom(
-                    "Invalid binary data for member public key",
-                ))?;
+                let pk = MemberPublicKey::from_bytes(v).ok_or_else(|| {
+                    serde::de::Error::custom("Invalid binary data for member public key")
+                })?;
                 Ok(SerdeMemberPublicKey(pk))
             }
         }

--- a/jormungandr/src/blockchain/branch.rs
+++ b/jormungandr/src/blockchain/branch.rs
@@ -25,6 +25,12 @@ struct BranchData {
     last_updated: std::time::SystemTime,
 }
 
+impl Default for Branches {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Branches {
     pub fn new() -> Self {
         Branches {

--- a/jormungandr/src/blockchain/candidate.rs
+++ b/jormungandr/src/blockchain/candidate.rs
@@ -19,6 +19,7 @@ use thiserror::Error;
 
 type HeaderStream = MessageQueue<Header>;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("the incoming header stream is empty")]

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -48,7 +48,7 @@ See Internal documentation for more details: doc/internal_design.md
 [`Ref`]: ./struct.Ref.html
 [`Branch`]: ./struct.Branch.html
 */
-
+#![allow(clippy::large_enum_variant)]
 use super::{branch::Branches, reference_cache::RefCache};
 use crate::{
     blockcfg::{
@@ -306,6 +306,7 @@ impl Blockchain {
     }
 
     /// create and store a reference of this leader to the new
+    #[allow(clippy::too_many_arguments)]
     async fn create_and_store_reference(
         &self,
         header_hash: HeaderHash,
@@ -349,7 +350,7 @@ impl Blockchain {
     /// TODO: the case where the block is in storage but not yet in the cache
     ///       is not implemented
     pub async fn get_ref(&self, header_hash: HeaderHash) -> Result<Option<Arc<Ref>>> {
-        let maybe_ref = self.ref_cache.get(header_hash.clone()).await;
+        let maybe_ref = self.ref_cache.get(header_hash).await;
         let block_exists = self
             .storage
             .block_exists(header_hash)
@@ -371,12 +372,12 @@ impl Blockchain {
     /// load the header's parent `Ref`.
     async fn load_header_parent(&self, header: Header, force: bool) -> Result<PreCheckedHeader> {
         let block_id = header.hash();
-        let parent_block_id = header.block_parent_hash().clone();
+        let parent_block_id = header.block_parent_hash();
 
         let maybe_self_ref = if force {
             Ok(None)
         } else {
-            self.get_ref(block_id.clone()).await
+            self.get_ref(block_id).await
         }?;
         let maybe_parent_ref = self.get_ref(parent_block_id).await?;
 
@@ -616,7 +617,7 @@ impl Blockchain {
 
         let already_exist = self
             .storage
-            .block_exists(block0_id.clone())
+            .block_exists(block0_id)
             .map_err(|e| Error::with_chain(e, "Cannot check if block0 is in storage"))?;
 
         if already_exist {
@@ -652,7 +653,7 @@ impl Blockchain {
         let block0_id = block0.header.hash();
         let already_exist = self
             .storage
-            .block_exists(block0_id.clone())
+            .block_exists(block0_id)
             .map_err(|e| Error::with_chain(e, "Cannot check if block0 is in storage"))?;
 
         if !already_exist {
@@ -745,7 +746,7 @@ impl Blockchain {
                     let block_process_end = std::time::SystemTime::now();
                     let duration = block_process_end
                         .duration_since(block_process_start)
-                        .unwrap_or(std::time::Duration::from_secs(0));
+                        .unwrap_or_else(|_| std::time::Duration::from_secs(0));
                     block_processing += duration;
                 }
             }
@@ -805,6 +806,7 @@ fn write_reward_info(
     Ok(())
 }
 
+#[allow(clippy::type_complexity)]
 pub fn new_epoch_leadership_from(
     epoch: Epoch,
     parent: Arc<Ref>,

--- a/jormungandr/src/blockchain/checkpoints.rs
+++ b/jormungandr/src/blockchain/checkpoints.rs
@@ -16,7 +16,7 @@ impl Checkpoints {
     /// For now the algorithm provide the current block, the parent, the last block of the
     /// previous epoch, the last block of the epoch before that... until the block0.
     pub fn new_from(from: Arc<Ref>) -> Self {
-        let mut checkpoints = vec![from.hash(), from.block_parent_hash().clone()];
+        let mut checkpoints = vec![from.hash(), from.block_parent_hash()];
 
         let mut ignore_prev = 0;
         let mut current_ref = from;

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -27,7 +27,7 @@ mod chunk_sizes {
 pub use self::{
     branch::Branch,
     chain::{
-        new_epoch_leadership_from, Blockchain, CheckHeaderProof, Error, ErrorKind,
+        new_epoch_leadership_from, Blockchain, CheckHeaderProof, EpochLeadership, Error, ErrorKind,
         PreCheckedHeader, MAIN_BRANCH_TAG,
     },
     chain_selection::{compare_against, ComparisonResult},

--- a/jormungandr/src/blockchain/multiverse.rs
+++ b/jormungandr/src/blockchain/multiverse.rs
@@ -7,6 +7,12 @@ pub struct Multiverse<T> {
     inner: Arc<RwLock<MultiverseData<T>>>,
 }
 
+impl<T> Default for Multiverse<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> Multiverse<T> {
     pub fn new() -> Self {
         Multiverse {

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -380,6 +380,7 @@ async fn process_and_propagate_new_ref(
         .map(|_| ())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn process_leadership_block(
     logger: Logger,
     mut blockchain: Blockchain,
@@ -509,6 +510,7 @@ async fn process_block_announcement(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn process_network_blocks(
     mut blockchain: Blockchain,
     blockchain_tip: Tip,
@@ -530,7 +532,7 @@ async fn process_network_blocks(
             Some(block) => {
                 latest_block = Some(Arc::new(block.clone()));
                 let res = process_network_block(
-                    &mut blockchain,
+                    &blockchain,
                     block.clone(),
                     &mut tx_msg_box,
                     explorer_msg_box.as_mut(),
@@ -568,7 +570,7 @@ async fn process_network_blocks(
 
     match maybe_updated {
         Some(new_block_ref) => {
-            let r = process_and_propagate_new_ref(
+            process_and_propagate_new_ref(
                 &logger,
                 &mut blockchain,
                 blockchain_tip,
@@ -578,13 +580,10 @@ async fn process_network_blocks(
             .await?;
 
             // Add block if found
-            match latest_block {
-                Some(b) => {
-                    stats_counter.set_tip_block(b);
-                }
-                None => (),
+            if let Some(b) = latest_block {
+                stats_counter.set_tip_block(b);
             };
-            Ok(r)
+            Ok(())
         }
         None => Ok(()),
     }

--- a/jormungandr/src/diagnostic.rs
+++ b/jormungandr/src/diagnostic.rs
@@ -78,8 +78,5 @@ fn getrlimit(resource: RlimitResource) -> Result<u64, DiagnosticError> {
     let retcode = unsafe { libc::getrlimit(resource, &mut limits as *mut rlimit) };
     nix::errno::Errno::result(retcode).map_err(DiagnosticError::UnixError)?;
 
-    Ok(limits
-        .rlim_cur
-        .try_into()
-        .expect("rlim always converts to a u64"))
+    Ok(limits.rlim_cur.expect("rlim always converts to a u64"))
 }

--- a/jormungandr/src/diagnostic.rs
+++ b/jormungandr/src/diagnostic.rs
@@ -63,7 +63,6 @@ enum RlimitResource {
 #[cfg(all(unix, not(target_os = "android")))]
 fn getrlimit(resource: RlimitResource) -> Result<u64, DiagnosticError> {
     use libc::rlimit;
-    use std::convert::TryInto;
 
     let mut limits = rlimit {
         rlim_cur: 0,
@@ -78,5 +77,5 @@ fn getrlimit(resource: RlimitResource) -> Result<u64, DiagnosticError> {
     let retcode = unsafe { libc::getrlimit(resource, &mut limits as *mut rlimit) };
     nix::errno::Errno::result(retcode).map_err(DiagnosticError::UnixError)?;
 
-    Ok(limits.rlim_cur.expect("rlim always converts to a u64"))
+    Ok(limits.rlim_cur)
 }

--- a/jormungandr/src/diagnostic.rs
+++ b/jormungandr/src/diagnostic.rs
@@ -42,14 +42,14 @@ impl Display for Diagnostic {
             "limit for open files (RLIMIT_NOFILE): {}",
             self.open_files_limit
                 .map(|v| v.to_string())
-                .unwrap_or("N/A".to_string())
+                .unwrap_or_else(|| "N/A".to_string())
         )?;
         write!(
             formatter,
             "; limit for CPU usage (RLIMIT_CPU): {}",
             self.cpu_usage_limit
                 .map(|v| v.to_string())
-                .unwrap_or("N/A".to_string())
+                .unwrap_or_else(|| "N/A".to_string())
         )
     }
 }

--- a/jormungandr/src/explorer/graphql/connections.rs
+++ b/jormungandr/src/explorer/graphql/connections.rs
@@ -296,6 +296,7 @@ pub type TransactionConnection = Connection<TransactionEdge, TransactionCount>;
 pub type PoolConnection = Connection<PoolEdge, PoolCount>;
 pub type VotePlanConnection = Connection<VotePlanEdge, VotePlanCount>;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum TransactionNodeFetchInfo {
     Id(HeaderHash),

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -1254,7 +1254,7 @@ impl Query {
                                 certificate::PoolId::clone(pool_id),
                                 StakePoolData::clone(stake_pool_data),
                             ),
-                            i.try_into().unwrap(),
+                            i,
                         )
                     })
                     .collect::<Vec<(Pool, u32)>>()
@@ -1315,7 +1315,7 @@ impl Query {
                         let (pool_id, vote_plan_data) = &vote_plans[usize::try_from(i).unwrap()];
                         (
                             VotePlanStatus::vote_plan_from_data(vote_plan_data.as_ref().clone()),
-                            i.try_into().unwrap(),
+                            i,
                         )
                     })
                     .collect::<Vec<(VotePlanStatus, u32)>>()

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -490,9 +490,9 @@ fn apply_block_to_addresses(mut addresses: Addresses, block: &ExplorerBlock) -> 
         for address in included_addresses {
             addresses = addresses.insert_or_update_simple(
                 address,
-                Arc::new(PersistentSequence::new().append(id.clone())),
+                Arc::new(PersistentSequence::new().append(id)),
                 |set| {
-                    let new_set = set.append(id.clone());
+                    let new_set = set.append(id);
                     Some(Arc::new(new_set))
                 },
             )
@@ -634,10 +634,8 @@ fn apply_block_to_vote_plans(
                                 proposals[vote_cast.proposal_index() as usize].votes = proposals
                                     [vote_cast.proposal_index() as usize]
                                     .votes
-                                    .insert_or_update(voter, Arc::new(choice.clone()), |_| {
-                                        Ok::<_, std::convert::Infallible>(Some(Arc::new(
-                                            choice.clone(),
-                                        )))
+                                    .insert_or_update(voter, Arc::new(*choice), |_| {
+                                        Ok::<_, std::convert::Infallible>(Some(Arc::new(*choice)))
                                     })
                                     .unwrap();
                                 let vote_plan = ExplorerVotePlan {

--- a/jormungandr/src/fragment/logs.rs
+++ b/jormungandr/src/fragment/logs.rs
@@ -95,7 +95,7 @@ impl Logs {
         result
     }
 
-    pub fn logs<'a>(&'a self) -> impl Iterator<Item = &'a FragmentLog> {
+    pub fn logs(&self) -> impl Iterator<Item = &FragmentLog> {
         self.entries.iter().map(|(_, v)| v)
     }
 }

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -512,6 +512,7 @@ pub fn stream_request<T, R>(
 }
 
 /// ...
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum TransactionMsg {
     SendTransaction(FragmentOrigin, Vec<Fragment>),

--- a/jormungandr/src/leadership/logs.rs
+++ b/jormungandr/src/leadership/logs.rs
@@ -134,7 +134,7 @@ pub(super) mod internal {
             }
         }
 
-        pub fn logs<'a>(&'a self) -> impl Iterator<Item = &'a LeadershipLog> {
+        pub fn logs(&self) -> impl Iterator<Item = &LeadershipLog> {
             self.entries.iter().map(|(_, v)| v)
         }
     }

--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -536,6 +536,7 @@ impl Module {
         }
     }
 
+    #[allow(clippy::comparison_chain)]
     async fn action_schedule(self) -> Result<Self, LeadershipError> {
         let current_slot_position = self.current_slot_position().unwrap();
 

--- a/jormungandr/src/log/stream.rs
+++ b/jormungandr/src/log/stream.rs
@@ -42,12 +42,12 @@ pub trait Log: Sized {
 
     /// A helper for other trait methods and macros.
     /// This method should not be used directly.
-    fn log_with_static<'a, M>(
+    fn log_with_static<M>(
         self,
         logger: Logger,
         message: M,
-        record_static: RecordStatic<'a>,
-    ) -> LoggingStream<'a, Self, M>
+        record_static: RecordStatic<'_>,
+    ) -> LoggingStream<'_, Self, M>
     where
         M: Display,
     {

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -230,7 +230,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         let fragment_msgbox = fragment_msgbox.clone();
 
         services.spawn_try_future("leadership", move |info| {
-            let fut = leadership::Module::new(
+            leadership::Module::new(
                 info,
                 leadership_logs,
                 blockchain_tip,
@@ -241,9 +241,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
             .and_then(|module| module.run())
             .map_err(|e| {
                 eprint!("leadership error: {}", e);
-            });
-
-            fut
+            })
         });
     }
 
@@ -268,8 +266,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         let blockchain_tip = blockchain_tip;
         let no_blockchain_updates_warning_interval = bootstrapped_node
             .settings
-            .no_blockchain_updates_warning_interval
-            .clone();
+            .no_blockchain_updates_warning_interval;
 
         services.spawn_future("stuck_notifier", move |info| {
             stuck_notifier::check_last_block_time(

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -163,7 +163,7 @@ impl BootstrapInfo {
                 let v = (bytes_diff as f64) / td.as_secs_f64();
                 print_sz(v)
             })
-            .unwrap_or("N/A".to_string());
+            .unwrap_or_else(|_| "N/A".to_string());
 
         self.last_reported = current;
         self.last_bytes_received = self.bytes_received;
@@ -192,7 +192,7 @@ where
     St: Future<Output = Result<(), futures::channel::oneshot::Canceled>> + Unpin + Clone,
 {
     const PROCESS_LOGGING_DISTANCE: u64 = 2500;
-    let block0 = blockchain.block0().clone();
+    let block0 = *blockchain.block0();
 
     let mut bootstrap_info = BootstrapInfo::new();
     let mut maybe_parent_tip = None;

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -131,10 +131,7 @@ impl<T> CommHandle<T> {
     }
 
     pub fn is_client(&self) -> bool {
-        match self.direction {
-            SubscriptionDirection::Client => true,
-            _ => false,
-        }
+        matches!(self.direction, SubscriptionDirection::Client)
     }
 
     pub fn clear_pending(&mut self) {
@@ -149,14 +146,11 @@ impl<T> CommHandle<T> {
     /// the handle to send a potential pending item over the new subscription.
     pub fn update(&mut self, newer: CommHandle<T>) {
         self.direction = newer.direction;
-        match mem::replace(&mut self.state, newer.state) {
-            SubscriptionState::Pending(item) => {
-                // If there is an error sending the pending item,
-                // it is silently dropped. Logging infrastructure to debug
-                // this would be nice.
-                let _ = self.try_send(item);
-            }
-            _ => {}
+        if let SubscriptionState::Pending(item) = mem::replace(&mut self.state, newer.state) {
+            // If there is an error sending the pending item,
+            // it is silently dropped. Logging infrastructure to debug
+            // this would be nice.
+            let _ = self.try_send(item);
         }
     }
 
@@ -277,7 +271,7 @@ impl PeerComms {
 
     pub fn auth_nonce(&self) -> Option<[u8; NONCE_LEN]> {
         match self.auth {
-            PeerAuth::ServerNonce(nonce) => Some(nonce.clone()),
+            PeerAuth::ServerNonce(nonce) => Some(nonce),
             _ => None,
         }
     }
@@ -285,7 +279,7 @@ impl PeerComms {
     pub fn generate_auth_nonce(&mut self) -> [u8; NONCE_LEN] {
         let mut nonce = [0u8; NONCE_LEN];
         rand::thread_rng().fill(&mut nonce[..]);
-        self.auth = PeerAuth::ServerNonce(nonce.clone());
+        self.auth = PeerAuth::ServerNonce(nonce);
         nonce
     }
 
@@ -428,15 +422,15 @@ impl Default for PeerStats {
 
 impl PeerStats {
     pub fn last_block_received(&self) -> Option<SystemTime> {
-        self.last_block_received.clone()
+        self.last_block_received
     }
 
     pub fn last_fragment_received(&self) -> Option<SystemTime> {
-        self.last_fragment_received.clone()
+        self.last_fragment_received
     }
 
     pub fn last_gossip_received(&self) -> Option<SystemTime> {
-        self.last_gossip_received.clone()
+        self.last_gossip_received
     }
 
     fn update_last_block_received(&mut self, timestamp: SystemTime) {

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -79,7 +79,7 @@ impl PeerMap {
         }
     }
 
-    pub fn entry<'a>(&'a mut self, id: Address) -> Option<Entry<'a>> {
+    pub fn entry(&mut self, id: Address) -> Option<Entry<'_>> {
         use linked_hash_map::Entry::*;
 
         match self.map.entry(id) {

--- a/jormungandr/src/network/p2p/gossip.rs
+++ b/jormungandr/src/network/p2p/gossip.rs
@@ -94,16 +94,13 @@ impl Gossip {
                 // Check using same methods by trying to cast address to ipv4
                 // FIXME: use Ipv6 tests when Ipv6Addr convenience methods get stabilized:
                 // https://github.com/rust-lang/rust/issues/27709
-                match ip.to_ipv4() {
-                    Some(ipv4) => {
-                        if ipv4.is_private() {
-                            return false;
-                        }
-                        if ipv4.is_link_local() {
-                            return false;
-                        }
+                if let Some(ipv4) = ip.to_ipv4() {
+                    if ipv4.is_private() {
+                        return false;
                     }
-                    None => {}
+                    if ipv4.is_link_local() {
+                        return false;
+                    }
                 }
             }
         }

--- a/jormungandr/src/network/p2p/policy.rs
+++ b/jormungandr/src/network/p2p/policy.rs
@@ -51,7 +51,7 @@ impl Policy {
             quarantine_duration: pc.quarantine_duration.into(),
             max_quarantine: pc
                 .max_quarantine
-                .unwrap_or(DEFAULT_MAX_QUARANTINE_DURATION.into())
+                .unwrap_or_else(|| DEFAULT_MAX_QUARANTINE_DURATION.into())
                 .into(),
             records: LruCache::new(
                 pc.max_num_quarantine_records

--- a/jormungandr/src/rest/context.rs
+++ b/jormungandr/src/rest/context.rs
@@ -47,6 +47,12 @@ pub enum Error {
     Diagnostic,
 }
 
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Context {
     pub fn new() -> Self {
         Context {

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -15,7 +15,7 @@ pub async fn get_account_state(
         .await
         .map_err(warp::reject::custom)?
         .map(|r| warp::reply::json(&r))
-        .ok_or(warp::reject::not_found())
+        .ok_or_else(warp::reject::not_found)
 }
 
 pub async fn get_message_logs(context: ContextLock) -> Result<impl Reply, Rejection> {
@@ -57,7 +57,7 @@ pub async fn get_block_id(
     logic::get_block_id(&context, &block_id_hex)
         .await
         .map_err(warp::reject::custom)?
-        .ok_or(warp::reject::not_found())
+        .ok_or_else(warp::reject::not_found)
 }
 
 #[derive(Deserialize)]
@@ -75,7 +75,7 @@ pub async fn get_block_next_id(
     logic::get_block_next_id(&context, &block_id_hex, count as usize)
         .await
         .map_err(warp::reject::custom)?
-        .ok_or(warp::reject::not_found())
+        .ok_or_else(warp::reject::not_found)
 }
 
 pub async fn get_stake_distribution(context: ContextLock) -> Result<impl Reply, Rejection> {
@@ -95,7 +95,7 @@ pub async fn get_stake_distribution_at(
         .await
         .map_err(warp::reject::custom)?
         .map(|r| warp::reply::json(&r))
-        .ok_or(warp::reject::not_found())
+        .ok_or_else(warp::reject::not_found)
 }
 
 pub async fn get_settings(context: ContextLock) -> Result<impl Reply, Rejection> {
@@ -139,7 +139,7 @@ pub async fn delete_leaders(leader_id: u32, context: ContextLock) -> Result<impl
         .await
         .map_err(warp::reject::custom)?
         .map(|()| warp::reply())
-        .ok_or(warp::reject::not_found())
+        .ok_or_else(warp::reject::not_found)
 }
 
 pub async fn get_leaders_logs(context: ContextLock) -> Result<impl Reply, Rejection> {
@@ -175,7 +175,7 @@ pub async fn get_rewards_info_epoch(
         .await
         .map_err(warp::reject::custom)?
         .map(|r| warp::reply::json(&r))
-        .ok_or(warp::reject::not_found())
+        .ok_or_else(warp::reject::not_found)
 }
 
 pub async fn get_rewards_info_history(
@@ -199,7 +199,7 @@ pub async fn get_utxo(
         .await
         .map_err(warp::reject::custom)?
         .map(|r| warp::reply::json(&r))
-        .ok_or(warp::reject::not_found())
+        .ok_or_else(warp::reject::not_found)
 }
 
 pub async fn get_stake_pool(
@@ -211,7 +211,7 @@ pub async fn get_stake_pool(
         .await
         .map_err(warp::reject::custom)?
         .map(|r| warp::reply::json(&r))
-        .ok_or(warp::reject::not_found())
+        .ok_or_else(warp::reject::not_found)
 }
 
 pub async fn get_diagnostic(context: ContextLock) -> Result<impl Reply, Rejection> {

--- a/jormungandr/src/rest/v0/logic.rs
+++ b/jormungandr/src/rest/v0/logic.rs
@@ -43,6 +43,7 @@ use std::sync::Arc;
 
 use futures::{channel::mpsc::SendError, channel::mpsc::TrySendError, prelude::*};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
@@ -203,7 +204,7 @@ async fn create_stats(context: &Context) -> Result<Option<NodeStats>, Error> {
             }?;
             block_tx_count += 1;
             block_input_sum = (block_input_sum + total_input)?;
-            let fee = (total_input - total_output).unwrap_or(Value::zero());
+            let fee = (total_input - total_output).unwrap_or_else(|_| Value::zero());
             block_fee_sum = (block_fee_sum + fee)?;
             Ok(())
         })

--- a/jormungandr/src/rest/v1/logic.rs
+++ b/jormungandr/src/rest/v1/logic.rs
@@ -13,6 +13,7 @@ use futures::{channel::mpsc::SendError, channel::mpsc::TrySendError, prelude::*}
 use jormungandr_lib::interfaces::{FragmentLog, FragmentOrigin, FragmentStatus};
 use std::{collections::HashMap, str::FromStr};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]

--- a/jormungandr/src/rest/v1/mod.rs
+++ b/jormungandr/src/rest/v1/mod.rs
@@ -30,7 +30,7 @@ pub fn filter(
 
         let logs = warp::path!("logs")
             .and(warp::get())
-            .and(with_context.clone())
+            .and(with_context)
             .and_then(handlers::get_fragments_logs)
             .boxed();
 

--- a/jormungandr/src/secure/enclave.rs
+++ b/jormungandr/src/secure/enclave.rs
@@ -90,6 +90,12 @@ impl EnclaveLeadersWithCache {
     }
 }
 
+impl Default for Enclave {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Enclave {
     pub fn new() -> Self {
         Enclave {

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -7,7 +7,6 @@ use crate::{
 pub use jormungandr_lib::interfaces::{Cors, Rest, Tls};
 use jormungandr_lib::{interfaces::Mempool, time::Duration};
 
-use poldercast;
 use serde::{de::Error as _, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use slog::FilterLevel;
 
@@ -284,7 +283,7 @@ impl<'de> Deserialize<'de> for Topic {
                 write!(fmt, "Topic: messages or blocks")
             }
 
-            fn visit_str<'a, E>(self, v: &'a str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -314,7 +313,7 @@ impl<'de> Deserialize<'de> for InterestLevel {
                 write!(fmt, "Interest Level: low, normal or high")
             }
 
-            fn visit_str<'a, E>(self, v: &'a str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -72,8 +72,8 @@ impl RawSettings {
             });
         }
 
-        let cmd_level = self.command_line.log_level.clone();
-        let cmd_format = self.command_line.log_format.clone();
+        let cmd_level = self.command_line.log_level;
+        let cmd_format = self.command_line.log_format;
         let cmd_output = self.command_line.log_output.clone();
 
         if cmd_level.is_some() || cmd_format.is_some() || cmd_output.is_some() {
@@ -96,7 +96,7 @@ impl RawSettings {
     }
 
     fn rest_config(&self) -> Option<Rest> {
-        let cmd_listen_opt = self.command_line.rest_arguments.listen.clone();
+        let cmd_listen_opt = self.command_line.rest_arguments.listen;
         let config_rest_opt = self.config.as_ref().and_then(|cfg| cfg.rest.as_ref());
         match (config_rest_opt, cmd_listen_opt) {
             (Some(config_rest), Some(cmd_listen)) => Some(Rest {
@@ -153,9 +153,9 @@ impl RawSettings {
             &command_arguments.block_0_hash,
         ) {
             (None, None) => return Err(Error::ExpectedBlock0Info),
-            (Some(path), Some(hash)) => Block0Info::Path(path.clone(), Some(hash.clone())),
+            (Some(path), Some(hash)) => Block0Info::Path(path.clone(), Some(*hash)),
             (Some(path), None) => Block0Info::Path(path.clone(), None),
-            (None, Some(hash)) => Block0Info::Hash(hash.clone()),
+            (None, Some(hash)) => Block0Info::Hash(*hash),
         };
 
         let explorer = command_arguments.explorer_enabled
@@ -181,11 +181,11 @@ impl RawSettings {
             explorer,
             no_blockchain_updates_warning_interval: config
                 .as_ref()
-                .and_then(|config| config.no_blockchain_updates_warning_interval.clone())
+                .and_then(|config| config.no_blockchain_updates_warning_interval)
                 .map(|d| d.into())
-                .unwrap_or(std::time::Duration::from_secs(
-                    DEFAULT_NO_BLOCKCHAIN_UPDATES_WARNING_INTERVAL,
-                )),
+                .unwrap_or_else(|| {
+                    std::time::Duration::from_secs(DEFAULT_NO_BLOCKCHAIN_UPDATES_WARNING_INTERVAL)
+                }),
         })
     }
 }
@@ -226,7 +226,7 @@ fn generate_network(
                     let address = poldercast::Address::from(address);
                     Some(config::TrustedPeer {
                         address,
-                        id: peer.id.clone(),
+                        id: peer.id,
                     })
                 }
                 Ok(None) => {
@@ -255,7 +255,7 @@ fn generate_network(
 
     for (topic, interest_level) in p2p
         .topics_of_interest
-        .unwrap_or(config::default_interests())
+        .unwrap_or_else(config::default_interests)
     {
         let sub = poldercast::Subscription {
             topic: topic.0,
@@ -297,7 +297,7 @@ fn generate_network(
         gossip_interval: p2p
             .gossip_interval
             .map(|d| d.into())
-            .unwrap_or(std::time::Duration::from_secs(10)),
+            .unwrap_or_else(|| std::time::Duration::from_secs(10)),
         topology_force_reset_interval: p2p.topology_force_reset_interval.map(|d| d.into()),
         max_bootstrap_attempts: p2p.max_bootstrap_attempts,
         http_fetch_block0_service,

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -156,10 +156,11 @@ impl Configuration {
         use jormungandr_lib::multiaddr::multiaddr_to_socket_addr;
 
         self.listen_address
-            .or(self
-                .profile
-                .address()
-                .and_then(|address| multiaddr_to_socket_addr(address.multi_address())))
+            .or_else(|| {
+                self.profile
+                    .address()
+                    .and_then(|address| multiaddr_to_socket_addr(address.multi_address()))
+            })
             .map(Listen::new)
     }
 }

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -122,7 +122,7 @@ pub async fn prepare_block_0(
                     if &got != expected_hash {
                         return Err(Error::Block0Mismatch {
                             got,
-                            expected: expected_hash.clone(),
+                            expected: *expected_hash,
                         });
                     }
                 }

--- a/jormungandr/src/state.rs
+++ b/jormungandr/src/state.rs
@@ -7,3 +7,9 @@ impl State {
         State {}
     }
 }
+
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/jormungandr/src/stuck_notifier.rs
+++ b/jormungandr/src/stuck_notifier.rs
@@ -43,7 +43,7 @@ pub async fn check_last_block_time(
         let system_current_blockdate = system_current_slot
             .and_then(|scs| era.from_slot_to_era(scs))
             .map(|ep| format!("{}", ep))
-            .unwrap_or("date-computation-error".to_string());
+            .unwrap_or_else(|| "date-computation-error".to_string());
 
         let header = tip.header();
         match now.duration_since(tip_time) {

--- a/testing/iapyx/src/cli/args/interactive/command.rs
+++ b/testing/iapyx/src/cli/args/interactive/command.rs
@@ -340,6 +340,7 @@ impl Generate {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
 pub enum IapyxCommandError {
     #[error("{0}")]

--- a/testing/iapyx/src/wallet.rs
+++ b/testing/iapyx/src/wallet.rs
@@ -17,6 +17,7 @@ use wallet_core::Conversion;
 use wallet_core::Proposal;
 use wallet_core::Wallet as Inner;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("cannot recover from mnemonics: {0}")]

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
@@ -131,7 +131,7 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
-    pub fn convert_to_bytes_string<P: AsRef<Path>, S: Into<String>>(
+    pub fn convert_from_bytes_string<P: AsRef<Path>, S: Into<String>>(
         self,
         key_type: S,
         input: P,
@@ -147,7 +147,7 @@ impl Key {
             .as_single_line()
     }
 
-    pub fn convert_to_bytes_string_expect_fail<P: AsRef<Path>, S: Into<String>>(
+    pub fn convert_from_bytes_string_expect_fail<P: AsRef<Path>, S: Into<String>>(
         self,
         key_type: S,
         input: P,

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
@@ -67,7 +67,7 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
-    pub fn to_public<S: Into<String>>(self, private_key: S) -> String {
+    pub fn into_public<S: Into<String>>(self, private_key: S) -> String {
         let input_file = NamedTempFile::new("key_to_public.input").unwrap();
         input_file.write_str(&private_key.into()).unwrap();
 
@@ -81,7 +81,7 @@ impl Key {
             .as_single_line()
     }
 
-    pub fn to_public_expect_fail<S: Into<String>>(self, private_key: S, expected_msg_path: &str) {
+    pub fn into_public_expect_fail<S: Into<String>>(self, private_key: S, expected_msg_path: &str) {
         let input_file = NamedTempFile::new("key_to_public.input").unwrap();
         input_file.write_str(&private_key.into()).unwrap();
 
@@ -94,6 +94,7 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes<S: Into<String>, P: AsRef<Path>>(self, private_key: S, output: P) {
         let input = NamedTempFile::new("key_to_bytes.input").unwrap();
         input.write_str(&private_key.into()).unwrap();
@@ -101,6 +102,7 @@ impl Key {
         self.to_bytes_from_file(input.path(), output.as_ref())
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes_from_file<P: AsRef<Path>, Q: AsRef<Path>>(self, input: P, output: Q) {
         self.key_command
             .to_bytes()
@@ -111,6 +113,7 @@ impl Key {
             .success();
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes_expect_fail<P: AsRef<Path>, Q: AsRef<Path>>(
         self,
         input: P,
@@ -127,6 +130,7 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_bytes<P: AsRef<Path>, S: Into<String>>(self, key_type: S, input: P) -> String {
         self.key_command
             .from_bytes()
@@ -139,6 +143,7 @@ impl Key {
             .as_single_line()
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_bytes_expect_fail<P: AsRef<Path>, S: Into<String>>(
         self,
         key_type: S,

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
@@ -67,7 +67,7 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
-    pub fn into_public<S: Into<String>>(self, private_key: S) -> String {
+    pub fn into_public_string<S: Into<String>>(self, private_key: S) -> String {
         let input_file = NamedTempFile::new("key_to_public.input").unwrap();
         input_file.write_str(&private_key.into()).unwrap();
 
@@ -94,16 +94,14 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_bytes<S: Into<String>, P: AsRef<Path>>(self, private_key: S, output: P) {
+    pub fn dump_bytes_to_file<S: Into<String>, P: AsRef<Path>>(self, private_key: S, output: P) {
         let input = NamedTempFile::new("key_to_bytes.input").unwrap();
         input.write_str(&private_key.into()).unwrap();
 
-        self.to_bytes_from_file(input.path(), output.as_ref())
+        self.copy_bytes_to_file(input.path(), output.as_ref())
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_bytes_from_file<P: AsRef<Path>, Q: AsRef<Path>>(self, input: P, output: Q) {
+    pub fn copy_bytes_to_file<P: AsRef<Path>, Q: AsRef<Path>>(self, input: P, output: Q) {
         self.key_command
             .to_bytes()
             .output(output)
@@ -113,7 +111,7 @@ impl Key {
             .success();
     }
 
-    pub fn into_bytes_expect_fail<P: AsRef<Path>, Q: AsRef<Path>>(
+    pub fn copy_bytes_to_file_expect_fail<P: AsRef<Path>, Q: AsRef<Path>>(
         self,
         input: P,
         output: Q,
@@ -129,7 +127,11 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
-    pub fn into_bytes<P: AsRef<Path>, S: Into<String>>(self, key_type: S, input: P) -> String {
+    pub fn convert_to_string<P: AsRef<Path>, S: Into<String>>(
+        self,
+        key_type: S,
+        input: P,
+    ) -> String {
         self.key_command
             .from_bytes()
             .key_type(key_type)
@@ -141,8 +143,7 @@ impl Key {
             .as_single_line()
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn from_bytes_expect_fail<P: AsRef<Path>, S: Into<String>>(
+    pub fn convert_to_string_expect_fail<P: AsRef<Path>, S: Into<String>>(
         self,
         key_type: S,
         input: P,

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
@@ -131,7 +131,7 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
-    pub fn convert_to_string<P: AsRef<Path>, S: Into<String>>(
+    pub fn convert_to_bytes_string<P: AsRef<Path>, S: Into<String>>(
         self,
         key_type: S,
         input: P,
@@ -147,7 +147,7 @@ impl Key {
             .as_single_line()
     }
 
-    pub fn convert_to_string_expect_fail<P: AsRef<Path>, S: Into<String>>(
+    pub fn convert_to_bytes_string_expect_fail<P: AsRef<Path>, S: Into<String>>(
         self,
         key_type: S,
         input: P,

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
@@ -67,7 +67,7 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
-    pub fn into_public_string<S: Into<String>>(self, private_key: S) -> String {
+    pub fn convert_to_public_string<S: Into<String>>(self, private_key: S) -> String {
         let input_file = NamedTempFile::new("key_to_public.input").unwrap();
         input_file.write_str(&private_key.into()).unwrap();
 
@@ -81,7 +81,11 @@ impl Key {
             .as_single_line()
     }
 
-    pub fn into_public_expect_fail<S: Into<String>>(self, private_key: S, expected_msg_path: &str) {
+    pub fn convert_to_public_string_expect_fail<S: Into<String>>(
+        self,
+        private_key: S,
+        expected_msg_path: &str,
+    ) {
         let input_file = NamedTempFile::new("key_to_public.input").unwrap();
         input_file.write_str(&private_key.into()).unwrap();
 

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
@@ -102,10 +102,10 @@ impl Key {
         let input = NamedTempFile::new("key_to_bytes.input").unwrap();
         input.write_str(&private_key.into()).unwrap();
 
-        self.copy_bytes_to_file(input.path(), output.as_ref())
+        self.convert_to_bytes_file(input.path(), output.as_ref())
     }
 
-    pub fn copy_bytes_to_file<P: AsRef<Path>, Q: AsRef<Path>>(self, input: P, output: Q) {
+    pub fn convert_to_bytes_file<P: AsRef<Path>, Q: AsRef<Path>>(self, input: P, output: Q) {
         self.key_command
             .to_bytes()
             .output(output)
@@ -115,7 +115,7 @@ impl Key {
             .success();
     }
 
-    pub fn copy_bytes_to_file_expect_fail<P: AsRef<Path>, Q: AsRef<Path>>(
+    pub fn convert_to_bytes_file_expect_fail<P: AsRef<Path>, Q: AsRef<Path>>(
         self,
         input: P,
         output: Q,

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/key.rs
@@ -113,8 +113,7 @@ impl Key {
             .success();
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_bytes_expect_fail<P: AsRef<Path>, Q: AsRef<Path>>(
+    pub fn into_bytes_expect_fail<P: AsRef<Path>, Q: AsRef<Path>>(
         self,
         input: P,
         output: Q,
@@ -130,8 +129,7 @@ impl Key {
             .stderr(predicates::str::contains(expected_msg_path));
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn from_bytes<P: AsRef<Path>, S: Into<String>>(self, key_type: S, input: P) -> String {
+    pub fn into_bytes<P: AsRef<Path>, S: Into<String>>(self, key_type: S, input: P) -> String {
         self.key_command
             .from_bytes()
             .key_type(key_type)

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
@@ -279,8 +279,7 @@ impl Transaction {
         self.command.seal(staging_file).build().assert().success();
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_message<P: AsRef<Path>>(self, staging_file: P) -> String {
+    pub fn convert_to_message<P: AsRef<Path>>(self, staging_file: P) -> String {
         self.command
             .to_message(staging_file)
             .build()
@@ -290,8 +289,11 @@ impl Transaction {
             .as_single_line()
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_message_expect_fail<P: AsRef<Path>>(self, staging_file: P, expected_msg: &str) {
+    pub fn convert_to_message_expect_fail<P: AsRef<Path>>(
+        self,
+        staging_file: P,
+        expected_msg: &str,
+    ) {
         self.command
             .to_message(staging_file)
             .build()
@@ -321,7 +323,7 @@ impl Transaction {
     }
 
     pub fn fragment_id<P: AsRef<Path>>(self, staging_file: P) -> Hash {
-        let fragment_hex = self.to_message(staging_file);
+        let fragment_hex = self.convert_to_message(staging_file);
         let fragment_bytes = hex::decode(&fragment_hex).expect("Failed to parse message hex");
         Fragment::deserialize(fragment_bytes.as_slice())
             .expect("Failed to parse message")

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
@@ -279,6 +279,7 @@ impl Transaction {
         self.command.seal(staging_file).build().assert().success();
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_message<P: AsRef<Path>>(self, staging_file: P) -> String {
         self.command
             .to_message(staging_file)
@@ -289,6 +290,7 @@ impl Transaction {
             .as_single_line()
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_message_expect_fail<P: AsRef<Path>>(self, staging_file: P, expected_msg: &str) {
         self.command
             .to_message(staging_file)

--- a/testing/jormungandr-integration-tests/src/common/jcli/command/key/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/command/key/mod.rs
@@ -14,6 +14,7 @@ pub struct KeyCommand {
     command: Command,
 }
 
+#[allow(clippy::wrong_self_convention)]
 impl KeyCommand {
     pub fn new(command: Command) -> Self {
         Self { command }

--- a/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
@@ -162,6 +162,7 @@ impl TransactionCommand {
         self
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_message<P: AsRef<Path>>(mut self, staging_file: P) -> Self {
         self.command
             .arg("to-message")

--- a/testing/jormungandr-integration-tests/src/common/jcli/services/certificate_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/services/certificate_builder.rs
@@ -14,6 +14,7 @@ impl CertificateBuilder {
     pub fn new(jcli: JCli) -> Self {
         Self { jcli }
     }
+    #[allow(clippy::too_many_arguments)]
     pub fn new_signed_stake_pool_cert(
         &self,
         pool_kes_pk: &str,

--- a/testing/jormungandr-integration-tests/src/common/jcli/services/fragment_check.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/services/fragment_check.rs
@@ -28,7 +28,7 @@ impl<'a> FragmentCheck<'a> {
     }
 
     pub fn fragment_id(&self) -> FragmentId {
-        self.id.clone()
+        self.id
     }
 
     pub fn assert_in_block(&self) -> FragmentId {
@@ -85,7 +85,7 @@ impl<'a> FragmentCheck<'a> {
                 self.jormungandr.logger.get_log_content()
             ),
         )
-        .map(|()| self.id.clone())
+        .map(|()| self.id)
         .map_err(|_| Error::TransactionNotInBlock {
             message_log: format!(
                 "{:?}",
@@ -95,7 +95,7 @@ impl<'a> FragmentCheck<'a> {
                     .message()
                     .logs(&self.jormungandr.rest_uri())
             ),
-            transaction_id: Hash::from_hash(self.id.clone()),
+            transaction_id: Hash::from_hash(self.id),
             log_content: self.jormungandr.logger.get_log_content(),
         })
     }
@@ -129,7 +129,6 @@ impl<'a> FragmentCheck<'a> {
     pub fn assert_log_shows_rejected(self, expected_msg: &str) {
         let fragments = self
             .jcli
-            .clone()
             .rest()
             .v0()
             .message()

--- a/testing/jormungandr-integration-tests/src/common/jcli/services/fragments_check.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/services/fragments_check.rs
@@ -60,7 +60,6 @@ impl<'a> FragmentsCheck<'a> {
     pub fn check_log_shows_in_block(self) -> Result<(), Error> {
         let fragments = self
             .jcli
-            .clone()
             .rest()
             .v0()
             .message()

--- a/testing/jormungandr-integration-tests/src/common/jcli/services/transaction_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/services/transaction_builder.rs
@@ -307,13 +307,13 @@ impl TransactionBuilder {
     pub fn to_message(&self) -> String {
         self.jcli
             .transaction()
-            .to_message(self.staging_file().path())
+            .convert_to_message(self.staging_file().path())
     }
 
     pub fn to_message_expect_fail(&self, expected_msg: &str) {
         self.jcli
             .transaction()
-            .to_message_expect_fail(self.staging_file().path(), expected_msg);
+            .convert_to_message_expect_fail(self.staging_file().path(), expected_msg);
     }
 
     pub fn transaction_id(&self) -> Hash {

--- a/testing/jormungandr-integration-tests/src/common/jcli/services/transaction_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/services/transaction_builder.rs
@@ -36,7 +36,7 @@ impl TransactionBuilder {
     }
 
     fn truncate_end_of_line(cert_content: &str) -> String {
-        let mut content = cert_content.clone().to_string();
+        let mut content = cert_content.to_string();
         if content.ends_with('\n') {
             let len = content.len();
             content.truncate(len - 1);

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -153,7 +153,7 @@ impl JormungandrProcess {
     pub fn to_remote(&self) -> RemoteJormungandr {
         let mut builder = RemoteJormungandrBuilder::new(self.alias.clone());
         builder
-            .with_rest(self.rest_socket_addr.clone())
+            .with_rest(self.rest_socket_addr)
             .with_logger(self.logger.log_file_path.clone());
         builder.build()
     }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
@@ -493,10 +493,7 @@ where
                     })
                 }
                 (Err(err), OnFail::Panic) => {
-                    panic!(format!(
-                        "Jormungandr node cannot start due to error: {}",
-                        err
-                    ));
+                    panic!("Jormungandr node cannot start due to error: {}", err);
                 }
                 (Err(err), _) => {
                     println!(

--- a/testing/jormungandr-integration-tests/src/common/network/controller.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/controller.rs
@@ -106,8 +106,8 @@ impl Controller {
         expected_msg: &str,
     ) -> Result<(), ControllerError> {
         let mut starter = self.make_starter_for(&spawn_params)?;
-        let process = starter.start_with_fail_in_logs(expected_msg)?;
-        Ok(process)
+        starter.start_with_fail_in_logs(expected_msg)?;
+        Ok(())
     }
 
     pub fn spawn_custom(

--- a/testing/jormungandr-integration-tests/src/jcli/address/account.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/account.rs
@@ -8,7 +8,7 @@ pub fn test_account_address_made_of_incorrect_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let mut public_key = jcli.key().to_public(&private_key);
+    let mut public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     public_key.remove(20);
@@ -29,7 +29,7 @@ pub fn test_account_address_made_of_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     let account_address = jcli

--- a/testing/jormungandr-integration-tests/src/jcli/address/account.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/account.rs
@@ -8,7 +8,7 @@ pub fn test_account_address_made_of_incorrect_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let mut public_key = jcli.key().into_public_string(&private_key);
+    let mut public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     public_key.remove(20);
@@ -29,7 +29,7 @@ pub fn test_account_address_made_of_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let account_address = jcli

--- a/testing/jormungandr-integration-tests/src/jcli/address/account.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/account.rs
@@ -8,7 +8,7 @@ pub fn test_account_address_made_of_incorrect_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let mut public_key = jcli.key().into_public(&private_key);
+    let mut public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     public_key.remove(20);
@@ -29,7 +29,7 @@ pub fn test_account_address_made_of_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let account_address = jcli

--- a/testing/jormungandr-integration-tests/src/jcli/address/info.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/info.rs
@@ -15,7 +15,7 @@ pub fn test_info_account_address() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     let account_address = jcli
         .address()
         .account(&public_key, None, Discrimination::Test);
@@ -33,7 +33,7 @@ pub fn test_info_account_address_for_prod() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     let account_address = jcli
         .address()
         .account(&public_key, None, Discrimination::Production);
@@ -51,10 +51,10 @@ pub fn test_info_delegation_address() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let delegation_key = jcli.key().into_public(&private_key);
+    let delegation_key = jcli.key().into_public_string(&private_key);
     let account_address =
         jcli.address()
             .delegation(&public_key, &delegation_key, Discrimination::Test);

--- a/testing/jormungandr-integration-tests/src/jcli/address/info.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/info.rs
@@ -15,7 +15,7 @@ pub fn test_info_account_address() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     let account_address = jcli
         .address()
         .account(&public_key, None, Discrimination::Test);
@@ -33,7 +33,7 @@ pub fn test_info_account_address_for_prod() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     let account_address = jcli
         .address()
         .account(&public_key, None, Discrimination::Production);
@@ -51,10 +51,10 @@ pub fn test_info_delegation_address() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let delegation_key = jcli.key().into_public_string(&private_key);
+    let delegation_key = jcli.key().convert_to_public_string(&private_key);
     let account_address =
         jcli.address()
             .delegation(&public_key, &delegation_key, Discrimination::Test);

--- a/testing/jormungandr-integration-tests/src/jcli/address/info.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/info.rs
@@ -15,7 +15,7 @@ pub fn test_info_account_address() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     let account_address = jcli
         .address()
         .account(&public_key, None, Discrimination::Test);
@@ -33,7 +33,7 @@ pub fn test_info_account_address_for_prod() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     let account_address = jcli
         .address()
         .account(&public_key, None, Discrimination::Production);
@@ -51,10 +51,10 @@ pub fn test_info_delegation_address() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let delegation_key = jcli.key().to_public(&private_key);
+    let delegation_key = jcli.key().into_public(&private_key);
     let account_address =
         jcli.address()
             .delegation(&public_key, &delegation_key, Discrimination::Test);

--- a/testing/jormungandr-integration-tests/src/jcli/address/single.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/single.rs
@@ -8,7 +8,7 @@ pub fn test_utxo_address_made_of_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let utxo_address = jcli
@@ -28,14 +28,14 @@ pub fn test_delegation_address_made_of_ed25519_extended_seed_key() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let private_key = jcli
         .key()
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private delegation key: {}", &private_key);
-    let delegation_key = jcli.key().into_public_string(&private_key);
+    let delegation_key = jcli.key().convert_to_public_string(&private_key);
     println!("delegation key: {}", &delegation_key);
 
     let delegation_address =
@@ -58,7 +58,7 @@ pub fn test_delegation_address_is_the_same_as_public() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -81,7 +81,7 @@ pub fn test_delegation_address_for_prod_discrimination() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -104,7 +104,7 @@ pub fn test_single_address_for_prod_discrimination() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -124,7 +124,7 @@ pub fn test_account_address_for_prod_discrimination() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -139,7 +139,7 @@ pub fn test_utxo_address_made_of_incorrect_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let mut public_key = jcli.key().into_public_string(&private_key);
+    let mut public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     public_key.push('A');
@@ -160,7 +160,7 @@ pub fn test_delegation_address_made_of_random_string() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_key = "adfasdfasdfdasfasdfadfasdf";
@@ -181,12 +181,12 @@ pub fn test_delegation_address_made_of_incorrect_public_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let mut public_key = jcli.key().into_public_string(&private_key);
+    let mut public_key = jcli.key().convert_to_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private delegation key: {}", &private_key);
-    let delegation_key = jcli.key().into_public_string(&private_key);
+    let delegation_key = jcli.key().convert_to_public_string(&private_key);
     println!("delegation key: {}", &delegation_key);
 
     public_key.push('A');

--- a/testing/jormungandr-integration-tests/src/jcli/address/single.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/single.rs
@@ -8,7 +8,7 @@ pub fn test_utxo_address_made_of_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let utxo_address = jcli
@@ -28,14 +28,14 @@ pub fn test_delegation_address_made_of_ed25519_extended_seed_key() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let private_key = jcli
         .key()
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private delegation key: {}", &private_key);
-    let delegation_key = jcli.key().into_public(&private_key);
+    let delegation_key = jcli.key().into_public_string(&private_key);
     println!("delegation key: {}", &delegation_key);
 
     let delegation_address =
@@ -58,7 +58,7 @@ pub fn test_delegation_address_is_the_same_as_public() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -81,7 +81,7 @@ pub fn test_delegation_address_for_prod_discrimination() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -104,7 +104,7 @@ pub fn test_single_address_for_prod_discrimination() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -124,7 +124,7 @@ pub fn test_account_address_for_prod_discrimination() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -139,7 +139,7 @@ pub fn test_utxo_address_made_of_incorrect_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let mut public_key = jcli.key().into_public(&private_key);
+    let mut public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     public_key.push('A');
@@ -160,7 +160,7 @@ pub fn test_delegation_address_made_of_random_string() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_key = "adfasdfasdfdasfasdfadfasdf";
@@ -181,12 +181,12 @@ pub fn test_delegation_address_made_of_incorrect_public_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let mut public_key = jcli.key().into_public(&private_key);
+    let mut public_key = jcli.key().into_public_string(&private_key);
     println!("public key: {}", &public_key);
 
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private delegation key: {}", &private_key);
-    let delegation_key = jcli.key().into_public(&private_key);
+    let delegation_key = jcli.key().into_public_string(&private_key);
     println!("delegation key: {}", &delegation_key);
 
     public_key.push('A');

--- a/testing/jormungandr-integration-tests/src/jcli/address/single.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/single.rs
@@ -8,7 +8,7 @@ pub fn test_utxo_address_made_of_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     let utxo_address = jcli
@@ -28,14 +28,14 @@ pub fn test_delegation_address_made_of_ed25519_extended_seed_key() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     let private_key = jcli
         .key()
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private delegation key: {}", &private_key);
-    let delegation_key = jcli.key().to_public(&private_key);
+    let delegation_key = jcli.key().into_public(&private_key);
     println!("delegation key: {}", &delegation_key);
 
     let delegation_address =
@@ -58,7 +58,7 @@ pub fn test_delegation_address_is_the_same_as_public() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -81,7 +81,7 @@ pub fn test_delegation_address_for_prod_discrimination() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -104,7 +104,7 @@ pub fn test_single_address_for_prod_discrimination() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -124,7 +124,7 @@ pub fn test_account_address_for_prod_discrimination() {
         .generate_with_seed("ed25519Extended", &correct_seed);
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_address =
@@ -139,7 +139,7 @@ pub fn test_utxo_address_made_of_incorrect_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let mut public_key = jcli.key().to_public(&private_key);
+    let mut public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     public_key.push('A');
@@ -160,7 +160,7 @@ pub fn test_delegation_address_made_of_random_string() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     let delegation_key = "adfasdfasdfdasfasdfadfasdf";
@@ -181,12 +181,12 @@ pub fn test_delegation_address_made_of_incorrect_public_ed25519_extended_key() {
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private key: {}", &private_key);
 
-    let mut public_key = jcli.key().to_public(&private_key);
+    let mut public_key = jcli.key().into_public(&private_key);
     println!("public key: {}", &public_key);
 
     let private_key = jcli.key().generate("ed25519Extended");
     println!("private delegation key: {}", &private_key);
-    let delegation_key = jcli.key().to_public(&private_key);
+    let delegation_key = jcli.key().into_public(&private_key);
     println!("delegation key: {}", &delegation_key);
 
     public_key.push('A');

--- a/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -103,7 +103,7 @@ pub fn test_genesis_for_prod_with_initial_funds_for_testing_address_fail_to_buil
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate_default();
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     let test_address = jcli
         .address()
         .single(&public_key, None, Discrimination::Test);

--- a/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -103,7 +103,7 @@ pub fn test_genesis_for_prod_with_initial_funds_for_testing_address_fail_to_buil
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate_default();
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     let test_address = jcli
         .address()
         .single(&public_key, None, Discrimination::Test);

--- a/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/genesis/encode.rs
@@ -103,7 +103,7 @@ pub fn test_genesis_for_prod_with_initial_funds_for_testing_address_fail_to_buil
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate_default();
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     let test_address = jcli
         .address()
         .single(&public_key, None, Discrimination::Test);

--- a/testing/jormungandr-integration-tests/src/jcli/key/from_bytes.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/from_bytes.rs
@@ -28,7 +28,7 @@ fn transform_key_to_bytes_and_back(key_type: &str) {
     let private_key = jcli.key().generate(key_type);
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     jcli.key().to_bytes(&private_key, byte_key_file.path());
-    let key_after_transformation = jcli.key().from_bytes(key_type, byte_key_file.path());
+    let key_after_transformation = jcli.key().into_bytes(key_type, byte_key_file.path());
 
     assert_eq!(
         &private_key, &key_after_transformation,

--- a/testing/jormungandr-integration-tests/src/jcli/key/from_bytes.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/from_bytes.rs
@@ -27,8 +27,9 @@ fn transform_key_to_bytes_and_back(key_type: &str) {
 
     let private_key = jcli.key().generate(key_type);
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
-    jcli.key().to_bytes(&private_key, byte_key_file.path());
-    let key_after_transformation = jcli.key().into_bytes(key_type, byte_key_file.path());
+    jcli.key()
+        .convert_to_string(&private_key, byte_key_file.path());
+    let key_after_transformation = jcli.key().convert_to_string(key_type, byte_key_file.path());
 
     assert_eq!(
         &private_key, &key_after_transformation,
@@ -43,7 +44,7 @@ pub fn test_from_bytes_for_invalid_key() {
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     byte_key_file.write_str(
         "ed25519e_sk1kp80gevhccz8cnst6x97rmlc9n5fls2nmcqcjfn65vdktt0wy9f3zcf76hp7detq9sz8cmhlcyzw5h3ralf98rdwl4wcwcgaaqna3pgz9qgk0").unwrap();
-    jcli.key().from_bytes_expect_fail(
+    jcli.key().convert_to_string_expect_fail(
         "ed25519Extended",
         byte_key_file.path(),
         "Odd number of digits",
@@ -56,7 +57,7 @@ pub fn test_from_bytes_for_unknown_key() {
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     byte_key_file.write_str(
         "ed25519e_sk1kp80gevhccz8cnst6x97rmlc9n5fls2nmcqcjfn65vdktt0wy9f3zcf76hp7detq9sz8cmhlcyzw5h3ralf98rdwl4wcwcgaaqna3pgz9qgk0").unwrap();
-    jcli.key().from_bytes_expect_fail(
+    jcli.key().convert_to_string_expect_fail(
         "ed25519Exten",
         byte_key_file.path(),
         "Invalid value for '--type <key-type>':",

--- a/testing/jormungandr-integration-tests/src/jcli/key/from_bytes.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/from_bytes.rs
@@ -28,8 +28,10 @@ fn transform_key_to_bytes_and_back(key_type: &str) {
     let private_key = jcli.key().generate(key_type);
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     jcli.key()
-        .convert_to_string(&private_key, byte_key_file.path());
-    let key_after_transformation = jcli.key().convert_to_string(key_type, byte_key_file.path());
+        .dump_bytes_to_file(&private_key, byte_key_file.path());
+    let key_after_transformation = jcli
+        .key()
+        .convert_to_bytes_string(key_type, byte_key_file.path());
 
     assert_eq!(
         &private_key, &key_after_transformation,
@@ -44,7 +46,7 @@ pub fn test_from_bytes_for_invalid_key() {
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     byte_key_file.write_str(
         "ed25519e_sk1kp80gevhccz8cnst6x97rmlc9n5fls2nmcqcjfn65vdktt0wy9f3zcf76hp7detq9sz8cmhlcyzw5h3ralf98rdwl4wcwcgaaqna3pgz9qgk0").unwrap();
-    jcli.key().convert_to_string_expect_fail(
+    jcli.key().convert_to_bytes_string_expect_fail(
         "ed25519Extended",
         byte_key_file.path(),
         "Odd number of digits",
@@ -57,7 +59,7 @@ pub fn test_from_bytes_for_unknown_key() {
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     byte_key_file.write_str(
         "ed25519e_sk1kp80gevhccz8cnst6x97rmlc9n5fls2nmcqcjfn65vdktt0wy9f3zcf76hp7detq9sz8cmhlcyzw5h3ralf98rdwl4wcwcgaaqna3pgz9qgk0").unwrap();
-    jcli.key().convert_to_string_expect_fail(
+    jcli.key().convert_to_bytes_string_expect_fail(
         "ed25519Exten",
         byte_key_file.path(),
         "Invalid value for '--type <key-type>':",

--- a/testing/jormungandr-integration-tests/src/jcli/key/from_bytes.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/from_bytes.rs
@@ -31,7 +31,7 @@ fn transform_key_to_bytes_and_back(key_type: &str) {
         .dump_bytes_to_file(&private_key, byte_key_file.path());
     let key_after_transformation = jcli
         .key()
-        .convert_to_bytes_string(key_type, byte_key_file.path());
+        .convert_from_bytes_string(key_type, byte_key_file.path());
 
     assert_eq!(
         &private_key, &key_after_transformation,
@@ -46,7 +46,7 @@ pub fn test_from_bytes_for_invalid_key() {
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     byte_key_file.write_str(
         "ed25519e_sk1kp80gevhccz8cnst6x97rmlc9n5fls2nmcqcjfn65vdktt0wy9f3zcf76hp7detq9sz8cmhlcyzw5h3ralf98rdwl4wcwcgaaqna3pgz9qgk0").unwrap();
-    jcli.key().convert_to_bytes_string_expect_fail(
+    jcli.key().convert_from_bytes_string_expect_fail(
         "ed25519Extended",
         byte_key_file.path(),
         "Odd number of digits",
@@ -59,7 +59,7 @@ pub fn test_from_bytes_for_unknown_key() {
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     byte_key_file.write_str(
         "ed25519e_sk1kp80gevhccz8cnst6x97rmlc9n5fls2nmcqcjfn65vdktt0wy9f3zcf76hp7detq9sz8cmhlcyzw5h3ralf98rdwl4wcwcgaaqna3pgz9qgk0").unwrap();
-    jcli.key().convert_to_bytes_string_expect_fail(
+    jcli.key().convert_from_bytes_string_expect_fail(
         "ed25519Exten",
         byte_key_file.path(),
         "Invalid value for '--type <key-type>':",

--- a/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
@@ -39,7 +39,7 @@ pub fn test_to_bytes_for_invalid_key() {
     let byte_key_file = temp_dir.child("byte_file");
     byte_key_file.write_str("ed25519e_sk1kp80gevhccz8cnst6x97rmlc9n5fls2nmcqcjfn65vdktt0wy9f3zcf76hp7detq9sz8cmhlcyzw5h3ralf98rdwl4wcwcgaaqna3pgz9qgk0").unwrap();
     let output_file = temp_dir.child("output_byte_file");
-    jcli.key().copy_bytes_to_file_expect_fail(
+    jcli.key().convert_to_bytes_file_expect_fail(
         byte_key_file.path(),
         output_file.path(),
         "invalid Bech32",

--- a/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
@@ -12,7 +12,7 @@ pub fn test_key_from_and_to_bytes() {
         .dump_bytes_to_file(&private_key, byte_key_file.path());
     let key_after_transformation = jcli
         .key()
-        .convert_to_bytes_string("Ed25519Extended", byte_key_file.path());
+        .convert_from_bytes_string("Ed25519Extended", byte_key_file.path());
 
     assert_eq!(
         &private_key, &key_after_transformation,
@@ -25,8 +25,11 @@ pub fn test_key_from_and_to_bytes() {
 pub fn test_to_bytes_for_non_existent_input_file() {
     let jcli: JCli = Default::default();
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
-    jcli.key()
-        .convert_to_bytes_string_expect_fail("ed25519Extended", byte_key_file.path(), "file");
+    jcli.key().convert_from_bytes_string_expect_fail(
+        "ed25519Extended",
+        byte_key_file.path(),
+        "file",
+    );
 }
 
 #[test]

--- a/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
@@ -11,7 +11,7 @@ pub fn test_key_from_and_to_bytes() {
     jcli.key().to_bytes(&private_key, byte_key_file.path());
     let key_after_transformation = jcli
         .key()
-        .from_bytes("Ed25519Extended", byte_key_file.path());
+        .into_bytes("Ed25519Extended", byte_key_file.path());
 
     assert_eq!(
         &private_key, &key_after_transformation,
@@ -36,5 +36,5 @@ pub fn test_to_bytes_for_invalid_key() {
     byte_key_file.write_str("ed25519e_sk1kp80gevhccz8cnst6x97rmlc9n5fls2nmcqcjfn65vdktt0wy9f3zcf76hp7detq9sz8cmhlcyzw5h3ralf98rdwl4wcwcgaaqna3pgz9qgk0").unwrap();
     let output_file = temp_dir.child("output_byte_file");
     jcli.key()
-        .to_bytes_expect_fail(byte_key_file.path(), output_file.path(), "invalid Bech32");
+        .into_bytes_expect_fail(byte_key_file.path(), output_file.path(), "invalid Bech32");
 }

--- a/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
@@ -8,10 +8,11 @@ pub fn test_key_from_and_to_bytes() {
     let jcli: JCli = Default::default();
     let private_key = jcli.key().generate("Ed25519Extended");
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
-    jcli.key().to_bytes(&private_key, byte_key_file.path());
+    jcli.key()
+        .convert_to_string(&private_key, byte_key_file.path());
     let key_after_transformation = jcli
         .key()
-        .into_bytes("Ed25519Extended", byte_key_file.path());
+        .convert_to_string("Ed25519Extended", byte_key_file.path());
 
     assert_eq!(
         &private_key, &key_after_transformation,
@@ -25,7 +26,7 @@ pub fn test_to_bytes_for_non_existent_input_file() {
     let jcli: JCli = Default::default();
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     jcli.key()
-        .from_bytes_expect_fail("ed25519Extended", byte_key_file.path(), "file");
+        .convert_to_string_expect_fail("ed25519Extended", byte_key_file.path(), "file");
 }
 
 #[test]
@@ -35,6 +36,9 @@ pub fn test_to_bytes_for_invalid_key() {
     let byte_key_file = temp_dir.child("byte_file");
     byte_key_file.write_str("ed25519e_sk1kp80gevhccz8cnst6x97rmlc9n5fls2nmcqcjfn65vdktt0wy9f3zcf76hp7detq9sz8cmhlcyzw5h3ralf98rdwl4wcwcgaaqna3pgz9qgk0").unwrap();
     let output_file = temp_dir.child("output_byte_file");
-    jcli.key()
-        .into_bytes_expect_fail(byte_key_file.path(), output_file.path(), "invalid Bech32");
+    jcli.key().copy_bytes_to_file_expect_fail(
+        byte_key_file.path(),
+        output_file.path(),
+        "invalid Bech32",
+    );
 }

--- a/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/to_bytes.rs
@@ -9,10 +9,10 @@ pub fn test_key_from_and_to_bytes() {
     let private_key = jcli.key().generate("Ed25519Extended");
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     jcli.key()
-        .convert_to_string(&private_key, byte_key_file.path());
+        .dump_bytes_to_file(&private_key, byte_key_file.path());
     let key_after_transformation = jcli
         .key()
-        .convert_to_string("Ed25519Extended", byte_key_file.path());
+        .convert_to_bytes_string("Ed25519Extended", byte_key_file.path());
 
     assert_eq!(
         &private_key, &key_after_transformation,
@@ -26,7 +26,7 @@ pub fn test_to_bytes_for_non_existent_input_file() {
     let jcli: JCli = Default::default();
     let byte_key_file = NamedTempFile::new("byte_file").unwrap();
     jcli.key()
-        .convert_to_string_expect_fail("ed25519Extended", byte_key_file.path(), "file");
+        .convert_to_bytes_string_expect_fail("ed25519Extended", byte_key_file.path(), "file");
 }
 
 #[test]

--- a/testing/jormungandr-integration-tests/src/jcli/key/to_public.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/to_public.rs
@@ -4,14 +4,14 @@ use crate::common::jcli::JCli;
 pub fn test_key_to_public() {
     let jcli: JCli = Default::default();
     let private_key = "ed25519_sk1357nu8uaxvdekg6uhqmdd0zcd3tjv3qq0p2029uk6pvfxuks5rzstp5ceq";
-    let public_key = jcli.key().into_public_string(private_key.to_owned());
+    let public_key = jcli.key().convert_to_public_string(private_key.to_owned());
     assert_ne!(public_key, "", "generated key is empty");
 }
 
 #[test]
 pub fn test_key_to_public_invalid_key() {
     let jcli: JCli = Default::default();
-    jcli.key().into_public_expect_fail(
+    jcli.key().convert_to_public_string_expect_fail(
         "ed2551ssss9_sk1357nu8uaxvdekg6uhqmdd0zcd3tjv3qq0p2029uk6pvfxuks5rzstp5ceq",
         "invalid checksum",
     );
@@ -20,7 +20,7 @@ pub fn test_key_to_public_invalid_key() {
 #[test]
 pub fn test_key_to_public_invalid_chars_key() {
     let jcli: JCli = Default::default();
-    jcli.key().into_public_expect_fail(
+    jcli.key().convert_to_public_string_expect_fail(
         "node:: ed2551ssss9_sk1357nu8uaxvdekg6uhqmdd0zcd3tjv3qq0p2029uk6pvfxuks5rzstp5ceq",
         "invalid character",
     );
@@ -30,6 +30,6 @@ pub fn test_key_to_public_invalid_chars_key() {
 pub fn test_private_key_to_public_key() {
     let jcli: JCli = Default::default();
     let private_key = jcli.key().generate("Ed25519Extended");
-    let public_key = jcli.key().into_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(&private_key);
     assert_ne!(public_key, "", "generated key is empty");
 }

--- a/testing/jormungandr-integration-tests/src/jcli/key/to_public.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/to_public.rs
@@ -4,14 +4,14 @@ use crate::common::jcli::JCli;
 pub fn test_key_to_public() {
     let jcli: JCli = Default::default();
     let private_key = "ed25519_sk1357nu8uaxvdekg6uhqmdd0zcd3tjv3qq0p2029uk6pvfxuks5rzstp5ceq";
-    let public_key = jcli.key().to_public(private_key.to_owned());
+    let public_key = jcli.key().into_public(private_key.to_owned());
     assert_ne!(public_key, "", "generated key is empty");
 }
 
 #[test]
 pub fn test_key_to_public_invalid_key() {
     let jcli: JCli = Default::default();
-    jcli.key().to_public_expect_fail(
+    jcli.key().into_public_expect_fail(
         "ed2551ssss9_sk1357nu8uaxvdekg6uhqmdd0zcd3tjv3qq0p2029uk6pvfxuks5rzstp5ceq",
         "invalid checksum",
     );
@@ -20,7 +20,7 @@ pub fn test_key_to_public_invalid_key() {
 #[test]
 pub fn test_key_to_public_invalid_chars_key() {
     let jcli: JCli = Default::default();
-    jcli.key().to_public_expect_fail(
+    jcli.key().into_public_expect_fail(
         "node:: ed2551ssss9_sk1357nu8uaxvdekg6uhqmdd0zcd3tjv3qq0p2029uk6pvfxuks5rzstp5ceq",
         "invalid character",
     );
@@ -30,6 +30,6 @@ pub fn test_key_to_public_invalid_chars_key() {
 pub fn test_private_key_to_public_key() {
     let jcli: JCli = Default::default();
     let private_key = jcli.key().generate("Ed25519Extended");
-    let public_key = jcli.key().to_public(&private_key);
+    let public_key = jcli.key().into_public(&private_key);
     assert_ne!(public_key, "", "generated key is empty");
 }

--- a/testing/jormungandr-integration-tests/src/jcli/key/to_public.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/to_public.rs
@@ -4,7 +4,7 @@ use crate::common::jcli::JCli;
 pub fn test_key_to_public() {
     let jcli: JCli = Default::default();
     let private_key = "ed25519_sk1357nu8uaxvdekg6uhqmdd0zcd3tjv3qq0p2029uk6pvfxuks5rzstp5ceq";
-    let public_key = jcli.key().into_public(private_key.to_owned());
+    let public_key = jcli.key().into_public_string(private_key.to_owned());
     assert_ne!(public_key, "", "generated key is empty");
 }
 
@@ -30,6 +30,6 @@ pub fn test_key_to_public_invalid_chars_key() {
 pub fn test_private_key_to_public_key() {
     let jcli: JCli = Default::default();
     let private_key = jcli.key().generate("Ed25519Extended");
-    let public_key = jcli.key().into_public(&private_key);
+    let public_key = jcli.key().into_public_string(&private_key);
     assert_ne!(public_key, "", "generated key is empty");
 }

--- a/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
@@ -33,10 +33,10 @@ pub fn test_legacy_node_all_fragments() {
 
     let config = ConfigurationBuilder::new()
         .with_funds(vec![
-            first_stake_pool_owner.into_initial_fund(1_000_000),
-            second_stake_pool_owner.into_initial_fund(2_000_000),
-            full_delegator.into_initial_fund(2_000_000),
-            split_delegator.into_initial_fund(2_000_000),
+            first_stake_pool_owner.to_initial_fund(1_000_000),
+            second_stake_pool_owner.to_initial_fund(2_000_000),
+            full_delegator.to_initial_fund(2_000_000),
+            split_delegator.to_initial_fund(2_000_000),
         ])
         .build(&temp_dir);
 

--- a/testing/jormungandr-integration-tests/src/jormungandr/vit/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/vit/mod.rs
@@ -131,7 +131,7 @@ pub fn test_vote_flow_bft() {
         .with_funds(
             wallets
                 .iter()
-                .map(|x| x.into_initial_fund(initial_fund_per_wallet))
+                .map(|x| x.to_initial_fund(initial_fund_per_wallet))
                 .collect(),
         )
         .with_committees(&wallets)
@@ -322,9 +322,9 @@ pub fn jcli_e2e_flow() {
     let config = ConfigurationBuilder::new()
         .with_explorer()
         .with_funds(vec![
-            alice.into_initial_fund(1_000_000),
-            bob.into_initial_fund(1_000_000),
-            clarice.into_initial_fund(1_000_000),
+            alice.to_initial_fund(1_000_000),
+            bob.to_initial_fund(1_000_000),
+            clarice.to_initial_fund(1_000_000),
         ])
         .with_block0_consensus(ConsensusType::Bft)
         .with_kes_update_speed(KESUpdateSpeed::new(43200).unwrap())

--- a/testing/jormungandr-integration-tests/src/non_functional/compatibility.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/compatibility.rs
@@ -93,8 +93,8 @@ fn test_upgrade_and_downgrade_from_legacy_to_master(version: Version, temp_dir: 
 
     let config = ConfigurationBuilder::new()
         .with_funds(vec![
-            sender.into_initial_fund(1_000_000),
-            receiver.into_initial_fund(1_000_000),
+            sender.to_initial_fund(1_000_000),
+            receiver.to_initial_fund(1_000_000),
         ])
         .with_storage(&temp_dir.child("storage"))
         .build(temp_dir);

--- a/testing/jormungandr-scenario-tests/src/interactive/args/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/mod.rs
@@ -77,13 +77,13 @@ impl<'a> UserInteractionController<'a> {
             .iter()
             .cloned()
             .find(|x| x.address() == to_address)
-            .unwrap_or_else(|| panic!(format!("cannot find wallet with alias: {}", to_str)));
+            .unwrap_or_else(|| panic!("cannot find wallet with alias: {}", to_str));
 
         let mut temp_wallets = self.wallets_mut().clone();
         let from = temp_wallets
             .iter_mut()
             .find(|x| x.address() == from_address)
-            .unwrap_or_else(|| panic!(format!("cannot find wallet with alias: {}", from_str)));
+            .unwrap_or_else(|| panic!("cannot find wallet with alias: {}", from_str));
 
         let check = self
             .controller

--- a/testing/jormungandr-scenario-tests/src/interactive/args/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/mod.rs
@@ -77,13 +77,13 @@ impl<'a> UserInteractionController<'a> {
             .iter()
             .cloned()
             .find(|x| x.address() == to_address)
-            .expect(&format!("cannot find wallet with alias: {}", to_str));
+            .unwrap_or_else(|| panic!(format!("cannot find wallet with alias: {}", to_str)));
 
         let mut temp_wallets = self.wallets_mut().clone();
         let from = temp_wallets
             .iter_mut()
             .find(|x| x.address() == from_address)
-            .expect(&format!("cannot find wallet with alias: {}", from_str));
+            .unwrap_or_else(|| panic!(format!("cannot find wallet with alias: {}", from_str)));
 
         let check = self
             .controller

--- a/testing/jormungandr-scenario-tests/src/interactive/args/send.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/send.rs
@@ -73,9 +73,9 @@ impl SendTransaction {
             return Ok(());
         }
 
-        Err(InteractiveCommandError::UserError(format!(
-            "alias not found {}",
-            self.via.clone()
-        )))?
+        Err(
+            InteractiveCommandError::UserError(format!("alias not found {}", self.via.clone()))
+                .into(),
+        )
     }
 }

--- a/testing/jormungandr-scenario-tests/src/interactive/args/spawn.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/spawn.rs
@@ -88,7 +88,7 @@ fn spawn_node(
         let legacy_release = releases
             .iter()
             .find(|x| x.version() == version)
-            .ok_or(InteractiveCommandError::UserError(version.to_string()))?;
+            .ok_or_else(|| InteractiveCommandError::UserError(version.to_string()))?;
 
         let node = controller
             .controller_mut()

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -535,6 +535,7 @@ impl LegacyNode {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn<R: RngCore>(
         jormungandr: &Path,
         context: &Context<R>,
@@ -569,7 +570,7 @@ impl LegacyNode {
             },
             LogEntry {
                 format: format.to_string(),
-                level: level.to_string(),
+                level,
                 output: LogOutput::File(log_file),
             },
         ]));

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -536,6 +536,7 @@ impl Node {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn<R: RngCore>(
         jormungandr: &Path,
         context: &Context<R>,
@@ -570,7 +571,7 @@ impl Node {
             },
             LogEntry {
                 format: format.to_string(),
-                level: level.to_string(),
+                level,
                 output: LogOutput::File(log_file),
             },
         ]));
@@ -624,12 +625,9 @@ impl Node {
         let process = command.spawn().map_err(Error::CannotSpawnNode)?;
 
         let node = Node {
-            alias: alias.clone().into(),
-
+            alias: alias.into(),
             dir,
-
             process,
-
             progress_bar,
             node_settings: node_settings.clone(),
             status: Arc::new(Mutex::new(Status::Running)),

--- a/testing/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -189,7 +189,7 @@ impl Controller {
 
     pub fn stake_pool(&mut self, node_alias: &str) -> Result<StakePool> {
         if let Some(stake_pool) = self.settings.stake_pools.get(node_alias) {
-            Ok(stake_pool.clone().into())
+            Ok(stake_pool.clone())
         } else {
             Err(ErrorKind::StakePoolNotFound(node_alias.to_owned()).into())
         }
@@ -205,7 +205,7 @@ impl Controller {
 
     pub fn vote_plan(&self, alias: &str) -> Result<VotePlanDef> {
         if let Some(vote_plan) = self.blockchain.vote_plan(alias) {
-            Ok(vote_plan.clone().into())
+            Ok(vote_plan)
         } else {
             Err(ErrorKind::VotePlanNotFound(alias.to_owned()).into())
         }
@@ -463,7 +463,7 @@ impl Controller {
         let mut builder = FragmentSenderSetupBuilder::from(setup);
         let root_dir: PathBuf = PathBuf::from(self.working_directory().path());
         builder.dump_fragments_into(root_dir.join("fragments"));
-        let hash = Hash::from_hash(self.block0_hash.clone());
+        let hash = Hash::from_hash(self.block0_hash);
 
         FragmentSender::new(
             hash,

--- a/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
@@ -130,10 +130,10 @@ impl ScenariosRepository {
             .iter()
             .find(|x| x.name() == scenario_name)
             .unwrap_or_else(|| {
-                panic!(format!(
+                panic!(
                     "Cannot find scenario '{}' under the tag '{:?}'. Available are: {:?}",
                     scenario_name, self.tag, scenarios_to_run
-                ))
+                )
             });
         let scenario_to_run = scenario.method();
 

--- a/testing/jormungandr-scenario-tests/src/scenario/repository/result.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/result.rs
@@ -30,24 +30,15 @@ impl ScenarioResult {
     }
 
     pub fn is_failed(&self) -> bool {
-        match *self.scenario_status() {
-            ScenarioStatus::Failed { .. } => true,
-            _ => false,
-        }
+        matches!(*self.scenario_status(), ScenarioStatus::Failed { .. })
     }
 
     pub fn is_ignored(&self) -> bool {
-        match *self.scenario_status() {
-            ScenarioStatus::Ignored => true,
-            _ => false,
-        }
+        matches!(*self.scenario_status(), ScenarioStatus::Ignored)
     }
 
     pub fn is_passed(&self) -> bool {
-        match *self.scenario_status() {
-            ScenarioStatus::Passed => true,
-            _ => false,
-        }
+        matches!(*self.scenario_status(), ScenarioStatus::Passed)
     }
 
     pub fn from_result(

--- a/testing/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -141,7 +141,6 @@ impl PrepareSettings for Settings {
         RNG: RngCore + CryptoRng,
     {
         let nodes = topology
-            .clone()
             .into_iter()
             .map(|(alias, template)| {
                 (

--- a/testing/jormungandr-scenario-tests/src/test/features/explorer.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/explorer.rs
@@ -59,14 +59,12 @@ pub fn passive_node_explorer(mut context: Context<ChaChaRng>) -> Result<Scenario
     passive.wait_for_bootstrap()?;
 
     let mut alice = controller.wallet("alice")?;
-    let mut bob = controller.wallet("bob")?;
+    let bob = controller.wallet("bob")?;
 
-    let mem_pool_check = controller.fragment_sender().send_transaction(
-        &mut alice,
-        &mut bob,
-        &leader_1,
-        1_000.into(),
-    )?;
+    let mem_pool_check =
+        controller
+            .fragment_sender()
+            .send_transaction(&mut alice, &bob, &leader_1, 1_000.into())?;
 
     // give some time to update explorer
     jortestkit::process::sleep(60);

--- a/testing/jormungandr-scenario-tests/src/test/features/leadership_log.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/leadership_log.rs
@@ -61,7 +61,7 @@ pub fn leader_restart_preserves_leadership_log(
 
     // logs during epoch 0 should be empty
     utils::assert(
-        leader_2.leadership_log()?.len() > 0,
+        !leader_2.leadership_log()?.is_empty(),
         "leadeship log should NOT be empty in current epoch",
     )?;
 
@@ -71,7 +71,7 @@ pub fn leader_restart_preserves_leadership_log(
 
     // logs during epoch 0 should be empty
     utils::assert(
-        leader_2.leadership_log()?.len() > 0,
+        !leader_2.leadership_log()?.is_empty(),
         "leadeship log should NOT be empty in new epoch",
     )?;
 

--- a/testing/jormungandr-scenario-tests/src/test/features/p2p/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/p2p/mod.rs
@@ -71,7 +71,7 @@ pub fn assert_are_in_network_view(
         utils::assert(
             network_view
                 .iter()
-                .any(|address| address.to_string() == peer.address().to_string()),
+                .any(|address| *address == peer.address().to_string()),
             &format!(
                 "{}: Peer {} is not present in network view list",
                 info,

--- a/testing/jormungandr-scenario-tests/src/test/features/vote.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/vote.rs
@@ -156,7 +156,7 @@ pub fn vote_e2e_flow(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> 
     let mut alice = controller.wallet("Alice")?;
     controller.fragment_sender().send_vote_tally(
         &mut alice,
-        &fund1_vote_plan.clone().into(),
+        &fund1_vote_plan.into(),
         &wallet_node,
     )?;
 

--- a/testing/jormungandr-scenario-tests/src/test/legacy/disruption.rs
+++ b/testing/jormungandr-scenario-tests/src/test/legacy/disruption.rs
@@ -367,7 +367,7 @@ pub fn newest_node_enters_legacy_network(
         controller
             .new_spawn_params(LEADER_4)
             .persistence_mode(PersistenceMode::Persistent)
-            .jormungandr(legacy_app.clone()),
+            .jormungandr(legacy_app),
         &last_release.version(),
     )?;
     old_leader4.wait_for_bootstrap()?;

--- a/testing/jormungandr-scenario-tests/src/vit_station/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/vit_station/controller.rs
@@ -110,7 +110,7 @@ impl VitStationController {
     }
 
     pub fn address(&self) -> SocketAddr {
-        self.settings.address.clone()
+        self.settings.address
     }
 
     pub fn proposals(&self) -> Result<Vec<Proposal>> {
@@ -153,11 +153,11 @@ impl VitStation {
     }
 
     pub fn address(&self) -> SocketAddr {
-        self.settings.address.clone()
+        self.settings.address
     }
 
     pub fn controller(self) -> VitStationController {
-        let rest_uri = uri_from_socket_addr(self.settings.address.clone());
+        let rest_uri = uri_from_socket_addr(self.settings.address);
 
         VitStationController {
             alias: self.alias().clone(),
@@ -202,7 +202,7 @@ impl VitStation {
             .build();
 
         let vit_station = VitStation {
-            alias: alias.clone().into(),
+            alias: alias.into(),
             process: command.spawn().unwrap(),
             progress_bar,
             settings,

--- a/testing/jormungandr-scenario-tests/src/vit_station/data.rs
+++ b/testing/jormungandr-scenario-tests/src/vit_station/data.rs
@@ -15,6 +15,7 @@ impl DbGenerator {
         Self { vote_plans }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn to_vote_plan(vote_plan_def: &VotePlanDef) -> VotePlan {
         vote_plan_def.clone().into()
     }
@@ -23,7 +24,7 @@ impl DbGenerator {
         std::fs::File::create(&db_file).unwrap();
 
         let snapshot = Generator::new().snapshot();
-        let mut snapshot_proposals = snapshot.proposals().clone();
+        let mut snapshot_proposals = snapshot.proposals();
 
         for (_, vote_plan) in self.vote_plans.iter().enumerate() {
             for (index, proposal) in vote_plan.proposals().iter().enumerate() {

--- a/testing/jormungandr-scenario-tests/src/wallet/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/wallet/mod.rs
@@ -150,7 +150,7 @@ impl WalletProxy {
             context.progress_bar_mode(),
         );
 
-        settings.node_backend_address = Some(node_setting.config().rest.listen.clone());
+        settings.node_backend_address = Some(node_setting.config().rest.listen);
 
         let mut command = Command::new("iapyx-proxy");
         command
@@ -164,7 +164,7 @@ impl WalletProxy {
             .arg(block0.to_str().unwrap());
 
         let wallet_proxy = WalletProxy {
-            alias: alias.clone().into(),
+            alias: alias.into(),
             process: command.spawn().unwrap(),
             progress_bar,
             settings,

--- a/testing/jormungandr-scenario-tests/src/wallet/settings.rs
+++ b/testing/jormungandr-scenario-tests/src/wallet/settings.rs
@@ -22,7 +22,7 @@ impl PrepareWalletProxySettings for WalletProxySettings {
 
         WalletProxySettings {
             proxy_address: context.generate_new_rest_listen_address(),
-            vit_station_address: vit_station_settings.address.clone(),
+            vit_station_address: vit_station_settings.address,
             node_backend_address: None,
         }
     }

--- a/testing/jormungandr-testing-utils/src/lib.rs
+++ b/testing/jormungandr-testing-utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 pub mod stake_pool;
 pub mod testing;
 pub mod wallet;

--- a/testing/jormungandr-testing-utils/src/testing/fragments/load/generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/load/generator.rs
@@ -27,7 +27,7 @@ impl<'a> FragmentGenerator<'a> {
             wallets: Vec::new(),
             fragment_sender: FragmentSender::new(block_hash, fees, fragment_sender_setup),
             rand: OsRng,
-            jormungandr: jormungandr,
+            jormungandr,
             split_marker: 0,
         }
     }
@@ -81,7 +81,7 @@ impl<'a> FragmentGenerator<'a> {
 
         self.fragment_sender
             .send_transaction(&mut sender, &reciever, &self.jormungandr, 1.into())
-            .map(|x| x.fragment_id().clone())
+            .map(|x| *x.fragment_id())
             .map_err(|e| RequestFailure::General(format!("{:?}", e)))
     }
 }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/mod.rs
@@ -192,7 +192,7 @@ impl FragmentBuilder {
         let vote_cast = VoteCast::new(
             vote_plan.to_id(),
             proposal_index as u8,
-            Payload::public(choice.clone()),
+            Payload::public(*choice),
         );
         self.fragment_factory().vote_cast(&inner_wallet, vote_cast)
     }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
@@ -77,11 +77,11 @@ impl<'a> FragmentSender<'a> {
     }
 
     pub fn block0_hash(&self) -> Hash {
-        self.block0_hash.clone()
+        self.block0_hash
     }
 
     pub fn fees(&self) -> LinearFee {
-        self.fees.clone()
+        self.fees
     }
 
     pub fn clone_with_setup(&self, setup: FragmentSenderSetup<'a>) -> Self {

--- a/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
@@ -122,6 +122,12 @@ pub struct FragmentSenderSetupBuilder<'a> {
     setup: FragmentSenderSetup<'a>,
 }
 
+impl<'a> Default for FragmentSenderSetupBuilder<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> FragmentSenderSetupBuilder<'a> {
     pub fn from(setup: FragmentSenderSetup<'a>) -> Self {
         Self { setup }

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
@@ -76,15 +76,15 @@ pub struct WalletProxySettings {
 
 impl WalletProxySettings {
     pub fn base_address(&self) -> SocketAddr {
-        self.proxy_address.clone()
+        self.proxy_address
     }
 
     pub fn base_vit_address(&self) -> SocketAddr {
-        self.vit_station_address.clone()
+        self.vit_station_address
     }
 
     pub fn base_node_backend_address(&self) -> Option<SocketAddr> {
-        self.node_backend_address.clone()
+        self.node_backend_address
     }
 
     pub fn address(&self) -> String {
@@ -145,7 +145,7 @@ impl Settings {
                 initial: Vec::new(),
             },
             vit_stations,
-            wallet_proxies: wallet_proxies,
+            wallet_proxies,
             legacy_wallets: HashMap::new(),
             stake_pools: HashMap::new(),
             vote_plans: HashMap::new(),
@@ -184,11 +184,13 @@ impl Settings {
     fn populate_block0_blockchain_vote_plans(&mut self, vote_plans: Vec<VotePlanDef>) {
         let mut vote_plans_fragments = Vec::new();
         for vote_plan_def in vote_plans {
-            let owner = self.wallets.get(&vote_plan_def.owner()).expect(&format!(
-                "Owner {} of {} is unknown wallet ",
-                vote_plan_def.owner(),
-                vote_plan_def.alias()
-            ));
+            let owner = self.wallets.get(&vote_plan_def.owner()).unwrap_or_else(|| {
+                panic!(format!(
+                    "Owner {} of {} is unknown wallet ",
+                    vote_plan_def.owner(),
+                    vote_plan_def.alias()
+                ))
+            });
             let vote_plan: VotePlan = vote_plan_def.into();
             vote_plans_fragments.push(create_initial_vote_plan(
                 &vote_plan,
@@ -237,7 +239,7 @@ impl Settings {
                 let wallet = self
                     .wallets
                     .get(&committee)
-                    .expect(&format!("committee not defined {}", committee));
+                    .unwrap_or_else(|| panic!(format!("committee not defined {}", committee)));
                 committees.push(CommitteeIdDef::from(wallet.committee_id()));
             }
             committees

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
@@ -185,11 +185,11 @@ impl Settings {
         let mut vote_plans_fragments = Vec::new();
         for vote_plan_def in vote_plans {
             let owner = self.wallets.get(&vote_plan_def.owner()).unwrap_or_else(|| {
-                panic!(format!(
+                panic!(
                     "Owner {} of {} is unknown wallet ",
                     vote_plan_def.owner(),
                     vote_plan_def.alias()
-                ))
+                )
             });
             let vote_plan: VotePlan = vote_plan_def.into();
             vote_plans_fragments.push(create_initial_vote_plan(
@@ -239,7 +239,7 @@ impl Settings {
                 let wallet = self
                     .wallets
                     .get(&committee)
-                    .unwrap_or_else(|| panic!(format!("committee not defined {}", committee)));
+                    .unwrap_or_else(|| panic!("committee not defined {}", committee));
                 committees.push(CommitteeIdDef::from(wallet.committee_id()));
             }
             committees

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/topology.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/topology.rs
@@ -40,6 +40,15 @@ impl Node {
     }
 }
 
+impl IntoIterator for Topology {
+    type Item = (NodeAlias, Node);
+    type IntoIter = std::collections::hash_map::IntoIter<NodeAlias, Node>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.nodes.into_iter()
+    }
+}
+
 impl Topology {
     pub fn node<K>(&self, alias: &K) -> Option<&Node>
     where
@@ -47,10 +56,6 @@ impl Topology {
         K: Hash + Eq,
     {
         self.nodes.get(alias)
-    }
-
-    pub fn into_iter(self) -> impl Iterator<Item = (NodeAlias, Node)> {
-        self.nodes.into_iter()
     }
 
     pub fn aliases(&self) -> impl Iterator<Item = &NodeAlias> {

--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/jormungandr_config.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/jormungandr_config.rs
@@ -23,8 +23,8 @@ pub struct JormungandrParams<Conf = NodeConfig> {
     log_file_path: PathBuf,
 }
 
-#[allow(clippy::too_many_arguments)]
 impl<Conf: TestConfig> JormungandrParams<Conf> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new<Secs>(
         node_config: Conf,
         node_config_path: impl Into<PathBuf>,

--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/jormungandr_config.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/jormungandr_config.rs
@@ -23,6 +23,7 @@ pub struct JormungandrParams<Conf = NodeConfig> {
     log_file_path: PathBuf,
 }
 
+#[allow(clippy::too_many_arguments)]
 impl<Conf: TestConfig> JormungandrParams<Conf> {
     pub fn new<Secs>(
         node_config: Conf,
@@ -145,10 +146,12 @@ impl<Conf: TestConfig> JormungandrParams<Conf> {
     }
 
     pub fn block0_utxo(&self) -> Vec<UTxOInfo> {
-        let block0_bytes = std::fs::read(self.genesis_block_path()).expect(&format!(
-            "Failed to load block 0 binary file '{}'",
-            self.genesis_block_path().display()
-        ));
+        let block0_bytes = std::fs::read(self.genesis_block_path()).unwrap_or_else(|_| {
+            panic!(format!(
+                "Failed to load block 0 binary file '{}'",
+                self.genesis_block_path().display()
+            ))
+        });
         mempack::read_from_raw::<Block>(&block0_bytes)
             .unwrap_or_else(|_| {
                 panic!(

--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/jormungandr_config.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/jormungandr_config.rs
@@ -147,10 +147,10 @@ impl<Conf: TestConfig> JormungandrParams<Conf> {
 
     pub fn block0_utxo(&self) -> Vec<UTxOInfo> {
         let block0_bytes = std::fs::read(self.genesis_block_path()).unwrap_or_else(|_| {
-            panic!(format!(
+            panic!(
                 "Failed to load block 0 binary file '{}'",
                 self.genesis_block_path().display()
-            ))
+            )
         });
         mempack::read_from_raw::<Block>(&block0_bytes)
             .unwrap_or_else(|_| {

--- a/testing/jormungandr-testing-utils/src/testing/node/explorer/load/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/explorer/load/mod.rs
@@ -44,7 +44,7 @@ impl ExplorerRequestGen {
     }
 
     pub fn next_address(&mut self) -> Option<&String> {
-        if self.addresses.len() == 0 {
+        if self.addresses.is_empty() {
             return None;
         }
 
@@ -53,7 +53,7 @@ impl ExplorerRequestGen {
     }
 
     pub fn next_pool_id(&mut self) -> Option<&String> {
-        if self.stake_pools.len() == 0 {
+        if self.stake_pools.is_empty() {
             return None;
         }
 
@@ -107,7 +107,7 @@ impl RequestGenerator for ExplorerRequestGen {
                 let limit = self.next_usize_in_range(1, 1000) as i64;
                 if let Some(pool_id) = self.next_pool_id() {
                     explorer
-                        .stake_pool(pool_id.to_string(), limit.into())
+                        .stake_pool(pool_id.to_string(), limit)
                         .map(|_| ())
                         .map_err(|e| {
                             RequestFailure::General(format!(

--- a/testing/jormungandr-testing-utils/src/testing/node/explorer/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/explorer/mod.rs
@@ -57,7 +57,7 @@ impl Explorer {
     }
 
     pub fn print_request<T: Serialize>(&self, query: &QueryBody<T>) {
-        if self.print_log == false {
+        if !self.print_log {
             return;
         }
 

--- a/testing/jormungandr-testing-utils/src/testing/node/grpc/server/builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/grpc/server/builder.rs
@@ -19,12 +19,18 @@ pub struct MockBuilder {
     protocol_version: ProtocolVersion,
 }
 
+impl Default for MockBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MockBuilder {
     pub fn new() -> Self {
-        let genesis_hash: Hash = TestGen::hash().into();
+        let genesis_hash: Hash = TestGen::hash();
         Self {
             mock_port: 9999,
-            genesis_hash: genesis_hash.clone(),
+            genesis_hash,
             tip: super::data::header(30, &genesis_hash),
             protocol_version: ProtocolVersion::GenesisPraos,
         }
@@ -52,7 +58,7 @@ impl MockBuilder {
 
     fn build_data(&self) -> Arc<RwLock<MockServerData>> {
         let data = MockServerData::new(
-            self.genesis_hash.clone(),
+            self.genesis_hash,
             self.tip.clone(),
             self.protocol_version.clone(),
         );
@@ -87,5 +93,5 @@ fn start_thread(data: Arc<RwLock<MockServerData>>, mock_port: u16) -> MockContro
             .await
             .unwrap();
     });
-    MockController::new(temp_dir, logger, shutdown_signal, data.clone(), mock_port)
+    MockController::new(temp_dir, logger, shutdown_signal, data, mock_port)
 }

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/load.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/load.rs
@@ -36,7 +36,7 @@ impl RestRequestGen {
     }
 
     pub fn next_address(&mut self) -> Option<&String> {
-        if self.addresses.len() == 0 {
+        if self.addresses.is_empty() {
             return None;
         }
 
@@ -45,7 +45,7 @@ impl RestRequestGen {
     }
 
     pub fn next_pool_id(&mut self) -> Option<&String> {
-        if self.stake_pools.len() == 0 {
+        if self.stake_pools.is_empty() {
             return None;
         }
 

--- a/testing/jormungandr-testing-utils/src/testing/node/verifier.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/verifier.rs
@@ -38,7 +38,7 @@ impl JormungandrStateVerifier {
         to: &Wallet,
         value: Value,
     ) -> Result<(), StateVerifierError> {
-        self.wallet_lost_value(&from, value.clone())?;
+        self.wallet_lost_value(&from, value)?;
         self.wallet_gain_value(&to, value)?;
         Ok(())
     }
@@ -76,7 +76,7 @@ impl JormungandrStateVerifier {
             .as_ref()
             .ok_or(StateVerifierError::NoSnapshot)?;
         let expected = snapshot.value_for(wallet)?.checked_add(value)?;
-        let actual = self.rest.account_state(wallet)?.value().clone();
+        let actual = *self.rest.account_state(wallet)?.value();
         assert_eq!(
             expected, actual,
             "No value was added to account: {} vs {}",
@@ -114,7 +114,7 @@ impl StateSnapshot {
         let state = self
             .wallets
             .get(&address)
-            .ok_or(StateVerifierError::NoWalletInSnapshot(address.clone()))?;
-        Ok(state.value().clone())
+            .ok_or_else(|| StateVerifierError::NoWalletInSnapshot(address.clone()))?;
+        Ok(*state.value())
     }
 }

--- a/testing/jormungandr-testing-utils/src/testing/vit/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/vit/mod.rs
@@ -7,7 +7,6 @@ use chain_impl_mockchain::{
     value::Value,
     vote::{Options, PayloadType},
 };
-use json;
 
 pub fn proposal_with_3_options(rewards_increase: u64) -> Proposal {
     let action = VoteAction::Parameters {
@@ -19,7 +18,7 @@ pub fn proposal_with_3_options(rewards_increase: u64) -> Proposal {
     Proposal::new(
         VoteTestGen::external_proposal_id(),
         Options::new_length(3).unwrap(),
-        action.clone(),
+        action,
     )
 }
 

--- a/testing/jormungandr-testing-utils/src/wallet/mod.rs
+++ b/testing/jormungandr-testing-utils/src/wallet/mod.rs
@@ -88,7 +88,7 @@ impl Wallet {
         ))
     }
 
-    pub fn into_initial_fund(&self, value: u64) -> InitialUTxO {
+    pub fn to_initial_fund(&self, value: u64) -> InitialUTxO {
         InitialUTxO {
             address: self.address(),
             value: value.into(),


### PR DESCRIPTION
Many changes:
* Removed reduntant clones
* Use `macthes!` for boolean match
* Use `or_else` instead of `or` patterns (for lazyness)
* Removed redundant lambda functions
* ... 

Should close #2660 among with https://github.com/input-output-hk/chain-libs/pull/483