### PR TITLE
Add tracking tips explorer multiverse

### DIFF
--- a/jormungandr/src/explorer/error.rs
+++ b/jormungandr/src/explorer/error.rs
@@ -1,35 +1,25 @@
+use crate::blockcfg::HeaderHash;
 use crate::{blockchain::StorageError, intercom};
+use thiserror::Error;
 
-error_chain! {
-    foreign_links {
-        StorageError(StorageError);
-        // FIXME: fold into StorageError with more generic work in intercom streaming
-        StreamingError(intercom::Error);
-    }
-    errors {
-        BlockNotFound(hash: String) {
-            description("block not found"),
-            display("block '{}' cannot be found in the explorer", hash)
-        }
-        AncestorNotFound(hash: String) {
-            description("ancestor of block is not in explorer"),
-            display("ancestor of block '{}' cannot be found in the explorer", hash)
-        }
-        TransactionAlreadyExists(id: String) {
-            description("tried to index already existing transaction")
-            display("transaction '{}' is already indexed", id)
-        }
-        BlockAlreadyExists(id: String) {
-            description("tried to index already indexed block")
-            display("block '{}' is already indexed", id)
-        }
-        ChainLengthBlockAlreadyExists(chain_length: u32) {
-            description("tried to index already indexed chainlength in the given branch")
-            display("chain length: {} is already indexed", chain_length)
-        }
-        BootstrapError(msg: String) {
-            description("failed to initialize explorer's database from storage")
-            display("the explorer's database couldn't be initialized: {}", msg)
-        }
-    }
+#[derive(Debug, Error)]
+pub enum ExplorerError {
+    #[error("block {0} not found in explorer")]
+    BlockNotFound(HeaderHash),
+    #[error("ancestor of block '{0}' not found in explorer")]
+    AncestorNotFound(HeaderHash),
+    #[error("transaction '{0}' is already indexed")]
+    TransactionAlreadyExists(crate::blockcfg::FragmentId),
+    #[error("tried to index block '{0}' twice")]
+    BlockAlreadyExists(HeaderHash),
+    #[error("block with {0} chain length already exists in explorer branch")]
+    ChainLengthBlockAlreadyExists(crate::blockcfg::ChainLength),
+    #[error("the explorer's database couldn't be initialized: {0}")]
+    BootstrapError(String),
+    #[error("storage error")]
+    StorageError(#[from] StorageError),
+    #[error("streaming error")]
+    StreamingError(#[from] intercom::Error),
 }
+
+pub type Result<T> = std::result::Result<T, ExplorerError>;

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -713,7 +713,7 @@ impl Status {
     }
 
     pub async fn latest_block(&self, context: &Context) -> FieldResult<Block> {
-        latest_block(context).await.map(|b| Block::from(b))
+        latest_block(context).await.map(Block::from)
     }
 
     pub async fn epoch_stability_depth(&self, context: &Context) -> String {

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -384,7 +384,13 @@ impl ExplorerDB {
     }
 
     pub async fn is_block_confirmed(&self, block_id: &HeaderHash) -> bool {
-        if let Some(block) = self.get_block(block_id).await {
+        let current_branch = self
+            .multiverse
+            .get_ref(&self.longest_chain_tip.get_block_id().await)
+            .await
+            .unwrap();
+
+        if let Some(block) = current_branch.state().blocks.lookup(&block_id) {
             let confirmed_block_chain_length: ChainLength = self
                 .stable_store
                 .confirmed_block_chain_length

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -337,7 +337,7 @@ impl ExplorerDB {
         // the tip changes which means now a block is confirmed (at least after
         // the initial epoch_stability_depth blocks).
 
-        let block = if let Some(state_ref) = self.multiverse.get_ref(hash).await {
+        let block = if let Some(state_ref) = self.multiverse.get_ref(&hash).await {
             let state = state_ref.state();
             Arc::clone(state.blocks.lookup(&hash).unwrap())
         } else {

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod graphql;
 mod indexing;
+mod multiverse;
 mod persistent_sequence;
 
 use self::error::{Error, ErrorKind, Result};

--- a/jormungandr/src/explorer/multiverse.rs
+++ b/jormungandr/src/explorer/multiverse.rs
@@ -60,7 +60,8 @@ impl Multiverse {
 
     /// run the garbage collection of the multiverse
     ///
-    pub async fn gc(&self, depth: u32) {
+    #[allow(dead_code)]
+    pub(super) async fn gc(&self, depth: u32) {
         let mut guard = self.inner.write().await;
         guard.multiverse.gc(depth)
     }

--- a/jormungandr/src/explorer/multiverse.rs
+++ b/jormungandr/src/explorer/multiverse.rs
@@ -1,0 +1,96 @@
+use crate::blockcfg::{ChainLength, HeaderHash, Multiverse as MultiverseData};
+use chain_impl_mockchain::multiverse;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use super::State;
+
+pub struct Multiverse {
+    inner: Arc<RwLock<Inner>>,
+}
+
+pub(super) type Ref = multiverse::Ref<State>;
+
+struct Inner {
+    multiverse: MultiverseData<State>,
+    tips: BTreeSet<(ChainLength, HeaderHash)>,
+}
+
+impl Multiverse {
+    pub(super) fn new(
+        chain_length: ChainLength,
+        block0_id: HeaderHash,
+        initial_state: State,
+    ) -> (multiverse::Ref<State>, Self) {
+        let mut multiverse = MultiverseData::new();
+        let initial_ref = multiverse.insert(chain_length, block0_id, initial_state);
+
+        let mut tips = BTreeSet::new();
+        tips.insert((chain_length, block0_id));
+
+        (
+            initial_ref,
+            Multiverse {
+                inner: Arc::new(RwLock::new(Inner { multiverse, tips })),
+            },
+        )
+    }
+
+    pub(super) async fn insert(
+        &self,
+        chain_length: ChainLength,
+        parent: HeaderHash,
+        hash: HeaderHash,
+        value: State,
+    ) -> multiverse::Ref<State> {
+        let mut guard = self.inner.write().await;
+
+        guard
+            .tips
+            .remove(&(chain_length.nth_ancestor(1).unwrap(), parent));
+        guard.tips.insert((chain_length, hash));
+        guard.multiverse.insert(chain_length, hash, value)
+    }
+
+    pub(super) async fn get_ref(&self, hash: &HeaderHash) -> Option<multiverse::Ref<State>> {
+        let guard = self.inner.read().await;
+        guard.multiverse.get_ref(&hash)
+    }
+
+    /// run the garbage collection of the multiverse
+    ///
+    pub async fn gc(&self, depth: u32) {
+        let mut guard = self.inner.write().await;
+        guard.multiverse.gc(depth)
+    }
+
+    /// get all the branches this block is in, None here means the block was never added
+    /// or it was moved to stable storage
+    pub(super) async fn tips(&self) -> Vec<(HeaderHash, multiverse::Ref<State>)> {
+        let mut guard = self.inner.write().await;
+        let mut states = Vec::new();
+
+        // garbage collect old tips too
+        let mut new_tips = BTreeSet::new();
+
+        for (length, hash) in guard.tips.iter().rev() {
+            if let Some(state) = guard.multiverse.get_ref(hash) {
+                states.push((*hash, state));
+                new_tips.insert((*length, *hash));
+            }
+        }
+
+        guard.tips = new_tips;
+
+        states
+    }
+}
+
+impl Clone for Multiverse {
+    fn clone(&self) -> Self {
+        Multiverse {
+            inner: self.inner.clone(),
+        }
+    }
+}

--- a/jormungandr/src/explorer/multiverse.rs
+++ b/jormungandr/src/explorer/multiverse.rs
@@ -60,7 +60,6 @@ impl Multiverse {
 
     /// run the garbage collection of the multiverse
     ///
-    #[allow(dead_code)]
     pub(super) async fn gc(&self, depth: u32) {
         let mut guard = self.inner.write().await;
         guard.multiverse.gc(depth)

--- a/jormungandr/src/start_up/error.rs
+++ b/jormungandr/src/start_up/error.rs
@@ -54,7 +54,7 @@ pub enum Error {
     #[error("Block 0 is set to start in the future")]
     Block0InFuture,
     #[error("Error while loading the explorer from storage")]
-    ExplorerBootstrapError(#[from] explorer::error::Error),
+    ExplorerBootstrapError(#[from] explorer::error::ExplorerError),
     #[error("A service has terminated with an error")]
     ServiceTerminatedWithError(#[from] crate::utils::task::ServiceError),
     #[error("Unable to get system limits: {0}")]


### PR DESCRIPTION
Intermediate step, see #2963 

This essentially changes the explorer backend/indexing, but without adding the breaking changes to graphql.

This may conflict with #2962, it's not really dependent, but it touches the same things. I would merge #2962 first anyway, so maybe I'll rebase this one on top.

# Backend

- Add tip tracking multiverse wrapper (proxy)
- Move branch dependent methods/queries to `State`, so the `ExplorerDB` can be used like `get_branch(hash)` or `get_main_branch(hash)`. Also, change the graphql queries so they use `get_main_branch`, so this PR still retains most of the current behaviour.

# GraphQL API

The changes to the `graphql/mod.rs` are only to make things still compile, most queries keep the current behavior except for

- block by id searches in all candidate branches.
- transaction by id searches in all candidate branches.
- vote plan by id searches in all candidate branches.

breaking changes will come in the next PR.