### PR TITLE
Use pipes instead of file for logging in tests

### DIFF
--- a/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -301,11 +301,18 @@ impl ConfigurationBuilder {
             (None, false) => default_log_file(),
             (None, true) => {
                 let path = default_log_file();
-                node_config.log = Some(Log(vec![LogEntry {
-                    level: "trace".to_string(),
-                    format: "json".to_string(),
-                    output: LogOutput::File(path.clone()),
-                }]));
+                node_config.log = Some(Log(vec![
+                    LogEntry {
+                        level: "trace".to_string(),
+                        format: "json".to_string(),
+                        output: LogOutput::Stdout,
+                    },
+                    LogEntry {
+                        level: "trace".to_string(),
+                        format: "json".to_string(),
+                        output: LogOutput::File(path.clone()),
+                    },
+                ]));
                 path
             }
         };
@@ -382,7 +389,6 @@ impl ConfigurationBuilder {
         );
 
         params.write_node_config();
-
         params
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/mod.rs
@@ -69,6 +69,6 @@ impl FragmentNode for JormungandrProcess {
         println!("Fragment '{}' in block: {} ({})", fragment_id, block, date);
     }
     fn log_content(&self) -> Vec<String> {
-        self.logger.get_log_content()
+        self.logger.get_lines_as_string()
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/mod.rs
@@ -12,19 +12,16 @@ use jormungandr_testing_utils::testing::MemPoolCheck;
 pub use process::*;
 pub use starter::*;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use thiserror::Error;
 
 use jormungandr_testing_utils::testing::{FragmentNode, FragmentNodeError};
 
 #[derive(Error, Debug)]
 pub enum JormungandrError {
-    #[error("error in logs. Error lines: {error_lines}, logs location: {log_location}, full content:{logs}")]
-    ErrorInLogs {
-        logs: String,
-        log_location: PathBuf,
-        error_lines: String,
-    },
+    #[error("error in logs. Error lines: {error_lines}, full content:{logs}")]
+    ErrorInLogs { logs: String, error_lines: String },
+    #[error("error(s) in log detected: port already in use")]
+    PortAlreadyInUse,
 }
 
 impl FragmentNode for JormungandrProcess {
@@ -72,6 +69,6 @@ impl FragmentNode for JormungandrProcess {
         println!("Fragment '{}' in block: {} ({})", fragment_id, block, date);
     }
     fn log_content(&self) -> Vec<String> {
-        self.logger.get_lines_from_log().collect()
+        self.logger.get_log_content()
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -15,7 +15,7 @@ use jormungandr_testing_utils::testing::{
     JormungandrParams, SyncNode, TestConfig,
 };
 use jormungandr_testing_utils::testing::{RemoteJormungandr, RemoteJormungandrBuilder};
-use jortestkit::process::{self as process_utils, output_extensions::ProcessOutput, ProcessError};
+use jortestkit::prelude::ProcessOutput;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::process::Child;
@@ -47,18 +47,18 @@ pub struct JormungandrProcess {
 
 impl JormungandrProcess {
     pub(crate) fn from_config<Conf: TestConfig>(
-        child: Child,
+        mut child: Child,
         params: &JormungandrParams<Conf>,
         temp_dir: Option<TempDir>,
         alias: String,
     ) -> Self {
-        let log_file_path = params.log_file_path();
         let node_config = params.node_config();
+        let stdout = child.stdout.take().unwrap();
         JormungandrProcess {
             child,
             temp_dir,
             alias,
-            logger: JormungandrLogger::new(log_file_path),
+            logger: JormungandrLogger::new(stdout),
             p2p_public_address: node_config.p2p_public_address(),
             rest_socket_addr: node_config.rest_socket_addr(),
             genesis_block_hash: Hash::from_str(params.genesis_block_hash()).unwrap(),
@@ -68,11 +68,8 @@ impl JormungandrProcess {
     }
 
     pub fn status(&self, strategy: &StartupVerificationMode) -> Status {
-        let port_occupied_msgs = vec!["error 87", "error 98", "panicked at 'Box<Any>'"];
-        if self
-            .logger
-            .raw_log_contains_any_of(port_occupied_msgs.into_iter())
-        {
+        let port_occupied_msgs = ["error 87", "error 98", "panicked at 'Box<Any>'"];
+        if self.logger.contains_any_of(&port_occupied_msgs) {
             return Status::Stopped(JormungandrError::PortAlreadyInUse);
         }
         if let Err(err) = self.check_no_errors_in_log() {
@@ -81,15 +78,12 @@ impl JormungandrProcess {
 
         match strategy {
             StartupVerificationMode::Log => {
-                let bootstrap_completed_msgs = vec![
+                let bootstrap_completed_msgs = [
                     "listening and accepting gRPC connections",
                     "genesis block fetched",
                 ];
 
-                if self
-                    .logger
-                    .raw_log_contains_any_of(bootstrap_completed_msgs.into_iter())
-                {
+                if self.logger.contains_any_of(&bootstrap_completed_msgs) {
                     Status::Running
                 } else {
                     Status::Starting
@@ -121,7 +115,7 @@ impl JormungandrProcess {
                     {
                         Status::Running
                     }
-                    a => Status::Starting,
+                    _ => Status::Starting,
                 }
             }
         }
@@ -165,12 +159,14 @@ impl JormungandrProcess {
     }
 
     pub fn check_no_errors_in_log(&self) -> Result<(), JormungandrError> {
-        let error_lines = self.logger.get_lines_with_error().collect::<Vec<String>>();
+        let error_lines = self
+            .logger
+            .get_lines_with_level(LogLevel::ERROR)
+            .collect::<Vec<_>>();
 
         if !error_lines.is_empty() {
             return Err(JormungandrError::ErrorInLogs {
                 logs: self.logger.get_log_content(),
-                log_location: self.logger.log_file_path.clone(),
                 error_lines: format!("{:?}", error_lines),
             });
         }
@@ -223,9 +219,7 @@ impl JormungandrProcess {
 
     pub fn to_remote(&self) -> RemoteJormungandr {
         let mut builder = RemoteJormungandrBuilder::new(self.alias.clone());
-        builder
-            .with_rest(self.rest_socket_addr)
-            .with_logger(self.logger.log_file_path.clone());
+        builder.with_rest(self.rest_socket_addr);
         builder.build()
     }
 
@@ -245,12 +239,21 @@ impl JormungandrProcess {
 
 impl Drop for JormungandrProcess {
     fn drop(&mut self) {
+        let errors = self
+            .logger
+            .get_lines_with_level(LogLevel::ERROR)
+            .collect::<Vec<_>>();
+        if !errors.is_empty() {
+            println!("Error lines:");
+            for line in errors {
+                println!("{}", line);
+            }
+        }
         // There's no kill like overkill
         let _ = self.child.kill();
 
         // FIXME: These should be better done in a test harness
         self.child.wait().unwrap();
-        self.logger.print_error_and_invalid_logs();
     }
 }
 
@@ -282,10 +285,17 @@ impl SyncNode for JormungandrProcess {
     }
 
     fn get_lines_with_error_and_invalid(&self) -> Vec<String> {
-        self.logger.get_lines_with_error_and_invalid().collect()
+        self.logger
+            .get_lines_with_level(LogLevel::ERROR)
+            .map(|x| x.to_string())
+            .collect()
     }
 
     fn is_running(&self) -> bool {
-        todo!()
+        if let Status::Running = self.status(&StartupVerificationMode::Log) {
+            true
+        } else {
+            false
+        }
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -292,10 +292,6 @@ impl SyncNode for JormungandrProcess {
     }
 
     fn is_running(&self) -> bool {
-        if let Status::Running = self.status(&StartupVerificationMode::Log) {
-            true
-        } else {
-            false
-        }
+        matches!(self.status(&StartupVerificationMode::Log), Status::Running)
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -107,7 +107,7 @@ impl JormungandrProcess {
 
                 let output = output.try_as_single_node_yaml();
 
-                match output.ok().map(|x| x.get("uptime").unwrap().clone()) {
+                match output.ok().and_then(|x| x.get("uptime").cloned()) {
                     Some(uptime)
                         if uptime.parse::<i32>().unwrap_or_else(|_| {
                             panic!("Cannot parse uptime {}", uptime.to_string())

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/commands.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/commands.rs
@@ -2,7 +2,6 @@ use super::{FromGenesis, Role};
 
 use jormungandr_testing_utils::testing::{JormungandrParams, TestConfig};
 use serde::Serialize;
-use std::fs::File;
 use std::iter::FromIterator;
 use std::path::Path;
 use std::process::Command;

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/commands.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/commands.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use std::fs::File;
 use std::iter::FromIterator;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 pub struct CommandBuilder<'a> {
     bin: &'a Path,
@@ -94,27 +94,12 @@ impl<'a> CommandBuilder<'a> {
             }
         }
 
-        if let Some(log_file) = self.log_file {
-            command.stderr(get_stdio_from_log_file(log_file));
-        }
+        command.stderr(std::process::Stdio::piped());
+        command.stdout(std::process::Stdio::piped());
 
         println!("Running start jormungandr command: {:?}", &command);
         command
     }
-}
-
-#[cfg(unix)]
-fn get_stdio_from_log_file(log_file_path: &Path) -> std::process::Stdio {
-    use std::os::unix::io::{FromRawFd, IntoRawFd};
-    let file = File::create(log_file_path).expect("couldn't create log file for jormungandr");
-    unsafe { Stdio::from_raw_fd(file.into_raw_fd()) }
-}
-
-#[cfg(windows)]
-fn get_stdio_from_log_file(log_file_path: &Path) -> std::process::Stdio {
-    use std::os::windows::io::{FromRawHandle, IntoRawHandle};
-    let file = File::create(log_file_path).expect("couldn't create log file for jormungandr");
-    unsafe { Stdio::from_raw_handle(file.into_raw_handle()) }
 }
 
 pub fn get_command<Conf: TestConfig + Serialize>(

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
@@ -1,7 +1,9 @@
 mod commands;
 pub use commands::{get_command, CommandBuilder};
 
+use super::process::{StartupVerificationMode, Status};
 use super::ConfigurationBuilder;
+use super::JormungandrError;
 use crate::common::{
     configuration::get_jormungandr_app,
     jcli::{JCli, JCliCommand},
@@ -41,22 +43,14 @@ pub enum StartupError {
     LegacyConfigConversion(#[from] LegacyConfigConverterError),
     #[error("node wasn't properly bootstrap after {timeout} s. Log file: {log_content}")]
     Timeout { timeout: u64, log_content: String },
-    #[error("error(s) in log detected: {log_content}")]
-    ErrorInLogsFound { log_content: String },
-    #[error("error(s) in log detected: port already in use")]
-    PortAlreadyInUse,
+    #[error("error(s) while starting")]
+    JormungandrError(#[from] JormungandrError),
     #[error("expected message not found: {entry} in logs: {log_content}")]
     EntryNotFoundInLogs { entry: String, log_content: String },
 }
 
 const DEFAULT_SLEEP_BETWEEN_ATTEMPTS: u64 = 2;
 const DEFAULT_MAX_ATTEMPTS: u64 = 6;
-
-#[derive(Clone, Debug, Copy)]
-pub enum StartupVerificationMode {
-    Rest,
-    Log,
-}
 
 #[derive(Clone, Debug, Copy)]
 pub enum FromGenesis {
@@ -92,92 +86,6 @@ impl From<LeadershipMode> for FromGenesis {
             LeadershipMode::Leader => FromGenesis::File,
             LeadershipMode::Passive => FromGenesis::Hash,
         }
-    }
-}
-
-trait StartupVerification {
-    fn if_stopped(&self) -> bool;
-    fn if_succeed(&self) -> bool;
-}
-
-#[derive(Clone, Debug)]
-struct RestStartupVerification<'a, Conf> {
-    config: &'a JormungandrParams<Conf>,
-}
-
-impl<'a, Conf> RestStartupVerification<'a, Conf> {
-    pub fn new(config: &'a JormungandrParams<Conf>) -> Self {
-        RestStartupVerification { config }
-    }
-}
-
-impl<'a, Conf: TestConfig> StartupVerification for RestStartupVerification<'a, Conf> {
-    fn if_stopped(&self) -> bool {
-        let logger = JormungandrLogger::new(self.config.log_file_path());
-        logger.contains_error().unwrap_or(false)
-    }
-
-    fn if_succeed(&self) -> bool {
-        let jcli: JCli = Default::default();
-
-        let output = JCliCommand::new(Command::new(jcli.path()))
-            .rest()
-            .v0()
-            .node()
-            .stats(&self.config.rest_uri())
-            .build()
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap()
-            .wait_with_output()
-            .expect("failed to execute get_rest_stats command")
-            .try_as_single_node_yaml();
-
-        if output.is_err() {
-            return false;
-        }
-
-        match output.unwrap().get("uptime") {
-            Some(uptime) => {
-                uptime
-                    .parse::<i32>()
-                    .unwrap_or_else(|_| panic!("Cannot parse uptime {}", uptime.to_string()))
-                    > 2
-            }
-            None => false,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-struct LogStartupVerification<'a, Conf> {
-    config: &'a JormungandrParams<Conf>,
-}
-
-impl<'a, Conf> LogStartupVerification<'a, Conf> {
-    pub fn new(config: &'a JormungandrParams<Conf>) -> Self {
-        LogStartupVerification { config }
-    }
-}
-
-impl<'a, Conf: TestConfig> StartupVerification for LogStartupVerification<'a, Conf> {
-    fn if_stopped(&self) -> bool {
-        let logger = JormungandrLogger::new(self.config.log_file_path());
-        logger.contains_error().unwrap_or(false)
-    }
-
-    fn if_succeed(&self) -> bool {
-        let bootstrap_completed_msgs = [
-            "listening and accepting gRPC connections",
-            "genesis block fetched",
-        ];
-
-        let logger = JormungandrLogger::new(self.config.log_file_path());
-
-        bootstrap_completed_msgs
-            .iter()
-            .any(|msg| logger.contains_message(msg).unwrap_or(false))
     }
 }
 
@@ -403,25 +311,23 @@ where
     Conf: TestConfig + Serialize + Debug,
 {
     fn start_with_fail_in_logs(self, expected_msg_in_logs: &str) -> Result<(), StartupError> {
-        let log_file_path = self.params.log_file_path().to_owned();
         let sleep_duration = self.starter.sleep;
         let timeout = self.starter.timeout;
 
         let start = Instant::now();
-        let _process = self.start_async();
+        let process = self.start_async();
 
         loop {
-            let logger = JormungandrLogger::new(log_file_path.clone());
             if start.elapsed() > timeout {
                 return Err(StartupError::EntryNotFoundInLogs {
                     entry: expected_msg_in_logs.to_string(),
-                    log_content: logger.get_log_content(),
+                    log_content: process.logger.get_log_content(),
                 });
             }
             process_utils::sleep(sleep_duration);
-            if logger
-                .raw_log_contains_any_of(&[expected_msg_in_logs])
-                .unwrap_or(false)
+            if process
+                .logger
+                .raw_log_contains_any_of(vec![expected_msg_in_logs].into_iter())
             {
                 return Ok(());
             }
@@ -472,14 +378,13 @@ where
                 self.temp_dir.take(),
                 self.starter.alias.clone(),
             );
-
-            match (self.verify_is_up(), self.starter.on_fail) {
+            match (self.verify_is_up(&mut jormungandr), self.starter.on_fail) {
                 (Ok(()), _) => {
                     return Ok(jormungandr);
                 }
 
                 (
-                    Err(StartupError::PortAlreadyInUse { .. }),
+                    Err(StartupError::JormungandrError(JormungandrError::PortAlreadyInUse)),
                     OnFail::RetryUnlimitedOnPortOccupied,
                 ) => {
                     println!(
@@ -515,78 +420,26 @@ where
         }
     }
 
-    fn start_fail(self, expected_msg: &str) {
-        get_command(
-            &self.params,
-            &self.starter.jormungandr_app_path,
-            self.starter.role,
-            self.starter.from_genesis,
-        )
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains(expected_msg));
-    }
-
-    fn if_succeed(&self) -> bool {
-        match self.starter.verification_mode {
-            StartupVerificationMode::Rest => {
-                RestStartupVerification::new(&self.params).if_succeed()
-            }
-            StartupVerificationMode::Log => LogStartupVerification::new(&self.params).if_succeed(),
-        }
-    }
-
-    fn if_stopped(&self) -> bool {
-        match self.starter.verification_mode {
-            StartupVerificationMode::Rest => {
-                RestStartupVerification::new(&self.params).if_stopped()
-            }
-            StartupVerificationMode::Log => LogStartupVerification::new(&self.params).if_stopped(),
-        }
-    }
-
-    fn custom_errors_found(&self) -> Result<(), StartupError> {
-        let log_file_path = self.params.log_file_path();
-        if !log_file_path.exists() {
-            // Still too early in the startup phase
-            return Ok(());
-        }
-        let logger = JormungandrLogger::new(log_file_path);
-        let port_occupied_msgs = ["error 87", "error 98", "panicked at 'Box<Any>'"];
-        if logger
-            .raw_log_contains_any_of(&port_occupied_msgs)
-            .unwrap_or(false)
-        {
-            Err(StartupError::PortAlreadyInUse)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn verify_is_up(&self) -> Result<(), StartupError> {
+    fn verify_is_up(&self, process: &mut JormungandrProcess) -> Result<(), StartupError> {
         let start = Instant::now();
-        let log_file_path = self.params.log_file_path();
-        let logger = JormungandrLogger::new(log_file_path);
         loop {
             if start.elapsed() > self.starter.timeout {
                 return Err(StartupError::Timeout {
                     timeout: self.starter.timeout.as_secs(),
-                    log_content: file::read_file(&log_file_path),
+                    log_content: process.logger.get_log_content(),
                 });
             }
-            if self.if_succeed() {
-                println!("jormungandr is up");
-                return Ok(());
-            }
-            self.custom_errors_found()?;
-            if self.if_stopped() {
-                println!("attempt stopped due to error signal recieved");
-                logger.print_raw_log();
-                return Err(StartupError::ErrorInLogsFound {
-                    log_content: file::read_file(&log_file_path),
-                });
+            match process.status(&self.starter.verification_mode) {
+                Status::Running => {
+                    println!("jormungandr is up");
+                    return Ok(());
+                }
+                Status::Stopped(err) => {
+                    println!("attempt stopped due to error signal recieved");
+                    println!("Raw log:\n {}", process.logger.get_log_content());
+                    return Err(StartupError::JormungandrError(err));
+                }
+                Status::Starting => {}
             }
             process_utils::sleep(self.starter.sleep);
         }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
@@ -4,31 +4,25 @@ pub use commands::{get_command, CommandBuilder};
 use super::process::{StartupVerificationMode, Status};
 use super::ConfigurationBuilder;
 use super::JormungandrError;
-use crate::common::{
-    configuration::get_jormungandr_app,
-    jcli::{JCli, JCliCommand},
-    jormungandr::process::JormungandrProcess,
-};
+use crate::common::{configuration::get_jormungandr_app, jormungandr::process::JormungandrProcess};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::{fixture::FixtureError, TempDir};
 use jormungandr_lib::interfaces::NodeConfig;
 use jormungandr_testing_utils::{
     testing::{
-        network_builder::LeadershipMode,
-        node::{configuration::legacy, JormungandrLogger},
-        JormungandrParams, LegacyConfigConverter, LegacyConfigConverterError, SpeedBenchmarkDef,
-        SpeedBenchmarkRun, TestConfig,
+        network_builder::LeadershipMode, node::configuration::legacy, JormungandrParams,
+        LegacyConfigConverter, LegacyConfigConverterError, SpeedBenchmarkDef, SpeedBenchmarkRun,
+        TestConfig,
     },
     Version,
 };
-use jortestkit::file;
-use jortestkit::process::{self as process_utils, output_extensions::ProcessOutput, ProcessError};
+use jortestkit::process::{self as process_utils, ProcessError};
 use serde::Serialize;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::{
-    process::{Child, Command},
+    process::Child,
     time::{Duration, Instant},
 };
 
@@ -326,10 +320,7 @@ where
                 });
             }
             process_utils::sleep(sleep_duration);
-            if process
-                .logger
-                .raw_log_contains_any_of(vec![expected_msg_in_logs].into_iter())
-            {
+            if process.logger.contains_any_of(&[expected_msg_in_logs]) {
                 return Ok(());
             }
         }

--- a/testing/jormungandr-integration-tests/src/common/network/controller.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/controller.rs
@@ -130,11 +130,18 @@ impl Controller {
         }
 
         let log_file_path = dir.child("node.log").path().to_path_buf();
-        config.log = Some(Log(vec![LogEntry {
-            format: "json".into(),
-            level: "debug".into(),
-            output: LogOutput::File(log_file_path.clone()),
-        }]));
+        config.log = Some(Log(vec![
+            LogEntry {
+                format: "json".into(),
+                level: "debug".into(),
+                output: LogOutput::Stdout,
+            },
+            LogEntry {
+                format: "json".into(),
+                level: "debug".into(),
+                output: LogOutput::File(log_file_path.clone()),
+            },
+        ]));
 
         if let PersistenceMode::Persistent = spawn_params.get_persistence_mode() {
             let path_to_storage = dir.child("storage").path().into();

--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/server_tests.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/server_tests.rs
@@ -1,6 +1,6 @@
 use jormungandr_testing_utils::testing::node::{
     grpc::server::{MethodType, MockBuilder, MockExitCode, ProtocolVersion},
-    Level,
+    LogLevel,
 };
 
 use super::setup;
@@ -58,11 +58,11 @@ pub async fn wrong_genesis_hash() {
 
     setup.server.shutdown();
     assert!(
-        setup.server.logger.get_log_entries().any(|x| {
+        setup.server.logger.get_lines().into_iter().any(|x| {
             x.fields.msg == "connection to peer failed"
                 && x.error_contains("Block0Mismatch")
                 && x.fields.peer_addr == Some(mock_address.clone())
-                && x.level == Level::INFO
+                && x.level == LogLevel::INFO
         }),
         "Log content: {}",
         setup.server.logger.get_log_content()
@@ -95,9 +95,7 @@ pub async fn handshake_ok() {
         "Handshake with mock never happened"
     );
 
-    assert!(!setup
-        .server
-        .logger
-        .get_log_entries()
-        .any(|x| { x.fields.peer_addr == Some(mock_address.clone()) && x.level == Level::WARN }));
+    assert!(!setup.server.logger.get_lines().into_iter().any(|x| {
+        x.fields.peer_addr == Some(mock_address.clone()) && x.level == LogLevel::WARN
+    }));
 }

--- a/testing/jormungandr-scenario-tests/src/interactive/args/send/cast.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/send/cast.rs
@@ -1,6 +1,5 @@
 use super::UserInteractionController;
 use crate::{style, test::Result};
-use jortestkit::prelude::InteractiveCommandError;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -41,54 +40,20 @@ impl CastVote {
             panic!("Either proposal_index or proposal id has to be provided")
         });
 
-        let node = controller
-            .nodes()
-            .iter()
-            .cloned()
-            .find(|x| *x.alias() == self.via);
-        let legacy_node = controller
-            .legacy_nodes()
-            .iter()
-            .cloned()
-            .find(|x| *x.alias() == self.via);
-
-        if let Some(node) = node {
-            let mem_pool_check = controller.cast_vote(
-                &self.wallet,
-                &self.vote_plan,
-                &node,
-                proposal_index,
-                self.choice,
-            )?;
-            println!(
-                "{}",
-                style::info.apply_to(format!(
-                    "vote cast fragment '{}' successfully sent",
-                    mem_pool_check.fragment_id()
-                ))
-            );
-            return Ok(());
-        } else if let Some(legacy_node) = legacy_node {
-            let mem_pool_check = controller.cast_vote(
-                &self.wallet,
-                &self.vote_plan,
-                &legacy_node,
-                proposal_index,
-                self.choice,
-            )?;
-            println!(
-                "{}",
-                style::info.apply_to(format!(
-                    "vote cast fragment '{}' successfully sent",
-                    mem_pool_check.fragment_id()
-                ))
-            );
-            return Ok(());
-        }
-
-        Err(
-            InteractiveCommandError::UserError(format!("alias not found {}", self.via.clone()))
-                .into(),
-        )
+        let mem_pool_check = controller.cast_vote(
+            &self.wallet,
+            &self.vote_plan,
+            &self.via,
+            proposal_index,
+            self.choice,
+        )?;
+        println!(
+            "{}",
+            style::info.apply_to(format!(
+                "vote cast fragment '{}' successfully sent",
+                mem_pool_check.fragment_id()
+            ))
+        );
+        Ok(())
     }
 }

--- a/testing/jormungandr-scenario-tests/src/interactive/args/send/tally.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/send/tally.rs
@@ -1,6 +1,5 @@
 use super::UserInteractionController;
 use crate::{style, test::Result};
-use jortestkit::prelude::InteractiveCommandError;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -15,43 +14,14 @@ pub struct VoteTally {
 
 impl VoteTally {
     pub fn exec(&self, controller: &mut UserInteractionController) -> Result<()> {
-        let node = controller
-            .nodes()
-            .iter()
-            .cloned()
-            .find(|x| *x.alias() == self.via);
-        let legacy_node = controller
-            .legacy_nodes()
-            .iter()
-            .cloned()
-            .find(|x| *x.alias() == self.via);
-
-        if let Some(node) = node {
-            let mem_pool_check = controller.tally_vote(&self.committee, &self.vote_plan, &node)?;
-            println!(
-                "{}",
-                style::info.apply_to(format!(
-                    "tally vote fragment '{}' successfully sent",
-                    mem_pool_check.fragment_id()
-                ))
-            );
-            return Ok(());
-        } else if let Some(legacy_node) = legacy_node {
-            let mem_pool_check =
-                controller.tally_vote(&self.committee, &self.vote_plan, &legacy_node)?;
-            println!(
-                "{}",
-                style::info.apply_to(format!(
-                    "tally vote fragment '{}' successfully sent",
-                    mem_pool_check.fragment_id()
-                ))
-            );
-            return Ok(());
-        }
-
-        Err(
-            InteractiveCommandError::UserError(format!("alias not found {}", self.via.clone()))
-                .into(),
-        )
+        let mem_pool_check = controller.tally_vote(&self.committee, &self.vote_plan, &self.via)?;
+        println!(
+            "{}",
+            style::info.apply_to(format!(
+                "tally vote fragment '{}' successfully sent",
+                mem_pool_check.fragment_id()
+            ))
+        );
+        Ok(())
     }
 }

--- a/testing/jormungandr-scenario-tests/src/interactive/args/send/tx.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/send/tx.rs
@@ -1,6 +1,5 @@
 use super::UserInteractionController;
 use crate::{style, test::Result};
-use jortestkit::prelude::InteractiveCommandError;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -17,52 +16,19 @@ pub struct SendTransaction {
 
 impl SendTransaction {
     pub fn exec(&self, controller: &mut UserInteractionController) -> Result<()> {
-        let node = controller
-            .nodes()
-            .iter()
-            .cloned()
-            .find(|x| *x.alias() == self.via);
-        let legacy_node = controller
-            .legacy_nodes()
-            .iter()
-            .cloned()
-            .find(|x| *x.alias() == self.via);
-
-        if let Some(node) = node {
-            let mem_pool_check = controller.send_transaction(
-                &self.from,
-                &self.to,
-                &node,
-                self.ada.unwrap_or(100).into(),
-            )?;
-            println!(
-                "{}",
-                style::info.apply_to(format!(
-                    "fragment '{}' successfully sent",
-                    mem_pool_check.fragment_id()
-                ))
-            );
-            return Ok(());
-        } else if let Some(legacy_node) = legacy_node {
-            let mem_pool_check = controller.send_transaction(
-                &self.from,
-                &self.to,
-                &legacy_node,
-                self.ada.unwrap_or(100).into(),
-            )?;
-            println!(
-                "{}",
-                style::info.apply_to(format!(
-                    "fragment '{}' successfully sent",
-                    mem_pool_check.fragment_id()
-                ))
-            );
-            return Ok(());
-        }
-
-        Err(
-            InteractiveCommandError::UserError(format!("alias not found {}", self.via.clone()))
-                .into(),
-        )
+        let mem_pool_check = controller.send_transaction(
+            &self.from,
+            &self.to,
+            &self.via,
+            self.ada.unwrap_or(100).into(),
+        )?;
+        println!(
+            "{}",
+            style::info.apply_to(format!(
+                "fragment '{}' successfully sent",
+                mem_pool_check.fragment_id()
+            ))
+        );
+        Ok(())
     }
 }

--- a/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
@@ -193,7 +193,7 @@ fn show_logs_for(
     contains: &Option<String>,
     alias: &str,
     tail: Option<usize>,
-    logger: JormungandrLogger,
+    logger: &JormungandrLogger,
 ) {
     let logs: Vec<String> = {
         if only_errors {

--- a/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
@@ -1,5 +1,5 @@
 use super::{do_for_all_alias, UserInteractionController};
-use jormungandr_testing_utils::testing::node::JormungandrLogger;
+use jormungandr_testing_utils::testing::node::{JormungandrLogger, LogLevel};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -197,23 +197,26 @@ fn show_logs_for(
 ) {
     let logs: Vec<String> = {
         if only_errors {
-            logger.get_lines_with_error().collect()
+            logger
+                .get_lines_with_level(LogLevel::ERROR)
+                .map(|x| x.to_string())
+                .collect()
         } else if let Some(contains) = &contains {
             logger
-                .get_lines_from_log()
-                .filter(|x| x.contains(contains.as_str()))
+                .get_lines()
+                .into_iter()
+                .filter(|x| x.fields.msg.contains(contains.as_str()))
+                .map(|x| x.to_string())
                 .collect()
         } else if let Some(tail) = tail {
             logger
-                .get_lines_from_log()
-                .collect::<Vec<String>>()
-                .iter()
-                .cloned()
+                .get_lines_as_string()
+                .into_iter()
                 .rev()
                 .take(tail)
                 .collect()
         } else {
-            logger.get_lines_from_log().collect()
+            logger.get_lines_as_string()
         }
     };
 

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -332,7 +332,7 @@ impl LegacyNodeController {
                 return Err(Error::FragmentNotInMemPoolLogs {
                     alias: self.alias().to_string(),
                     fragment_id: *check.fragment_id(),
-                    logs: self.logger().get_lines_from_log().collect(),
+                    logs: self.logger().get_lines_as_string(),
                 });
             }
             std::thread::sleep(duration);
@@ -342,7 +342,7 @@ impl LegacyNodeController {
             fragment_id: *check.fragment_id(),
             duration: Duration::from_secs(duration.as_secs() * max_try),
             alias: self.alias().to_string(),
-            logs: self.logger().get_lines_from_log().collect(),
+            logs: self.logger().get_lines_as_string(),
         })
     }
 
@@ -438,7 +438,7 @@ impl LegacyNodeController {
         Err(Error::NodeFailedToBootstrap {
             alias: self.alias().to_string(),
             duration: Duration::from_secs(sleep.as_secs() * max_try),
-            logs: self.logger().get_lines_from_log().collect(),
+            logs: self.logger().get_lines_as_string(),
         })
     }
 
@@ -457,7 +457,7 @@ impl LegacyNodeController {
                 "node is still up after {} s from sending shutdown request",
                 sleep.as_secs()
             ),
-            logs: self.logger().get_lines_from_log().collect(),
+            logs: self.logger().get_lines_as_string(),
         })
     }
 
@@ -498,7 +498,7 @@ impl LegacyNodeController {
             Err(Error::NodeFailedToShutdown {
                 alias: self.alias().to_string(),
                 message: result,
-                logs: self.logger().get_lines_from_log().collect(),
+                logs: self.logger().get_lines_as_string(),
             })
         }
     }

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -799,6 +799,7 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
         }
 
         command.stderr(Stdio::piped());
+        command.stdout(Stdio::piped());
         command
     }
 }

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -435,7 +435,7 @@ impl NodeController {
         Err(Error::NodeFailedToBootstrap {
             alias: self.alias().to_string(),
             duration: Duration::from_secs(sleep.as_secs() * max_try),
-            logs: self.logger().get_lines_from_log().collect(),
+            logs: self.logger().get_lines_as_string(),
         })
     }
 
@@ -454,7 +454,7 @@ impl NodeController {
                 "node is still up after {} s from sending shutdown request",
                 sleep.as_secs()
             ),
-            logs: self.logger().get_lines_from_log().collect(),
+            logs: self.logger().get_lines_as_string(),
         })
     }
 
@@ -494,7 +494,7 @@ impl NodeController {
             Err(Error::NodeFailedToShutdown {
                 alias: self.alias().to_string(),
                 message: result,
-                logs: self.logger().get_lines_from_log().collect(),
+                logs: self.logger().get_lines_as_string(),
             })
         }
     }

--- a/testing/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -24,11 +24,13 @@ use jormungandr_testing_utils::{
     stake_pool::StakePool,
     testing::{
         benchmark_consumption,
+        fragments::DummySyncNode,
         network_builder::{
             Blockchain, LeadershipMode, NodeAlias, NodeSetting, PersistenceMode, SpawnParams,
             Topology, Wallet as WalletSetting, WalletAlias,
         },
         ConsumptionBenchmarkRun, FragmentSender, FragmentSenderSetup, FragmentSenderSetupBuilder,
+        SyncNode,
     },
     wallet::Wallet,
     Version,
@@ -458,14 +460,14 @@ impl Controller {
         }
     }
 
-    pub fn fragment_sender(&self) -> FragmentSender {
-        self.fragment_sender_with_setup(Default::default())
+    pub fn fragment_sender(&self) -> FragmentSender<DummySyncNode> {
+        self.fragment_sender_with_setup(FragmentSenderSetup::default())
     }
 
-    pub fn fragment_sender_with_setup<'a>(
+    pub fn fragment_sender_with_setup<'a, S: SyncNode + Send>(
         &self,
-        setup: FragmentSenderSetup<'a>,
-    ) -> FragmentSender<'a> {
+        setup: FragmentSenderSetup<'a, S>,
+    ) -> FragmentSender<'a, S> {
         let mut builder = FragmentSenderSetupBuilder::from(setup);
         let root_dir: PathBuf = PathBuf::from(self.working_directory().path());
         builder.dump_fragments_into(root_dir.join("fragments"));

--- a/testing/jormungandr-scenario-tests/src/scenario/fragment_node.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/fragment_node.rs
@@ -43,6 +43,6 @@ impl FragmentNode for NodeController {
         ));
     }
     fn log_content(&self) -> Vec<String> {
-        self.logger().get_lines_from_log().collect()
+        self.logger().get_lines_as_string()
     }
 }

--- a/testing/jormungandr-scenario-tests/src/test/legacy/fragment_propagation.rs
+++ b/testing/jormungandr-scenario-tests/src/test/legacy/fragment_propagation.rs
@@ -174,7 +174,7 @@ fn get_legacy_data(title: &str, context: &mut Context<ChaChaRng>) -> (PathBuf, V
     (legacy_app, last_release.version())
 }
 
-fn send_all_fragment_types<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+fn send_all_fragment_types<A: FragmentNode + SyncNode + Sized + Send>(
     controller: &mut Controller,
     passive: &A,
     version: Option<Version>,

--- a/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -30,9 +30,7 @@ pub fn wait(seconds: u64) {
     std::thread::sleep(Duration::from_secs(seconds));
 }
 
-pub fn measure_single_transaction_propagation_speed<
-    A: SyncNode + FragmentNode + Send + Sized + Sync,
->(
+pub fn measure_single_transaction_propagation_speed<A: SyncNode + FragmentNode + Send + Sized>(
     controller: &mut Controller,
     mut wallet1: &mut Wallet,
     wallet2: &Wallet,

--- a/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -19,6 +19,7 @@ use std::{collections::HashMap, time::Duration};
 use chain_impl_mockchain::fragment::{Fragment, FragmentId};
 pub use jormungandr_testing_utils::testing::{
     assert, assert_equals,
+    node::LogLevel,
     sync::{
         measure_and_log_sync_time, measure_fragment_propagation_speed,
         measure_how_many_nodes_are_running,
@@ -89,7 +90,10 @@ impl SyncNode for NodeController {
     }
 
     fn get_lines_with_error_and_invalid(&self) -> Vec<String> {
-        self.logger().get_lines_with_error_and_invalid().collect()
+        self.logger()
+            .get_lines_with_level(LogLevel::ERROR)
+            .map(|x| x.to_string())
+            .collect()
     }
 }
 
@@ -136,7 +140,7 @@ impl FragmentNode for LegacyNodeController {
         ));
     }
     fn log_content(&self) -> Vec<String> {
-        self.logger().get_lines_from_log().collect()
+        self.logger().get_lines_as_string()
     }
 }
 
@@ -166,7 +170,10 @@ impl SyncNode for LegacyNodeController {
     }
 
     fn get_lines_with_error_and_invalid(&self) -> Vec<String> {
-        self.logger().get_lines_with_error_and_invalid().collect()
+        self.logger()
+            .get_lines_with_level(LogLevel::ERROR)
+            .map(|x| x.to_string())
+            .collect()
     }
 
     fn is_running(&self) -> bool {

--- a/testing/jormungandr-testing-utils/src/testing/fragments/adversary.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/adversary.rs
@@ -64,7 +64,7 @@ impl AdversaryFragmentSenderError {
 
 pub struct AdversaryFragmentSenderSetup<'a> {
     pub verify: bool,
-    pub sync_nodes: Vec<&'a (dyn SyncNode + Sync + Send)>,
+    pub sync_nodes: Vec<&'a (dyn SyncNode)>,
     pub dump_fragments: Option<PathBuf>,
 }
 
@@ -85,7 +85,7 @@ impl<'a> AdversaryFragmentSenderSetup<'a> {
         }
     }
 
-    pub fn sync_before(nodes: Vec<&'a (dyn SyncNode + Sync + Send)>) -> Self {
+    pub fn sync_before(nodes: Vec<&'a (dyn SyncNode)>) -> Self {
         Self {
             verify: true,
             sync_nodes: nodes,
@@ -101,7 +101,7 @@ impl<'a> AdversaryFragmentSenderSetup<'a> {
         self.sync_nodes.is_empty()
     }
 
-    pub fn sync_nodes(&self) -> Vec<&'a (dyn SyncNode + Send + Sync)> {
+    pub fn sync_nodes(&self) -> Vec<&'a (dyn SyncNode)> {
         self.sync_nodes.clone()
     }
 }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/generator.rs
@@ -1,4 +1,5 @@
 use super::{FragmentSender, FragmentSenderError, MemPoolCheck};
+use crate::testing::SyncNode;
 use crate::{
     stake_pool::StakePool,
     testing::{node::Explorer, RemoteJormungandr, VotePlanBuilder},
@@ -15,7 +16,7 @@ use rand::RngCore;
 use rand_core::OsRng;
 use std::iter;
 
-pub struct FragmentGenerator<'a> {
+pub struct FragmentGenerator<'a, S: SyncNode + Send> {
     sender: Wallet,
     receiver: Wallet,
     active_stake_pools: Vec<StakePool>,
@@ -25,17 +26,17 @@ pub struct FragmentGenerator<'a> {
     rand: OsRng,
     explorer: Explorer,
     slots_per_epoch: u32,
-    fragment_sender: FragmentSender<'a>,
+    fragment_sender: FragmentSender<'a, S>,
 }
 
-impl<'a> FragmentGenerator<'a> {
+impl<'a, S: SyncNode + Send> FragmentGenerator<'a, S> {
     pub fn new(
         sender: Wallet,
         receiver: Wallet,
         node: RemoteJormungandr,
         explorer: Explorer,
         slots_per_epoch: u32,
-        fragment_sender: FragmentSender<'a>,
+        fragment_sender: FragmentSender<'a, S>,
     ) -> Self {
         Self {
             sender,
@@ -206,7 +207,7 @@ impl<'a> FragmentGenerator<'a> {
     }
 }
 
-impl<'a> RequestGenerator for FragmentGenerator<'a> {
+impl<'a, S: SyncNode + Send> RequestGenerator for FragmentGenerator<'a, S> {
     fn next(
         &mut self,
     ) -> Result<Vec<Option<jortestkit::load::Id>>, jortestkit::load::RequestFailure> {

--- a/testing/jormungandr-testing-utils/src/testing/fragments/load/adversary_generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/load/adversary_generator.rs
@@ -2,24 +2,26 @@ use crate::testing::AdversaryFragmentSender;
 use crate::testing::FragmentSender;
 use crate::testing::FragmentSenderSetup;
 use crate::testing::RemoteJormungandr;
+use crate::testing::SyncNode;
 use crate::wallet::Wallet;
 use chain_impl_mockchain::fragment::FragmentId;
 use jortestkit::load::{Id, RequestFailure, RequestGenerator};
 use rand_core::OsRng;
-pub struct AdversaryFragmentGenerator<'a> {
+
+pub struct AdversaryFragmentGenerator<'a, S: SyncNode + Send> {
     wallets: Vec<Wallet>,
     jormungandr: RemoteJormungandr,
-    fragment_sender: FragmentSender<'a>,
-    adversary_fragment_sender: AdversaryFragmentSender<'a>,
+    fragment_sender: FragmentSender<'a, S>,
+    adversary_fragment_sender: AdversaryFragmentSender<'a, S>,
     rand: OsRng,
     split_marker: usize,
 }
 
-impl<'a> AdversaryFragmentGenerator<'a> {
+impl<'a, S: SyncNode + Send> AdversaryFragmentGenerator<'a, S> {
     pub fn new(
         jormungandr: RemoteJormungandr,
-        fragment_sender: FragmentSender<'a>,
-        adversary_fragment_sender: AdversaryFragmentSender<'a>,
+        fragment_sender: FragmentSender<'a, S>,
+        adversary_fragment_sender: AdversaryFragmentSender<'a, S>,
     ) -> Self {
         Self {
             wallets: Vec::new(),
@@ -85,7 +87,7 @@ impl<'a> AdversaryFragmentGenerator<'a> {
     }
 }
 
-impl<'a> RequestGenerator for AdversaryFragmentGenerator<'a> {
+impl<'a, S: SyncNode + Send> RequestGenerator for AdversaryFragmentGenerator<'a, S> {
     fn next(&mut self) -> Result<Vec<Option<Id>>, RequestFailure> {
         self.send_transaction()
             .map(|fragment_id| vec![Some(fragment_id.to_string())])

--- a/testing/jormungandr-testing-utils/src/testing/fragments/load/batch_generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/load/batch_generator.rs
@@ -1,6 +1,7 @@
 use crate::testing::FragmentSender;
 use crate::testing::FragmentSenderSetup;
 use crate::testing::RemoteJormungandr;
+use crate::testing::SyncNode;
 use crate::wallet::LinearFee;
 use crate::wallet::Wallet;
 use chain_impl_mockchain::fragment::Fragment;
@@ -8,19 +9,18 @@ use jormungandr_lib::crypto::hash::Hash;
 use jortestkit::load::{Id, RequestFailure, RequestGenerator};
 use rand_core::OsRng;
 
-#[derive(Clone)]
-pub struct BatchFragmentGenerator<'a> {
+pub struct BatchFragmentGenerator<'a, S: SyncNode + Send> {
     wallets: Vec<Wallet>,
     jormungandr: RemoteJormungandr,
-    fragment_sender: FragmentSender<'a>,
+    fragment_sender: FragmentSender<'a, S>,
     rand: OsRng,
     split_marker: usize,
     batch_size: u8,
 }
 
-impl<'a> BatchFragmentGenerator<'a> {
+impl<'a, S: SyncNode + Send> BatchFragmentGenerator<'a, S> {
     pub fn new(
-        fragment_sender_setup: FragmentSenderSetup<'a>,
+        fragment_sender_setup: FragmentSenderSetup<'a, S>,
         jormungandr: RemoteJormungandr,
         block_hash: Hash,
         fees: LinearFee,
@@ -122,7 +122,7 @@ impl<'a> BatchFragmentGenerator<'a> {
     }
 }
 
-impl RequestGenerator for BatchFragmentGenerator<'_> {
+impl<S: SyncNode + Send> RequestGenerator for BatchFragmentGenerator<'_, S> {
     fn next(&mut self) -> Result<Vec<Option<Id>>, RequestFailure> {
         self.send_batch()
     }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/load/transaction_generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/load/transaction_generator.rs
@@ -1,6 +1,7 @@
 use crate::testing::FragmentSender;
 use crate::testing::FragmentSenderSetup;
 use crate::testing::RemoteJormungandr;
+use crate::testing::SyncNode;
 use crate::wallet::LinearFee;
 use crate::wallet::Wallet;
 use chain_impl_mockchain::fragment::FragmentId;
@@ -8,18 +9,17 @@ use jormungandr_lib::crypto::hash::Hash;
 use jortestkit::load::{Id, RequestFailure, RequestGenerator};
 use rand_core::OsRng;
 
-#[derive(Clone)]
-pub struct TransactionGenerator<'a> {
+pub struct TransactionGenerator<'a, S: SyncNode + Send> {
     wallets: Vec<Wallet>,
     jormungandr: RemoteJormungandr,
-    fragment_sender: FragmentSender<'a>,
+    fragment_sender: FragmentSender<'a, S>,
     rand: OsRng,
     split_marker: usize,
 }
 
-impl<'a> TransactionGenerator<'a> {
+impl<'a, S: SyncNode + Send> TransactionGenerator<'a, S> {
     pub fn new(
-        fragment_sender_setup: FragmentSenderSetup<'a>,
+        fragment_sender_setup: FragmentSenderSetup<'a, S>,
         jormungandr: RemoteJormungandr,
         block_hash: Hash,
         fees: LinearFee,
@@ -87,7 +87,7 @@ impl<'a> TransactionGenerator<'a> {
     }
 }
 
-impl RequestGenerator for TransactionGenerator<'_> {
+impl<S: SyncNode + Send> RequestGenerator for TransactionGenerator<'_, S> {
     fn next(&mut self) -> Result<Vec<Option<Id>>, RequestFailure> {
         self.send_transaction()
             .map(|fragment_id| vec![Some(fragment_id.to_string())])

--- a/testing/jormungandr-testing-utils/src/testing/fragments/load/vote_casts_generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/load/vote_casts_generator.rs
@@ -1,3 +1,4 @@
+use crate::testing::SyncNode;
 use crate::{
     testing::{FragmentSender, FragmentSenderError, MemPoolCheck, RemoteJormungandr},
     wallet::Wallet,
@@ -7,21 +8,21 @@ use jortestkit::load::{RequestFailure, RequestGenerator};
 use rand::RngCore;
 use rand_core::OsRng;
 
-pub struct VoteCastsGenerator<'a> {
+pub struct VoteCastsGenerator<'a, S: SyncNode + Send> {
     voters: Vec<Wallet>,
     vote_plan: VotePlan,
     node: RemoteJormungandr,
     rand: OsRng,
-    fragment_sender: FragmentSender<'a>,
+    fragment_sender: FragmentSender<'a, S>,
     send_marker: usize,
 }
 
-impl<'a> VoteCastsGenerator<'a> {
+impl<'a, S: SyncNode + Send> VoteCastsGenerator<'a, S> {
     pub fn new(
         voters: Vec<Wallet>,
         vote_plan: VotePlan,
         node: RemoteJormungandr,
-        fragment_sender: FragmentSender<'a>,
+        fragment_sender: FragmentSender<'a, S>,
     ) -> Self {
         Self {
             voters,
@@ -54,7 +55,7 @@ impl<'a> VoteCastsGenerator<'a> {
     }
 }
 
-impl<'a> RequestGenerator for VoteCastsGenerator<'a> {
+impl<'a, S: SyncNode + Send> RequestGenerator for VoteCastsGenerator<'a, S> {
     fn next(
         &mut self,
     ) -> Result<Vec<Option<jortestkit::load::Id>>, jortestkit::load::RequestFailure> {

--- a/testing/jormungandr-testing-utils/src/testing/fragments/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/mod.rs
@@ -7,6 +7,7 @@ pub use self::{
     initial_certificates::{signed_delegation_cert, signed_stake_pool_cert, vote_plan_cert},
     node::{FragmentNode, FragmentNodeError, MemPoolCheck},
     sender::{FragmentSender, FragmentSenderError},
+    setup::DummySyncNode,
     setup::{FragmentSenderSetup, FragmentSenderSetupBuilder, VerifyStrategy},
     transaction::{transaction_to, transaction_to_many},
     verifier::{FragmentVerifier, FragmentVerifierError},

--- a/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
@@ -96,7 +96,7 @@ impl<'a> FragmentSender<'a> {
         }
     }
 
-    pub fn send_batch_fragments<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_batch_fragments<A: FragmentNode + SyncNode + Sized>(
         &self,
         fragments: Vec<Fragment>,
         node: &A,
@@ -106,7 +106,7 @@ impl<'a> FragmentSender<'a> {
         node.send_batch_fragments(fragments).map_err(|e| e.into())
     }
 
-    pub fn send_transaction<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_transaction<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         to: &Wallet,
@@ -119,7 +119,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_transaction_to_many<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_transaction_to_many<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         to: &[Wallet],
@@ -133,7 +133,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_full_delegation<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_full_delegation<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -144,7 +144,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_split_delegation<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_split_delegation<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         distribution: &[(&StakePool, u8)],
@@ -156,7 +156,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_owner_delegation<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_owner_delegation<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -167,7 +167,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_pool_registration<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_pool_registration<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -178,7 +178,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_pool_update<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_pool_update<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -191,7 +191,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_pool_retire<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_pool_retire<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -202,7 +202,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_vote_plan<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_vote_plan<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -213,7 +213,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_vote_cast<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_vote_cast<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -232,7 +232,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_public_vote_tally<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_public_vote_tally<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -241,7 +241,7 @@ impl<'a> FragmentSender<'a> {
         self.send_vote_tally(from, vote_plan, via, VoteTallyPayload::Public)
     }
 
-    pub fn send_encrypted_tally<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_encrypted_tally<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -252,7 +252,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_private_vote_tally<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_private_vote_tally<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -262,7 +262,7 @@ impl<'a> FragmentSender<'a> {
         self.send_vote_tally(from, vote_plan, via, VoteTallyPayload::Private { inner })
     }
 
-    pub fn send_vote_tally<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_vote_tally<A: FragmentNode + SyncNode + Sized>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -275,7 +275,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_transactions<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_transactions<A: FragmentNode + SyncNode + Sized>(
         &self,
         n: u32,
         mut wallet1: &mut Wallet,
@@ -293,9 +293,7 @@ impl<'a> FragmentSender<'a> {
         Ok(())
     }
 
-    pub fn send_transactions_with_iteration_delay<
-        A: FragmentNode + SyncNode + Sized + Sync + Send,
-    >(
+    pub fn send_transactions_with_iteration_delay<A: FragmentNode + SyncNode + Sized>(
         &self,
         n: u32,
         mut wallet1: &mut Wallet,
@@ -315,7 +313,7 @@ impl<'a> FragmentSender<'a> {
         Ok(())
     }
 
-    pub fn send_transactions_round_trip<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_transactions_round_trip<A: FragmentNode + SyncNode + Sized>(
         &self,
         n: u32,
         mut wallet1: &mut Wallet,
@@ -334,7 +332,7 @@ impl<'a> FragmentSender<'a> {
         Ok(())
     }
 
-    fn verify<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    fn verify<A: FragmentNode + SyncNode + Sized>(
         &self,
         check: &MemPoolCheck,
         node: &A,
@@ -364,7 +362,7 @@ impl<'a> FragmentSender<'a> {
         Ok(())
     }
 
-    pub fn send_fragment<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    pub fn send_fragment<A: FragmentNode + SyncNode + Sized>(
         &self,
         sender: &mut Wallet,
         fragment: Fragment,
@@ -419,7 +417,7 @@ impl<'a> FragmentSender<'a> {
         }
     }
 
-    fn wait_for_node_sync_if_enabled<A: FragmentNode + SyncNode + Sized + Sync + Send>(
+    fn wait_for_node_sync_if_enabled<A: FragmentNode + SyncNode + Sized>(
         &self,
         node: &A,
     ) -> Result<(), SyncNodeError> {

--- a/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
@@ -65,14 +65,14 @@ impl FragmentSenderError {
 }
 
 #[derive(Clone)]
-pub struct FragmentSender<'a> {
+pub struct FragmentSender<'a, S: SyncNode + Send> {
     block0_hash: Hash,
     fees: LinearFee,
-    setup: FragmentSenderSetup<'a>,
+    setup: FragmentSenderSetup<'a, S>,
 }
 
-impl<'a> FragmentSender<'a> {
-    pub fn new(block0_hash: Hash, fees: LinearFee, setup: FragmentSenderSetup<'a>) -> Self {
+impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
+    pub fn new(block0_hash: Hash, fees: LinearFee, setup: FragmentSenderSetup<'a, S>) -> Self {
         Self {
             block0_hash,
             fees,
@@ -88,15 +88,18 @@ impl<'a> FragmentSender<'a> {
         self.fees
     }
 
-    pub fn clone_with_setup(&self, setup: FragmentSenderSetup<'a>) -> Self {
-        Self {
+    pub fn clone_with_setup<U: SyncNode + Send>(
+        &self,
+        setup: FragmentSenderSetup<'a, U>,
+    ) -> FragmentSender<'a, U> {
+        FragmentSender {
             fees: self.fees(),
             block0_hash: self.block0_hash(),
             setup,
         }
     }
 
-    pub fn send_batch_fragments<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_batch_fragments<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         fragments: Vec<Fragment>,
         node: &A,
@@ -106,7 +109,7 @@ impl<'a> FragmentSender<'a> {
         node.send_batch_fragments(fragments).map_err(|e| e.into())
     }
 
-    pub fn send_transaction<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_transaction<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         to: &Wallet,
@@ -119,7 +122,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_transaction_to_many<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_transaction_to_many<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         to: &[Wallet],
@@ -133,7 +136,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_full_delegation<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_full_delegation<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -144,7 +147,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_split_delegation<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_split_delegation<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         distribution: &[(&StakePool, u8)],
@@ -156,7 +159,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_owner_delegation<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_owner_delegation<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -167,7 +170,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_pool_registration<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_pool_registration<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -178,7 +181,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_pool_update<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_pool_update<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -191,7 +194,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_pool_retire<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_pool_retire<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         to: &StakePool,
@@ -202,7 +205,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_vote_plan<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_vote_plan<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -213,7 +216,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_vote_cast<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_vote_cast<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -232,7 +235,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_public_vote_tally<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_public_vote_tally<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -241,7 +244,7 @@ impl<'a> FragmentSender<'a> {
         self.send_vote_tally(from, vote_plan, via, VoteTallyPayload::Public)
     }
 
-    pub fn send_encrypted_tally<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_encrypted_tally<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -252,7 +255,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_private_vote_tally<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_private_vote_tally<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -262,7 +265,7 @@ impl<'a> FragmentSender<'a> {
         self.send_vote_tally(from, vote_plan, via, VoteTallyPayload::Private { inner })
     }
 
-    pub fn send_vote_tally<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_vote_tally<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         from: &mut Wallet,
         vote_plan: &VotePlan,
@@ -275,7 +278,7 @@ impl<'a> FragmentSender<'a> {
         self.send_fragment(from, fragment, via)
     }
 
-    pub fn send_transactions<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_transactions<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         n: u32,
         mut wallet1: &mut Wallet,
@@ -293,7 +296,7 @@ impl<'a> FragmentSender<'a> {
         Ok(())
     }
 
-    pub fn send_transactions_with_iteration_delay<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_transactions_with_iteration_delay<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         n: u32,
         mut wallet1: &mut Wallet,
@@ -313,7 +316,7 @@ impl<'a> FragmentSender<'a> {
         Ok(())
     }
 
-    pub fn send_transactions_round_trip<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_transactions_round_trip<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         n: u32,
         mut wallet1: &mut Wallet,
@@ -332,7 +335,7 @@ impl<'a> FragmentSender<'a> {
         Ok(())
     }
 
-    fn verify<A: FragmentNode + SyncNode + Sized>(
+    fn verify<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         check: &MemPoolCheck,
         node: &A,
@@ -362,7 +365,7 @@ impl<'a> FragmentSender<'a> {
         Ok(())
     }
 
-    pub fn send_fragment<A: FragmentNode + SyncNode + Sized>(
+    pub fn send_fragment<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         sender: &mut Wallet,
         fragment: Fragment,
@@ -417,7 +420,7 @@ impl<'a> FragmentSender<'a> {
         }
     }
 
-    fn wait_for_node_sync_if_enabled<A: FragmentNode + SyncNode + Sized>(
+    fn wait_for_node_sync_if_enabled<A: FragmentNode + SyncNode + Sized + Send>(
         &self,
         node: &A,
     ) -> Result<(), SyncNodeError> {

--- a/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
@@ -94,6 +94,7 @@ impl<'a, S: SyncNode + Send> FragmentSenderSetup<'a, S> {
     }
 }
 
+#[derive(Clone)]
 pub struct DummySyncNode;
 use crate::testing::fragments::Hash;
 

--- a/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
@@ -29,7 +29,7 @@ impl<'a> fmt::Debug for VerifyStrategy<'a> {
 #[derive(Clone)]
 pub struct FragmentSenderSetup<'a> {
     pub resend_on_error: Option<u8>,
-    pub sync_nodes: Vec<&'a (dyn SyncNode + Sync + Send)>,
+    pub sync_nodes: Vec<&'a (dyn SyncNode)>,
     pub ignore_any_errors: bool,
     pub dump_fragments: Option<PathBuf>,
     /// Sender will confirm transaction (increment account counter)
@@ -56,7 +56,7 @@ impl<'a> FragmentSenderSetup<'a> {
         builder.into()
     }
 
-    pub fn resend_3_times_and_sync_with(sync_nodes: Vec<&'a (dyn SyncNode + Sync + Send)>) -> Self {
+    pub fn resend_3_times_and_sync_with(sync_nodes: Vec<&'a (dyn SyncNode)>) -> Self {
         let mut builder = FragmentSenderSetupBuilder::new();
         builder.resend_on_error(3).sync_nodes(sync_nodes);
         builder.into()
@@ -84,7 +84,7 @@ impl<'a> FragmentSenderSetup<'a> {
         self.resend_on_error
     }
 
-    pub fn sync_nodes(&self) -> Vec<&'a (dyn SyncNode + Send + Sync)> {
+    pub fn sync_nodes(&self) -> Vec<&'a (dyn SyncNode)> {
         self.sync_nodes.clone()
     }
 
@@ -144,7 +144,7 @@ impl<'a> FragmentSenderSetupBuilder<'a> {
         self
     }
 
-    pub fn sync_nodes(&mut self, sync_nodes: Vec<&'a (dyn SyncNode + Send + Sync)>) -> &mut Self {
+    pub fn sync_nodes(&mut self, sync_nodes: Vec<&'a (dyn SyncNode)>) -> &mut Self {
         self.setup.sync_nodes = sync_nodes;
         self
     }

--- a/testing/jormungandr-testing-utils/src/testing/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/mod.rs
@@ -11,10 +11,10 @@ mod vit;
 pub use fragments::{
     signed_delegation_cert, signed_stake_pool_cert, vote_plan_cert, AdversaryFragmentSender,
     AdversaryFragmentSenderError, AdversaryFragmentSenderSetup, BatchFragmentGenerator,
-    FragmentBuilder, FragmentBuilderError, FragmentGenerator, FragmentNode, FragmentNodeError,
-    FragmentSender, FragmentSenderError, FragmentSenderSetup, FragmentSenderSetupBuilder,
-    FragmentStatusProvider, FragmentVerifier, FragmentVerifierError, MemPoolCheck, VerifyStrategy,
-    VoteCastsGenerator,
+    DummySyncNode, FragmentBuilder, FragmentBuilderError, FragmentGenerator, FragmentNode,
+    FragmentNodeError, FragmentSender, FragmentSenderError, FragmentSenderSetup,
+    FragmentSenderSetupBuilder, FragmentStatusProvider, FragmentVerifier, FragmentVerifierError,
+    MemPoolCheck, VerifyStrategy, VoteCastsGenerator,
 };
 pub use jortestkit::archive::decompress;
 pub use jortestkit::github::{CachedReleases, GitHubApiBuilder, GitHubApiError, Release};

--- a/testing/jormungandr-testing-utils/src/testing/node/benchmark.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/benchmark.rs
@@ -25,13 +25,15 @@ pub fn speed_benchmark_from_log(
     stop_measurement: &str,
 ) -> SpeedBenchmarkFinish {
     let start_entry: Timestamp = log
-        .get_log_entries()
+        .get_lines()
+        .into_iter()
         .find(|x| x.fields.msg.contains(start_measurement))
         .expect("cannot find start mesurement entry in log")
         .into();
 
     let stop_entry: Timestamp = log
-        .get_log_entries()
+        .get_lines()
+        .into_iter()
         .find(|x| x.fields.msg.contains(stop_measurement))
         .expect("cannot find stop mesurement entry in log")
         .into();

--- a/testing/jormungandr-testing-utils/src/testing/node/logger.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/logger.rs
@@ -166,8 +166,20 @@ impl JormungandrLogger {
         self.collected.borrow()
     }
 
-    pub fn get_log_content(&self) -> Vec<String> {
-        self.entries().iter().map(LogEntry::to_string).collect()
+    pub fn get_log_content(&self) -> String {
+        self.entries()
+            .iter()
+            .map(LogEntry::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    pub fn get_lines_as_string(&self) -> Vec<String> {
+        self.entries().iter().map(|x| x.to_string()).collect()
+    }
+
+    pub fn get_lines(&self) -> Vec<LogEntry> {
+        self.entries().clone()
     }
 
     pub fn get_lines_with_level(&self, level: Level) -> impl Iterator<Item = LogEntry> {
@@ -198,7 +210,7 @@ impl JormungandrLogger {
     pub fn contains_any_of(&self, messages: &[&str]) -> bool {
         self.entries()
             .iter()
-            .any(|line| messages.iter().any(|x| line.contains(x)))
+            .any(|line| messages.iter().any(|x| line.fields.msg.contains(x)))
     }
 
     pub fn get_created_blocks_hashes(&self) -> Vec<Hash> {
@@ -227,7 +239,7 @@ impl JormungandrLogger {
         })
     }
 
-    pub fn assert_no_errors(&mut self, message: &str) {
+    pub fn assert_no_errors(&self, message: &str) {
         let error_lines = self.get_lines_with_level(Level::ERROR).collect::<Vec<_>>();
 
         assert_eq!(

--- a/testing/jormungandr-testing-utils/src/testing/node/logger.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/logger.rs
@@ -21,10 +21,13 @@ pub struct JormungandrLogger {
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone, PartialOrd)]
 pub enum Level {
+    #[serde(alias = "TRCE")]
     TRACE,
+    #[serde(alias = "DEBG")]
     DEBUG,
     INFO,
     WARN,
+    #[serde(alias = "ERRO")]
     ERROR,
 }
 

--- a/testing/jormungandr-testing-utils/src/testing/node/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/mod.rs
@@ -11,7 +11,7 @@ pub mod explorer;
 pub use benchmark::*;
 pub use explorer::{Explorer, ExplorerError};
 pub use legacy::{download_last_n_releases, get_jormungandr_bin, version_0_8_19, Version};
-pub use logger::{JormungandrLogger, Level, LogEntry};
+pub use logger::{JormungandrLogger, Level as LogLevel, LogEntry};
 pub use rest::{
     uri_from_socket_addr, JormungandrRest, RawRest, RestError, RestRequestGen, RestSettings,
 };

--- a/testing/jormungandr-testing-utils/src/testing/sync/measure.rs
+++ b/testing/jormungandr-testing-utils/src/testing/sync/measure.rs
@@ -61,7 +61,7 @@ fn print_error_for_failed_leaders<A: SyncNode + ?Sized>(leaders_ids: Vec<u32>, l
     }
 }
 
-pub fn measure_fragment_propagation_speed<A: FragmentNode + Sized + Send>(
+pub fn measure_fragment_propagation_speed<A: FragmentNode + Sized>(
     fragment_id: FragmentId,
     leaders: &[&A],
     sync_wait: Thresholds<Speed>,

--- a/testing/jormungandr-testing-utils/src/testing/sync/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/sync/mod.rs
@@ -13,8 +13,8 @@ pub use report::{MeasurementReportInterval, MeasurementReporter};
 pub use wait::SyncWaitParams;
 
 pub fn ensure_node_is_in_sync_with_others(
-    target_node: &(dyn SyncNode + Sync + Send),
-    other_nodes: Vec<&(dyn SyncNode + Sync + Send)>,
+    target_node: &(dyn SyncNode + Send),
+    other_nodes: Vec<&(dyn SyncNode + Send)>,
     sync_wait: Thresholds<Speed>,
     info: &str,
 ) -> Result<(), SyncNodeError> {

--- a/testing/jormungandr-testing-utils/src/testing/sync/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/sync/mod.rs
@@ -13,8 +13,8 @@ pub use report::{MeasurementReportInterval, MeasurementReporter};
 pub use wait::SyncWaitParams;
 
 pub fn ensure_node_is_in_sync_with_others(
-    target_node: &(dyn SyncNode + Send),
-    other_nodes: Vec<&(dyn SyncNode + Send)>,
+    target_node: &(impl SyncNode + Send),
+    other_nodes: Vec<&(impl SyncNode + Send)>,
     sync_wait: Thresholds<Speed>,
     info: &str,
 ) -> Result<(), SyncNodeError> {

--- a/testing/mjolnir/src/mjolnir_app/bootstrap/scenario/duration.rs
+++ b/testing/mjolnir/src/mjolnir_app/bootstrap/scenario/duration.rs
@@ -3,7 +3,7 @@ use assert_fs::TempDir;
 use indicatif::{MultiProgress, ProgressBar};
 use jormungandr_lib::interfaces::NodeState;
 use jormungandr_testing_utils::testing::{
-    benchmark_speed, SpeedBenchmarkFinish, SpeedBenchmarkRun,
+    benchmark_speed, node::LogLevel, SpeedBenchmarkFinish, SpeedBenchmarkRun,
 };
 
 use crate::mjolnir_app::bootstrap::ClientLoadConfig;
@@ -71,7 +71,12 @@ impl DurationBasedClientLoad {
 
             node.check_no_errors_in_log()?;
 
-            progress_bar.set_error_lines(node.logger.get_lines_with_error().collect());
+            progress_bar.set_error_lines(
+                node.logger
+                    .get_lines_with_level(LogLevel::ERROR)
+                    .map(|x| x.to_string())
+                    .collect(),
+            );
 
             if instant.elapsed().as_secs() > target {
                 return Ok(None);

--- a/testing/mjolnir/src/mjolnir_app/bootstrap/scenario/iteration.rs
+++ b/testing/mjolnir/src/mjolnir_app/bootstrap/scenario/iteration.rs
@@ -4,7 +4,7 @@ use crate::mjolnir_app::MjolnirError;
 use assert_fs::TempDir;
 use indicatif::{MultiProgress, ProgressBar};
 use jormungandr_lib::interfaces::NodeState;
-use jormungandr_testing_utils::testing::{benchmark_speed, SpeedBenchmarkFinish};
+use jormungandr_testing_utils::testing::{benchmark_speed, node::LogLevel, SpeedBenchmarkFinish};
 use std::{thread, time};
 pub struct IterationBasedClientLoad {
     config: ClientLoadConfig,
@@ -47,7 +47,12 @@ impl IterationBasedClientLoad {
                 progress_bar.set_progress(&format!("block: {}", last_loaded_block))
             }
             node.check_no_errors_in_log()?;
-            progress_bar.set_error_lines(node.logger.get_lines_with_error().collect());
+            progress_bar.set_error_lines(
+                node.logger
+                    .get_lines_with_level(LogLevel::ERROR)
+                    .map(|x| x.to_string())
+                    .collect(),
+            );
 
             let stats = node.rest().stats()?;
             if stats.state == NodeState::Running {

--- a/testing/mjolnir/src/mjolnir_app/fragment/batch/tx_only.rs
+++ b/testing/mjolnir/src/mjolnir_app/fragment/batch/tx_only.rs
@@ -67,7 +67,7 @@ impl TxOnly {
 
         let mut request_gen = BatchFragmentGenerator::new(
             FragmentSenderSetup::no_verify(),
-            remote_jormungandr.clone(),
+            remote_jormungandr,
             block0_hash,
             fees,
             10,
@@ -82,6 +82,9 @@ impl TxOnly {
             30,
         );
 
+        let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
+        builder.with_rest(self.endpoint.parse().unwrap());
+        let remote_jormungandr = builder.build();
         let status_provider = FragmentStatusProvider::new(remote_jormungandr);
 
         let stats =

--- a/testing/mjolnir/src/mjolnir_app/fragment/standard/all.rs
+++ b/testing/mjolnir/src/mjolnir_app/fragment/standard/all.rs
@@ -87,7 +87,7 @@ impl AllFragments {
         let mut generator = FragmentGenerator::new(
             faucet,
             receiver,
-            remote_jormungandr.clone(),
+            remote_jormungandr,
             explorer.clone(),
             settings.slots_per_epoch,
             fragment_sender,
@@ -110,7 +110,9 @@ impl AllFragments {
             self.build_monitor(),
             30,
         );
-
+        let mut builder = RemoteJormungandrBuilder::new("node".to_string());
+        builder.with_rest(self.endpoint.parse().unwrap());
+        let remote_jormungandr = builder.build();
         let fragment_status_provider = FragmentStatusProvider::new(remote_jormungandr);
 
         let stats =


### PR DESCRIPTION
Use a pipe for reading logs from child processes instead of reading from files, because that caused synchronization problems.

The main problem is that reading from stdout is blocking, the current solution is to spawn a new thread that blocks on new messages and then send them back on a channel. It's not ideal because we spawn a new thread for each new process, but it should not be too much of a problem.
I also tried with async processes and output (`tokio::process`) but I had issues with I/O drivers not receiving updates in some cases and I dropped it. 
Another option could be to use some crate that exposes non future-based non blocking reads (mio only supports unix) 
