### PR TITLE
Cache responses from GitHub API in testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "jortestkit"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jortestkit.git?branch=master#a8d0061a1df4e28a42d620ad2a9acce0405664b7"
+source = "git+https://github.com/input-output-hk/jortestkit.git?branch=master#dc7e6dfe0e787e6839da23baa6261702153cc2d1"
 dependencies = [
  "assert_fs",
  "bech32",

--- a/testing/jormungandr-testing-utils/src/testing/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/mod.rs
@@ -18,7 +18,7 @@ pub use fragments::{
     VoteCastsGenerator,
 };
 pub use jortestkit::archive::decompress;
-pub use jortestkit::github::{GitHubApi, GitHubApiError, Release};
+pub use jortestkit::github::{CachedReleases, GitHubApi, GitHubApiError, Release};
 pub use jortestkit::measurement::{
     benchmark_consumption, benchmark_efficiency, benchmark_endurance, benchmark_speed,
     ConsumptionBenchmarkError, ConsumptionBenchmarkRun, EfficiencyBenchmarkDef,


### PR DESCRIPTION
Cache responses from API so that we do not incur into rate limiting in testing, needs to be merged with https://github.com/input-output-hk/jortestkit/pull/51