### PR TITLE
Remove old jcli commands

### DIFF
--- a/doc/jcli/vote.md
+++ b/doc/jcli/vote.md
@@ -165,7 +165,7 @@ jcli votes tally merge-shares  share_file1 share_file2 ... > merged_shares.json
 With the merged shares file, we are finally able to process the final tally result as follows:
 
 ```shell
-jcli votes tally decrypt \
+jcli votes tally decrypt-results \
 --vote-plan active_plans.json \
 --vote-plan-id $"vote_plan_id" \
 --shares merged_shares.json \

--- a/jcli/src/jcli_app/certificate/new_vote_tally.rs
+++ b/jcli/src/jcli_app/certificate/new_vote_tally.rs
@@ -44,7 +44,8 @@ pub struct PrivateTally {
     #[structopt(long)]
     pub vote_plan: PathBuf,
 
-    /// path to the json file containing the vote plan result
+    /// The id of the vote plan to include in the certificate.
+    /// Can be left unspecified if there is only one vote plan in the input
     #[structopt(long)]
     pub vote_plan_id: Option<Hash>,
 

--- a/jcli/src/jcli_app/vote/tally/decryption_tally.rs
+++ b/jcli/src/jcli_app/vote/tally/decryption_tally.rs
@@ -10,22 +10,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-// TODO: this generate shares for a single proposal, we might remove it later
-/// Create the decryption share for decrypting the tally of private voting.
-/// The outputs are provided as hex-encoded byte sequences.
-#[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case")]
-pub struct TallyGenerateDecryptionShare {
-    /// The path to hex-encoded encrypted tally state. If this parameter is not
-    /// specified, the encrypted tally state will be read from the standard
-    /// input.
-    #[structopt(long = "tally")]
-    encrypted_tally: Option<PathBuf>,
-    /// The path to hex-encoded decryption key.
-    #[structopt(long = "key")]
-    decryption_key: PathBuf,
-}
-
 /// Create decryption shares for all proposals in a vote plan.
 ///
 /// The decryption share data will be printed in hexadecimal encoding
@@ -71,20 +55,6 @@ fn read_decryption_key<P: AsRef<Path>>(path: &Option<P>) -> Result<OpeningVoteKe
             )
             .ok_or(Error::DecryptionKeyRead)
         })
-}
-
-impl TallyGenerateDecryptionShare {
-    pub fn exec(&self) -> Result<(), Error> {
-        let encrypted_tally_hex = io::read_line(&self.encrypted_tally)?;
-        let encrypted_tally_bytes = base64::decode(encrypted_tally_hex)?;
-        let encrypted_tally =
-            EncryptedTally::from_bytes(&encrypted_tally_bytes).ok_or(Error::EncryptedTallyRead)?;
-        let decryption_key = read_decryption_key(&Some(&self.decryption_key))?;
-        let (_state, share) = encrypted_tally.finish(&decryption_key);
-        println!("{}", base64::encode(share.to_bytes()));
-
-        Ok(())
-    }
 }
 
 impl TallyGenerateVotePlanDecryptionShares {

--- a/jcli/src/jcli_app/vote/tally/mod.rs
+++ b/jcli/src/jcli_app/vote/tally/mod.rs
@@ -11,20 +11,10 @@ pub enum Tally {
     ///
     /// The decryption share data will be printed in hexadecimal encoding
     /// on standard output.
-    DecryptionShare(decryption_tally::TallyGenerateDecryptionShare),
-    /// Create a decryption share for private voting tally.
-    ///
-    /// The decryption share data will be printed in hexadecimal encoding
-    /// on standard output.
     DecryptionShares(decryption_tally::TallyGenerateVotePlanDecryptionShares),
     /// Merge multiple sets of shares in a single object to be used in the
     /// decryption of a vote plan.
     MergeShares(decryption_tally::MergeShares),
-    /// Decrypt a tally with decryption shares.
-    ///
-    /// The decrypted tally data will be printed in hexadecimal encoding
-    /// on standard output.
-    Decrypt(decrypt_shares::TallyDecryptWithAllShares),
     /// Decrypt all proposals in a vote plan.
     ///
     /// The decrypted tally data will be printed in hexadecimal encoding
@@ -35,9 +25,7 @@ pub enum Tally {
 impl Tally {
     pub fn exec(self) -> Result<(), Error> {
         match self {
-            Tally::DecryptionShare(cmd) => cmd.exec(),
             Tally::DecryptionShares(cmd) => cmd.exec(),
-            Tally::Decrypt(cmd) => cmd.exec(),
             Tally::DecryptResults(cmd) => cmd.exec(),
             Tally::MergeShares(cmd) => cmd.exec(),
         }


### PR DESCRIPTION
Remove old commands for tallying private votes since they are superseded by new ones and having two sets of commands creates confusion.

Will probably break tests that relies on these to work, we should either disable or fix them (@dkijania ) before merging.