### PR TITLE
Improve diagnostics of fragment rejection errors

### DIFF
--- a/jormungandr/src/fragment/selection.rs
+++ b/jormungandr/src/fragment/selection.rs
@@ -9,6 +9,8 @@ use jormungandr_lib::interfaces::FragmentStatus;
 
 use slog::Logger;
 
+use std::iter;
+
 pub enum SelectionOutput {
     Commit { fragment_id: FragmentId },
     RequestSmallerFee,
@@ -82,11 +84,11 @@ impl FragmentSelectionAlgorithm for OldestFirst {
                     }
                     Err(error) => {
                         use std::error::Error as _;
-                        let msg = if let Some(source) = error.source() {
-                            format!("{}: {}", error, source)
-                        } else {
-                            error.to_string()
-                        };
+                        let mut msg = error.to_string();
+                        for e in iter::successors(error.source(), |e| e.source()) {
+                            msg.push_str(": ");
+                            msg.push_str(&e.to_string());
+                        }
                         debug!(logger, "fragment is rejected"; "error" => ?error);
                         logs.modify(id, FragmentStatus::Rejected { reason: msg })
                     }

--- a/jormungandr/src/fragment/selection.rs
+++ b/jormungandr/src/fragment/selection.rs
@@ -82,13 +82,13 @@ impl FragmentSelectionAlgorithm for OldestFirst {
                     }
                     Err(error) => {
                         use std::error::Error as _;
-                        let error = if let Some(source) = error.source() {
+                        let msg = if let Some(source) = error.source() {
                             format!("{}: {}", error, source)
                         } else {
                             error.to_string()
                         };
-                        debug!(logger, "fragment is rejected"; "reason" => %error);
-                        logs.modify(id, FragmentStatus::Rejected { reason: error })
+                        debug!(logger, "fragment is rejected"; "error" => ?error);
+                        logs.modify(id, FragmentStatus::Rejected { reason: msg })
                     }
                 }
 


### PR DESCRIPTION
That rabbit hole goes deep, we need to drill down to a few layers of errors to se what went wrong with voting.
Luckily, they are already represented in the source chain.