### PR TITLE
Cli log config overrides yaml

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -518,12 +518,18 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let raw_settings = RawSettings::load(command_line)?;
 
     let log_settings = raw_settings.log_settings();
-    let _logger_guards = log_settings.init_log()?;
+    let (_logger_guards, log_info_msg) = log_settings.init_log()?;
 
     let init_span = span!(Level::TRACE, "task", kind = "init");
     let async_span = init_span.clone();
     let _enter = init_span.enter();
     tracing::info!("Starting {}", env!("FULL_VERSION"),);
+
+    if let Some(msg) = log_info_msg {
+        // if log settings were overriden, we will have an info
+        // message which we can unpack at this point.
+        tracing::info!("{}", msg);
+    }
 
     let diagnostic = Diagnostic::new()?;
     tracing::debug!("system settings are: {}", diagnostic);

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -134,7 +134,7 @@ impl Subscriber for BoxedSubscriber {
 impl Layer<BoxedSubscriber> for BoxedSubscriber {}
 
 impl LogSettings {
-    pub fn init_log(self) -> Result<Vec<WorkerGuard>, Error> {
+    pub fn init_log(self) -> Result<(Vec<WorkerGuard>, LogInfoMsg), Error> {
         use tracing_subscriber::prelude::*;
         let mut guards = Vec::new();
         let mut layers: Vec<Layered<_, BoxedSubscriber>> = Vec::new();
@@ -161,7 +161,7 @@ impl LogSettings {
                 .map_err(Error::SetGlobalSubscriberError)?;
         }
 
-        Ok(guards)
+        Ok((guards, self.1))
     }
 }
 

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -16,7 +16,12 @@ use tracing_subscriber::fmt::SubscriberBuilder;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::layer::{Layer, Layered};
 
-pub struct LogSettings(pub Vec<LogSettingsEntry>);
+pub struct LogSettings(pub Vec<LogSettingsEntry>, pub LogInfoMsg);
+
+/// A wrapper to return an optional string message that we
+/// have to manually log with `info!`, we need this because
+/// some code executes before the logs are initialized.
+pub type LogInfoMsg = Option<String>;
 
 #[derive(Debug)]
 pub struct LogSettingsEntry {

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -60,21 +60,6 @@ impl RawSettings {
     }
 
     pub fn log_settings(&self) -> LogSettings {
-        // FIXME: remove this after refactoring is done
-        // changing the flow for creating the LogSettings inner Vec to this:
-        //  * [X] Read log settings from the config file path
-        //  * [X] If no log settings are found:
-        //    + [X] add LogSettingsEntry with default values
-        //  * [X] If the command line specifies log arguments:
-        //    + [X] Check that the arg is Some(output), else, skip
-        //    + [X] Read the log settings, and look if we already
-        //          have this output configured
-        //    + [X] If the output is aleady configured:
-        //      - [X] overwrite entry.level if cli_entry.level is Some(level)
-        //      - [X] overwrite entry.format if cli_entry.format is Some(format)
-        //      - [X] log to info! that the output was overriden
-        //    + [X] If the output is not aleady configured:
-        //      - [X] add new entry for output with default values for other fields.
         let mut entries = Vec::new();
 
         //  Read log settings from the config file path.

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -87,13 +87,16 @@ impl RawSettings {
                 format: cmd_format.unwrap_or(DEFAULT_LOG_FORMAT),
                 output,
             };
-            // log to info! that the output was overriden,
-            // we send this as a message because tracing Subscribers
-            // do not get initiated until after this code runs
-            log_info_msg = Some(format!(
-                "log settings overriden from command line: {:?} replaced with {:?}",
-                entries, command_line_entry
-            ));
+            // check if there are entries being overriden
+            if !entries.is_empty() {
+                // log to info! that the output was overriden,
+                // we send this as a message because tracing Subscribers
+                // do not get initiated until after this code runs
+                log_info_msg = Some(format!(
+                    "log settings overriden from command line: {:?} replaced with {:?}",
+                    entries, command_line_entry
+                ));
+            }
             // Replace any existing setting entries with the
             // command line settings entry.
             entries = vec![command_line_entry];

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -62,18 +62,22 @@ impl RawSettings {
     pub fn log_settings(&self) -> LogSettings {
         // FIXME: remove this after refactoring is done
         // changing the flow for creating the LogSettings inner Vec to this:
-        //  * Read log settings from the config file path
-        //  * If no log settings are found:
-        //    + add LogSettingsEntry with default values
-        //  * If the command line specifies log arguments:
-        //    + Check that the arg is Some(output), else, skip
-        //    + Read the log settings, and look if we already
-        //      have this output configured
-        //    + If the output is aleady configured:
-        //      - overwrite entry.level if cli_entry.level is Some(level)
-        //      - overwrite entry.format if cli_entry.format is Some(format)
+        //  * [X] Read log settings from the config file path
+        //  * [X] If no log settings are found:
+        //    + [X] add LogSettingsEntry with default values
+        //  * [ ] If the command line specifies log arguments:
+        //    + [X] Check that the arg is Some(output), else, skip
+        //    + [ ] Read the log settings, and look if we already
+        //          have this output configured
+        //    + [ ] If the output is aleady configured:
+        //      - [ ] overwrite entry.level if cli_entry.level is Some(level)
+        //      - [ ] overwrite entry.format if cli_entry.format is Some(format)
+        //      - [ ] log to info! that the output was overriden
+        //    + [ ] If the output is not aleady configured:
+        //      - [ ] add new entry for output with default values for other fields.
         let mut entries = Vec::new();
 
+        //  Read log settings from the config file path.
         if let Some(log) = self.config.as_ref().and_then(|cfg| cfg.log.as_ref()) {
             log.0.iter().for_each(|entry| {
                 entries.push(LogSettingsEntry {
@@ -96,6 +100,8 @@ impl RawSettings {
             });
         }
 
+        //  If no log settings are found, add LogSettingsEntry with default
+        //  values.
         if entries.is_empty() {
             entries.push(LogSettingsEntry {
                 level: DEFAULT_FILTER_LEVEL,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -110,6 +110,29 @@ impl RawSettings {
             });
         }
 
+        // If the command line specifies log arguments, check that the arg
+        // is Some(output), else, skip.
+        let cmd_output = self.command_line.log_output.clone();
+
+        if let Some(output) = cmd_output {
+            let cmd_level = self.command_line.log_level;
+            let cmd_format = self.command_line.log_format;
+
+            // Read the log settings, and look if we already
+            // have this output configured
+            for entry in entries.iter_mut() {
+                // If the output is aleady configured:
+                if &entry.output == &output {
+                    // - [ ] overwrite entry.level if cli_entry.level is Some(level)
+                    // - [ ] overwrite entry.format if cli_entry.format is Some(format)
+                    // - [ ] log to info! that the output was overriden
+                } else {
+                    // If the output is not aleady configured:
+                    // - [ ] add new entry for output with default values for other fields.
+                }
+            }
+        }
+
         LogSettings(entries)
     }
 

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -95,7 +95,7 @@ impl RawSettings {
             // have this output configured
             for entry in entries.iter_mut() {
                 // If the output is aleady configured:
-                if &entry.output == &output {
+                if entry.output == output {
                     // overwrite entry.level if cli_entry.level is Some(level)
                     // overwrite entry.format if cli_entry.format is Some(format)
                     let override_entry = LogSettingsEntry {

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -60,6 +60,18 @@ impl RawSettings {
     }
 
     pub fn log_settings(&self) -> LogSettings {
+        // FIXME: remove this after refactoring is done
+        // changing the flow for creating the LogSettings inner Vec to this:
+        //  * Read log settings from the config file path
+        //  * If no log settings are found:
+        //    + add LogSettingsEntry with default values
+        //  * If the command line specifies log arguments:
+        //    + Check that the arg is Some(output), else, skip
+        //    + Read the log settings, and look if we already
+        //      have this output configured
+        //    + If the output is aleady configured:
+        //      - overwrite entry.level if cli_entry.level is Some(level)
+        //      - overwrite entry.format if cli_entry.format is Some(format)
         let mut entries = Vec::new();
 
         if let Some(log) = self.config.as_ref().and_then(|cfg| cfg.log.as_ref()) {

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -3,7 +3,7 @@ pub mod network;
 
 use self::config::{Config, Leadership};
 use self::network::{Protocol, TrustedPeer};
-use crate::settings::logging::{LogFormat, LogOutput, LogSettings, LogSettingsEntry};
+use crate::settings::logging::{LogFormat, LogInfoMsg, LogOutput, LogSettings, LogSettingsEntry};
 use crate::settings::{command_arguments::*, Block0Info};
 pub use jormungandr_lib::interfaces::{Cors, Mempool, Rest, Tls};
 use std::{fs::File, path::PathBuf};
@@ -61,6 +61,7 @@ impl RawSettings {
 
     pub fn log_settings(&self) -> LogSettings {
         let mut entries = Vec::new();
+        let mut log_info_msg: LogInfoMsg = None;
 
         //  Read log settings from the config file path.
         if let Some(log) = self.config.as_ref().and_then(|cfg| cfg.log.as_ref()) {
@@ -122,7 +123,7 @@ impl RawSettings {
             }
         }
 
-        LogSettings(entries)
+        LogSettings(entries, log_info_msg)
     }
 
     fn rest_config(&self) -> Option<Rest> {


### PR DESCRIPTION
- changes logic for configuring log settings
- instead of appending CLI log settings to those read from a YAML file,
  when log output settings are defined in the CLI, they override those coming from a YAML file.

Implements https://github.com/input-output-hk/jormungandr/issues/3041