### PR TITLE
Reduce CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,34 +87,6 @@ jobs:
           paths:
             - /usr/local/cargo/advisory-db
 
-  rustfmt:
-    executor: rust-stable
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init --depth=1
-      - run:
-          name: Print version information
-          command: rustfmt --version
-      - run:
-          name: Check rustfmt
-          command: cargo fmt -- --check
-
-  clippy:
-    executor: rust-stable
-    environment:
-      RUSTFLAGS: -D warnings
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init --depth=1
-      - run:
-          name: Print version information
-          command: cargo clippy -- --version
-      - run:
-          name: Check clippy
-          command: cargo clippy
-
   test_debug:
     executor: rust-stable
     environment:
@@ -122,14 +94,6 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
       - test
-
-  test_release:
-    executor: rust-stable
-    environment:
-      RUSTFLAGS: -D warnings
-    steps:
-      - test:
-          mode: --release
 
 commands:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,6 @@ executors:
     docker:
       - image: inputoutput/rust:stable
     working_directory: /home/circleci/build
-  rust-beta:
-    docker:
-      - image: instrumentisto/rust:beta
-    working_directory: /home/build
 
 jobs:
   cargo_fetch:
@@ -135,14 +131,6 @@ jobs:
       - test:
           mode: --release
 
-  test_beta:
-    executor: rust-beta
-    environment:
-      RUSTFLAGS: -D warnings
-      CARGO_INCREMENTAL: 0
-    steps:
-      - test
-
 commands:
   test:
     description: "Steps for the test jobs"
@@ -208,19 +196,9 @@ workflows:
   test_all:
     jobs:
       - cargo_fetch
-      - rustfmt
-      - clippy:
-          requires:
-            - cargo_fetch
       - cargo_audit:
           requires:
             - cargo_fetch
       - test_debug:
-          requires:
-            - cargo_fetch
-      - test_release:
-          requires:
-            - cargo_fetch
-      - test_beta:
           requires:
             - cargo_fetch


### PR DESCRIPTION
Remove jobs:
- rustfmt
- clippy
- test_release
- test_beta

GitHub Actions now provide a more comprehensive test plan, though
the jobs take much longer to run there.
Leave the test_debug job to as a rapid canary in the coal mine test.
Also leave cargo_audit, which is not yet ported to GitHub actions.