### PR TITLE
[Tests] Scenario tests print report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,6 +1523,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "function_name"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b2afa9b514dc3a75af6cf24d1914e1c7eb6f1b86de849147563548d5c0a0cd"
+dependencies = [
+ "function_name-proc-macro",
+]
+
+[[package]]
+name = "function_name-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6790a8d356d2f65d7972181e866b92a50a87c27d6a48cbe9dbb8be13ca784c7d"
+dependencies = [
+ "proc-macro-crate",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "futures"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,6 +2342,7 @@ dependencies = [
  "custom_debug",
  "dialoguer 0.7.1",
  "error-chain",
+ "function_name",
  "futures 0.3.8",
  "hex",
  "iapyx",
@@ -2329,6 +2350,7 @@ dependencies = [
  "jormungandr-lib",
  "jormungandr-testing-utils",
  "jortestkit 0.1.0",
+ "json",
  "lazy_static",
  "poldercast",
  "rand 0.7.3",

--- a/testing/jormungandr-scenario-tests/Cargo.toml
+++ b/testing/jormungandr-scenario-tests/Cargo.toml
@@ -27,6 +27,8 @@ poldercast = { git = "https://github.com/primetype/poldercast.git" }
 rand = "0.7"
 rand_core = "0.5"
 rand_chacha = "0.2"
+json = "0.12.4"
+function_name = "0.2.0"
 regex = "1.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/testing/jormungandr-scenario-tests/src/example_scenarios.rs
+++ b/testing/jormungandr-scenario-tests/src/example_scenarios.rs
@@ -6,11 +6,14 @@ use crate::{
     test::Result,
     Context,
 };
+use function_name::named;
 use rand_chacha::ChaChaRng;
 
+#[named]
 pub fn scenario_1(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "simple network example",
+        name,
         &mut context,
         topology [
             "node1",
@@ -49,12 +52,14 @@ pub fn scenario_1(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
 
     node2.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn scenario_2(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Testing the network",
+        name,
         &mut context,
         topology [
             "Leader1",
@@ -120,5 +125,5 @@ pub fn scenario_2(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     passive2.shutdown()?;
     passive3.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/interactive/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/mod.rs
@@ -12,9 +12,13 @@ use rand_chacha::ChaChaRng;
 use std::ffi::OsStr;
 use structopt::StructOpt;
 
+use function_name::named;
+
+#[named]
 pub fn interactive(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Testing the network",
+        name,
         &mut context,
         topology [
             "Leader1",
@@ -42,7 +46,7 @@ pub fn interactive(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
         controller: UserInteractionController::new(&mut controller),
     })?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
 fn jormungandr_user_interaction() -> UserInteraction {

--- a/testing/jormungandr-scenario-tests/src/main.rs
+++ b/testing/jormungandr-scenario-tests/src/main.rs
@@ -9,18 +9,19 @@ mod vit_station;
 mod scenario;
 mod example_scenarios;
 mod interactive;
+mod report;
 mod slog;
 mod test;
 mod wallet;
 
 use node::{Node, NodeBlock0, NodeController};
 use programs::prepare_command;
+use report::Reporter;
 use scenario::{
     parse_progress_bar_mode_from_str,
     repository::{parse_tag_from_str, ScenarioResult, ScenariosRepository, Tag},
     Context, ProgressBarMode, Seed,
 };
-
 use vit_station::{VitStation, VitStationController, VitStationControllerError};
 
 pub use jortestkit::console::style;
@@ -102,6 +103,10 @@ struct CommandArgs {
     /// lists tests under tag
     #[structopt(long = "list-only")]
     list_only: Option<String>,
+
+    /// print junit like report to output
+    #[structopt(short = "r", long = "print-report")]
+    report: bool,
 }
 
 fn main() {
@@ -152,6 +157,11 @@ fn main() {
 
     let scenario_suite_result = scenarios_repo.run(&context);
     println!("{}", scenario_suite_result.result_string());
+
+    if command_args.report {
+        let reporter = Reporter::new(scenario_suite_result.clone());
+        reporter.print()
+    }
 
     if command_args.set_exit_code {
         std::process::exit(if scenario_suite_result.is_failed() {

--- a/testing/jormungandr-scenario-tests/src/report.rs
+++ b/testing/jormungandr-scenario-tests/src/report.rs
@@ -1,0 +1,101 @@
+use crate::scenario::repository::{ScenarioStatus, ScenarioSuiteResult};
+
+use json::object;
+
+pub struct Reporter {
+    scenario_suite_result: ScenarioSuiteResult,
+}
+
+impl Reporter {
+    pub fn new(scenario_suite_result: ScenarioSuiteResult) -> Self {
+        Self {
+            scenario_suite_result,
+        }
+    }
+
+    pub fn print(&self) {
+        println!(
+            "{}",
+            object! {
+                type: "suite",
+                event: "started",
+                test_count: self.scenario_suite_result.results().len()
+            }
+        );
+
+        for scenario in self.scenario_suite_result.results().iter() {
+            println!(
+                "{}",
+                object! {
+                    type: "test",
+                    event: "started",
+                    name: scenario.name()
+                }
+            );
+
+            match scenario.scenario_status() {
+                ScenarioStatus::Passed => {
+                    println!(
+                        "{}",
+                        object! {
+                            type: "test",
+                            name: scenario.name(),
+                            event: "ok"
+                        }
+                    );
+                }
+                ScenarioStatus::Ignored => {
+                    println!(
+                        "{}",
+                        object! {
+                            type: "test",
+                            name: scenario.name(),
+                            event: "ignored"
+                        }
+                    );
+                }
+                ScenarioStatus::Failed(reason) => {
+                    println!(
+                        "{}",
+                        object! {
+                            type: "test",
+                            name: scenario.name(),
+                            event: "failed",
+                            stdout: reason.to_string()
+                        }
+                    );
+                }
+            }
+        }
+
+        if self.scenario_suite_result.passed() {
+            println!(
+                "{}",
+                object! {
+                    type: "suite",
+                    event: "ok",
+                    passed: self.scenario_suite_result.count_passed(),
+                    failed: self.scenario_suite_result.count_failed(),
+                    allowed_fail: 0,
+                    ignored: self.scenario_suite_result.count_ignored(),
+                    measured: 0,
+                    filtered_out: 0,
+                }
+            );
+        } else {
+            println!(
+                "{}",
+                object! {
+                    type: "suite",
+                    event: "failed",
+                    passed: self.scenario_suite_result.count_passed(),
+                    failed: self.scenario_suite_result.count_failed(),
+                    allowed_fail: 0,
+                    ignored: self.scenario_suite_result.count_ignored(),
+                    measured: 0,
+                    filtered_out: 0
+                }
+            );
+        }
+    }
+}

--- a/testing/jormungandr-scenario-tests/src/scenario/repository/result.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/result.rs
@@ -3,24 +3,28 @@ use std::{any::Any, fmt};
 
 #[derive(Clone, Debug)]
 pub struct ScenarioResult {
+    pub name: String,
     pub scenario_status: ScenarioStatus,
 }
 
 impl ScenarioResult {
-    pub fn passed() -> Self {
+    pub fn passed<S: Into<String>>(name: S) -> Self {
         ScenarioResult {
+            name: name.into(),
             scenario_status: ScenarioStatus::Passed,
         }
     }
 
-    pub fn failed<S: Into<String>>(reason: S) -> Self {
+    pub fn failed<P: Into<String>, S: Into<String>>(name: P, reason: S) -> Self {
         ScenarioResult {
+            name: name.into(),
             scenario_status: ScenarioStatus::Failed(reason.into()),
         }
     }
 
-    pub fn ignored() -> Self {
+    pub fn ignored<S: Into<String>>(name: S) -> Self {
         ScenarioResult {
+            name: name.into(),
             scenario_status: ScenarioStatus::Ignored,
         }
     }
@@ -41,15 +45,20 @@ impl ScenarioResult {
         matches!(*self.scenario_status(), ScenarioStatus::Passed)
     }
 
-    pub fn from_result(
+    pub fn name(&self) -> String {
+        self.name.to_string()
+    }
+
+    pub fn from_result<S: Into<String>>(
+        name: S,
         result: std::result::Result<Result<ScenarioResult>, std::boxed::Box<dyn Any + Send>>,
     ) -> ScenarioResult {
         match result {
             Ok(inner) => match inner {
                 Ok(scenario_result) => scenario_result,
-                Err(err) => ScenarioResult::failed(err.to_string()),
+                Err(err) => ScenarioResult::failed(name, err.to_string()),
             },
-            Err(_) => ScenarioResult::failed("no data".to_string()),
+            Err(_) => ScenarioResult::failed(name, "no data"),
         }
     }
 }

--- a/testing/jormungandr-scenario-tests/src/scenario/repository/scenario.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/scenario.rs
@@ -17,6 +17,10 @@ impl Scenario {
         }
     }
 
+    pub fn tags(&self) -> &[Tag] {
+        &self.tags
+    }
+
     pub fn has_tag(&self, tag: Tag) -> bool {
         self.tags.iter().any(|t| *t == tag)
     }

--- a/testing/jormungandr-scenario-tests/src/scenario/repository/suite_result.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/suite_result.rs
@@ -20,6 +20,10 @@ impl ScenarioSuiteResult {
         self.count_failed() > 0
     }
 
+    pub fn passed(&self) -> bool {
+        !self.is_failed()
+    }
+
     pub fn count_passed(&self) -> usize {
         self.results.iter().filter(|x| x.is_passed()).count()
     }
@@ -54,5 +58,9 @@ impl ScenarioSuiteResult {
         let mut suite_result = Self::new();
         suite_result.push(result);
         suite_result
+    }
+
+    pub fn results(&self) -> &[ScenarioResult] {
+        &self.results
     }
 }

--- a/testing/jormungandr-scenario-tests/src/test/comm/leader_leader.rs
+++ b/testing/jormungandr-scenario-tests/src/test/comm/leader_leader.rs
@@ -12,9 +12,13 @@ use rand_chacha::ChaChaRng;
 const LEADER_1: &str = "Leader1";
 const LEADER_2: &str = "Leader2";
 
+use function_name::named;
+
+#[named]
 pub fn two_transaction_to_two_leaders(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "L2101-Leader_to_leader_communication",
+        name,
         &mut context,
         topology [
             LEADER_1 -> LEADER_2,
@@ -68,5 +72,5 @@ pub fn two_transaction_to_two_leaders(mut context: Context<ChaChaRng>) -> Result
     monitor.snapshot()?;
     monitor.stop().print();
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/comm/passive_leader.rs
+++ b/testing/jormungandr-scenario-tests/src/test/comm/passive_leader.rs
@@ -13,9 +13,13 @@ use rand_chacha::ChaChaRng;
 const LEADER: &str = "Leader";
 const PASSIVE: &str = "Passive";
 
+use function_name::named;
+
+#[named]
 pub fn transaction_to_passive(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "L2001-transaction_propagation_from_passive",
+        name,
         &mut context,
         topology [
             LEADER,
@@ -64,14 +68,16 @@ pub fn transaction_to_passive(mut context: Context<ChaChaRng>) -> Result<Scenari
     passive.shutdown()?;
     leader.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
 const LEADER_2: &str = "LEADER_2";
 
+#[named]
 pub fn leader_restart(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "L2003-leader_is_restarted",
+        name,
         &mut context,
         topology [
             LEADER_2,
@@ -159,12 +165,14 @@ pub fn leader_restart(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
     leader_2.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn passive_node_is_updated(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "L2004-passive_node_is_updated",
+        name,
         &mut context,
         topology [
             LEADER,
@@ -216,5 +224,5 @@ pub fn passive_node_is_updated(mut context: Context<ChaChaRng>) -> Result<Scenar
     leader.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/features/explorer.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/explorer.rs
@@ -3,6 +3,7 @@ use crate::{
     test::{utils, Result},
     Context, ScenarioResult,
 };
+use function_name::named;
 use jormungandr_lib::interfaces::Explorer;
 use rand_chacha::ChaChaRng;
 const LEADER_1: &str = "Leader_1";
@@ -10,9 +11,11 @@ const LEADER_2: &str = "Leader_2";
 const LEADER_3: &str = "Leader_3";
 const PASSIVE: &str = "Passive";
 
+#[named]
 pub fn passive_node_explorer(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Passive node with explorer",
+        name,
         &mut context,
         topology [
             LEADER_1,
@@ -88,5 +91,5 @@ pub fn passive_node_explorer(mut context: Context<ChaChaRng>) -> Result<Scenario
     passive.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/features/leader_promotion.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/leader_promotion.rs
@@ -4,14 +4,17 @@ use crate::{
     test::{utils, Result},
     Context, ScenarioResult,
 };
+use function_name::named;
 use jormungandr_lib::interfaces::EnclaveLeaderId;
 use rand_chacha::ChaChaRng;
 const LEADER: &str = "Leader";
 const PASSIVE: &str = "Passive";
 
+#[named]
 pub fn passive_node_promotion(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Passive node promotion to leader",
+        name,
         &mut context,
         topology [
             LEADER,
@@ -55,7 +58,7 @@ pub fn passive_node_promotion(mut context: Context<ChaChaRng>) -> Result<Scenari
     passive.shutdown()?;
     leader.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
 fn promote_and_assert_leaders_id(

--- a/testing/jormungandr-scenario-tests/src/test/features/leadership_log.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/leadership_log.rs
@@ -6,16 +6,19 @@ use crate::{
 
 use std::time::SystemTime;
 
+use function_name::named;
 use jortestkit::process::sleep;
 use rand_chacha::ChaChaRng;
 const LEADER_1: &str = "Leader1";
 const LEADER_2: &str = "Leader2";
 
+#[named]
 pub fn leader_restart_preserves_leadership_log(
     mut context: Context<ChaChaRng>,
 ) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Passive node promotion to leader",
+        name,
         &mut context,
         topology [
             LEADER_1,
@@ -78,5 +81,5 @@ pub fn leader_restart_preserves_leadership_log(
     leader_2.shutdown()?;
     leader_1.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/features/p2p/connections.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/p2p/connections.rs
@@ -3,15 +3,18 @@ use crate::{
     test::{utils, Result},
     Context, ScenarioResult,
 };
+use function_name::named;
 use rand_chacha::ChaChaRng;
 const LEADER1: &str = "LEADER1";
 const LEADER2: &str = "LEADER2";
 const LEADER3: &str = "LEADER3";
 const LEADER4: &str = "LEADER4";
 
+#[named]
 pub fn max_connections(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "p2p stats",
+        name,
         &mut context,
         topology [
             LEADER1,
@@ -61,5 +64,5 @@ pub fn max_connections(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
     leader3.shutdown()?;
     leader4.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/features/p2p/stats.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/p2p/stats.rs
@@ -9,9 +9,13 @@ const LEADER2: &str = "LEADER2";
 const LEADER3: &str = "LEADER3";
 const LEADER4: &str = "LEADER4";
 
+use function_name::named;
+
+#[named]
 pub fn p2p_stats_test(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "p2p stats",
+        name,
         &mut context,
         topology [
             LEADER1,
@@ -102,5 +106,5 @@ pub fn p2p_stats_test(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
     leader1.shutdown()?;
     leader3.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/features/stake_pool/retire.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/stake_pool/retire.rs
@@ -9,10 +9,13 @@ const LEADER_1: &str = "Leader_1";
 const LEADER_2: &str = "Leader_2";
 const LEADER_3: &str = "Leader_3";
 const LEADER_4: &str = "Leader_4";
+use function_name::named;
 
+#[named]
 pub fn retire_stake_pool_explorer(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Retire stake pool explorer",
+        name,
         &mut context,
         topology [
             LEADER_1,
@@ -126,5 +129,5 @@ pub fn retire_stake_pool_explorer(mut context: Context<ChaChaRng>) -> Result<Sce
     leader_3.shutdown()?;
     leader_4.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/features/vote.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/vote.rs
@@ -3,6 +3,7 @@ use crate::{
     test::{utils, Result},
     Context, ScenarioResult,
 };
+use function_name::named;
 use jormungandr_lib::interfaces::Explorer;
 use jormungandr_testing_utils::testing::network_builder::SpawnParams;
 use jormungandr_testing_utils::testing::node::time;
@@ -32,9 +33,11 @@ pub enum Vote {
     NO = 2,
 }
 
+#[named]
 pub fn vote_e2e_flow(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Passive node promotion to leader",
+        name,
         &mut context,
         topology [
             LEADER_1,
@@ -193,5 +196,5 @@ pub fn vote_e2e_flow(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> 
     leader_2.shutdown()?;
     leader_1.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/legacy/disruption.rs
+++ b/testing/jormungandr-scenario-tests/src/test/legacy/disruption.rs
@@ -126,7 +126,7 @@ fn test_legacy_release(
     leader1.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
 pub fn disruption_last_nth_release_title(n: u32) -> Cow<'static, str> {
@@ -260,7 +260,7 @@ fn test_legacy_disruption_release(
     leader1.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
 pub fn newest_node_enters_legacy_network(
@@ -391,5 +391,5 @@ pub fn newest_node_enters_legacy_network(
     leader1.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(title))
 }

--- a/testing/jormungandr-scenario-tests/src/test/legacy/fragment_propagation.rs
+++ b/testing/jormungandr-scenario-tests/src/test/legacy/fragment_propagation.rs
@@ -1,6 +1,7 @@
 use super::{LEADER, PASSIVE};
 use crate::scenario::{repository::ScenarioResult, Context, Controller};
 use crate::test::Result;
+use function_name::named;
 use jormungandr_testing_utils::{
     stake_pool::StakePool,
     testing::{
@@ -13,6 +14,7 @@ use jormungandr_testing_utils::{
 use rand_chacha::ChaChaRng;
 use std::path::PathBuf;
 
+#[named]
 pub fn legacy_current_node_fragment_propagation(
     mut context: Context<ChaChaRng>,
 ) -> Result<ScenarioResult> {
@@ -62,9 +64,10 @@ pub fn legacy_current_node_fragment_propagation(
     passive.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(title))
 }
 
+#[named]
 pub fn current_node_legacy_fragment_propagation(
     mut context: Context<ChaChaRng>,
 ) -> Result<ScenarioResult> {
@@ -115,9 +118,10 @@ pub fn current_node_legacy_fragment_propagation(
     passive.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(title))
 }
 
+#[named]
 pub fn current_node_fragment_propagation(
     mut context: Context<ChaChaRng>,
 ) -> Result<ScenarioResult> {
@@ -160,7 +164,7 @@ pub fn current_node_fragment_propagation(
     passive.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(title))
 }
 
 fn get_legacy_data(title: &str, context: &mut Context<ChaChaRng>) -> (PathBuf, Version) {

--- a/testing/jormungandr-scenario-tests/src/test/network/bft/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/network/bft/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     Context, ScenarioResult,
 };
+use function_name::named;
 use rand_chacha::ChaChaRng;
 
 const LEADER_1: &str = "Leader1";
@@ -17,9 +18,11 @@ const LEADER_5: &str = "Leader5";
 #[allow(dead_code)]
 const PASSIVE: &str = "Passive";
 
+#[named]
 pub fn bft_cascade(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Bft nodes",
+        name,
         &mut context,
         topology [
             LEADER_1,
@@ -102,5 +105,5 @@ pub fn bft_cascade(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     leader3.shutdown()?;
     leader2.shutdown()?;
     leader1.shutdown()?;
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/network/real.rs
+++ b/testing/jormungandr-scenario-tests/src/test/network/real.rs
@@ -251,5 +251,5 @@ pub fn real_network(
     )?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/network/topology/scenarios.rs
+++ b/testing/jormungandr-scenario-tests/src/test/network/topology/scenarios.rs
@@ -21,7 +21,11 @@ const CORE_NODE: &str = "Core";
 const RELAY_NODE_1: &str = "Relay1";
 const RELAY_NODE_2: &str = "Relay2";
 
+use function_name::named;
+
+#[named]
 pub fn fully_connected(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
         "T3001_Fully-Connected",
         &mut context,
@@ -98,12 +102,14 @@ pub fn fully_connected(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
     leader1.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn star(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "T3002_Star",
+        name,
         &mut context,
         topology [
             LEADER_5,
@@ -180,12 +186,14 @@ pub fn star(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     leader1.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn mesh(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "T3004_Mesh",
+        name,
         &mut context,
         topology [
             LEADER_4,
@@ -265,12 +273,14 @@ pub fn mesh(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     leader3.shutdown()?;
     leader2.shutdown()?;
     leader1.shutdown()?;
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn point_to_point(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "T3005-Point-to-Point",
+        name,
         &mut context,
         topology [
             LEADER_4,
@@ -343,12 +353,14 @@ pub fn point_to_point(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
     leader1.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn point_to_point_on_file_storage(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "T3005-Point-to-Point-file-storage",
+        name,
         &mut context,
         topology [
             LEADER_4,
@@ -433,12 +445,14 @@ pub fn point_to_point_on_file_storage(mut context: Context<ChaChaRng>) -> Result
     leader1.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn tree(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "T3006-Tree",
+        name,
         &mut context,
         topology [
             LEADER_1,
@@ -528,12 +542,14 @@ pub fn tree(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     leader1.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn relay(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "T3007-Relay",
+        name,
         &mut context,
         topology [
             CORE_NODE,
@@ -654,5 +670,5 @@ pub fn relay(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     core.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
+++ b/testing/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
@@ -8,13 +8,16 @@ use crate::{
     },
     Context,
 };
+use function_name::named;
 use rand_chacha::ChaChaRng;
 
+#[named]
 pub fn passive_leader_disruption_no_overlap(
     mut context: Context<ChaChaRng>,
 ) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "passive_leader_disruption_no_overlap",
+        name,
         &mut context,
         topology [
             LEADER,
@@ -86,14 +89,16 @@ pub fn passive_leader_disruption_no_overlap(
     leader.shutdown()?;
     passive.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn passive_leader_disruption_overlap(
     mut context: Context<ChaChaRng>,
 ) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "passive_leader_disruption_overlap",
+        name,
         &mut context,
         topology [
             LEADER,
@@ -150,12 +155,14 @@ pub fn passive_leader_disruption_overlap(
     leader.shutdown()?;
     passive.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn leader_leader_disruption_overlap(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "leader_leader_disruption_overlap",
+        name,
         &mut context,
         topology [
             LEADER_2,
@@ -219,14 +226,16 @@ pub fn leader_leader_disruption_overlap(mut context: Context<ChaChaRng>) -> Resu
     leader1.shutdown()?;
     leader2.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn leader_leader_disruption_no_overlap(
     mut context: Context<ChaChaRng>,
 ) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "leader_leader_disruption_no_overlap",
+        name,
         &mut context,
         topology [
             LEADER_2,
@@ -300,12 +309,14 @@ pub fn leader_leader_disruption_no_overlap(
     leader1.shutdown()?;
     leader2.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn point_to_point_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "point_to_point_disruption",
+        name,
         &mut context,
         topology [
             LEADER_2,
@@ -371,14 +382,16 @@ pub fn point_to_point_disruption(mut context: Context<ChaChaRng>) -> Result<Scen
     leader3.shutdown()?;
     leader1.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn point_to_point_disruption_overlap(
     mut context: Context<ChaChaRng>,
 ) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "point_to_point_disruption_overlap",
+        name,
         &mut context,
         topology [
             LEADER_2,
@@ -505,12 +518,14 @@ pub fn point_to_point_disruption_overlap(
     leader2.shutdown()?;
     leader1.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn custom_network_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "custom_network_disruption",
+        name,
         &mut context,
         topology [
             LEADER_5,
@@ -620,12 +635,14 @@ pub fn custom_network_disruption(mut context: Context<ChaChaRng>) -> Result<Scen
     leader3.shutdown()?;
     leader1.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }
 
+#[named]
 pub fn mesh_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Disruption_Mesh",
+        name,
         &mut context,
         topology [
             LEADER_4,
@@ -729,5 +746,5 @@ pub fn mesh_disruption(mut context: Context<ChaChaRng>) -> Result<ScenarioResult
     leader2.shutdown()?;
     leader1.shutdown()?;
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }

--- a/testing/jormungandr-scenario-tests/src/test/non_functional/soak.rs
+++ b/testing/jormungandr-scenario-tests/src/test/non_functional/soak.rs
@@ -13,10 +13,13 @@ use std::time::{Duration, SystemTime};
 const CORE_NODE: &str = "Core";
 const RELAY_NODE_1: &str = "Relay1";
 const RELAY_NODE_2: &str = "Relay2";
+use function_name::named;
 
+#[named]
 pub fn relay_soak(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
+    let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        "Relay-Soak",
+        &name,
         &mut context,
         topology [
             CORE_NODE,
@@ -163,5 +166,5 @@ pub fn relay_soak(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     core.shutdown()?;
 
     controller.finalize();
-    Ok(ScenarioResult::passed())
+    Ok(ScenarioResult::passed(name))
 }


### PR DESCRIPTION
Added parameter which allows to print  json like test events, similar when using:

`cargo test -- -Z unstable-options --format json`  

Output is like below:

```
{"type":"suite","event":"started","test_count":1}
{"type":"test","event":"started","name":"max_connections"}
{"type":"test","name":"max_connections","event":"ok"}
{"type":"suite","event":"ok","passed":1,"failed":0,"allowed_fail":0,"ignored":0,"measured":0,"filtered_out":0}
```

This PR will help parsing nightly test jobs, which now can get unified test report 