### PR TITLE
jcli vote-plan certificate check

### DIFF
--- a/jcli/src/jcli_app/certificate/mod.rs
+++ b/jcli/src/jcli_app/certificate/mod.rs
@@ -102,7 +102,7 @@ pub enum Error {
     InvalidJson(#[from] serde_json::Error),
     #[error("invalid binary share data")]
     InvalidBinaryShare,
-    #[error("private vote plans should contain all committee member public keys")]
+    #[error("private vote plans `committee_public_keys` cannot be empty")]
     InvalidPrivateVotePlanCommitteeKeys,
 }
 

--- a/jcli/src/jcli_app/certificate/mod.rs
+++ b/jcli/src/jcli_app/certificate/mod.rs
@@ -102,6 +102,8 @@ pub enum Error {
     InvalidJson(#[from] serde_json::Error),
     #[error("invalid binary share data")]
     InvalidBinaryShare,
+    #[error("private vote plans should contain all committee member public keys")]
+    InvalidPrivateVotePlanCommitteeKeys,
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/jcli/src/jcli_app/certificate/new_vote_plan.rs
+++ b/jcli/src/jcli_app/certificate/new_vote_plan.rs
@@ -2,7 +2,10 @@ use crate::jcli_app::{
     certificate::{write_cert, Error},
     utils::io,
 };
-use chain_impl_mockchain::certificate::{Certificate, VotePlan};
+use chain_impl_mockchain::{
+    certificate::{Certificate, VotePlan},
+    vote::PayloadType,
+};
 use jormungandr_lib::interfaces::VotePlanDef;
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -26,11 +29,25 @@ pub struct VotePlanRegistration {
 #[derive(Deserialize)]
 struct VotePlanConfiguration(#[serde(with = "VotePlanDef")] VotePlan);
 
+fn validate_voteplan(voteplan: &VotePlan) -> Result<(), Error> {
+    // if voteplan is private committee member keys should be filled
+    match voteplan.payload_type() {
+        PayloadType::Public => {}
+        PayloadType::Private => {
+            if voteplan.committee_public_keys().is_empty() {
+                return Err(Error::InvalidPrivateVotePlanCommitteeKeys);
+            }
+        }
+    }
+    Ok(())
+}
+
 impl VotePlanRegistration {
     pub fn exec(self) -> Result<(), Error> {
         let configuration = io::open_file_read(&self.input)?;
         let vote_plan_certificate: VotePlanConfiguration =
             serde_yaml::from_reader(configuration).map_err(Error::VotePlanConfig)?;
+        validate_voteplan(&vote_plan_certificate.0)?;
         let cert = Certificate::VotePlan(vote_plan_certificate.0);
         write_cert(self.output.as_deref(), cert.into())
     }


### PR DESCRIPTION
This fixes #2845 and #2846.
The issues were actually related:
`committee_public_keys` defaults to an empty `Vec`, since it is not really required for the public part. So when not checking for the keys it just uses an empty one for the private one which is incorrect.