### PR TITLE
Start tokio runtime for scenario tests

### DIFF
--- a/testing/jormungandr-scenario-tests/src/bin/jormungandr-scenario-tests.rs
+++ b/testing/jormungandr-scenario-tests/src/bin/jormungandr-scenario-tests.rs
@@ -91,7 +91,8 @@ struct CommandArgs {
     report: bool,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let command_args = CommandArgs::from_args();
 
     std::env::set_var("RUST_BACKTRACE", "full");

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -21,7 +21,6 @@ pub use jormungandr_testing_utils::testing::{
     node::{grpc::JormungandrClient, JormungandrLogger},
     FragmentNode, FragmentNodeError, MemPoolCheck,
 };
-use tokio::runtime;
 
 use futures::executor::block_on;
 use rand_core::RngCore;
@@ -527,9 +526,8 @@ impl LegacyNode {
 
         LegacyNodeController {
             alias: self.alias().clone(),
-            grpc_client: runtime::Runtime::new().unwrap().block_on(async {
-                JormungandrClient::from_address(&p2p_address).expect("cannot setup grpc client")
-            }),
+            grpc_client: JormungandrClient::from_address(&p2p_address)
+                .expect("cannot setup grpc client"),
             settings: self.node_settings.clone(),
             status: self.status.clone(),
             progress_bar: self.progress_bar.clone(),

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -29,7 +29,6 @@ pub use jormungandr_testing_utils::testing::{
     FragmentNode, MemPoolCheck, NamedProcess,
 };
 use jormungandr_testing_utils::{testing::node::Explorer, Version};
-use tokio::runtime;
 
 use futures::executor::block_on;
 use indicatif::ProgressBar;
@@ -532,9 +531,8 @@ impl Node {
 
         NodeController {
             alias: self.alias().clone(),
-            grpc_client: runtime::Runtime::new().unwrap().block_on(async {
-                JormungandrClient::from_address(&p2p_address).expect("cannot setup grpc client")
-            }),
+            grpc_client: JormungandrClient::from_address(&p2p_address)
+                .expect("cannot setup grpc client"),
             rest_client: JormungandrRest::new(rest_uri),
             settings: self.node_settings.clone(),
             status: self.status.clone(),


### PR DESCRIPTION
Since some parts used in testing require a tokio runtime, it seems convenient to just start it at the beginning.

Also need to update tokio used in scenario tests to 1.1,  I see https://github.com/input-output-hk/jormungandr/pull/2965 is already doing that, so we can wait for it to be merged.