### PR TITLE
Wait between client requests

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/client_tests.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/client_tests.rs
@@ -24,6 +24,9 @@ use jormungandr_testing_utils::testing::node::grpc::client::MockClientError;
 
 use assert_fs::TempDir;
 use rand::Rng;
+use std::time::Duration;
+
+const CLIENT_RETRY_WAIT: Duration = Duration::from_millis(500);
 
 // L1001 Handshake sanity
 #[tokio::test]
@@ -382,7 +385,9 @@ pub async fn pull_blocks_correct_hashes_partial() {
 
     let client = Config::attach_to_local_node(config.get_p2p_listen_port()).client();
 
-    while client.tip().await.chain_length() < 10.into() {}
+    while client.tip().await.chain_length() < 10.into() {
+        tokio::time::delay_for(CLIENT_RETRY_WAIT).await;
+    }
 
     let block_hashes_from_logs = server.logger.get_created_blocks_hashes();
     let start = 2;
@@ -414,7 +419,9 @@ pub async fn pull_blocks_hashes_wrong_order() {
 
     let client = Config::attach_to_local_node(config.get_p2p_listen_port()).client();
 
-    while client.tip().await.chain_length() < 10.into() {}
+    while client.tip().await.chain_length() < 10.into() {
+        tokio::time::delay_for(CLIENT_RETRY_WAIT).await;
+    }
 
     let block_hashes_from_logs = server.logger.get_created_blocks_hashes();
     let start = 2;


### PR DESCRIPTION
The tight loop caused a lot of requests that, among other things, impaired the log drain