### PR TITLE
Update to parity-multiaddr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,12 +308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2734baf8ed08920ccecce1b48a2dfce4ac74a973144add031163bd21a1c5dab"
-
-[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,13 +362,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.3.3"
+name = "blake2s_simd"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
- "byte-tools 0.2.0",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -383,8 +378,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
- "byte-tools 0.3.1",
+ "block-padding 0.1.5",
+ "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
 ]
@@ -395,6 +390,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding 0.2.1",
  "generic-array 0.14.4",
 ]
 
@@ -404,8 +400,14 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
- "byte-tools 0.3.1",
+ "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blockchain"
@@ -416,6 +418,12 @@ dependencies = [
  "lru",
  "thiserror",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bson"
@@ -460,12 +468,6 @@ name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
-
-[[package]]
-name = "byte-tools"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 
 [[package]]
 name = "byte-tools"
@@ -649,7 +651,7 @@ dependencies = [
  "quickcheck",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "sha2 0.9.2",
+ "sha2",
  "typed-bytes 0.1.0",
 ]
 
@@ -668,7 +670,7 @@ dependencies = [
  "generic-array 0.14.4",
  "hex",
  "rand_core 0.5.1",
- "sha2 0.9.2",
+ "sha2",
  "typed-bytes 0.1.0 (git+https://github.com/input-output-hk/chain-wallet-libs)",
 ]
 
@@ -836,17 +838,6 @@ checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
 dependencies = [
  "chrono",
  "parse-zoneinfo",
-]
-
-[[package]]
-name = "cid"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6908948032561f2550467a477f659cdc358320a805237b9b5035c0350c441def"
-dependencies = [
- "integer-encoding",
- "multibase",
- "multihash",
 ]
 
 [[package]]
@@ -1077,12 +1068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "cryptoxide"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1133,12 @@ dependencies = [
  "syn 1.0.48",
  "synstructure",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "data-pile"
@@ -1218,15 +1209,6 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "digest"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-dependencies = [
- "generic-array 0.9.0",
-]
 
 [[package]]
 name = "digest"
@@ -1336,7 +1318,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.2",
+ "sha2",
  "zeroize",
 ]
 
@@ -1626,15 +1608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -2097,16 +2070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca80fdd4829ab7569b7a72db4784b2f819d42f124e189c47dba0f72861c3888a"
-dependencies = [
- "async-trait",
- "futures 0.3.8",
-]
-
-[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,8 +2183,8 @@ dependencies = [
  "libc",
  "linked-hash-map",
  "lru",
- "multiaddr",
  "nix 0.19.0",
+ "parity-multiaddr",
  "pin-project 1.0.1",
  "poldercast",
  "rand 0.7.3",
@@ -2309,7 +2272,7 @@ dependencies = [
  "ed25519-bip32",
  "hex",
  "humantime",
- "multiaddr",
+ "parity-multiaddr",
  "poldercast",
  "quickcheck",
  "rand 0.7.3",
@@ -2541,6 +2504,12 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.48",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
@@ -2823,34 +2792,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiaddr"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c47add5e6a96020ca53393aebf77193fd5f578a4e7a73ab505f41e4be06e8c"
-dependencies = [
- "byteorder",
- "cid",
- "integer-encoding",
-]
-
-[[package]]
-name = "multibase"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-dependencies = [
- "base-x",
-]
-
-[[package]]
 name = "multihash"
-version = "0.8.0"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62469025f45dee2464ef9fc845f4683c543993792c1993e7d903c17a4546b74"
+checksum = "567122ab6492f49b59def14ecc36e13e64dca4188196dd0cd41f9f3f979f3df6"
 dependencies = [
- "sha1",
- "sha2 0.7.1",
- "tiny-keccak",
+ "blake2b_simd",
+ "blake2s_simd",
+ "digest 0.9.0",
+ "sha-1 0.9.2",
+ "sha2",
+ "sha3",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3085,6 +3038,24 @@ checksum = "d2cc1b4330bb29087e791ae2a5cf56be64fb8946a4ff5aec2ba11c6ca51f5d60"
 dependencies = [
  "log 0.4.11",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parity-multiaddr"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fe99b938abd57507e37f8d4ef30cd74b33c71face2809b37b8beb71bab15ab"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url",
 ]
 
 [[package]]
@@ -3333,14 +3304,12 @@ checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
 
 [[package]]
 name = "poldercast"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2092e813bc4ed38ab601e0b4299b9617a2b888635f6a595a62fbc7fee811bcae"
+version = "0.14.0-dev"
+source = "git+https://github.com/mzabaluev/poldercast.git?branch=address-must-make-sense-by-construction#c0f337a4dcf74e2f1030c2fabca5f6982d10a06b"
 dependencies = [
- "cid",
  "hex",
  "lru",
- "multiaddr",
+ "parity-multiaddr",
  "rand 0.7.3",
  "rayon",
  "serde",
@@ -4156,24 +4125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171698ce4ec7cbb93babeb3190021b4d72e96ccb98e33d277ae4ea959d6f2d9e"
-
-[[package]]
-name = "sha2"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
-dependencies = [
- "block-buffer 0.3.3",
- "byte-tools 0.2.0",
- "digest 0.7.6",
- "fake-simd",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4183,6 +4134,18 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
  "opaque-debug 0.3.0",
 ]
 
@@ -4367,6 +4330,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -4645,15 +4614,6 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -5211,6 +5171,12 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "untrusted"

--- a/jormungandr-lib/Cargo.toml
+++ b/jormungandr-lib/Cargo.toml
@@ -20,10 +20,10 @@ rand_chacha = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 humantime = "2.0"
 thiserror = "1.0"
-poldercast = "0.13.4"
+poldercast = { git = "https://github.com/mzabaluev/poldercast.git", branch = "address-must-make-sense-by-construction" }
+multiaddr = { package = "parity-multiaddr", version = "0.9" }
 hex = "0.4"
 bech32 = "0.7"
-multiaddr = "0.3.1"
 warp = { version = "0.2.4", features = ["tls"] }
 base64 = "0.13.0"
 

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -35,7 +35,8 @@ humantime = "2.0"
 jormungandr-lib = { path = "../jormungandr-lib" }
 lazy_static = "1.4"
 linked-hash-map = "0.5"
-poldercast = "0.13.4"
+poldercast = { git = "https://github.com/mzabaluev/poldercast.git", branch = "address-must-make-sense-by-construction" }
+multiaddr = { package = "parity-multiaddr", version = "0.9" }
 rand = "0.7"
 rand_chacha = "0.2.2"
 rustls = "0.18.1"
@@ -57,7 +58,6 @@ async-trait = "0.1"
 lru = "^0.6.1"
 warp = { version = "0.2.4", features = ["tls"] }
 pin-project = "1.0"
-multiaddr = "0.3.1"
 
 [dependencies.reqwest]
 version = "0.10.7"

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -89,7 +89,7 @@ pub fn connect(state: ConnectionState, channels: Channels) -> (ConnectHandle, Co
         .await
         .map_err(ConnectError::Subscription)?;
         let inbound = InboundSubscriptions {
-            peer_address: Address::new(peer.connection).unwrap(),
+            peer_address: Address::tcp(peer.connection),
             block_events: block_sub,
             fragments: fragment_sub,
             gossip: gossip_sub,

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -14,7 +14,6 @@ mod service;
 mod subscription;
 
 use self::convert::Encode;
-use jormungandr_lib::multiaddr::multiaddr_to_socket_addr;
 
 use futures::{future, prelude::*};
 use poldercast::Address;
@@ -479,7 +478,7 @@ fn connect_and_propagate(
     channels: Channels,
     mut options: p2p::comm::ConnectOptions,
 ) {
-    let addr = match multiaddr_to_socket_addr(node.multi_address()) {
+    let addr = match node.to_socket_addr() {
         Some(addr) => addr,
         None => {
             debug!(
@@ -555,7 +554,7 @@ fn trusted_peers_shuffled(config: &Configuration) -> Vec<SocketAddr> {
     let mut peers = config
         .trusted_peers
         .iter()
-        .filter_map(|peer| multiaddr_to_socket_addr(peer.address.multi_address()))
+        .filter_map(|peer| peer.address.to_socket_addr())
         .collect::<Vec<_>>();
     let mut rng = rand::thread_rng();
     peers.shuffle(&mut rng);
@@ -611,7 +610,7 @@ async fn netboot_peers(config: &Configuration, logger: &Logger) -> BootstrapPeer
     let trusted_peers = config
         .trusted_peers
         .iter()
-        .filter_map(|tp| multiaddr_to_socket_addr(tp.address.multi_address()).map(Peer::new))
+        .filter_map(|tp| tp.address.to_socket_addr().map(Peer::new))
         .collect::<Vec<_>>();
     if config.bootstrap_from_trusted_peers {
         let _: usize = peers.add_peers(&trusted_peers);

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -141,12 +141,10 @@ impl PeerMap {
     }
 
     pub fn infos(&self) -> Vec<PeerInfo> {
-        use jormungandr_lib::multiaddr::multiaddr_to_socket_addr;
-
         self.map
             .iter()
-            .map(|(id, data)| PeerInfo {
-                addr: multiaddr_to_socket_addr(id.multi_address()),
+            .map(|(addr, data)| PeerInfo {
+                addr: addr.to_socket_addr(),
                 stats: data.stats.clone(),
             })
             .collect()

--- a/testing/jormungandr-integration-tests/Cargo.toml
+++ b/testing/jormungandr-integration-tests/Cargo.toml
@@ -35,7 +35,7 @@ assert_fs = "1.0"
 predicates = "1.0"
 assert_cmd = "1.0.1"
 regex = "1.4"
-poldercast = "0.13.4"
+poldercast = { git = "https://github.com/mzabaluev/poldercast.git", branch = "address-must-make-sense-by-construction" }
 thiserror = "1.0"
 url = "2.1.1"
 yaml-rust = "0.4.4"

--- a/testing/jormungandr-scenario-tests/Cargo.toml
+++ b/testing/jormungandr-scenario-tests/Cargo.toml
@@ -23,7 +23,7 @@ vit-servicing-station-tests = { git = "https://github.com/input-output-hk/vit-se
 vit-servicing-station-lib = { git = "https://github.com/input-output-hk/vit-servicing-station", branch = "master" }
 jortestkit = { path = "../jortestkit" }
 iapyx = {path = "../iapyx"}
-poldercast = "0.13.4"
+poldercast = { git = "https://github.com/mzabaluev/poldercast.git", branch = "address-must-make-sense-by-construction" }
 rand = "0.7"
 rand_core = "0.5"
 rand_chacha = "0.2"

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -470,7 +470,7 @@ impl LegacyNodeController {
                     .config
                     .p2p
                     .public_address
-                    .to_socketaddr()
+                    .to_socket_addr()
                     .unwrap()
                     .port(),
             )

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -450,19 +450,15 @@ impl NodeController {
     }
 
     fn ports_are_opened(&self) -> bool {
-        use jormungandr_lib::multiaddr::multiaddr_to_socket_addr;
-
         self.port_opened(self.settings.config.rest.listen.port())
             && self.port_opened(
-                multiaddr_to_socket_addr(
-                    self.settings
-                        .config
-                        .p2p
-                        .get_listen_address()
-                        .multi_address(),
-                )
-                .unwrap()
-                .port(),
+                self.settings
+                    .config
+                    .p2p
+                    .get_listen_address()
+                    .to_socket_addr()
+                    .unwrap()
+                    .port(),
             )
     }
 

--- a/testing/jormungandr-scenario-tests/src/test/features/p2p/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/p2p/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     test::{utils, Result},
 };
 
-use jormungandr_lib::{interfaces::PeerRecord, multiaddr::multiaddr_to_socket_addr};
+use jormungandr_lib::interfaces::PeerRecord;
 
 pub fn assert_connected_cnt(
     node: &NodeController,
@@ -92,7 +92,7 @@ pub fn assert_are_not_in_network_view(
         utils::assert(
             network_view
                 .iter()
-                .any(|info| info.addr == multiaddr_to_socket_addr(peer.address().multi_address())),
+                .any(|info| info.addr == peer.address().to_socket_addr()),
             &format!(
                 "{}: Peer {} is present in network view list, while it should not",
                 info,
@@ -113,9 +113,7 @@ pub fn assert_are_in_network_stats(
         utils::assert(
             network_stats.iter().any(|x| {
                 x.addr
-                    .and_then(|a| {
-                        multiaddr_to_socket_addr(peer.address().multi_address()).map(|b| a == b)
-                    })
+                    .and_then(|a| peer.address().to_socket_addr().map(|b| a == b))
                     .unwrap_or(false)
             }),
             &format!(
@@ -138,9 +136,7 @@ pub fn assert_are_not_in_network_stats(
         utils::assert(
             !network_stats.iter().any(|x| {
                 x.addr
-                    .and_then(|a| {
-                        multiaddr_to_socket_addr(peer.address().multi_address()).map(|b| a == b)
-                    })
+                    .and_then(|a| peer.address().to_socket_addr().map(|b| a == b))
                     .unwrap_or(false)
             }),
             &format!(

--- a/testing/jormungandr-testing-utils/Cargo.toml
+++ b/testing/jormungandr-testing-utils/Cargo.toml
@@ -34,7 +34,7 @@ chrono = { version = "0.4", features = ["serde"] }
 humantime = "2.0"
 custom_debug = "0.5"
 thiserror = "1.0"
-poldercast = "0.13.4"
+poldercast = { git = "https://github.com/mzabaluev/poldercast.git", branch = "address-must-make-sense-by-construction" }
 sysinfo = { version = "0.15.3" }
 slog = { version = "^2.5.1", features = [ "max_level_trace", "release_max_level_trace" ] }
 slog-async = "2.5.0"


### PR DESCRIPTION
Temporarily use an unmerged branch of poldercast that integrates parity-multiaddr instead of multiaddr.
Also replace the jormungandr dependency the same way and update to the API changes.