### PR TITLE
[Tests] move failing tests to unstable

### DIFF
--- a/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
@@ -352,18 +352,22 @@ fn scenarios_repository() -> Vec<Scenario> {
         vec![Tag::Short, Tag::Unstable],
     ));
 
-    repository.push(Scenario::new("relay_soak", relay_soak, vec![Tag::Long]));
+    repository.push(Scenario::new(
+        "relay_soak",
+        relay_soak,
+        vec![Tag::Long, Tag::Unstable],
+    ));
 
     repository.push(Scenario::new(
         "p2p_stats_test",
         p2p_stats_test,
-        vec![Tag::Short],
+        vec![Tag::Short, Tag::Unstable],
     ));
 
     repository.push(Scenario::new(
         "max_connections",
         max_connections,
-        vec![Tag::Short],
+        vec![Tag::Short, Tag::Unstable],
     ));
 
     repository.push(Scenario::new(


### PR DESCRIPTION
Move 3 failing test to unstable:
- [x] relay_soak
- [x] p2p_stats_test
- [x] max_connections