### PR TITLE
Add jcli command to tally all proposals in a vote plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "cbor_event",
  "chain-ser",
@@ -466,7 +466,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "bech32",
  "cfg-if 1.0.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "chain-ser",
 ]
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "bech32",
  "cfg-if 1.0.0",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "cardano-legacy-address",
  "cfg-if 1.0.0",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "chain-network"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "async-trait",
  "chain-crypto",
@@ -553,12 +553,12 @@ dependencies = [
 [[package]]
 name = "chain-ser"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "criterion",
  "data-pile",
@@ -571,7 +571,7 @@ dependencies = [
 [[package]]
 name = "chain-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "chain-core",
  "quickcheck",
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "cfg-if 1.0.0",
  "chain-core",
@@ -591,11 +591,13 @@ dependencies = [
 [[package]]
 name = "chain-vote"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "cryptoxide 0.2.1",
  "eccoxide",
  "rand_core 0.5.1",
+ "rayon",
+ "thiserror",
 ]
 
 [[package]]
@@ -1772,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 dependencies = [
  "thiserror",
 ]
@@ -1909,6 +1911,7 @@ dependencies = [
  "predicates",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
+ "rayon",
  "reqwest",
  "serde",
  "serde_derive",
@@ -3911,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 
 [[package]]
 name = "spin"
@@ -4616,7 +4619,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#abb5e0d470be99d66e5604c722eaef575f4d9fc1"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#88b56d22d402b88d347e7ab9ff8c6f9318e025be"
 
 [[package]]
 name = "typenum"

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -23,6 +23,7 @@ mime = "^0.3.7"
 structopt = "^0.3"
 bech32 = "0.7"
 hex = "0.4.2"
+rayon = "1.5"
 base64 = "0.13.0"
 chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }

--- a/jcli/src/jcli_app/utils/mod.rs
+++ b/jcli/src/jcli_app/utils/mod.rs
@@ -5,6 +5,7 @@ pub mod key_parser;
 // pub mod open_api_verifier;
 pub mod output_file;
 pub mod output_format;
+pub mod vote;
 
 pub use self::account_id::AccountId;
 // pub use self::open_api_verifier::OpenApiVerifier;

--- a/jcli/src/jcli_app/utils/vote.rs
+++ b/jcli/src/jcli_app/utils/vote.rs
@@ -77,7 +77,7 @@ pub struct TallyDecryptShare(#[serde(with = "serde_base64_bytes")] Vec<u8>);
 
 // Set of shares (belonging to a single committee member) for the decryption of a vote plan
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SingleMemberVotePlanShares(Vec<TallyDecryptShare>);
+pub struct MemberVotePlanShares(Vec<TallyDecryptShare>);
 
 // Set of decrypt shares (belonging to different committee members)
 // that decrypts a vote plan
@@ -92,7 +92,7 @@ impl TryFrom<TallyDecryptShare> for chain_vote::TallyDecryptShare {
     }
 }
 
-impl From<Vec<chain_vote::TallyDecryptShare>> for SingleMemberVotePlanShares {
+impl From<Vec<chain_vote::TallyDecryptShare>> for MemberVotePlanShares {
     fn from(shares: Vec<chain_vote::TallyDecryptShare>) -> Self {
         Self(
             shares
@@ -103,9 +103,9 @@ impl From<Vec<chain_vote::TallyDecryptShare>> for SingleMemberVotePlanShares {
     }
 }
 
-impl TryFrom<Vec<SingleMemberVotePlanShares>> for VotePlanDecryptShares {
+impl TryFrom<Vec<MemberVotePlanShares>> for VotePlanDecryptShares {
     type Error = SharesError;
-    fn try_from(shares: Vec<SingleMemberVotePlanShares>) -> Result<Self, Self::Error> {
+    fn try_from(shares: Vec<MemberVotePlanShares>) -> Result<Self, Self::Error> {
         let shares = shares.into_iter().map(|s| s.0).collect::<Vec<_>>();
         if shares.is_empty() {
             return Err(SharesError::Empty);

--- a/jcli/src/jcli_app/utils/vote.rs
+++ b/jcli/src/jcli_app/utils/vote.rs
@@ -1,0 +1,146 @@
+use crate::jcli_app::utils::io;
+use jormungandr_lib::crypto::hash::Hash;
+use jormungandr_lib::interfaces::{serde_base64_bytes, VotePlanStatus};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::convert::TryFrom;
+use std::path::Path;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum VotePlanError {
+    #[error("I/O error")]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    JsonError(#[from] serde_json::Error),
+    #[error("could not decode vote plan")]
+    VotePlansRead,
+    #[error("could not find vote plan with specified id")]
+    VotePlanIdNotFound,
+    #[error("please specify a correct id for the vote plan")]
+    UnclearVotePlan,
+}
+
+// Read json-encoded vote plan(s) from file and returns the one
+// with the specified id. If there is only one vote plan in the input
+// the id can be
+pub fn get_vote_plan_by_id<P: AsRef<Path>>(
+    vote_plan_file: &Option<P>,
+    id: Option<&Hash>,
+) -> Result<VotePlanStatus, VotePlanError> {
+    let value: Value = serde_json::from_reader(io::open_file_read(vote_plan_file)?)?;
+    match value {
+        Value::Array(vote_plans) => {
+            let plans = vote_plans
+                .into_iter()
+                .map(serde_json::from_value)
+                .collect::<Result<Vec<VotePlanStatus>, serde_json::Error>>()?;
+            match id {
+                Some(id) => plans
+                    .into_iter()
+                    .find(|plan| &plan.id == id)
+                    .ok_or(VotePlanError::VotePlanIdNotFound),
+                None if plans.len() == 1 => Ok(plans.into_iter().next().unwrap()),
+                _ => Err(VotePlanError::UnclearVotePlan),
+            }
+        }
+        obj @ Value::Object(_) => {
+            let vote_plan: VotePlanStatus = serde_json::from_value(obj)?;
+            match id {
+                None => Ok(vote_plan),
+                Some(id) if &vote_plan.id == id => Ok(vote_plan),
+                _ => Err(VotePlanError::VotePlanIdNotFound),
+            }
+        }
+        _ => Err(VotePlanError::VotePlansRead),
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SharesError {
+    #[error("I/O error")]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    JsonError(#[from] serde_json::Error),
+    #[error("shares cannot be empty")]
+    Empty,
+    #[error("proposals have different number of shares")]
+    ProposalSharesNotBalanced,
+    #[error("insufficient amount of shares for vote plan decryption")]
+    InsufficientShares,
+    #[error("invalid binary share data")]
+    InvalidBinaryShare,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TallyDecryptShare(#[serde(with = "serde_base64_bytes")] Vec<u8>);
+
+// Set of shares (belonging to a single committee member) for the decryption of a vote plan
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SingleMemberVotePlanShares(Vec<TallyDecryptShare>);
+
+// Set of decrypt shares (belonging to different committee members)
+// that decrypts a vote plan
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VotePlanDecryptShares(Vec<Vec<TallyDecryptShare>>);
+
+impl VotePlanDecryptShares {
+    pub fn into_shares(self) -> Vec<Vec<TallyDecryptShare>> {
+        self.0
+    }
+}
+
+impl TryFrom<TallyDecryptShare> for chain_vote::TallyDecryptShare {
+    type Error = SharesError;
+
+    fn try_from(value: TallyDecryptShare) -> Result<Self, Self::Error> {
+        chain_vote::TallyDecryptShare::from_bytes(&value.0).ok_or(SharesError::InvalidBinaryShare)
+    }
+}
+
+impl From<Vec<chain_vote::TallyDecryptShare>> for SingleMemberVotePlanShares {
+    fn from(shares: Vec<chain_vote::TallyDecryptShare>) -> Self {
+        Self(
+            shares
+                .into_iter()
+                .map(|s| TallyDecryptShare(s.to_bytes()))
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+impl TryFrom<Vec<SingleMemberVotePlanShares>> for VotePlanDecryptShares {
+    type Error = SharesError;
+    fn try_from(shares: Vec<SingleMemberVotePlanShares>) -> Result<Self, Self::Error> {
+        let shares = shares.into_iter().map(|s| s.0).collect::<Vec<_>>();
+        if shares.is_empty() {
+            return Err(SharesError::Empty);
+        }
+        let mut res = vec![Vec::new(); shares[0].len()];
+        // transponse 2d array
+        for member_shares in shares {
+            if member_shares.len() != res.len() {
+                return Err(SharesError::ProposalSharesNotBalanced);
+            }
+            for (i, share) in member_shares.into_iter().enumerate() {
+                res[i].push(share);
+            }
+        }
+        Ok(VotePlanDecryptShares(res))
+    }
+}
+
+pub fn read_vote_plan_shares_from_file<P: AsRef<Path>>(
+    share_path: &Option<P>,
+    proposals: usize,
+    threshold: Option<usize>,
+) -> Result<VotePlanDecryptShares, SharesError> {
+    let vote_plan_shares: VotePlanDecryptShares =
+        serde_json::from_reader(io::open_file_read(share_path)?)?;
+    if vote_plan_shares.0.len() != proposals || vote_plan_shares.0[0].len() < threshold.unwrap_or(1)
+    {
+        return Err(SharesError::InsufficientShares);
+    }
+
+    Ok(vote_plan_shares)
+}

--- a/jcli/src/jcli_app/vote/mod.rs
+++ b/jcli/src/jcli_app/vote/mod.rs
@@ -40,10 +40,20 @@ pub enum Error {
     InvalidCommitteMemberIndex,
     #[error("failed to read encrypted tally bytes")]
     EncryptedTallyRead,
+    #[error("failed to read vote plans")]
+    VotePlansRead,
+    #[error("no vote plan found with specified id")]
+    VotePlanIdNotFound,
+    #[error("please specify a vote plan id if multiple vote plans are provided")]
+    UnclearVotePlan,
     #[error("failed to read decryption key bytes")]
     DecryptionKeyRead,
     #[error("failed to read share bytes")]
     DecryptionShareRead,
+    #[error("missing shares for a proposal")]
+    MissingShares,
+    #[error(transparent)]
+    TallyError(#[from] chain_vote::TallyError),
     #[error(transparent)]
     FormatError(#[from] crate::jcli_app::utils::output_format::Error),
     #[error(transparent)]

--- a/jcli/src/jcli_app/vote/mod.rs
+++ b/jcli/src/jcli_app/vote/mod.rs
@@ -1,4 +1,5 @@
 use crate::jcli_app::utils::output_file::{self, OutputFile};
+use jormungandr_lib::interfaces::Tally;
 
 pub mod bech32_constants;
 mod committee;
@@ -50,6 +51,8 @@ pub enum Error {
     DecryptionKeyRead,
     #[error("failed to read share bytes")]
     DecryptionShareRead,
+    #[error("expected encrypted private tally, found {found:?}")]
+    PrivateTallyExpected { found: Option<Tally> },
     #[error("missing shares for a proposal")]
     MissingShares,
     #[error(transparent)]

--- a/jcli/src/jcli_app/vote/mod.rs
+++ b/jcli/src/jcli_app/vote/mod.rs
@@ -1,4 +1,5 @@
 use crate::jcli_app::utils::output_file::{self, OutputFile};
+use crate::jcli_app::utils::vote::{SharesError, VotePlanError};
 use jormungandr_lib::interfaces::Tally;
 
 pub mod bech32_constants;
@@ -41,26 +42,20 @@ pub enum Error {
     InvalidCommitteMemberIndex,
     #[error("failed to read encrypted tally bytes")]
     EncryptedTallyRead,
-    #[error("failed to read vote plans")]
-    VotePlansRead,
-    #[error("no vote plan found with specified id")]
-    VotePlanIdNotFound,
-    #[error("please specify a vote plan id if multiple vote plans are provided")]
-    UnclearVotePlan,
     #[error("failed to read decryption key bytes")]
     DecryptionKeyRead,
-    #[error("failed to read share bytes")]
-    DecryptionShareRead,
     #[error("expected encrypted private tally, found {found:?}")]
     PrivateTallyExpected { found: Option<Tally> },
-    #[error("missing shares for a proposal")]
-    MissingShares,
     #[error(transparent)]
     TallyError(#[from] chain_vote::TallyError),
     #[error(transparent)]
     FormatError(#[from] crate::jcli_app::utils::output_format::Error),
     #[error(transparent)]
     JsonError(#[from] serde_json::Error),
+    #[error(transparent)]
+    VotePlanError(#[from] VotePlanError),
+    #[error(transparent)]
+    SharesError(#[from] SharesError),
 }
 
 #[derive(StructOpt)]

--- a/jcli/src/jcli_app/vote/mod.rs
+++ b/jcli/src/jcli_app/vote/mod.rs
@@ -1,6 +1,5 @@
 use crate::jcli_app::utils::output_file::{self, OutputFile};
 use crate::jcli_app::utils::vote::{SharesError, VotePlanError};
-use jormungandr_lib::interfaces::Tally;
 
 pub mod bech32_constants;
 mod committee;
@@ -44,8 +43,8 @@ pub enum Error {
     EncryptedTallyRead,
     #[error("failed to read decryption key bytes")]
     DecryptionKeyRead,
-    #[error("expected encrypted private tally, found {found:?}")]
-    PrivateTallyExpected { found: Option<Tally> },
+    #[error("expected encrypted private tally, found {found}")]
+    PrivateTallyExpected { found: &'static str },
     #[error(transparent)]
     TallyError(#[from] chain_vote::TallyError),
     #[error(transparent)]

--- a/jcli/src/jcli_app/vote/tally/decrypt_shares.rs
+++ b/jcli/src/jcli_app/vote/tally/decrypt_shares.rs
@@ -36,7 +36,7 @@ pub struct TallyVotePlanWithAllShares {
     /// The path to json-encoded vote plan to decrypt. If this parameter is not
     /// specified, the vote plan will be read from the standard
     /// input.
-    #[structopt(long = "vote-plan-file")]
+    #[structopt(long = "vote-plan")]
     vote_plan: Option<PathBuf>,
     /// The id of the vote plan to decrypt.
     /// Can be left unspecified if there is only one vote plan in the input

--- a/jcli/src/jcli_app/vote/tally/decryption_tally.rs
+++ b/jcli/src/jcli_app/vote/tally/decryption_tally.rs
@@ -2,6 +2,8 @@ use super::Error;
 use crate::jcli_app::utils::io;
 use bech32::FromBase32;
 use chain_vote::{EncryptedTally, OpeningVoteKey};
+use jormungandr_lib::interfaces::{PrivateTallyState, Tally};
+use std::path::Path;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -20,31 +22,116 @@ pub struct TallyGenerateDecryptionShare {
     decryption_key: PathBuf,
 }
 
+/// Create decryption shares for all proposals in a vote plan.
+///
+/// The decryption share data will be printed in hexadecimal encoding
+/// on standard output.
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub struct TallyGenerateVotePlanDecryptionShares {
+    /// The path to json-encoded vote plan to decrypt. If this parameter is not
+    /// specified, the vote plan will be read from standard input.
+    #[structopt(long = "vote-plan")]
+    vote_plan: Option<PathBuf>,
+    /// The id of the vote plan to decrypt.
+    /// Can be left unspecified if there is only one vote plan in the input
+    #[structopt(long = "vote-plan-id")]
+    vote_plan_id: Option<String>,
+    /// The path to hex-encoded decryption key.
+    #[structopt(long = "key")]
+    decryption_key: PathBuf,
+}
+
+/// Merge multiple sets of shares in a single object to be used in the
+/// decryption of a vote plan.
+///
+/// The data will be printed in hexadecimal encoding
+/// on standard output.
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub struct MergeShares {
+    /// The path to the shares to merge
+    #[structopt(long = "shares")]
+    shares: Vec<PathBuf>,
+}
+
+fn read_decryption_key<P: AsRef<Path>>(path: &Option<P>) -> Result<OpeningVoteKey, Error> {
+    let data = io::read_line(path)?;
+    bech32::decode(&data)
+        .map_err(Error::from)
+        .and_then(|(hrp, raw_key)| {
+            if hrp != crate::jcli_app::vote::bech32_constants::MEMBER_SK_HRP {
+                return Err(Error::InvalidSecretKey);
+            }
+            OpeningVoteKey::from_bytes(
+                &Vec::<u8>::from_base32(&raw_key).map_err(|_| Error::DecryptionKeyRead)?,
+            )
+            .ok_or(Error::DecryptionKeyRead)
+        })
+}
+
 impl TallyGenerateDecryptionShare {
     pub fn exec(&self) -> Result<(), Error> {
         let encrypted_tally_hex = io::read_line(&self.encrypted_tally)?;
         let encrypted_tally_bytes = base64::decode(encrypted_tally_hex)?;
         let encrypted_tally =
             EncryptedTally::from_bytes(&encrypted_tally_bytes).ok_or(Error::EncryptedTallyRead)?;
-
-        let decryption_key = {
-            let data = io::read_line(&Some(&self.decryption_key))?;
-            bech32::decode(&data)
-                .map_err(Error::from)
-                .and_then(|(hrp, raw_key)| {
-                    if hrp != crate::jcli_app::vote::bech32_constants::MEMBER_SK_HRP {
-                        return Err(Error::InvalidSecretKey);
-                    }
-                    OpeningVoteKey::from_bytes(
-                        &Vec::<u8>::from_base32(&raw_key).map_err(|_| Error::DecryptionKeyRead)?,
-                    )
-                    .ok_or(Error::DecryptionKeyRead)
-                })?
-        };
-
+        let decryption_key = read_decryption_key(&Some(&self.decryption_key))?;
         let (_state, share) = encrypted_tally.finish(&decryption_key);
         println!("{}", base64::encode(share.to_bytes()));
 
+        Ok(())
+    }
+}
+
+impl TallyGenerateVotePlanDecryptionShares {
+    pub fn exec(&self) -> Result<(), Error> {
+        let vote_plan = super::get_vote_plan_by_id(&self.vote_plan, self.vote_plan_id.as_deref())?;
+        let decryption_key = read_decryption_key(&Some(&self.decryption_key))?;
+
+        let shares = vote_plan
+            .proposals
+            .into_iter()
+            .filter_map(|prop| match prop.tally {
+                Some(Tally::Private {
+                    state:
+                        PrivateTallyState::Encrypted {
+                            encrypted_tally, ..
+                        },
+                }) => {
+                    let encrypted_tally =
+                        EncryptedTally::from_bytes(&encrypted_tally.into_bytes())?;
+                    Some(base64::encode(
+                        encrypted_tally.finish(&decryption_key).1.to_bytes(),
+                    ))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        println!("{}", serde_json::to_value(shares)?);
+        Ok(())
+    }
+}
+
+impl MergeShares {
+    pub fn exec(&self) -> Result<(), Error> {
+        let shares = &self
+            .shares
+            .iter()
+            .map(|path| Ok(serde_json::from_reader(io::open_file_read(&Some(path))?)?))
+            .collect::<Result<Vec<Vec<String>>, Error>>()?;
+        let num_proposals = shares[0].len();
+        let mut res = vec![Vec::new(); num_proposals];
+        for member_shares in shares {
+            if member_shares.len() != num_proposals {
+                return Err(Error::MissingShares);
+            }
+            for (i, share) in member_shares.iter().enumerate() {
+                res[i].push(share);
+            }
+        }
+
+        println!("{}", serde_json::to_string(&res)?);
         Ok(())
     }
 }

--- a/jcli/src/jcli_app/vote/tally/decryption_tally.rs
+++ b/jcli/src/jcli_app/vote/tally/decryption_tally.rs
@@ -1,6 +1,6 @@
 use super::Error;
 use crate::jcli_app::utils::io;
-use crate::jcli_app::utils::vote::{self, SingleMemberVotePlanShares, VotePlanDecryptShares};
+use crate::jcli_app::utils::vote::{self, MemberVotePlanShares, VotePlanDecryptShares};
 use bech32::FromBase32;
 use chain_vote::{EncryptedTally, OpeningVoteKey};
 use jormungandr_lib::crypto::hash::Hash;
@@ -112,7 +112,7 @@ impl TallyGenerateVotePlanDecryptionShares {
             .collect::<Vec<_>>();
         println!(
             "{}",
-            serde_json::to_value(SingleMemberVotePlanShares::from(shares))?
+            serde_json::to_value(MemberVotePlanShares::from(shares))?
         );
         Ok(())
     }
@@ -124,7 +124,7 @@ impl MergeShares {
             .shares
             .iter()
             .map(|path| Ok(serde_json::from_reader(io::open_file_read(&Some(path))?)?))
-            .collect::<Result<Vec<SingleMemberVotePlanShares>, Error>>()?;
+            .collect::<Result<Vec<MemberVotePlanShares>, Error>>()?;
         let vote_plan_shares = VotePlanDecryptShares::try_from(shares)?;
         println!("{}", serde_json::to_string(&vote_plan_shares)?);
         Ok(())

--- a/jcli/src/jcli_app/vote/tally/decryption_tally.rs
+++ b/jcli/src/jcli_app/vote/tally/decryption_tally.rs
@@ -89,7 +89,8 @@ impl TallyGenerateDecryptionShare {
 
 impl TallyGenerateVotePlanDecryptionShares {
     pub fn exec(&self) -> Result<(), Error> {
-        let vote_plan = vote::get_vote_plan_by_id(&self.vote_plan, self.vote_plan_id.as_ref())?;
+        let vote_plan =
+            vote::get_vote_plan_by_id(self.vote_plan.as_ref(), self.vote_plan_id.as_ref())?;
         let decryption_key = read_decryption_key(&Some(&self.key))?;
 
         let shares = vote_plan

--- a/jcli/src/jcli_app/vote/tally/mod.rs
+++ b/jcli/src/jcli_app/vote/tally/mod.rs
@@ -37,6 +37,9 @@ impl Tally {
     }
 }
 
+// Read json-encoded vote plan(s) from file and returns the one
+// with the specified id. If there is only one vote plan in the input
+// the id can be omitted
 fn get_vote_plan_by_id<P: AsRef<Path>>(
     vote_plan_file: &Option<P>,
     id: Option<&str>,

--- a/jcli/src/jcli_app/vote/tally/mod.rs
+++ b/jcli/src/jcli_app/vote/tally/mod.rs
@@ -15,6 +15,14 @@ pub enum Tally {
     /// The decryption share data will be printed in hexadecimal encoding
     /// on standard output.
     DecryptionShare(decryption_tally::TallyGenerateDecryptionShare),
+    /// Create a decryption share for private voting tally.
+    ///
+    /// The decryption share data will be printed in hexadecimal encoding
+    /// on standard output.
+    VotePlanDecryptionShares(decryption_tally::TallyGenerateVotePlanDecryptionShares),
+    /// Merge multiple sets of shares in a single object to be used in the
+    /// decryption of a vote plan.
+    MergeShares(decryption_tally::MergeShares),
     /// Decrypt a tally with decryption shares.
     ///
     /// The decrypted tally data will be printed in hexadecimal encoding
@@ -31,15 +39,17 @@ impl Tally {
     pub fn exec(self) -> Result<(), Error> {
         match self {
             Tally::DecryptionShare(cmd) => cmd.exec(),
+            Tally::VotePlanDecryptionShares(cmd) => cmd.exec(),
             Tally::Decrypt(cmd) => cmd.exec(),
             Tally::DecryptVotePlan(cmd) => cmd.exec(),
+            Tally::MergeShares(cmd) => cmd.exec(),
         }
     }
 }
 
 // Read json-encoded vote plan(s) from file and returns the one
 // with the specified id. If there is only one vote plan in the input
-// the id can be omitted
+// the id can be
 fn get_vote_plan_by_id<P: AsRef<Path>>(
     vote_plan_file: &Option<P>,
     id: Option<&str>,

--- a/jcli/src/jcli_app/vote/tally/mod.rs
+++ b/jcli/src/jcli_app/vote/tally/mod.rs
@@ -16,7 +16,7 @@ pub enum Tally {
     ///
     /// The decryption share data will be printed in hexadecimal encoding
     /// on standard output.
-    VotePlanDecryptionShares(decryption_tally::TallyGenerateVotePlanDecryptionShares),
+    DecryptionShares(decryption_tally::TallyGenerateVotePlanDecryptionShares),
     /// Merge multiple sets of shares in a single object to be used in the
     /// decryption of a vote plan.
     MergeShares(decryption_tally::MergeShares),
@@ -29,16 +29,16 @@ pub enum Tally {
     ///
     /// The decrypted tally data will be printed in hexadecimal encoding
     /// on standard output.
-    DecryptVotePlan(decrypt_shares::TallyVotePlanWithAllShares),
+    DecryptResults(decrypt_shares::TallyVotePlanWithAllShares),
 }
 
 impl Tally {
     pub fn exec(self) -> Result<(), Error> {
         match self {
             Tally::DecryptionShare(cmd) => cmd.exec(),
-            Tally::VotePlanDecryptionShares(cmd) => cmd.exec(),
+            Tally::DecryptionShares(cmd) => cmd.exec(),
             Tally::Decrypt(cmd) => cmd.exec(),
-            Tally::DecryptVotePlan(cmd) => cmd.exec(),
+            Tally::DecryptResults(cmd) => cmd.exec(),
             Tally::MergeShares(cmd) => cmd.exec(),
         }
     }

--- a/jcli/src/jcli_app/vote/tally/mod.rs
+++ b/jcli/src/jcli_app/vote/tally/mod.rs
@@ -2,9 +2,6 @@ mod decrypt_shares;
 mod decryption_tally;
 
 use super::Error;
-use crate::jcli_app::utils::io;
-use jormungandr_lib::interfaces::VotePlanStatus;
-use std::path::Path;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -43,30 +40,6 @@ impl Tally {
             Tally::Decrypt(cmd) => cmd.exec(),
             Tally::DecryptVotePlan(cmd) => cmd.exec(),
             Tally::MergeShares(cmd) => cmd.exec(),
-        }
-    }
-}
-
-// Read json-encoded vote plan(s) from file and returns the one
-// with the specified id. If there is only one vote plan in the input
-// the id can be
-fn get_vote_plan_by_id<P: AsRef<Path>>(
-    vote_plan_file: &Option<P>,
-    id: Option<&str>,
-) -> Result<VotePlanStatus, Error> {
-    let mut vote_plans: Vec<VotePlanStatus> =
-        serde_json::from_reader(io::open_file_read(vote_plan_file)?)
-            .map_err(|_| Error::VotePlansRead)?;
-    match id {
-        Some(id) => vote_plans
-            .into_iter()
-            .find(|plan| plan.id.to_hex().contains(id))
-            .ok_or(Error::VotePlanIdNotFound),
-        None => {
-            if vote_plans.len() != 1 {
-                return Err(Error::UnclearVotePlan);
-            }
-            Ok(vote_plans.pop().unwrap())
         }
     }
 }

--- a/jcli/src/jcli_app/vote/tally/mod.rs
+++ b/jcli/src/jcli_app/vote/tally/mod.rs
@@ -2,6 +2,9 @@ mod decrypt_shares;
 mod decryption_tally;
 
 use super::Error;
+use crate::jcli_app::utils::io;
+use jormungandr_lib::interfaces::VotePlanStatus;
+use std::path::Path;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -17,6 +20,11 @@ pub enum Tally {
     /// The decrypted tally data will be printed in hexadecimal encoding
     /// on standard output.
     Decrypt(decrypt_shares::TallyDecryptWithAllShares),
+    /// Decrypt all proposals in a vote plan.
+    ///
+    /// The decrypted tally data will be printed in hexadecimal encoding
+    /// on standard output.
+    DecryptVotePlan(decrypt_shares::TallyVotePlanWithAllShares),
 }
 
 impl Tally {
@@ -24,6 +32,28 @@ impl Tally {
         match self {
             Tally::DecryptionShare(cmd) => cmd.exec(),
             Tally::Decrypt(cmd) => cmd.exec(),
+            Tally::DecryptVotePlan(cmd) => cmd.exec(),
+        }
+    }
+}
+
+fn get_vote_plan_by_id<P: AsRef<Path>>(
+    vote_plan_file: &Option<P>,
+    id: Option<&str>,
+) -> Result<VotePlanStatus, Error> {
+    let mut vote_plans: Vec<VotePlanStatus> =
+        serde_json::from_reader(io::open_file_read(vote_plan_file)?)
+            .map_err(|_| Error::VotePlansRead)?;
+    match id {
+        Some(id) => vote_plans
+            .into_iter()
+            .find(|plan| plan.id.to_hex().contains(id))
+            .ok_or(Error::VotePlanIdNotFound),
+        None => {
+            if vote_plans.len() != 1 {
+                return Err(Error::UnclearVotePlan);
+            }
+            Ok(vote_plans.pop().unwrap())
         }
     }
 }

--- a/jormungandr-lib/src/interfaces/mod.rs
+++ b/jormungandr-lib/src/interfaces/mod.rs
@@ -62,6 +62,6 @@ pub use self::transaction_witness::TransactionWitness;
 pub use self::utxo_info::{UTxOInfo, UTxOOutputInfo};
 pub use self::value::{Value, ValueDef};
 pub use self::vote::{
-    serde_base64_bytes, Payload, Tally, TallyResult, VotePlanDef, VotePlanStatus,
-    VoteProposalStatus, MEMBER_PUBLIC_KEY_BECH32_HRP,
+    serde_base64_bytes, Payload, PrivateTallyState, Tally, TallyResult, VotePlanDef,
+    VotePlanStatus, VoteProposalStatus, MEMBER_PUBLIC_KEY_BECH32_HRP,
 };

--- a/jormungandr-lib/src/interfaces/vote.rs
+++ b/jormungandr-lib/src/interfaces/vote.rs
@@ -404,6 +404,12 @@ impl TallyResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EncryptedTally(#[serde(with = "serde_base64_bytes")] Vec<u8>);
 
+impl EncryptedTally {
+    pub fn to_bytes(self) -> Vec<u8> {
+        self.0
+    }
+}
+
 pub mod serde_base64_bytes {
     use serde::de::{Error, Visitor};
     use serde::{Deserializer, Serializer};
@@ -534,6 +540,15 @@ impl From<vote::TallyResult> for TallyResult {
         Self {
             results: this.results().iter().map(|v| (*v).into()).collect(),
             options: this.options().choice_range().clone(),
+        }
+    }
+}
+
+impl From<chain_vote::Tally> for TallyResult {
+    fn from(this: chain_vote::Tally) -> Self {
+        Self {
+            results: this.votes.iter().map(|v| (*v).into()).collect(),
+            options: (0..this.votes.len().try_into().unwrap()),
         }
     }
 }

--- a/jormungandr-lib/src/interfaces/vote.rs
+++ b/jormungandr-lib/src/interfaces/vote.rs
@@ -405,7 +405,7 @@ impl TallyResult {
 pub struct EncryptedTally(#[serde(with = "serde_base64_bytes")] Vec<u8>);
 
 impl EncryptedTally {
-    pub fn to_bytes(self) -> Vec<u8> {
+    pub fn into_bytes(self) -> Vec<u8> {
         self.0
     }
 }
@@ -547,7 +547,7 @@ impl From<vote::TallyResult> for TallyResult {
 impl From<chain_vote::Tally> for TallyResult {
     fn from(this: chain_vote::Tally) -> Self {
         Self {
-            results: this.votes.iter().map(|v| (*v).into()).collect(),
+            results: this.votes.iter().copied().collect(),
             options: (0..this.votes.len().try_into().unwrap()),
         }
     }


### PR DESCRIPTION
Here I am keeping the old commands for compatibility reasons and I would like to remove them if not needed, but I think they are used in tests at the moment.

Intermediate steps outputs (generate shares, tally private vote) are only needed for inter-command communication, it probably makes sense if the format is fixed (i.e. always in json)

Working on decrypt shares I got a bit confused by `Vec<Vec<Share>>` or `Vec<Share>` since it's not obvious what the structure of that is, and they actually mean different things in different contexts (e.g. is `Vec<Share>` all the shares for a vote plan of a committee member or is it all the shares of multiple committee members for a single proposal), so I added some more types to clarify that.

This pr is becoming quite big, I don't know what the policy is, if I should split it up or navigating diffs by commits is enough.

First step for https://github.com/input-output-hk/jormungandr/issues/2972