### PR TITLE
Improve log formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,8 +479,8 @@ dependencies = [
  "rand_core 0.5.1",
  "rayon",
  "sparse-array",
- "strum",
- "strum_macros",
+ "strum 0.19.5",
+ "strum_macros 0.19.4",
  "thiserror",
  "typed-bytes",
 ]
@@ -2031,6 +2031,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-json",
+ "strum 0.20.0",
  "symmetric-cipher",
  "sysinfo 0.15.9",
  "tar",
@@ -3729,10 +3730,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89a286a7e3b5720b9a477b23253bc50debac207c8d21505f8e70b36792f11b5"
 
 [[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+dependencies = [
+ "strum_macros 0.20.1",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.59",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
  "proc-macro2 1.0.24",

--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/server_tests.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/server_tests.rs
@@ -59,9 +59,9 @@ pub async fn wrong_genesis_hash() {
     setup.server.shutdown();
     assert!(
         setup.server.logger.get_lines().into_iter().any(|x| {
-            x.fields.msg == "connection to peer failed"
+            x.message() == "connection to peer failed"
                 && x.error_contains("Block0Mismatch")
-                && x.fields.peer_addr == Some(mock_address.clone())
+                && x.fields.get("peer_addr") == Some(&mock_address)
                 && x.level == LogLevel::INFO
         }),
         "Log content: {}",
@@ -96,6 +96,6 @@ pub async fn handshake_ok() {
     );
 
     assert!(!setup.server.logger.get_lines().into_iter().any(|x| {
-        x.fields.peer_addr == Some(mock_address.clone()) && x.level == LogLevel::WARN
+        x.fields.get("peer_addr") == Some(&mock_address) && x.level == LogLevel::WARN
     }));
 }

--- a/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
@@ -205,7 +205,7 @@ fn show_logs_for(
             logger
                 .get_lines()
                 .into_iter()
-                .filter(|x| x.fields.msg.contains(contains.as_str()))
+                .filter(|x| x.message().contains(contains.as_str()))
                 .map(|x| x.to_string())
                 .collect()
         } else if let Some(tail) = tail {

--- a/testing/jormungandr-testing-utils/Cargo.toml
+++ b/testing/jormungandr-testing-utils/Cargo.toml
@@ -60,6 +60,7 @@ symmetric-cipher = { git = "https://github.com/input-output-hk/chain-wallet-libs
 qrcodegen = "1.6"
 quircs = "0.10.0"
 image = "0.23.12"
+strum = { version = "0.20", features = ["derive"] }
 
 
 [dependencies.reqwest]

--- a/testing/jormungandr-testing-utils/src/testing/node/benchmark.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/benchmark.rs
@@ -27,14 +27,14 @@ pub fn speed_benchmark_from_log(
     let start_entry: Timestamp = log
         .get_lines()
         .into_iter()
-        .find(|x| x.fields.msg.contains(start_measurement))
+        .find(|x| x.message().contains(start_measurement))
         .expect("cannot find start mesurement entry in log")
         .into();
 
     let stop_entry: Timestamp = log
         .get_lines()
         .into_iter()
-        .find(|x| x.fields.msg.contains(stop_measurement))
+        .find(|x| x.message().contains(stop_measurement))
         .expect("cannot find stop mesurement entry in log")
         .into();
 

--- a/testing/jormungandr-testing-utils/src/testing/node/logger.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/logger.rs
@@ -32,19 +32,7 @@ pub enum Level {
 }
 
 const SUCCESFULLY_CREATED_BLOCK_MSG: &str = "block from leader event successfully stored";
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Fields {
-    #[serde(alias = "message", default = "String::new")]
-    pub msg: String,
-    #[serde(alias = "kind")]
-    pub task: Option<String>,
-    pub hash: Option<String>,
-    pub reason: Option<String>,
-    pub error: Option<String>,
-    pub block_date: Option<String>,
-    pub peer_addr: Option<String>,
-}
+type RawFields = HashMap<String, String>;
 
 // TODO: convert strings to enums for level/task/
 // TODO: convert ts to DateTime
@@ -53,7 +41,10 @@ pub struct LogEntry {
     pub level: Level,
     #[serde(alias = "timestamp")]
     pub ts: String,
-    pub fields: Fields,
+    pub fields: RawFields,
+    pub target: String,
+    pub span: Option<RawFields>,
+    pub spans: Option<Vec<RawFields>>,
 }
 
 impl fmt::Display for LogEntry {
@@ -77,32 +68,59 @@ pub struct LogEntryLegacy {
 
 impl From<LogEntryLegacy> for LogEntry {
     fn from(log_entry: LogEntryLegacy) -> Self {
+        macro_rules! insert_if_some {
+            ($container:expr, $value:expr) => {
+                if let Some(v) = $value {
+                    $container.insert(stringify!($value).to_string(), v);
+                }
+            };
+        }
+
+        let LogEntryLegacy {
+            msg,
+            task,
+            hash,
+            reason,
+            error,
+            block_date,
+            peer_addr,
+            level,
+            ts,
+        } = log_entry;
+        let mut fields = HashMap::new();
+
+        fields.insert(LogEntry::MESSAGE.to_string(), msg);
+        insert_if_some!(fields, task);
+        insert_if_some!(fields, hash);
+        insert_if_some!(fields, reason);
+        insert_if_some!(fields, error);
+        insert_if_some!(fields, block_date);
+        insert_if_some!(fields, peer_addr);
+
         Self {
-            level: log_entry.level,
-            ts: log_entry.ts,
-            fields: Fields {
-                msg: log_entry.msg,
-                task: log_entry.task,
-                hash: log_entry.hash,
-                reason: log_entry.reason,
-                error: log_entry.error,
-                block_date: log_entry.block_date,
-                peer_addr: log_entry.peer_addr,
-            },
+            level,
+            ts,
+            fields,
+            target: String::new(),
+            span: None,
+            spans: None,
         }
     }
 }
 
 impl LogEntry {
+    // this is the name of the field used by tracing to print messages
+    const MESSAGE: &'static str = "message";
+
     pub fn reason_contains(&self, reason_part: &str) -> bool {
-        match &self.fields.reason {
+        match &self.fields.get("reason") {
             Some(reason) => reason.contains(reason_part),
             None => false,
         }
     }
 
     pub fn error_contains(&self, error_part: &str) -> bool {
-        match &self.fields.error {
+        match &self.fields.get("error") {
             Some(error) => error.contains(error_part),
             None => false,
         }
@@ -110,7 +128,7 @@ impl LogEntry {
 
     pub fn block_date(&self) -> Option<BlockDate> {
         self.fields
-            .block_date
+            .get("block_date")
             .clone()
             .map(|block| block::BlockDate::from_str(&block).unwrap().into())
     }
@@ -118,6 +136,10 @@ impl LogEntry {
     pub fn is_later_than(&self, reference_time: &SystemTime) -> bool {
         let entry_system_time = SystemTime::from_str(&self.ts).unwrap();
         entry_system_time.duration_since(*reference_time).is_ok()
+    }
+
+    pub fn message(&self) -> String {
+        self.fields.get(Self::MESSAGE).cloned().unwrap_or_default()
     }
 }
 
@@ -146,8 +168,12 @@ impl JormungandrLogger {
         let collected = &mut self.collected.borrow_mut();
         let now = Instant::now();
         while let Ok((time, line)) = self.rx.try_recv() {
-            // we are reading from logs produce from the node, if they are not valid there is something wrong
-            collected.push(Self::try_parse_line_as_entry(&line).unwrap());
+            // we are reading from logs produced by the node, if they are not valid there is something wrong
+            let entry = Self::try_parse_line_as_entry(&line).unwrap();
+            // Filter out logs produced by other libraries
+            if entry.target.starts_with("jormungandr") {
+                collected.push(entry);
+            }
             // Stop reading if the are more recent messages available, otherwise
             // we risk that a very active process could result in endless collection
             // of its output
@@ -194,14 +220,14 @@ impl JormungandrLogger {
             entry.level == Level::ERROR
                 || Self::get_error_indicators()
                     .iter()
-                    .any(|indicator| entry.fields.msg.contains(indicator))
+                    .any(|indicator| entry.message().contains(indicator))
         })
     }
 
     pub fn last_validated_block_date(&self) -> Option<BlockDate> {
         self.entries()
             .iter()
-            .filter(|x| x.fields.msg.contains("validated block"))
+            .filter(|x| x.message().contains("validated block"))
             .map(|x| x.block_date())
             .last()
             .unwrap_or(None)
@@ -210,19 +236,19 @@ impl JormungandrLogger {
     pub fn contains_any_of(&self, messages: &[&str]) -> bool {
         self.entries()
             .iter()
-            .any(|line| messages.iter().any(|x| line.fields.msg.contains(x)))
+            .any(|line| messages.iter().any(|x| line.message().contains(x)))
     }
 
     pub fn get_created_blocks_hashes(&self) -> Vec<Hash> {
         self.filter_entries_with_block_creation()
-            .map(|item| Hash::from_str(&item.fields.hash.unwrap()).unwrap())
+            .map(|item| Hash::from_str(&item.span.unwrap().get("hash").unwrap()).unwrap())
             .collect()
     }
 
     pub fn get_created_blocks_hashes_after(&self, reference_time: SystemTime) -> Vec<Hash> {
         self.filter_entries_with_block_creation()
             .filter(|item| item.is_later_than(&reference_time))
-            .map(|item| Hash::from_str(&item.fields.hash.unwrap()).unwrap())
+            .map(|item| Hash::from_str(&item.span.unwrap().get("hash").unwrap()).unwrap())
             .collect()
     }
 
@@ -231,11 +257,9 @@ impl JormungandrLogger {
     }
 
     fn filter_entries_with_block_creation(&self) -> impl Iterator<Item = LogEntry> {
-        let expected_task = Some("block".to_string());
         self.entries().clone().into_iter().filter(move |x| {
-            x.fields.msg == SUCCESFULLY_CREATED_BLOCK_MSG
-                && x.fields.task == expected_task
-                && x.fields.hash.is_some()
+            x.message() == SUCCESFULLY_CREATED_BLOCK_MSG
+                && x.span.as_ref().and_then(|span| span.get("hash")).is_some()
         })
     }
 
@@ -257,35 +281,42 @@ impl JormungandrLogger {
         if let Ok(result) = legacy_entry {
             return Ok(result.into());
         }
-        // parse and aggregate spans fields
-        let mut jsonize_entry: serde_json::Value = serde_json::from_str(&line)?;
-        let mut aggreagated: HashMap<String, serde_json::Value> = HashMap::new();
-        if let Some(fields) = jsonize_entry.get("fields") {
-            // main span "fields" is ensured be an object, it is safe to unwrap here
-            for (k, v) in fields.as_object().unwrap().iter() {
-                aggreagated.insert(k.clone(), v.clone());
+
+        // Fields could be of various types, since we do not need to modify or
+        // interact with them, it is easier to just map them to strings
+        macro_rules! stringify_map {
+            ($container:expr, $field:expr) => {
+                let mapped = $container
+                    .index($field)
+                    .as_object()
+                    .expect("not an object")
+                    .into_iter()
+                    .map(|(k, v)| {
+                        (
+                            k,
+                            if v.is_string() {
+                                v.to_owned()
+                            } else {
+                                serde_json::Value::String(v.to_string())
+                            },
+                        )
+                    })
+                    .collect();
+                *$container.index_mut($field) = mapped;
+            };
+        };
+
+        let mut value: serde_json::Value = serde_json::from_str(&line).unwrap();
+        stringify_map!(value, "fields");
+        if value.get("span").is_some() {
+            stringify_map!(value, "span");
+        }
+        let spans = value.get_mut("spans").and_then(|x| x.as_array_mut());
+        if let Some(spans) = spans {
+            for i in 0..spans.len() {
+                stringify_map!(spans, i);
             }
         }
-        if let Some(main_span) = jsonize_entry.get("span") {
-            // main span "span" is ensured be an object, it is safe to unwrap here
-            for (k, v) in main_span.as_object().unwrap().iter() {
-                aggreagated.insert(k.clone(), v.clone());
-            }
-        }
-        if let Some(spans) = jsonize_entry.get("spans") {
-            // spans is ensured to be an array, so it should be safe to unwrap here
-            for s in spans.as_array().unwrap() {
-                // same here, inner spans are represented as objects
-                let span_values = s.as_object().unwrap();
-                for (k, v) in span_values.iter() {
-                    aggreagated.insert(k.clone(), v.clone());
-                }
-            }
-        }
-        *(jsonize_entry
-            .get_mut("fields")
-            .ok_or_else(|| serde_json::error::Error::custom("Could not get mutable `fields`"))?) =
-            serde_json::to_value(aggreagated)?;
-        serde_json::from_value(jsonize_entry)
+        serde_json::from_value(value)
     }
 }


### PR DESCRIPTION
Improve formatting of logs in testing environment by mimicking `tracing_subscriber` default behavior instead of using json.
This pr also rework the structure of `LogEntry` struct and how it's handled to make it closer to what we get from the logging output (i.e. there are no fixed fields, just multiple key-value pairs)


**Example:**
`Mar 08 09:30:04.007 DEBUG service{kind=block}: process_leadership_block{hash=7c4052f3f017488e09f9566ab74e1951e6df645203f9adae88b215dcdc2ab50e,parent=3ce3cf198285607b1c2616c26f038118b6ea10fbaa8940fdd6a23e3452027c92,date=0.14}:  jormungandr::blockchain::process: propagating block to the network 
`
instead of 
` {"level":"DEBUG","ts":"Mar 08 09:30:04.007","fields":{"message":"propagating block to the network"},"target":"jormungandr::blockchain::process","span":{"name":"process_leadership_block","hash":"7c4052f3f017488e09f9566ab74e1951e6df645203f9adae88b215dcdc2ab50e","date":"0.14","parent":"3ce3cf198285607b1c2616c26f038118b6ea10fbaa8940fdd6a23e3452027c92"},"spans":[{"kind":"block","name":"service"},{"name":"process_leadership_block","hash":"7c4052f3f017488e09f9566ab74e1951e6df645203f9adae88b215dcdc2ab50e","parent":"3ce3cf198285607b1c2616c26f038118b6ea10fbaa8940fdd6a23e3452027c92","date":"0.14"}]}
`