### PR TITLE
Improve dynamic composition of tracing subscribers

### DIFF
--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -518,17 +518,19 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let raw_settings = RawSettings::load(command_line)?;
 
     let log_settings = raw_settings.log_settings();
-    let (_logger_guards, log_info_msg) = log_settings.init_log()?;
+    let (_logger_guards, log_info_msgs) = log_settings.init_log()?;
 
     let init_span = span!(Level::TRACE, "task", kind = "init");
     let async_span = init_span.clone();
     let _enter = init_span.enter();
     tracing::info!("Starting {}", env!("FULL_VERSION"),);
 
-    if let Some(msg) = log_info_msg {
+    if let Some(msgs) = log_info_msgs {
         // if log settings were overriden, we will have an info
         // message which we can unpack at this point.
-        tracing::info!("{}", msg);
+        for msg in &msgs {
+            tracing::info!("{}", msg);
+        }
     }
 
     let diagnostic = Diagnostic::new()?;

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -329,11 +329,7 @@ impl GossipService for NodeService {
         let parent_span = self.subscription_span(subscriber, "gossip");
         let subscriber = Address::tcp(addr);
         parent_span.in_scope(|| {
-            let span = span!(
-                Level::TRACE,
-                "fragment_subscription",
-                direction = "in"
-            );
+            let span = span!(Level::TRACE, "fragment_subscription", direction = "in");
 
             self.global_state.spawn(
                 subscription::process_gossip(

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -202,12 +202,14 @@ impl LogSettings {
                 match settings.format {
                     LogFormat::Default | LogFormat::Plain => {
                         // create a reloadable layer, and return the handle
+                        // FIXME: use this handle to reload layer
                         let (layer, _handle) = reload::Layer::new(
                             tracing_subscriber::fmt::Layer::new().with_writer(non_blocking),
                         );
                         (Some(layer), None)
                     }
                     LogFormat::Json => {
+                        // FIXME: use this handle to reload layer
                         let (layer, _handle) = reload::Layer::new(
                             tracing_subscriber::fmt::Layer::new()
                                 .json()

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -13,7 +13,10 @@ use tracing::subscriber::SetGlobalDefaultError;
 #[allow(unused_imports)]
 use tracing_subscriber::layer::SubscriberExt;
 
-pub struct LogSettings(pub Vec<LogSettingsEntry>, pub LogInfoMsg);
+pub struct LogSettings {
+    pub entries: Vec<LogSettingsEntry>,
+    pub msgs: LogInfoMsg,
+}
 
 /// A wrapper to return an optional string message that we
 /// have to manually log with `info!`, we need this because
@@ -175,7 +178,7 @@ impl LogSettings {
         // Parse which settings are present for possible outputs
         let mut layer_settings = LogOutputLayerSettings::default();
         let mut info_msgs: Vec<String> = Vec::new();
-        for config in self.0.into_iter() {
+        for config in self.entries.into_iter() {
             layer_settings.read_setting(config, &mut info_msgs);
         }
         let (std_out_layer, std_out_layer_json) = if let Some(settings) = layer_settings.stdout {
@@ -297,7 +300,7 @@ impl LogSettings {
         // panics if something goes wrong.
         registry.init();
 
-        let log_msgs = match (self.1, info_msgs.is_empty()) {
+        let log_msgs = match (self.msgs, info_msgs.is_empty()) {
             (None, true) => None,
             (None, false) => Some(info_msgs),
             (Some(msgs), true) => Some(msgs),

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -215,15 +215,15 @@ impl LogSettings {
             (None, None)
         };
         #[cfg(feature = "systemd")]
-        let journald_layer = if let Some(entry) = layer_settings.journald {
-            entry.format.require_default()?;
+        let journald_layer = if let Some(settings) = layer_settings.journald {
+            settings.format.require_default()?;
             let layer = tracing_journald::layer().map_err(Error::Journald)?;
             Some(layer)
         } else {
             None
         };
         #[cfg(feature = "gelf")]
-        let gelf_layer = if let Some(entry) = layer_settings.gelf {
+        let gelf_layer = if let Some(settings) = layer_settings.gelf {
             // have to use if let because it's an enum
             if let LogOutput::Gelf { backend, .. } = settings.output {
                 let (layer, task) = tracing_gelf::Logger::builder()

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -169,6 +169,7 @@ impl LogSettings {
             for layer in layer_iter {
                 init_layer = BoxedSubscriber(Box::new(init_layer.with(layer)));
             }
+            // FIXME: this should only be run once
             tracing::subscriber::set_global_default(init_layer)
                 .map_err(Error::SetGlobalSubscriberError)?;
         }
@@ -191,8 +192,8 @@ impl LogSettingsEntry {
 
         match output {
             LogOutput::Stdout => {
-                let (subscriber, guard) = tracing_appender::non_blocking(std::io::stdout());
-                let builder = builder.with_writer(subscriber).with_max_level(*level);
+                let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
+                let builder = builder.with_writer(non_blocking).with_max_level(*level);
                 let subscriber: Box<dyn Subscriber + Send + Sync> = match format {
                     LogFormat::Default | LogFormat::Plain => Box::new(builder.finish()),
                     LogFormat::Json => Box::new(builder.json().finish()),
@@ -200,8 +201,8 @@ impl LogSettingsEntry {
                 Ok((subscriber, Some(guard)))
             }
             LogOutput::Stderr => {
-                let (subscriber, guard) = tracing_appender::non_blocking(std::io::stderr());
-                let builder = builder.with_writer(subscriber).with_max_level(*level);
+                let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stderr());
+                let builder = builder.with_writer(non_blocking).with_max_level(*level);
                 let subscriber: Box<dyn Subscriber + Send + Sync> = match format {
                     LogFormat::Default | LogFormat::Plain => Box::new(builder.finish()),
                     LogFormat::Json => Box::new(builder.json().finish()),
@@ -218,8 +219,8 @@ impl LogSettingsEntry {
                         path: path.clone(),
                         cause,
                     })?;
-                let (subscriber, guard) = tracing_appender::non_blocking(file);
-                let builder = builder.with_writer(subscriber).with_max_level(*level);
+                let (non_blocking, guard) = tracing_appender::non_blocking(file);
+                let builder = builder.with_writer(non_blocking).with_max_level(*level);
                 let subscriber: Box<dyn Subscriber + Send + Sync> = match format {
                     LogFormat::Default | LogFormat::Plain => Box::new(builder.finish()),
                     LogFormat::Json => Box::new(builder.json().finish()),

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -183,12 +183,15 @@ impl LogSettings {
             guards.push(guard);
             match settings.format {
                 LogFormat::Default | LogFormat::Plain => {
-                    let layer = tracing_subscriber::fmt::Layer::new().with_writer(non_blocking);
+                    let layer = tracing_subscriber::fmt::Layer::new()
+                        .with_level(true)
+                        .with_writer(non_blocking);
                     (Some(layer), None)
                 }
                 LogFormat::Json => {
                     let layer = tracing_subscriber::fmt::Layer::new()
                         .json()
+                        .with_level(true)
                         .with_writer(non_blocking);
                     (None, Some(layer))
                 }
@@ -201,12 +204,15 @@ impl LogSettings {
             guards.push(guard);
             match settings.format {
                 LogFormat::Default | LogFormat::Plain => {
-                    let layer = tracing_subscriber::fmt::Layer::new().with_writer(non_blocking);
+                    let layer = tracing_subscriber::fmt::Layer::new()
+                        .with_level(true)
+                        .with_writer(non_blocking);
                     (Some(layer), None)
                 }
                 LogFormat::Json => {
                     let layer = tracing_subscriber::fmt::Layer::new()
                         .json()
+                        .with_level(true)
                         .with_writer(non_blocking);
                     (None, Some(layer))
                 }
@@ -231,12 +237,15 @@ impl LogSettings {
 
                 match settings.format {
                     LogFormat::Default | LogFormat::Plain => {
-                        let layer = tracing_subscriber::fmt::Layer::new().with_writer(non_blocking);
+                        let layer = tracing_subscriber::fmt::Layer::new()
+                            .with_level(true)
+                            .with_writer(non_blocking);
                         (Some(layer), None)
                     }
                     LogFormat::Json => {
                         let layer = tracing_subscriber::fmt::Layer::new()
                             .json()
+                            .with_level(true)
                             .with_writer(non_blocking);
                         (None, Some(layer))
                     }

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -18,7 +18,7 @@ pub struct LogSettings(pub Vec<LogSettingsEntry>, pub LogInfoMsg);
 /// A wrapper to return an optional string message that we
 /// have to manually log with `info!`, we need this because
 /// some code executes before the logs are initialized.
-pub type LogInfoMsg = Option<String>;
+pub type LogInfoMsg = Option<Vec<String>>;
 
 #[derive(Clone, Debug)]
 pub struct LogSettingsEntry {

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -135,6 +135,19 @@ impl Layer<BoxedSubscriber> for BoxedSubscriber {}
 
 impl LogSettings {
     pub fn init_log(self) -> Result<(Vec<WorkerGuard>, LogInfoMsg), Error> {
+        // WIP: Replacing this code
+        //
+        // * Use tracing_subscriber::registry::Registry instead of
+        //   boxing subscribers
+        // * Create specific layer types for each output format, implement
+        //   ````
+        //   impl<S> tracing_subscriber::Layer<S> for OutputLayer
+        //   where
+        //       S: Subscriber + for<'span> LookupSpan<'span>
+        //   ```
+        //   * expand code from LogSettingsEntry::to_subscriber, to remove
+        //   * implement uniform process of composing Layer and Subscriber types
+        //     for each output format
         use tracing_subscriber::prelude::*;
         let mut guards = Vec::new();
         let mut layers: Vec<Layered<_, BoxedSubscriber>> = Vec::new();

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -224,11 +224,16 @@ impl LogSettings {
         };
         #[cfg(feature = "gelf")]
         let gelf_layer = if let Some(entry) = layer_settings.gelf {
-            let (layer, task) = tracing_gelf::Logger::builder()
-                .connect_tcp(entry.output.backend.clone())
-                .map_err(Error::Gelf)?;
-            tokio::spawn(task);
-            Some(layer)
+            // have to use if let because it's an enum
+            if let LogOutput::Gelf { backend, .. } = settings.output {
+                let (layer, task) = tracing_gelf::Logger::builder()
+                    .connect_tcp(backend)
+                    .map_err(Error::Gelf)?;
+                tokio::spawn(task);
+                Some(layer)
+            } else {
+                None
+            }
         } else {
             None
         };

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -117,7 +117,10 @@ impl RawSettings {
         } else {
             Some(info_msgs)
         };
-        LogSettings(entries, log_info_msg)
+        LogSettings {
+            entries,
+            msgs: log_info_msg,
+        }
     }
 
     fn rest_config(&self) -> Option<Rest> {

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -61,7 +61,7 @@ impl RawSettings {
 
     pub fn log_settings(&self) -> LogSettings {
         let mut entries = Vec::new();
-        let mut log_info_msg: LogInfoMsg = None;
+        let mut info_msgs: Vec<String> = Vec::new();
 
         //  Read log settings from the config file path.
         if let Some(log) = self.config.as_ref().and_then(|cfg| cfg.log.as_ref()) {
@@ -92,7 +92,7 @@ impl RawSettings {
                 // log to info! that the output was overriden,
                 // we send this as a message because tracing Subscribers
                 // do not get initiated until after this code runs
-                log_info_msg = Some(format!(
+                info_msgs.push(format!(
                     "log settings overriden from command line: {:?} replaced with {:?}",
                     entries, command_line_entry
                 ));
@@ -112,6 +112,11 @@ impl RawSettings {
             });
         }
 
+        let log_info_msg: LogInfoMsg = if info_msgs.is_empty() {
+            None
+        } else {
+            Some(info_msgs)
+        };
         LogSettings(entries, log_info_msg)
     }
 

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -203,17 +203,16 @@ impl Services {
     {
         let handle = self.runtime.handle().clone();
         let now = Instant::now();
-        let tracing_span = span!(Level::TRACE, "service", kind = name);
+        let parent_span = span!(Level::TRACE, "service", kind = name);
         let future_service_info = TokioServiceInfo {
             name,
             up_time: now,
-            span: tracing_span,
+            span: parent_span.clone(),
             handle,
         };
-        let parent_span = future_service_info.span.clone();
         self.runtime
             .block_on(f(future_service_info).instrument(span!(
-                parent: parent_span,
+                parent: parent_span.clone(),
                 Level::TRACE,
                 "service",
                 kind = name

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -210,13 +210,14 @@ impl Services {
             span: parent_span.clone(),
             handle,
         };
-        self.runtime
-            .block_on(f(future_service_info).instrument(span!(
-                parent: parent_span,
-                Level::TRACE,
-                "service",
-                kind = name
-            )))
+        parent_span.in_scope(|| {
+            self.runtime
+                .block_on(f(future_service_info).instrument(span!(
+                    Level::TRACE,
+                    "service",
+                    kind = name
+                )))
+        })
     }
 }
 

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -212,7 +212,7 @@ impl Services {
         };
         self.runtime
             .block_on(f(future_service_info).instrument(span!(
-                parent: parent_span.clone(),
+                parent: parent_span,
                 Level::TRACE,
                 "service",
                 kind = name


### PR DESCRIPTION
Attempt at making dynamic subscribers use the `tracing_subscriber::registry::Registry` as a way to compose multiple layers into one that is configured as the global default.

Added messages to be logged after the subscribers have been initialized. These messages are used to inform when log settings have been overriden, which happens when there are multiple entries with the same output.