### PR TITLE
Explorer add gc and transaction branch tracking

### DIFF
--- a/jormungandr/src/explorer/error.rs
+++ b/jormungandr/src/explorer/error.rs
@@ -1,35 +1,25 @@
+use crate::blockcfg::HeaderHash;
 use crate::{blockchain::StorageError, intercom};
+use thiserror::Error;
 
-error_chain! {
-    foreign_links {
-        StorageError(StorageError);
-        // FIXME: fold into StorageError with more generic work in intercom streaming
-        StreamingError(intercom::Error);
-    }
-    errors {
-        BlockNotFound(hash: String) {
-            description("block not found"),
-            display("block '{}' cannot be found in the explorer", hash)
-        }
-        AncestorNotFound(hash: String) {
-            description("ancestor of block is not in explorer"),
-            display("ancestor of block '{}' cannot be found in the explorer", hash)
-        }
-        TransactionAlreadyExists(id: String) {
-            description("tried to index already existing transaction")
-            display("transaction '{}' is already indexed", id)
-        }
-        BlockAlreadyExists(id: String) {
-            description("tried to index already indexed block")
-            display("block '{}' is already indexed", id)
-        }
-        ChainLengthBlockAlreadyExists(chain_length: u32) {
-            description("tried to index already indexed chainlength in the given branch")
-            display("chain length: {} is already indexed", chain_length)
-        }
-        BootstrapError(msg: String) {
-            description("failed to initialize explorer's database from storage")
-            display("the explorer's database couldn't be initialized: {}", msg)
-        }
-    }
+#[derive(Debug, Error)]
+pub enum ExplorerError {
+    #[error("block {0} not found in explorer")]
+    BlockNotFound(HeaderHash),
+    #[error("ancestor of block '{0}' not found in explorer")]
+    AncestorNotFound(HeaderHash),
+    #[error("transaction '{0}' is already indexed")]
+    TransactionAlreadyExists(crate::blockcfg::FragmentId),
+    #[error("tried to index block '{0}' twice")]
+    BlockAlreadyExists(HeaderHash),
+    #[error("block with {0} chain length already exists in explorer branch")]
+    ChainLengthBlockAlreadyExists(crate::blockcfg::ChainLength),
+    #[error("the explorer's database couldn't be initialized: {0}")]
+    BootstrapError(String),
+    #[error("storage error")]
+    StorageError(#[from] StorageError),
+    #[error("streaming error")]
+    StreamingError(#[from] intercom::Error),
 }
+
+pub type Result<T> = std::result::Result<T, ExplorerError>;

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -1298,15 +1298,20 @@ impl Query {
         Block::from_string_hash(id, &context.db).await
     }
 
-    async fn block_by_chain_length(
+    async fn blocks_by_chain_length(
         length: ChainLength,
         context: &Context,
-    ) -> FieldResult<Option<Block>> {
-        Ok(context
+    ) -> FieldResult<Vec<Block>> {
+        let blocks = context
             .db
-            .find_block_by_chain_length(length.try_into()?)
+            .find_blocks_by_chain_length(length.try_into()?)
             .await
-            .map(Block::from_valid_hash))
+            .iter()
+            .cloned()
+            .map(Block::from_valid_hash)
+            .collect();
+
+        Ok(blocks)
     }
 
     /// query all the blocks in a paginated view

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -534,7 +534,7 @@ fn apply_block_to_transactions(
     block: &ExplorerBlock,
 ) -> Result<Transactions> {
     let block_id = block.id();
-    let ids = block.transactions.values().map(|tx| tx.id());
+    let ids = block.transactions.values().map(|(_offset, tx)| tx.id());
 
     for id in ids {
         transactions = transactions
@@ -555,7 +555,7 @@ fn apply_block_to_blocks(blocks: Blocks, block: &ExplorerBlock) -> Result<Blocks
 fn apply_block_to_addresses(mut addresses: Addresses, block: &ExplorerBlock) -> Result<Addresses> {
     let transactions = block.transactions.values();
 
-    for tx in transactions {
+    for (_, tx) in transactions {
         let id = tx.id();
 
         // A Hashset is used for preventing duplicates when the address is both an
@@ -637,7 +637,7 @@ fn apply_block_to_stake_pools(
 
     let mut data = data;
 
-    for tx in block.transactions.values() {
+    for (_, tx) in block.transactions.values() {
         if let Some(cert) = &tx.certificate {
             blocks = match cert {
                 Certificate::PoolRegistration(registration) => blocks
@@ -678,7 +678,7 @@ fn apply_block_to_vote_plans(
     blockchain_tip: &blockchain::Tip,
     block: &ExplorerBlock,
 ) -> VotePlans {
-    for tx in block.transactions.values() {
+    for (_, tx) in block.transactions.values() {
         if let Some(cert) = &tx.certificate {
             vote_plans = match cert {
                 Certificate::VotePlan(vote_plan) => vote_plans

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -4,8 +4,8 @@ mod indexing;
 mod multiverse;
 mod persistent_sequence;
 
-pub use self::graphql::create_schema;
 use self::error::{ExplorerError as Error, Result};
+pub use self::graphql::create_schema;
 use self::graphql::Context;
 use self::indexing::{
     Addresses, Blocks, ChainLengths, EpochData, Epochs, ExplorerAddress, ExplorerBlock,
@@ -232,10 +232,7 @@ impl ExplorerDB {
                     break;
                 }
                 let block = blockchain.storage().get(hash)?.ok_or_else(|| {
-                    Error::from(ErrorKind::BootstrapError(format!(
-                        "couldn't get block {} from the storage",
-                        hash
-                    )))
+                    Error::BootstrapError(format!("couldn't get block {} from the storage", hash))
                 })?;
                 hash = block.header.block_parent_hash();
                 blocks.push(block);

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -390,17 +390,19 @@ impl ExplorerDB {
             .await
     }
 
-    pub async fn find_block_by_chain_length(
-        &self,
-        chain_length: ChainLength,
-    ) -> Option<HeaderHash> {
-        self.with_latest_state(move |state| {
-            state
-                .chain_lengths
-                .lookup(&chain_length)
-                .map(|b| *b.as_ref())
-        })
-        .await
+    pub async fn find_blocks_by_chain_length(&self, chain_length: ChainLength) -> Vec<HeaderHash> {
+        let mut hashes = Vec::new();
+
+        for (_hash, state) in self.multiverse.tips().await.iter() {
+            if let Some(hash) = state.chain_lengths.lookup(&chain_length) {
+                hashes.push(**hash);
+            }
+        }
+
+        hashes.sort_unstable();
+        hashes.dedup();
+
+        hashes
     }
 
     pub async fn find_blocks_by_transaction(&self, transaction_id: &FragmentId) -> Vec<HeaderHash> {

--- a/jormungandr/src/explorer/multiverse.rs
+++ b/jormungandr/src/explorer/multiverse.rs
@@ -1,0 +1,101 @@
+use crate::blockcfg::{ChainLength, HeaderHash, Multiverse as MultiverseData};
+use chain_impl_mockchain::multiverse;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use super::State;
+
+pub struct Multiverse {
+    inner: Arc<RwLock<Inner>>,
+}
+
+pub(super) type Ref = multiverse::Ref<State>;
+
+struct Inner {
+    multiverse: MultiverseData<State>,
+    tips: HashSet<HeaderHash>,
+}
+
+impl Multiverse {
+    pub(super) fn new(
+        chain_length: ChainLength,
+        block0_id: HeaderHash,
+        initial_state: State,
+    ) -> (multiverse::Ref<State>, Self) {
+        let mut multiverse = MultiverseData::new();
+        let initial_ref = multiverse.insert(chain_length, block0_id, initial_state);
+
+        let mut tips = HashSet::new();
+        tips.insert(block0_id);
+
+        (
+            initial_ref,
+            Multiverse {
+                inner: Arc::new(RwLock::new(Inner { multiverse, tips })),
+            },
+        )
+    }
+
+    pub(super) async fn insert(
+        &self,
+        chain_length: ChainLength,
+        parent: HeaderHash,
+        hash: HeaderHash,
+        value: State,
+    ) -> multiverse::Ref<State> {
+        let mut guard = self.inner.write().await;
+
+        guard.tips.remove(&parent);
+        guard.tips.insert(hash);
+        guard.multiverse.insert(chain_length, hash, value)
+    }
+
+    pub(super) async fn get_ref(&self, hash: HeaderHash) -> Option<multiverse::Ref<State>> {
+        let guard = self.inner.read().await;
+        guard.multiverse.get_ref(&hash)
+    }
+
+    pub(super) async fn get(&self, hash: HeaderHash) -> Option<State> {
+        let guard = self.inner.read().await;
+        guard.multiverse.get(&hash).as_deref().cloned()
+    }
+
+    /// run the garbage collection of the multiverse
+    ///
+    pub async fn gc(&self, depth: u32) {
+        let mut guard = self.inner.write().await;
+        guard.multiverse.gc(depth)
+    }
+
+    /// get all the branches this block is in, None here means the block was never added
+    /// or it was moved to stable storage
+    pub(super) async fn tips(&self) -> Vec<Arc<State>> {
+        let mut guard = self.inner.write().await;
+        let mut states = Vec::new();
+
+        // garbage collect old tips too
+        let mut new_tips = HashSet::new();
+
+        for tip in guard.tips.iter() {
+            if let Some(state) = guard.multiverse.get(&tip) {
+                // TODO: probably return them sorted by chain length (descending)?
+                states.push(state);
+
+                new_tips.insert(*tip);
+            }
+        }
+
+        guard.tips = new_tips;
+
+        states
+    }
+}
+
+impl Clone for Multiverse {
+    fn clone(&self) -> Self {
+        Multiverse {
+            inner: self.inner.clone(),
+        }
+    }
+}

--- a/jormungandr/src/explorer/multiverse.rs
+++ b/jormungandr/src/explorer/multiverse.rs
@@ -70,7 +70,7 @@ impl Multiverse {
 
     /// get all the branches this block is in, None here means the block was never added
     /// or it was moved to stable storage
-    pub(super) async fn tips(&self) -> Vec<Arc<State>> {
+    pub(super) async fn tips(&self) -> Vec<(HeaderHash, Arc<State>)> {
         let mut guard = self.inner.write().await;
         let mut states = Vec::new();
 
@@ -80,7 +80,7 @@ impl Multiverse {
         for tip in guard.tips.iter() {
             if let Some(state) = guard.multiverse.get(&tip) {
                 // TODO: probably return them sorted by chain length (descending)?
-                states.push(state);
+                states.push((*tip, state));
 
                 new_tips.insert(*tip);
             }

--- a/jormungandr/src/start_up/error.rs
+++ b/jormungandr/src/start_up/error.rs
@@ -54,7 +54,7 @@ pub enum Error {
     #[error("Block 0 is set to start in the future")]
     Block0InFuture,
     #[error("Error while loading the explorer from storage")]
-    ExplorerBootstrapError(#[from] explorer::error::Error),
+    ExplorerBootstrapError(#[from] explorer::error::ExplorerError),
     #[error("A service has terminated with an error")]
     ServiceTerminatedWithError(#[from] crate::utils::task::ServiceError),
     #[error("Unable to get system limits: {0}")]


### PR DESCRIPTION
WIP: Still untested and unfinished, will add a better description later.

## Features
- Convert the explorer error to `thiserror`. The internal error type used for the graphql resolvers still needs to be converted.
- Use the `epoch_stability_depth` to add gc, as the explorer doesn't need the States behind the latest confirmed block.
- Keep track of all the tips, and add a way of getting this information.
- Transaction's `block` is now `blocks` (breaking change). Then each block can be used to get information on the branches.
- `Block::from_id` now looks on all the branches, not only the longest.
- Add `confirmed` and  `branches` queries to `Block`. Where `branches` returns a lists of the tips of each branch this block is in, at the moment of the query. This allows comparing chain lengths to know how deep the block is in, 
- TODO: it may be nice to also report branches the block is not in.
- TODO: add a top level query to know current branches?
- QUESTION: I don't really know yet what to do with all the queries, for example, transactions by address, all blocks, etc.
- I'm still not sure how to test these things in a reproducible way, I'm not sure if creating a fake in-memory block store is a good idea. Or maybe creating scenario-tests is better, although it's not really complex code. 
```graphql
{
  block(id: "25f8c36154aa37ed85bdd10b3d6be96100d945906e264dca4eb23327664b9c00") {
    id
    confirmed
    branches {
      id
      chainLength
    }
  }
}
````