### PR TITLE
Logging improvements for network client

### DIFF
--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -124,7 +124,7 @@ impl Process {
                     "hash" => header.hash().to_string(),
                     "parent" => header.parent_id().to_string(),
                     "date" => header.block_date().to_string(),
-                    "from_node_id" => node_id.to_string()));
+                    "peer" => node_id.to_string()));
 
                 info!(logger, "received block announcement from network");
 

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -33,7 +33,7 @@ pub fn connect(state: ConnectionState, channels: Channels) -> (ConnectHandle, Co
     let peer = state.peer();
     let keypair = state.global.keypair.clone();
     let legacy_node_id = state.global.config.legacy_node_id;
-    let logger = state.logger.clone();
+    let logger = state.logger().clone();
     let cf = async move {
         let mut grpc_client = if let Some(node_id) = legacy_node_id {
             let node_id: legacy::NodeId = node_id.as_ref().try_into().unwrap();

--- a/jormungandr/src/network/client/mod.rs
+++ b/jormungandr/src/network/client/mod.rs
@@ -66,9 +66,7 @@ impl Client {
         inbound: InboundSubscriptions,
         comms: &mut PeerComms,
     ) -> Self {
-        let logger = builder
-            .logger
-            .new(o!("peer_address" => inbound.peer_address.to_string()));
+        let logger = builder.logger;
 
         let block_sink = BlockAnnouncementProcessor::new(
             builder.channels.block_box,

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -246,11 +246,11 @@ pub struct ConnectionState {
 }
 
 impl ConnectionState {
-    fn new(global: GlobalStateR, peer: &Peer) -> Self {
+    fn new(global: GlobalStateR, peer: &Peer, logger: Logger) -> Self {
         ConnectionState {
             timeout: peer.timeout,
             connection: peer.connection.clone(),
-            logger: global.logger().new(o!("peer" => peer.connection)),
+            logger,
             global,
         }
     }
@@ -496,8 +496,8 @@ fn connect_and_propagate(
         return;
     }
     let peer = Peer::new(addr);
-    let conn_state = ConnectionState::new(state.clone(), &peer);
-    let conn_logger = conn_state.logger().new(o!("peer" => node.to_string()));
+    let conn_logger = state.logger().new(o!("peer" => node.to_string()));
+    let conn_state = ConnectionState::new(state.clone(), &peer, conn_logger.clone());
     info!(conn_logger, "connecting to peer");
     let (handle, connecting) = client::connect(conn_state, channels);
     let spawn_state = state.clone();


### PR DESCRIPTION
Logging improvements:

* Deduplicate peer information, now should only log peer multiaddr.
* Log block solicitations at info level including the hash of the first block.

One behavioral change is that an empty block solicitation is now logged and then the client gets disconnected, quarantining the server.