### PR TITLE
Consistently use hub in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,4 +313,4 @@ jobs:
       - name: Remove release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release delete ${{ needs.create_release.outputs.version }}
+        run: hub release delete ${{ needs.create_release.outputs.version }}


### PR DESCRIPTION
Not sure 'gh' exists in the virtual environment