### PR TITLE
Rework the bootstrap procedure

### DIFF
--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -43,6 +43,8 @@ pub enum Error {
     ApplyBlockFailed(#[source] BlockchainError),
     #[error("failed to select the new tip")]
     ChainSelectionFailed(#[source] BlockchainError),
+    #[error("failed to collect garbage and flush blocks to the permanent storage")]
+    GcFailed(#[source] BlockchainError),
     #[error("the bootstrap process was interrupted")]
     Interrupted,
     #[error("Trusted peers cannot be empty. To avoid bootstrap use `skip_bootstrap: true`")]

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -87,13 +87,9 @@ pub async fn bootstrap_from_peer(
 
     debug!(logger, "connecting to bootstrap peer {}", peer.connection);
 
-    let blockchain1 = blockchain.clone();
-    let tip1 = tip.clone();
-    let logger1 = logger.clone();
-
     let mut client = grpc::connect(&peer).await.map_err(Error::Connect)?;
 
-    let checkpoints = blockchain1.get_checkpoints(tip1.branch()).await;
+    let checkpoints = blockchain.get_checkpoints(tip.branch()).await;
     let checkpoints = net_data::block::try_ids_from_iter(checkpoints).unwrap();
 
     let remote_tip: Header = client
@@ -104,7 +100,7 @@ pub async fn bootstrap_from_peer(
     let remote_tip = BlockId::try_from(remote_tip.id().as_ref()).unwrap();
 
     info!(
-        logger1,
+        logger,
         "pulling blocks starting from checkpoints: {:?}; to tip {:?}", checkpoints, remote_tip,
     );
 

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -706,6 +706,11 @@ pub async fn bootstrap(
         }
     }
 
+    blockchain
+        .gc(branch.get_ref().await)
+        .await
+        .map_err(bootstrap::Error::GcFailed)?;
+
     Ok(bootstrapped)
 }
 


### PR DESCRIPTION
- Use `Tip` combined with `PullBlocks` instead of using `PullBlocksToTip`.
- Repeat the bootstrap procedure until catching with the current chain.
- Run the GC procedure after bootstrapping so that older blocks immediately appear in the permanent storage instead of waiting for the next "regular" GC run.

This establishes the basis for further improvements. In particular, integrating parallel block pulls logic (#2709).