### PR TITLE
Clean up handling code for REST fragments endpoints

### DIFF
--- a/jormungandr/src/rest/v1/handlers.rs
+++ b/jormungandr/src/rest/v1/handlers.rs
@@ -19,7 +19,7 @@ pub struct GetMessageStatusesQuery {
     fragment_ids: String,
 }
 
-pub async fn get_fragments_statuses(
+pub async fn get_fragment_statuses(
     query: GetMessageStatusesQuery,
     context: ContextLock,
 ) -> Result<impl Reply, Rejection> {
@@ -29,15 +29,15 @@ pub async fn get_fragments_statuses(
         .split(',')
         .map(|s| s.to_string())
         .collect();
-    logic::get_fragments_statuses(&context, fragment_ids)
+    logic::get_fragment_statuses(&context, fragment_ids)
         .await
         .map_err(warp::reject::custom)
         .map(|r| warp::reply::json(&r))
 }
 
-pub async fn get_fragments_logs(context: ContextLock) -> Result<impl Reply, Rejection> {
+pub async fn get_fragment_logs(context: ContextLock) -> Result<impl Reply, Rejection> {
     let context = context.read().await;
-    logic::get_fragments_logs(&context)
+    logic::get_fragment_logs(&context)
         .await
         .map_err(warp::reject::custom)
         .map(|r| warp::reply::json(&r))

--- a/jormungandr/src/rest/v1/handlers.rs
+++ b/jormungandr/src/rest/v1/handlers.rs
@@ -24,11 +24,7 @@ pub async fn get_fragment_statuses(
     context: ContextLock,
 ) -> Result<impl Reply, Rejection> {
     let context = context.read().await;
-    let fragment_ids = query
-        .fragment_ids
-        .split(',')
-        .map(|s| s.to_string())
-        .collect();
+    let fragment_ids = query.fragment_ids.split(',');
     logic::get_fragment_statuses(&context, fragment_ids)
         .await
         .map_err(warp::reject::custom)

--- a/jormungandr/src/rest/v1/logic.rs
+++ b/jormungandr/src/rest/v1/logic.rs
@@ -42,7 +42,7 @@ pub enum Error {
     Hex(#[from] hex::FromHexError),
 }
 
-pub async fn get_fragments_statuses(
+pub async fn get_fragment_statuses(
     context: &Context,
     ids: Vec<String>,
 ) -> Result<HashMap<String, FragmentStatus>, Error> {
@@ -98,7 +98,7 @@ pub async fn post_fragments(
     Ok(fragment_ids)
 }
 
-pub async fn get_fragments_logs(context: &Context) -> Result<Vec<FragmentLog>, Error> {
+pub async fn get_fragment_logs(context: &Context) -> Result<Vec<FragmentLog>, Error> {
     let span =
         span!(parent: context.span()?, Level::TRACE, "fragment_logs", request = "fragment_logs");
     async move {

--- a/jormungandr/src/rest/v1/logic.rs
+++ b/jormungandr/src/rest/v1/logic.rs
@@ -42,13 +42,13 @@ pub enum Error {
     Hex(#[from] hex::FromHexError),
 }
 
-pub async fn get_fragment_statuses(
+pub async fn get_fragment_statuses<'a>(
     context: &Context,
-    ids: Vec<String>,
+    ids: impl IntoIterator<Item = &'a str>,
 ) -> Result<HashMap<String, FragmentStatus>, Error> {
     let ids = ids
         .into_iter()
-        .map(|s| FragmentId::from_str(&s))
+        .map(|s| FragmentId::from_str(s))
         .collect::<Result<Vec<_>, _>>()?;
     let span = span!(parent: context.span()?, Level::TRACE, "fragment_statuses", request = "message_statuses");
     async move {

--- a/jormungandr/src/rest/v1/mod.rs
+++ b/jormungandr/src/rest/v1/mod.rs
@@ -25,13 +25,13 @@ pub fn filter(
             .and(warp::get())
             .and(warp::query())
             .and(with_context.clone())
-            .and_then(handlers::get_fragments_statuses)
+            .and_then(handlers::get_fragment_statuses)
             .boxed();
 
         let logs = warp::path!("logs")
             .and(warp::get())
             .and(with_context)
-            .and_then(handlers::get_fragments_logs)
+            .and_then(handlers::get_fragment_logs)
             .boxed();
 
         root.and(post.or(status).or(logs)).boxed()


### PR DESCRIPTION
Rename methods for greppability and consistency.
Accept the iterator over slices directly.