### PR TITLE
Wait before stopping the node so transactions are flushed to disk

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -157,9 +157,9 @@ pub fn test_node_recovers_kill_signal() {
         &jormungandr,
     );
     let snapshot_before = take_snapshot(&account_receiver, &jormungandr, new_utxo.clone());
+    // Wait before stopping so transactions are flushed to disk
+    std::thread::sleep(std::time::Duration::from_secs(1));
     jormungandr.stop();
-
-    std::thread::sleep(std::time::Duration::from_secs(2));
 
     let jormungandr = Starter::new()
         .config(config)


### PR DESCRIPTION
Tested locally this change seems to remove the spurious failures of issue #2592 (*) and hopefully fix CI too. The idea is to wait so that transactions are automatically flushed to disk (sled does this by default every 500ms), but I'm not sure if this relax some capability that this test aims to check. 

(*) I had a slightly different issue with the rest request failing because the account account did not exist, but I guess the root cause is the same.