### PR TITLE
Re-run security audit weekly

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,6 +3,8 @@ on:
   push:
     paths:
       - Cargo.lock
+  schedule:
+    - cron: '0 5 * * 0' # Weekly every Sunday 05:00 UTC
 jobs:
   security_audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run security audits also on a weekly schedule,
for the (unlikely) case `Cargo.lock` is not updated for a long time,
but new vulnerabilities get discovered and added to the database.