### PR TITLE
Add block downloader service implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -267,7 +267,7 @@ checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -477,9 +477,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytecount"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39a773ba75db12126d8d383f1bdbf7eb92ea47ec27dd0557aff1fedf172764c"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
 name = "byteorder"
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "cbor_event",
  "chain-ser",
@@ -595,7 +595,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "bech32",
  "cfg-if 1.0.0",
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "chain-ser",
 ]
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "bech32",
  "cfg-if 1.0.0",
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "cardano-legacy-address",
  "cfg-if 1.0.0",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "chain-network"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "async-trait",
  "chain-crypto",
@@ -690,12 +690,12 @@ dependencies = [
 [[package]]
 name = "chain-ser"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "criterion",
  "data-pile",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "chain-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "chain-core",
  "quickcheck",
@@ -718,7 +718,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "cfg-if 1.0.0",
  "chain-core",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "chain-vote"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 dependencies = [
  "cryptoxide 0.2.1",
  "eccoxide",
@@ -1009,9 +1009,9 @@ checksum = "da24927b5b899890bcb29205436c957b7892ec3a3fbffce81d710b9611e77778"
 
 [[package]]
 name = "csv"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
 dependencies = [
  "bstr",
  "csv-core",
@@ -1058,7 +1058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b35d34eb004bf2d33c093f1c55ee77829e8654644288d3b6afd8c2d99d23729"
 dependencies = [
  "proc-macro2 1.0.24",
- "syn 1.0.51",
+ "syn 1.0.53",
  "synstructure",
 ]
 
@@ -1085,7 +1085,7 @@ checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -1131,7 +1131,7 @@ checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -1310,7 +1310,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
  "synstructure",
 ]
 
@@ -1522,7 +1522,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -1680,7 +1680,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_json",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -1692,7 +1692,7 @@ dependencies = [
  "failure",
  "graphql_client_codegen",
  "proc-macro2 1.0.24",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -1981,7 +1981,10 @@ dependencies = [
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "indexmap"
@@ -2143,6 +2146,8 @@ dependencies = [
  "parity-multiaddr",
  "pin-project 1.0.2",
  "poldercast",
+ "quickcheck",
+ "quickcheck_async",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -2378,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2425,7 +2430,7 @@ checksum = "d40af234d8e971a9d7dda93ffbcc8a44a93f17e69e3067f72ce7a6894c41d51b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -2602,7 +2607,7 @@ dependencies = [
  "migrations_internals",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -2633,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -2644,7 +2649,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log 0.4.11",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -2675,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -2773,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -3080,7 +3085,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -3168,7 +3173,7 @@ checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -3179,7 +3184,7 @@ checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -3297,7 +3302,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
  "version_check 0.9.2",
 ]
 
@@ -3380,7 +3385,7 @@ dependencies = [
  "itertools 0.8.2",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -3434,6 +3439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck_async"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247df671941313a4e255a5015772917368f1b21bfedfbd89d68fbb27e802b2fa"
+dependencies = [
+ "quote 1.0.7",
+ "syn 1.0.53",
+]
+
+[[package]]
 name = "quickcheck_macros"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,7 +3456,7 @@ checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -3782,9 +3797,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.18"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70017ed5c555d79ee3538fc63ca09c70ad8f317dcadc1adc2c496b60c22bb24f"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
@@ -3994,7 +4009,7 @@ checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4273,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 
 [[package]]
 name = "spin"
@@ -4314,7 +4329,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4332,7 +4347,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4364,9 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
+checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4381,7 +4396,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
  "unicode-xid 0.2.1",
 ]
 
@@ -4534,7 +4549,7 @@ checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4617,9 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfe2523e6fa84ddf5e688151d4e5fddc51678de9752c6512a24714c23818d61"
+checksum = "a12a3eb39ee2c231be64487f1fcbe726c8f2514876a55480a5ab8559fc374252"
 dependencies = [
  "autocfg 1.0.1",
  "pin-project-lite 0.2.0",
@@ -4655,7 +4670,7 @@ checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4718,7 +4733,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite 0.1.11",
- "tokio 0.3.4",
+ "tokio 0.3.5",
 ]
 
 [[package]]
@@ -4778,7 +4793,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "prost-build",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4980,7 +4995,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -5055,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#f39380c166ca5e38cdfa41b07acfd1a0ecbd99a0"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#5bfb3a4aeb5a7822a1eca7bf7b18e5fa536720c7"
 
 [[package]]
 name = "typenum"
@@ -5455,11 +5470,11 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -5467,26 +5482,26 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.11",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -5494,9 +5509,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -5504,28 +5519,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d1cdc8b98a557f24733d50a1199c4b0635e465eecba9c45b214544da197f64"
+checksum = "0355fa0c1f9b792a09b6dcb6a8be24d51e71e6d74972f9eb4a44c4c004d24a25"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -5537,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
+checksum = "27e07b46b98024c2ba2f9e83a10c2ef0515f057f2da299c1762a2017de80438b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -5547,9 +5562,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5557,9 +5572,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
@@ -5686,7 +5701,7 @@ checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
  "synstructure",
 ]
 

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -38,7 +38,7 @@ lazy_static = "1.4"
 linked-hash-map = "0.5"
 poldercast = { git = "https://github.com/primetype/poldercast.git" }
 multiaddr = { package = "parity-multiaddr", version = "0.9" }
-rand = "0.7"
+rand = { version = "0.7", features = [ "small_rng" ] }
 rand_chacha = "0.2.2"
 rustls = "0.19.0"
 serde = "1.0"
@@ -69,6 +69,8 @@ features = ["rustls-tls"]
 [dev-dependencies]
 rand_core = "0.5"
 tokio = { version = "^0.2", features = ["full" ] }
+quickcheck = "0.9"
+quickcheck_async = "0.1"
 
 [build-dependencies]
 versionisator = "1.0.2"

--- a/jormungandr/src/blockchain/downloader.rs
+++ b/jormungandr/src/blockchain/downloader.rs
@@ -24,7 +24,8 @@ pub enum BlockDownloaderInput<StBlocks> {
 pub enum BlockDownloaderOutput {
     RequestDownloadFromPeer {
         peer: Peer,
-        block_ids: Vec<HeaderId>,
+        start: HeaderId,
+        end: HeaderId,
     },
 }
 
@@ -537,7 +538,8 @@ where
                             output
                                 .send(BlockDownloaderOutput::RequestDownloadFromPeer {
                                     peer,
-                                    block_ids: tail,
+                                    start: tail.first().cloned().unwrap(),
+                                    end: tail.last().cloned().unwrap(),
                                 })
                                 .await
                                 .map_err(DownloadTaskError::OutputSink)?;
@@ -568,7 +570,8 @@ where
                         output
                             .send(BlockDownloaderOutput::RequestDownloadFromPeer {
                                 peer,
-                                block_ids,
+                                start: block_ids.first().cloned().unwrap(),
+                                end: block_ids.last().cloned().unwrap(),
                             })
                             .await
                             .map_err(PreDownloadTaskError::OutputSink)?;

--- a/jormungandr/src/blockchain/downloader.rs
+++ b/jormungandr/src/blockchain/downloader.rs
@@ -1,0 +1,871 @@
+use crate::utils::task::TokioServiceInfo;
+use chain_impl_mockchain::{block::Block, header::HeaderId};
+use chain_network::data::Peer;
+use futures::{channel::mpsc, prelude::*, stream};
+use rand::RngCore;
+use std::{
+    collections::HashMap,
+    error::Error,
+    fmt::Debug,
+    mem::replace,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use tokio::sync::{Mutex, RwLock, Semaphore};
+
+pub enum BlockDownloaderInput<StBlocks> {
+    IncomingBlockStream { peer: Peer, stream: StBlocks },
+    AddPeer { peer: Peer },
+    RemovePeer { peer: Peer },
+}
+
+pub enum BlockDownloaderOutput {
+    RequestDownloadFromPeer {
+        peer: Peer,
+        block_ids: Vec<HeaderId>,
+    },
+}
+
+/// This structure represents the state of a peer that we use to download new
+/// blocks. The main goal of this is to ensure than we use a peer to download
+/// only one block stream at a time.
+struct BlockDownloadSource {
+    state: Arc<RwLock<BlockDownloadSourceState>>,
+}
+
+/// The state of a peer.
+enum BlockDownloadSourceState {
+    /// No downloads are pending or in progress and this peer can be used to
+    /// download blocks from it.
+    Ready,
+    /// Pending download.
+    Waiting { block_ids: Vec<HeaderId> },
+    /// The download is currently in progress.
+    Busy,
+}
+
+#[derive(Debug)]
+pub enum DownloadError<BlockSinkError: Error + Debug> {
+    /// The current source state cannot be used to process the incoming blocks
+    /// stream.
+    WrongSourceState,
+    /// En error occurred in the block sink.
+    BlockSinkError(BlockSinkError),
+}
+
+/// This structure maintains the list of peers to download blocks from and
+/// provides the logic for selecting those peers.
+#[derive(Clone)]
+struct BlockDownloadSourceManager {
+    peers: Arc<RwLock<HashMap<Peer, BlockDownloadSource>>>,
+    // This semaphore is used to block when there is no ready peers.
+    available_peer_count_semaphore: Arc<Semaphore>,
+}
+
+/// The structure returned by `BlockDownloadSourceManager::select`. It
+/// encapsulates a `BlockDownloadSource` instance. Upon a `drop()` call it
+/// ensures that this source released back to the parent
+/// `BlockDownloadSourceManager` instance.
+struct ManagedBlockDownloadSource {
+    peer: Peer,
+    source: BlockDownloadSource,
+    peers: Arc<RwLock<HashMap<Peer, BlockDownloadSource>>>,
+    peer_count_semaphore: Arc<Semaphore>,
+}
+
+/// The top-level download control structure responsible for handling download
+/// restarts in an event of download interruption.
+#[derive(Clone, Default)]
+struct BlockDownloadTaskManager {
+    tasks: Arc<Mutex<HashMap<Peer, (mpsc::Sender<Block>, ManagedBlockDownloadSource)>>>,
+}
+
+/// Limits the number of blocks in the queue.
+#[derive(Clone)]
+struct BlockDownloadBackPressureHandler {
+    trigger: usize,
+    release: usize,
+    current_value: Arc<AtomicUsize>,
+    is_active: Arc<AtomicBool>,
+    semaphore: Arc<Semaphore>,
+}
+
+#[derive(Debug)]
+pub enum DownloadServiceError<BlockSinkError: Error + Debug> {
+    BlockSinkDead,
+    BlockSink(BlockSinkError),
+}
+
+#[derive(Debug)]
+pub enum DownloadTaskError<OutputSinkError: Error + Debug> {
+    OutputSink(OutputSinkError),
+    DownloadError(DownloadError<mpsc::SendError>),
+}
+
+#[derive(Debug)]
+pub enum PreDownloadTaskError<OutputSinkError: Error + Debug> {
+    OutputSink(OutputSinkError),
+    BlockStreamsSink(mpsc::SendError),
+}
+
+impl BlockDownloadSource {
+    fn new() -> Self {
+        Self {
+            state: Arc::new(RwLock::new(BlockDownloadSourceState::Ready)),
+        }
+    }
+
+    /// Check if this source is ready to be used for the download.
+    async fn is_ready(&self) -> bool {
+        let state = self.state.read().await;
+        if let BlockDownloadSourceState::Ready = *state {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Queue the list of block IDs for the download.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the download was queued successfully and `false` otherwise.
+    async fn start_download(&self, block_ids: Vec<HeaderId>) -> bool {
+        let mut state = self.state.write().await;
+        if let BlockDownloadSourceState::Ready = *state {
+            *state = BlockDownloadSourceState::Waiting { block_ids };
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Cancel download if it has not started yet.
+    async fn cancel_download(&self) {
+        let mut state = self.state.write().await;
+        if let BlockDownloadSourceState::Waiting { .. } = *state {
+            *state = BlockDownloadSourceState::Ready;
+        }
+    }
+
+    /// Download blocks from `block_stream` to `block_sink`. This function will
+    /// exit if the stream contains an unexpected block or just ended.
+    ///
+    /// # Returns
+    ///
+    /// The `Ok` variant is an `Option` and the number of downloaded blocks.
+    /// `None` is returned if all scheduled blocks were successfully
+    /// downloaded. Otherwise, the list of blocks that are still to be
+    /// downloaded is returned.
+    async fn process_download<St, Si>(
+        &self,
+        block_stream: St,
+        mut block_sink: Si,
+    ) -> Result<(Option<Vec<HeaderId>>, usize), DownloadError<Si::Error>>
+    where
+        St: Stream<Item = Block> + Unpin,
+        Si: Sink<Block> + Unpin,
+        Si::Error: Error,
+    {
+        // lock state only for the time of checking and changing it
+        let mut block_ids = {
+            let mut state = self.state.write().await;
+            match *state {
+                BlockDownloadSourceState::Waiting { .. } => {}
+                _ => return Err(DownloadError::WrongSourceState),
+            }
+            if let BlockDownloadSourceState::Waiting { block_ids } =
+                replace(&mut *state, BlockDownloadSourceState::Busy)
+            {
+                block_ids
+            } else {
+                unreachable!("already checked that the variant is Waiting");
+            }
+        };
+
+        let expected_block_ids_stream = stream::iter(block_ids.iter().enumerate());
+        let mut block_stream = block_stream.zip(expected_block_ids_stream);
+        let mut blocks_processed = 0;
+        while let Some((block, (i, expected_block_id))) = block_stream.next().await {
+            if block.header.id() != *expected_block_id {
+                break;
+            }
+            block_sink
+                .send(block)
+                .await
+                .map_err(DownloadError::BlockSinkError)?;
+            blocks_processed = i + 1;
+        }
+
+        let tail = block_ids.split_off(blocks_processed);
+        let result = if tail.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(tail))
+        };
+
+        let mut state = self.state.write().await;
+        *state = BlockDownloadSourceState::Ready;
+
+        result.map(|maybe_tail| (maybe_tail, block_ids.len()))
+    }
+}
+
+impl Clone for BlockDownloadSource {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl BlockDownloadSourceManager {
+    fn new() -> Self {
+        Self {
+            peers: Default::default(),
+            available_peer_count_semaphore: Arc::new(Semaphore::new(0)),
+        }
+    }
+
+    /// Add a peer to download blocks from.
+    async fn add_peer(&self, peer: Peer) {
+        let mut peers = self.peers.write().await;
+        peers.insert(peer, BlockDownloadSource::new());
+        self.available_peer_count_semaphore.add_permits(1);
+    }
+
+    /// Remove a peer. If it is currently in use, the operations will be ran
+    /// until completion.
+    async fn remove_peer(&self, peer: &Peer) {
+        let mut peers = self.peers.write().await;
+        if let Some(downloader) = peers.remove(peer) {
+            // if a peer is in `Ready` state then the semaphore is not acquired
+            // by this peer and we need to decrease the number of permits here
+            if downloader.is_ready().await {
+                self.available_peer_count_semaphore.acquire().await.forget();
+            }
+        }
+    }
+
+    /// Select the peer to download blocks. This function locks if no peers are
+    /// available to start the download.
+    ///
+    /// # Returns
+    ///
+    /// A peer identifier and a handle object to download blocks from it.
+    async fn select<R>(&self, block_ids: Vec<HeaderId>, rng: &mut R) -> ManagedBlockDownloadSource
+    where
+        R: RngCore,
+    {
+        use futures::future::join_all;
+
+        let peer_count_guard = self.available_peer_count_semaphore.acquire().await;
+        let peers = self.peers.read().await;
+        let ready_peers_flags = join_all(
+            peers
+                .iter()
+                .map(|(_peer, downloader)| downloader.is_ready()),
+        )
+        .await;
+        let n_ready_peers = ready_peers_flags.iter().filter(|x| **x).count();
+        if n_ready_peers == 0 {
+            unreachable!("the peer counting semaphore is checked before");
+        }
+        let selection = rng.next_u64() as usize % n_ready_peers;
+        let (peer, downloader) = peers
+            .iter()
+            .zip(ready_peers_flags.into_iter())
+            .filter_map(|(kv, is_ready)| if is_ready { Some(kv) } else { None })
+            .nth(selection)
+            .unwrap();
+        downloader.start_download(block_ids).await;
+        // decrease the number of permits by one until the download is finished
+        peer_count_guard.forget();
+        ManagedBlockDownloadSource {
+            peer: peer.clone(),
+            source: downloader.clone(),
+            peers: self.peers.clone(),
+            peer_count_semaphore: self.available_peer_count_semaphore.clone(),
+        }
+    }
+}
+
+impl ManagedBlockDownloadSource {
+    fn peer(&self) -> &Peer {
+        &self.peer
+    }
+
+    /// See `BlockDownloadSource::process_download`.
+    async fn process_download<St, Si>(
+        &self,
+        block_stream: St,
+        block_sink: Si,
+    ) -> Result<(Option<Vec<HeaderId>>, usize), DownloadError<Si::Error>>
+    where
+        St: Stream<Item = Block> + Unpin,
+        Si: Sink<Block> + Unpin,
+        Si::Error: Error,
+    {
+        self.source.process_download(block_stream, block_sink).await
+    }
+}
+
+impl Drop for ManagedBlockDownloadSource {
+    fn drop(&mut self) {
+        // A hack to perform Drop in an async context. We actually need to run
+        // logic to release this resource back to the manager if it was not
+        // removed from the manager before.
+        let peers = self.peers.clone();
+        let peer = self.peer.clone();
+        let peer_count_semaphore = self.peer_count_semaphore.clone();
+        let source = self.source.clone();
+        tokio::spawn(async move {
+            let peers = peers.read().await;
+            // automatically increase the peer count if this peer was not
+            // removed from the manager
+            if peers.contains_key(&peer) {
+                peer_count_semaphore.add_permits(1);
+            }
+            source.cancel_download().await;
+        });
+    }
+}
+
+impl BlockDownloadBackPressureHandler {
+    /// # Arguments
+    ///
+    /// * `trigger` - the number of pending blocks after which `.add()` will
+    ///   lock.
+    /// * `release` - the number of pending blocks after which `.add()` will
+    ///   be unlocked if it was locked.
+    ///
+    /// # Panics
+    ///
+    /// When `trigger` is less than or equal to `release`.
+    fn new(trigger: usize, release: usize) -> Self {
+        assert!(trigger > release, "`trigger` must be higher than `release`");
+        Self {
+            trigger,
+            release,
+            current_value: Arc::new(AtomicUsize::new(0)),
+            is_active: Arc::new(AtomicBool::new(false)),
+            semaphore: Arc::new(Semaphore::new(1)),
+        }
+    }
+
+    /// Add unprocessed blocks. Note that this will lock when this handler is triggered.
+    async fn add(&self, n: usize) {
+        let guard = self.semaphore.acquire().await;
+        let previous_value = self.current_value.fetch_add(n, Ordering::Relaxed);
+        if previous_value + n >= self.trigger {
+            self.is_active.store(true, Ordering::Relaxed);
+            guard.forget();
+        }
+    }
+
+    /// Reduce the number of unprocessed blocks.
+    fn sub(&self, n: usize) {
+        let previous_value = self.current_value.fetch_sub(n, Ordering::Relaxed);
+        if previous_value - n > self.release {
+            return;
+        }
+        if !self.is_active.fetch_and(false, Ordering::Relaxed) {
+            return;
+        }
+        self.semaphore.add_permits(1);
+    }
+}
+
+impl BlockDownloadTaskManager {
+    fn new() -> Self {
+        Self {
+            tasks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Create a new block download task. The task is not considered as
+    /// finished until all blocks from that task are downloaded.
+    ///
+    /// # Returns
+    ///
+    /// The id of the peer used for download that is later used to identify
+    /// this task and a stream of downloaded blocks.
+    async fn new_task<R>(
+        &self,
+        block_ids: Vec<HeaderId>,
+        manager: &BlockDownloadSourceManager,
+        rng: &mut R,
+    ) -> (Peer, impl Stream<Item = Block>)
+    where
+        R: RngCore,
+    {
+        let (block_sink, block_stream) = mpsc::channel(block_ids.len());
+        let mut tasks = self.tasks.lock().await;
+        let source = manager.select(block_ids, rng).await;
+        let peer = source.peer().clone();
+        tasks.insert(peer.clone(), (block_sink, source));
+        (peer, block_stream)
+    }
+
+    /// The overall logic is the same as in
+    /// `BlockDownloadSource::process_download`. In addition the user needs to
+    /// provide the `peer` they obtained from `new_task` and the new `peer` in
+    /// case when there are pending blocks to download.
+    async fn process_download<St, R>(
+        &self,
+        peer: Peer,
+        block_stream: St,
+        manager: &BlockDownloadSourceManager,
+        rng: &mut R,
+    ) -> Result<
+        (Option<(Peer, Vec<HeaderId>)>, usize),
+        DownloadError<<mpsc::Sender<Block> as Sink<Block>>::Error>,
+    >
+    where
+        St: Stream<Item = Block> + Unpin,
+        R: RngCore,
+    {
+        let mut tasks = self.tasks.lock().await;
+        let (block_sink, source) = if let Some(res) = tasks.remove(&peer) {
+            res
+        } else {
+            return Ok((None, 0));
+        };
+        let (maybe_tail, n_blocks_downloaded) = source
+            .process_download(block_stream, block_sink.clone())
+            .await?;
+        // A corner case: when we have only one source manager.select() will
+        // block until a new peer appears.
+        drop(source);
+        let maybe_tail = if let Some(tail) = maybe_tail {
+            let source = manager.select(tail.clone(), rng).await;
+            let peer = source.peer().clone();
+            tasks.insert(peer.clone(), (block_sink, source));
+            Some((peer, tail))
+        } else {
+            None
+        };
+        Ok((maybe_tail, n_blocks_downloaded))
+    }
+}
+
+pub async fn block_downloader_task<StInput, StIds, StBlocks, SiOutput, SiBlocks>(
+    info: TokioServiceInfo,
+    input: StInput,
+    block_ids: StIds,
+    output: SiOutput,
+    blocks: SiBlocks,
+    ids_chunk_size: usize,
+    backpressure_trigger: usize,
+    backpressure_release: usize,
+) -> Result<(), DownloadServiceError<SiBlocks::Error>>
+where
+    StInput: Stream<Item = BlockDownloaderInput<StBlocks>> + Unpin,
+    StIds: Stream<Item = HeaderId> + Unpin,
+    StBlocks: Stream<Item = Block> + Unpin + Send + 'static,
+    SiOutput: Sink<BlockDownloaderOutput> + Unpin + Clone + Send + 'static,
+    SiBlocks: Sink<Block> + Unpin,
+    SiBlocks::Error: Error + Debug,
+    SiOutput::Error: Error + Debug,
+{
+    use rand::{rngs::SmallRng, thread_rng, SeedableRng};
+
+    enum InputInner<StBlocks> {
+        Input(BlockDownloaderInput<StBlocks>),
+        BlockIdsChunk(Vec<HeaderId>),
+    }
+
+    let input = input.map(InputInner::Input).map(Ok);
+
+    let block_ids_chunked = block_ids
+        .ready_chunks(ids_chunk_size)
+        .map(InputInner::BlockIdsChunk)
+        .map(Ok);
+
+    let input = futures::stream::select(input, block_ids_chunked);
+
+    let (block_streams_sink, block_output_stream) = mpsc::unbounded();
+    let block_output_future = block_output_stream
+        .flatten()
+        .map(Ok)
+        .forward(blocks)
+        .map(|result| match result {
+            Ok(_) => Err(DownloadServiceError::BlockSinkDead),
+            Err(err) => Err(DownloadServiceError::BlockSink(err)),
+        });
+
+    let mut input = futures::stream::select(input, block_output_future.into_stream());
+
+    let backpressure_handler =
+        BlockDownloadBackPressureHandler::new(backpressure_trigger, backpressure_release);
+    let download_source_manager = BlockDownloadSourceManager::new();
+    let download_task_manager = BlockDownloadTaskManager::new();
+
+    while let Some(msg) = input.next().await {
+        match msg? {
+            InputInner::Input(BlockDownloaderInput::AddPeer { peer }) => {
+                let download_source_manager = download_source_manager.clone();
+                info.spawn("add_peer", async move {
+                    download_source_manager.add_peer(peer).await
+                });
+            }
+
+            InputInner::Input(BlockDownloaderInput::RemovePeer { peer }) => {
+                let download_source_manager = download_source_manager.clone();
+                info.spawn("remove_peer", async move {
+                    download_source_manager.remove_peer(&peer).await
+                });
+            }
+
+            InputInner::Input(BlockDownloaderInput::IncomingBlockStream { peer, stream }) => {
+                let download_source_manager = download_source_manager.clone();
+                let download_task_manager = download_task_manager.clone();
+                let backpressure_handler = backpressure_handler.clone();
+                let mut output = output.clone();
+                info.spawn_fallible::<_, DownloadTaskError<SiOutput::Error>>(
+                    "process_block_stream",
+                    async move {
+                        let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+                        let (maybe_peer_and_tail, n_blocks_downloaded) = download_task_manager
+                            .process_download(peer, stream, &download_source_manager, &mut rng)
+                            .await
+                            .map_err(DownloadTaskError::DownloadError)?;
+                        backpressure_handler.sub(n_blocks_downloaded);
+                        if let Some((peer, tail)) = maybe_peer_and_tail {
+                            output
+                                .send(BlockDownloaderOutput::RequestDownloadFromPeer {
+                                    peer,
+                                    block_ids: tail,
+                                })
+                                .await
+                                .map_err(DownloadTaskError::OutputSink)?;
+                        }
+                        Ok(())
+                    },
+                );
+            }
+
+            InputInner::BlockIdsChunk(block_ids) => {
+                let download_source_manager = download_source_manager.clone();
+                let download_task_manager = download_task_manager.clone();
+                let backpressure_handler = backpressure_handler.clone();
+                let mut block_streams_sink = block_streams_sink.clone();
+                let mut output = output.clone();
+                info.spawn_fallible::<_, PreDownloadTaskError<SiOutput::Error>>(
+                    "prepare_block_download",
+                    async move {
+                        let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+                        backpressure_handler.add(block_ids.len()).await;
+                        let (peer, task_blocks_stream) = download_task_manager
+                            .new_task(block_ids.clone(), &download_source_manager, &mut rng)
+                            .await;
+                        block_streams_sink
+                            .send(task_blocks_stream)
+                            .await
+                            .map_err(PreDownloadTaskError::BlockStreamsSink)?;
+                        output
+                            .send(BlockDownloaderOutput::RequestDownloadFromPeer {
+                                peer,
+                                block_ids,
+                            })
+                            .await
+                            .map_err(PreDownloadTaskError::OutputSink)?;
+                        Ok(())
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chain_impl_mockchain::header::HeaderId;
+    use quickcheck::{Arbitrary, Gen};
+    use std::ops::Deref;
+    use tokio::time::{timeout, Duration};
+
+    // TODO replace TestBlocks with Vec<Block> when we are able to disable
+    // block contents in testing. For now this is used to reduce test times to
+    // some sensible numbers (minutes).
+    const TEST_BLOCKS_MAX_SIZE: usize = 10;
+
+    #[derive(Debug, Clone)]
+    struct TestBlocks(Vec<Block>);
+
+    impl Arbitrary for TestBlocks {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            let size = g.next_u64() as usize % TEST_BLOCKS_MAX_SIZE;
+            let mut blocks = Vec::with_capacity(size);
+            for _ in 0..size {
+                blocks.push(Arbitrary::arbitrary(g));
+            }
+            Self(blocks)
+        }
+    }
+
+    impl Deref for TestBlocks {
+        type Target = Vec<Block>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[tokio::test]
+    async fn backpressure() {
+        const TRIGGER: usize = 50;
+        const RELEASE: usize = 10;
+        let backpressure_handler = BlockDownloadBackPressureHandler::new(TRIGGER, RELEASE);
+        backpressure_handler.add(TRIGGER).await;
+        assert!(timeout(Duration::from_secs(1), backpressure_handler.add(1))
+            .await
+            .is_err());
+        backpressure_handler.sub(10);
+        assert!(timeout(Duration::from_secs(1), backpressure_handler.add(1))
+            .await
+            .is_err());
+        backpressure_handler.sub(35);
+        assert!(timeout(Duration::from_secs(1), backpressure_handler.add(1))
+            .await
+            .is_ok());
+    }
+
+    #[quickcheck_async::tokio]
+    async fn block_downloader(blocks: TestBlocks) {
+        if blocks.is_empty() {
+            return;
+        }
+
+        let ids: Vec<_> = blocks.iter().map(|block| block.header.id()).collect();
+        let block_stream = futures::stream::iter(blocks.iter().cloned());
+        let (block_sink, downloaded_blocks) = mpsc::unbounded();
+        let downloader = BlockDownloadSource::new();
+
+        assert!(downloader.is_ready().await);
+        assert!(downloader.start_download(ids.clone()).await);
+        assert!(
+            !downloader.start_download(ids.clone()).await,
+            "start cannot be called again before the download is finished"
+        );
+        assert!(
+            !downloader.is_ready().await,
+            "downloader is in ready only when there is no pending downloader"
+        );
+
+        assert!(downloader
+            .process_download(block_stream, block_sink)
+            .await
+            .unwrap()
+            .0
+            .is_none());
+
+        let downloaded_blocks: Vec<_> = downloaded_blocks.collect().await;
+        assert_eq!(*blocks, downloaded_blocks);
+
+        assert!(downloader.is_ready().await);
+        assert!(downloader.start_download(ids.clone()).await);
+    }
+
+    #[quickcheck_async::tokio]
+    async fn block_downloader_empty_stream(blocks: TestBlocks) {
+        if blocks.is_empty() {
+            return;
+        }
+
+        let ids: Vec<_> = blocks.iter().map(|block| block.header.id()).collect();
+        let block_stream: futures::stream::Empty<Block> = futures::stream::empty();
+        let (block_sink, downloaded_blocks) = mpsc::unbounded();
+        let downloader = BlockDownloadSource::new();
+
+        assert!(downloader.is_ready().await);
+        assert!(downloader.start_download(ids.clone()).await);
+        assert!(
+            !downloader.start_download(ids.clone()).await,
+            "start cannot be called again before the download is finished"
+        );
+        assert!(
+            !downloader.is_ready().await,
+            "downloader is in ready only when there is no pending downloader"
+        );
+
+        assert_eq!(
+            ids,
+            downloader
+                .process_download(block_stream, block_sink)
+                .await
+                .unwrap()
+                .0
+                .unwrap()
+        );
+
+        let expected_blocks: Vec<Block> = Vec::new();
+        let downloaded_blocks: Vec<_> = downloaded_blocks.collect().await;
+        assert_eq!(expected_blocks, downloaded_blocks);
+
+        assert!(downloader.is_ready().await);
+        assert!(downloader.start_download(ids.clone()).await);
+    }
+
+    #[quickcheck_async::tokio]
+    async fn block_downloader_unexpected_blocks(
+        blocks_expected1: TestBlocks,
+        blocks_expected2: TestBlocks,
+        blocks_unexpected: TestBlocks,
+    ) {
+        if blocks_expected1.is_empty()
+            || blocks_expected2.is_empty()
+            || blocks_unexpected.is_empty()
+        {
+            return;
+        }
+
+        let ids: Vec<_> = blocks_expected1
+            .iter()
+            .chain(blocks_expected2.iter())
+            .map(|block| block.header.id())
+            .collect();
+        let block_stream = futures::stream::iter(
+            blocks_expected1
+                .iter()
+                .chain(blocks_unexpected.iter())
+                .cloned(),
+        );
+        let (block_sink, downloaded_blocks) = mpsc::unbounded();
+        let downloader = BlockDownloadSource::new();
+
+        assert!(downloader.is_ready().await);
+        assert!(downloader.start_download(ids.clone()).await);
+        assert!(
+            !downloader.start_download(ids.clone()).await,
+            "start cannot be called again before the download is finished"
+        );
+        assert!(
+            !downloader.is_ready().await,
+            "downloader is in ready only when there is no pending downloader"
+        );
+
+        let tail_expected: Vec<_> = blocks_expected2
+            .iter()
+            .map(|block| block.header.id())
+            .collect();
+        assert_eq!(
+            tail_expected,
+            downloader
+                .process_download(block_stream, block_sink)
+                .await
+                .unwrap()
+                .0
+                .unwrap()
+        );
+
+        let downloaded_blocks: Vec<_> = downloaded_blocks.collect().await;
+        assert_eq!(*blocks_expected1, downloaded_blocks);
+
+        assert!(downloader.is_ready().await);
+        assert!(downloader.start_download(ids.clone()).await);
+    }
+
+    #[tokio::test]
+    async fn block_source_management() {
+        let block_source_manager = BlockDownloadSourceManager::new();
+        let mut rng = rand::thread_rng();
+        let block_ids: Vec<HeaderId> = Vec::new();
+
+        assert!(timeout(
+            Duration::from_secs(1),
+            block_source_manager.select(block_ids.clone(), &mut rng)
+        )
+        .await
+        .is_err());
+
+        let addr: std::net::SocketAddr = "127.0.0.1:4000".parse().unwrap();
+        let peer = Peer::from(Peer::from(addr));
+
+        block_source_manager.add_peer(peer.clone()).await;
+
+        let block_source = timeout(
+            Duration::from_secs(1),
+            block_source_manager.select(block_ids.clone(), &mut rng),
+        )
+        .await
+        .unwrap();
+
+        assert!(timeout(
+            Duration::from_secs(1),
+            block_source_manager.select(block_ids.clone(), &mut rng)
+        )
+        .await
+        .is_err());
+
+        std::mem::drop(block_source);
+
+        let block_source = timeout(
+            Duration::from_secs(1),
+            block_source_manager.select(block_ids.clone(), &mut rng),
+        )
+        .await
+        .unwrap();
+
+        block_source_manager.remove_peer(&peer).await;
+
+        std::mem::drop(block_source);
+
+        assert!(timeout(
+            Duration::from_secs(1),
+            block_source_manager.select(block_ids.clone(), &mut rng)
+        )
+        .await
+        .is_err());
+    }
+
+    #[quickcheck_async::tokio]
+    async fn block_download_manager(blocks1: TestBlocks, blocks2: TestBlocks) {
+        if blocks1.is_empty() || blocks2.is_empty() {
+            return;
+        }
+
+        let mut rng = rand::thread_rng();
+
+        let ids: Vec<_> = blocks1
+            .iter()
+            .chain(blocks2.iter())
+            .map(|block| block.header.id())
+            .collect();
+        let block_download_manager = BlockDownloadSourceManager::new();
+        let block_download_task_manager = BlockDownloadTaskManager::new();
+        let addr: std::net::SocketAddr = "127.0.0.1:4000".parse().unwrap();
+        let peer = Peer::from(Peer::from(addr));
+
+        block_download_manager.add_peer(peer).await;
+
+        let (peer, downloaded_blocks) = block_download_task_manager
+            .new_task(ids, &block_download_manager, &mut rng)
+            .await;
+
+        let block_stream = futures::stream::iter(blocks1.iter().cloned());
+        let (peer, _ids) = block_download_task_manager
+            .process_download(peer, block_stream, &block_download_manager, &mut rng)
+            .await
+            .unwrap()
+            .0
+            .unwrap();
+
+        let block_stream = futures::stream::iter(blocks2.iter().cloned());
+        assert!(block_download_task_manager
+            .process_download(peer, block_stream, &block_download_manager, &mut rng,)
+            .await
+            .unwrap()
+            .0
+            .is_none());
+
+        let expected_blocks: Vec<_> = blocks1.iter().chain(blocks2.iter()).cloned().collect();
+        let actual_blocks: Vec<_> = downloaded_blocks.collect().await;
+        assert_eq!(expected_blocks, actual_blocks);
+    }
+}

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -3,6 +3,7 @@ mod candidate;
 mod chain;
 mod chain_selection;
 mod checkpoints;
+mod downloader;
 mod multiverse;
 mod process;
 mod reference;


### PR DESCRIPTION
Added the service to download blocks from multiple peers simultaneously. This
service is designed for faster syncronization after the network connection
loss or during the bootstrap.

The tests currently run for a very long time (hours) because the `Arbitrary`
implementation for `Block` fills it with an arbitrary number of fragments. This
implementation was tested before on a dummy type, but it envolved too many
practically useless generalization.

Things remaining to be done:

- Faster testing.
- Proper error processing in `block_downloader_task`.

Depends on https://github.com/input-output-hk/chain-libs/pull/485 for sensible test times.

This service will be used as a single point that would:

- Download blocks during bootstrap.
- Do the same thing during the node run.
- Use the existing Jormungandr service module to spawn tasks.
- Configure backpressure handling.