### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,7 +3738,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.59",
+ "syn 1.0.62",
 ]
 
 [[package]]


### PR DESCRIPTION
A merge resulted in an unworkable Cargo.lock, fix this.