### PR TITLE
testing-utils: Remove extern crate statements

### DIFF
--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/block0_config_builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/block0_config_builder.rs
@@ -1,16 +1,7 @@
 #![allow(dead_code)]
 
-extern crate chain_addr;
-extern crate chain_crypto;
-extern crate chain_impl_mockchain;
-extern crate rand;
-extern crate rand_chacha;
-extern crate serde_derive;
-use self::chain_addr::{Address as ChainAddress, Discrimination, Kind};
-use self::chain_crypto::{Ed25519, Ed25519Extended, KeyPair, PublicKey, SecretKey};
-use self::rand::SeedableRng;
-use self::rand_chacha::ChaChaRng;
-use self::serde_derive::{Deserialize, Serialize};
+use chain_addr::{Address as ChainAddress, Discrimination, Kind};
+use chain_crypto::{Ed25519, Ed25519Extended, KeyPair, PublicKey, SecretKey};
 use chain_impl_mockchain::{chaintypes::ConsensusVersion, fee::LinearFee};
 use jormungandr_lib::{
     interfaces::{
@@ -21,6 +12,9 @@ use jormungandr_lib::{
     },
     time::SecondsSinceUnixEpoch,
 };
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
+use serde_derive::{Deserialize, Serialize};
 
 use std::num::NonZeroU32;
 use std::vec::Vec;

--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/mod.rs
@@ -1,8 +1,5 @@
-extern crate lazy_static;
-extern crate rand;
-
-use self::lazy_static::lazy_static;
-use self::rand::Rng;
+use lazy_static::lazy_static;
+use rand::Rng;
 use std::sync::atomic::{AtomicU16, Ordering};
 
 mod block0_config_builder;

--- a/testing/jormungandr-testing-utils/src/testing/node/grpc/convert/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/grpc/convert/mod.rs
@@ -11,7 +11,6 @@ impl Into<ChainBlock> for Block {
 
 #[cfg(test)]
 mod tests {
-    extern crate hex;
     use crate::mock::proto::node::Block;
     use chain_impl_mockchain::block::Block as ChainBlock;
 

--- a/testing/jormungandr-testing-utils/src/testing/node/logger.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/logger.rs
@@ -1,11 +1,7 @@
-extern crate regex;
-extern crate serde;
-extern crate serde_json;
-
-use self::serde::{Deserialize, Serialize};
 use crate::testing::file as file_utils;
 use chain_core::property::FromStr;
 use chain_impl_mockchain::{block, key::Hash};
+use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;


### PR DESCRIPTION
These are unnecessary, crate names work in the new path lookup.