### PR TITLE
Explorer add gc and confirmed block notion

### DIFF
--- a/jormungandr/src/blockchain/multiverse.rs
+++ b/jormungandr/src/blockchain/multiverse.rs
@@ -1,4 +1,4 @@
-use crate::blockcfg::{ChainLength, HeaderHash, Ledger, Multiverse as MultiverseData};
+use crate::blockcfg::{ChainLength, HeaderHash, Multiverse as MultiverseData};
 use chain_impl_mockchain::multiverse;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -43,12 +43,9 @@ impl<T: Clone> Multiverse<T> {
     }
 }
 
-impl Multiverse<Ledger> {
+impl<T> Multiverse<T> {
     /// run the garbage collection of the multiverse
     ///
-    /// TODO: this function is only working for the `Ledger` at the moment
-    ///       we need to generalize the `chain_impl_mockchain` to handle
-    ///       the garbage collection for any `T`
     pub async fn gc(&self, depth: u32) {
         let mut guard = self.inner.write().await;
         guard.gc(depth)

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -190,6 +190,10 @@ impl Block {
             });
         Ok(treasury)
     }
+
+    pub async fn is_confirmed(&self, context: &Context) -> bool {
+        context.db.is_block_confirmed(&self.hash).await
+    }
 }
 
 struct BftLeader {

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -702,6 +702,14 @@ impl Status {
         latest_block(context).await.map(|b| Block::from(&b))
     }
 
+    pub async fn epoch_stability_depth(&self, context: &Context) -> String {
+        context
+            .db
+            .blockchain_config
+            .epoch_stability_depth
+            .to_string()
+    }
+
     pub fn fee_settings(&self, context: &Context) -> FeeSettings {
         let chain_impl_mockchain::fee::LinearFee {
             constant,

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -772,37 +772,36 @@ fn apply_block_to_vote_plans(
 
 impl BlockchainConfig {
     fn from_config_params(params: &ConfigParams) -> BlockchainConfig {
-        let discrimination = params
-            .iter()
-            .filter_map(|param| match param {
-                ConfigParam::Discrimination(discrimination) => Some(discrimination),
-                _ => None,
-            })
-            .next()
-            .expect("the discrimination to be present");
+        let mut discrimination: Option<Discrimination> = None;
+        let mut consensus_version: Option<ConsensusVersion> = None;
+        let mut fees: Option<LinearFee> = None;
+        let mut epoch_stability_depth: Option<u32> = None;
 
-        let consensus_version = params
-            .iter()
-            .filter_map(|param| match param {
-                ConfigParam::ConsensusVersion(version) => Some(version),
-                _ => None,
-            })
-            .next()
-            .expect("consensus version to be present");
-
-        let fees = params
-            .iter()
-            .filter_map(|param| match param {
-                ConfigParam::LinearFee(fee) => Some(fee),
-                _ => None,
-            })
-            .next()
-            .expect("fee is not in config params");
+        for p in params.iter() {
+            match p {
+                ConfigParam::Discrimination(d) => {
+                    discrimination.replace(*d);
+                }
+                ConfigParam::ConsensusVersion(v) => {
+                    consensus_version.replace(*v);
+                }
+                ConfigParam::LinearFee(fee) => {
+                    fees.replace(*fee);
+                }
+                ConfigParam::EpochStabilityDepth(d) => {
+                    epoch_stability_depth.replace(*d);
+                }
+                _ => (),
+            }
+        }
 
         BlockchainConfig {
-            discrimination: *discrimination,
-            consensus_version: *consensus_version,
-            fees: *fees,
+            discrimination: discrimination.expect("discrimination not found in initial params"),
+            consensus_version: consensus_version
+                .expect("consensus version not found in initial params"),
+            fees: fees.expect("fees not found in initial params"),
+            epoch_stability_depth: epoch_stability_depth
+                .expect("epoch stability depth not found in initial params"),
         }
     }
 }

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -214,25 +214,25 @@ impl ExplorerDB {
 
         let block0_id = block0.id();
 
+        let maybe_head = blockchain.storage().get_tag(MAIN_BRANCH_TAG)?;
+        let (stream, hash) = match maybe_head {
+            Some(head) => (blockchain.storage().stream_from_to(block0_id, head)?, head),
+            None => {
+                return Err(Error::from(ErrorKind::BootstrapError(
+                    "Couldn't read the HEAD tag from storage".to_owned(),
+                )))
+            }
+        };
+
         let bootstraped_db = ExplorerDB {
             multiverse,
-            longest_chain_tip: Tip::new(block0.header.id()),
+            longest_chain_tip: Tip::new(hash),
             blockchain_config,
             blockchain: blockchain.clone(),
             blockchain_tip,
             stable_store: StableIndex {
                 confirmed_block_chain_length: Arc::new(AtomicU32::default()),
             },
-        };
-
-        let maybe_head = blockchain.storage().get_tag(MAIN_BRANCH_TAG)?;
-        let stream = match maybe_head {
-            Some(head) => blockchain.storage().stream_from_to(block0_id, head)?,
-            None => {
-                return Err(Error::from(ErrorKind::BootstrapError(
-                    "Couldn't read the HEAD tag from storage".to_owned(),
-                )))
-            }
         };
 
         let db = stream

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -62,6 +62,7 @@ pub struct BlockchainConfig {
     discrimination: Discrimination,
     consensus_version: ConsensusVersion,
     fees: LinearFee,
+    epoch_stability_depth: u32,
 }
 
 /// Inmutable data structure used to represent the explorer's state at a given Block

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -128,7 +128,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 .explorer_db
                 .expect("explorer db to be bootstrapped");
 
-            let mut explorer = explorer::Explorer::new(explorer_db);
+            let explorer = explorer::Explorer::new(explorer_db);
 
             // Context to give to the rest api
             let context = explorer.clone();


### PR DESCRIPTION
This adds the notion of `epoch_stability_depth` to the explorer. It's used both for multiverse garbage collection and to know if a block is confirmed.

Also, when working on this I found a problem with the way tip changes were handled in #2903

The thing is, tip changes are being sent to the explorer before having the block. This means, that we can't get the State at that particular hash, so we don't have the block and we can't know it's chain_length to find out which one is confirmed.

Also means that a query may come in the middle and try to use a branch not fully indexed and break things like @dkijania also found in #2950

This PR fixes it in a way that may be a bit hacky. It works by saving the tip update for the time the block comes, if it's not already there, so it doesn't care which one comes first.

A proper solution could be to send blocks to the explorer after knowing the branch solution result, but the problem is that by that point the node only has a `Ref` and not a `Block`, so that would require either carrying the block there, or sending the branch comparison result back (up in the stack trace).

An alternative could be to only send hashes, and get blocks from the storage, but I think this is blocking? and maybe not fast.