### PR TITLE
Ignore possible invalid utf-strings in logs

### DIFF
--- a/testing/jormungandr-testing-utils/src/testing/node/logger.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/logger.rs
@@ -283,7 +283,7 @@ impl JormungandrLogger {
         let file = File::open(self.log_file_path.clone())
             .unwrap_or_else(|_| panic!("cannot find log file: {:?}", &self.log_file_path));
         let reader = BufReader::new(file);
-        reader.lines().map(|line| line.unwrap())
+        reader.lines().flat_map(|line| line.ok())
     }
 
     pub fn get_log_entries(&self) -> impl Iterator<Item = LogEntry> + '_ {


### PR DESCRIPTION
I think failures like https://github.com/input-output-hk/jormungandr/runs/1952567767?check_suite_focus=true#step:11:2131 might be caused by concurrent access to the log file (maybe we changed log backend and writes are not atomic anymore?). This just discards such lines, if that is the case an operation will eventually read the right value.