### PR TITLE
Remove unneeded async/await calls and update reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,22 +1608,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
-dependencies = [
- "bytes 0.5.6",
- "futures-util",
- "hyper 0.13.10",
- "log",
- "rustls 0.18.1",
- "tokio 0.2.25",
- "tokio-rustls 0.14.1",
- "webpki",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
@@ -1807,7 +1791,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
- "reqwest 0.11.1",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1857,7 +1841,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "reqwest 0.11.1",
+ "reqwest",
  "rustls 0.19.0",
  "serde",
  "serde_derive",
@@ -1910,7 +1894,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "regex",
- "reqwest 0.11.1",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1984,7 +1968,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "regex",
- "reqwest 0.10.10",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2034,7 +2018,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "regex",
- "reqwest 0.10.10",
+ "reqwest",
  "semver 0.11.0",
  "serde",
  "serde_derive",
@@ -2083,7 +2067,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "reqwest 0.11.1",
+ "reqwest",
  "semver 0.11.0",
  "serde",
  "serde_derive",
@@ -3223,43 +3207,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
-dependencies = [
- "base64 0.13.0",
- "bytes 0.5.6",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "http",
- "http-body 0.3.1",
- "hyper 0.13.10",
- "hyper-rustls 0.21.0",
- "ipnet",
- "js-sys",
- "lazy_static",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite 0.2.6",
- "rustls 0.18.1",
- "serde",
- "serde_json",
- "serde_urlencoded 0.7.0",
- "tokio 0.2.25",
- "tokio-rustls 0.14.1",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.20.0",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
@@ -3272,7 +3219,7 @@ dependencies = [
  "http",
  "http-body 0.4.0",
  "hyper 0.14.4",
- "hyper-rustls 0.22.1",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -3290,7 +3237,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.21.0",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -4756,15 +4703,6 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/client_tests.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/client_tests.rs
@@ -16,7 +16,6 @@ use chain_impl_mockchain::{
 use chain_time::{Epoch, TimeEra};
 use jormungandr_lib::interfaces::InitialUTxO;
 use jormungandr_testing_utils::testing::node::grpc::client::MockClientError;
-use tokio::time::sleep;
 
 use rand::Rng;
 use std::time::Duration;
@@ -32,12 +31,12 @@ fn is_long_prefix<T: PartialEq>(word: &[T], affix: &[T]) -> bool {
 }
 
 // L1001 Handshake sanity
-#[tokio::test]
-pub async fn handshake_sanity() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn handshake_sanity() {
+    let setup = setup::client::default();
     let mut auth_nonce = [0u8; 32];
     rand::thread_rng().fill(&mut auth_nonce[..]);
-    let handshake_response = setup.client.handshake(&auth_nonce).await;
+    let handshake_response = setup.client.handshake(&auth_nonce);
 
     assert_eq!(
         *setup.config.genesis_block_hash(),
@@ -58,18 +57,16 @@ pub async fn handshake_sanity() {
 }
 
 // L1006 Tip request
-#[tokio::test]
-pub async fn tip_request() {
+#[test]
+pub fn tip_request() {
     let setup =
-        setup::client::bootstrap(ConfigurationBuilder::new().with_slot_duration(9).to_owned())
-            .await;
+        setup::client::bootstrap(ConfigurationBuilder::new().with_slot_duration(9).to_owned());
 
     setup
         .client
-        .wait_for_chain_length(1.into(), CHAIN_GROWTH_TIMEOUT)
-        .await;
+        .wait_for_chain_length(1.into(), CHAIN_GROWTH_TIMEOUT);
 
-    let tip_header = setup.client.tip().await;
+    let tip_header = setup.client.tip();
     let block_hashes = setup.server.logger.get_created_blocks_hashes();
 
     // TODO: this could fail if the server produces another block
@@ -77,17 +74,16 @@ pub async fn tip_request() {
 }
 
 // L1009 GetHeaders correct hash
-#[tokio::test]
-pub async fn get_headers_correct_hash() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn get_headers_correct_hash() {
+    let setup = setup::client::default();
 
-    sleep(Duration::from_secs(10)).await; // wait for the server to produce some blocks
+    std::thread::sleep(Duration::from_secs(10)); // wait for the server to produce some blocks
 
     let block_hashes = setup.server.logger.get_created_blocks_hashes();
     let headers: Vec<Header> = setup
         .client
         .headers(&block_hashes)
-        .await
         .expect("unexpected error returned");
     let headers_hashes: Vec<Hash> = headers.iter().map(|x| x.hash()).collect();
     assert!(
@@ -99,55 +95,54 @@ pub async fn get_headers_correct_hash() {
 }
 
 // L1010 GetHeaders incorrect hash
-#[tokio::test]
-pub async fn get_headers_incorrect_hash() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn get_headers_incorrect_hash() {
+    let setup = setup::client::default();
     let fake_hash: Hash = TestGen::hash();
     assert_eq!(
         MockClientError::InvalidRequest(format!(
             "not found (block {} is not known to this node)",
             fake_hash.to_string()
         )),
-        setup.client.headers(&[fake_hash]).await.err().unwrap(),
+        setup.client.headers(&[fake_hash]).err().unwrap(),
         "wrong error"
     );
 }
 
 // L1011 GetBlocks correct hash
-#[tokio::test]
-pub async fn get_blocks_correct_hash() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn get_blocks_correct_hash() {
+    let setup = setup::client::default();
 
-    let tip = setup.client.tip().await;
-    assert!(setup.client.get_blocks(&[tip.hash()]).await.is_ok());
+    let tip = setup.client.tip();
+    assert!(setup.client.get_blocks(&[tip.hash()]).is_ok());
 }
 
 // L1012 GetBlocks incorrect hash
-#[tokio::test]
-pub async fn get_blocks_incorrect_hash() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn get_blocks_incorrect_hash() {
+    let setup = setup::client::default();
     let fake_hash: Hash = TestGen::hash();
     assert_eq!(
         MockClientError::InvalidRequest(format!(
             "not found (block {} is not known to this node)",
             fake_hash.to_string()
         )),
-        setup.client.headers(&[fake_hash]).await.err().unwrap(),
+        setup.client.headers(&[fake_hash]).err().unwrap(),
         "wrong error"
     );
 }
 
 // L1013 PullBlocksToTip correct hash
-#[tokio::test]
-pub async fn pull_blocks_to_tip_correct_hash() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn pull_blocks_to_tip_correct_hash() {
+    let setup = setup::client::default();
 
-    sleep(Duration::from_secs(10)).await; // wait for the server to produce some blocks
+    std::thread::sleep(Duration::from_secs(10)); // wait for the server to produce some blocks
 
     let blocks = setup
         .client
         .pull_blocks_to_tip(Hash::from_str(setup.config.genesis_block_hash()).unwrap())
-        .await
         .unwrap();
 
     let blocks_hashes: Vec<Hash> = blocks.iter().map(|x| x.header.hash()).collect();
@@ -161,14 +156,14 @@ pub async fn pull_blocks_to_tip_correct_hash() {
     );
 }
 
-#[tokio::test]
-pub async fn pull_range_invalid_params() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn pull_range_invalid_params() {
+    let setup = setup::client::default();
 
-    sleep(Duration::from_secs(10)).await; // wait for the server to produce some blocks
+    std::thread::sleep(Duration::from_secs(10)); // wait for the server to produce some blocks
     let gen_hash = Hash::from_str(setup.config.genesis_block_hash()).unwrap();
     let client = setup.client;
-    let tip_hash = client.tip().await.hash();
+    let tip_hash = client.tip().hash();
     let fake_hash = TestGen::hash();
     let error = MockClientError::InvalidRequest(
         "not found (Could not find a known block in `from`)".into(),
@@ -180,30 +175,23 @@ pub async fn pull_range_invalid_params() {
         (&[gen_hash], fake_hash),
     ];
     for (from, to) in invalid_params.iter() {
-        assert_eq!(error, client.pull_headers(from, *to).await.err().unwrap());
-        assert_eq!(error, client.pull_blocks(from, *to).await.err().unwrap());
+        assert_eq!(error, client.pull_headers(from, *to).err().unwrap());
+        assert_eq!(error, client.pull_blocks(from, *to).err().unwrap());
     }
-    assert_eq!(
-        error,
-        client.pull_blocks_to_tip(fake_hash).await.err().unwrap()
-    );
+    assert_eq!(error, client.pull_blocks_to_tip(fake_hash).err().unwrap());
 }
 
 // L1018 Pull headers correct hash
-#[tokio::test]
-pub async fn pull_headers_correct_hash() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn pull_headers_correct_hash() {
+    let setup = setup::client::default();
 
-    sleep(Duration::from_secs(10)).await; // wait for the server to produce some blocks
+    std::thread::sleep(Duration::from_secs(10)); // wait for the server to produce some blocks
 
-    let tip_header = setup.client.tip().await;
+    let tip_header = setup.client.tip();
     let headers = setup
         .client
-        .pull_headers(
-            &[setup.client.get_genesis_block_hash().await],
-            tip_header.hash(),
-        )
-        .await
+        .pull_headers(&[setup.client.get_genesis_block_hash()], tip_header.hash())
         .unwrap();
     let hashes: Vec<Hash> = headers.iter().map(|x| x.hash()).collect();
 
@@ -217,10 +205,10 @@ pub async fn pull_headers_correct_hash() {
 }
 
 // L1020 Push headers incorrect header
-#[tokio::test]
-pub async fn push_headers() {
-    let setup = setup::client::default().await;
-    let tip_header = setup.client.tip().await;
+#[test]
+pub fn push_headers() {
+    let setup = setup::client::default();
+    let tip_header = setup.client.tip();
     let stake_pool = StakePoolBuilder::new().build();
 
     let time_era = TimeEra::new(
@@ -238,14 +226,14 @@ pub async fn push_headers() {
         .with_parent(&tip_header)
         .build(&stake_pool, &time_era);
 
-    assert!(setup.client.push_headers(block.header).await.is_ok());
+    assert!(setup.client.push_headers(block.header).is_ok());
 }
 
 // L1020 Push headers incorrect header
-#[tokio::test]
-pub async fn upload_block_incompatible_protocol() {
-    let setup = setup::client::default().await;
-    let tip_header = setup.client.tip().await;
+#[test]
+pub fn upload_block_incompatible_protocol() {
+    let setup = setup::client::default();
+    let tip_header = setup.client.tip();
     let stake_pool = StakePoolBuilder::new().build();
 
     let time_era = TimeEra::new(
@@ -267,21 +255,20 @@ pub async fn upload_block_incompatible_protocol() {
         MockClientError::InvalidRequest(
             "invalid request data (The block header verification failed: The block Version is incompatible with LeaderSelection.)".into() 
         ),
-        setup.client.upload_blocks(block.clone()).await.err().unwrap()
+        setup.client.upload_blocks(block.clone()).err().unwrap()
     );
 }
 
 // L1020 Push headers incorrect header
-#[tokio::test]
-pub async fn upload_block_nonexisting_stake_pool() {
+#[test]
+pub fn upload_block_nonexisting_stake_pool() {
     let setup = setup::client::bootstrap(
         ConfigurationBuilder::new()
             .with_slot_duration(1)
             .with_block0_consensus(ConsensusVersion::GenesisPraos)
             .to_owned(),
-    )
-    .await;
-    let tip_header = setup.client.tip().await;
+    );
+    let tip_header = setup.client.tip();
     let stake_pool = StakePoolBuilder::new().build();
 
     let time_era = TimeEra::new(
@@ -304,18 +291,13 @@ pub async fn upload_block_nonexisting_stake_pool() {
             "invalid request data (The block header verification failed: Invalid block message)"
                 .into()
         ),
-        setup
-            .client
-            .upload_blocks(block.clone())
-            .await
-            .err()
-            .unwrap()
+        setup.client.upload_blocks(block.clone()).err().unwrap()
     );
 }
 
 // L1020 Get fragments
-#[tokio::test]
-pub async fn get_fragments() {
+#[test]
+pub fn get_fragments() {
     let mut sender = startup::create_new_account_address();
     let receiver = startup::create_new_account_address();
     let config = ConfigurationBuilder::new()
@@ -326,7 +308,7 @@ pub async fn get_fragments() {
         }])
         .to_owned();
 
-    let setup = setup::client::bootstrap(config).await;
+    let setup = setup::client::bootstrap(config);
     let output_value = 1u64;
     let jcli: JCli = Default::default();
     let transaction = sender
@@ -343,20 +325,19 @@ pub async fn get_fragments() {
         .fragment_sender(&setup.server)
         .send(&transaction)
         .assert_in_block();
-    println!("{:?}", setup.client.get_fragments(vec![fragment_id]).await);
+    println!("{:?}", setup.client.get_fragments(vec![fragment_id]));
 }
 
 // L1021 PullBlocks correct hashes
-#[tokio::test]
-pub async fn pull_blocks_correct_hashes_all_blocks() {
-    let setup = setup::client::default().await;
-    sleep(Duration::from_secs(10)).await; // wait for the server to produce some blocks
+#[test]
+pub fn pull_blocks_correct_hashes_all_blocks() {
+    let setup = setup::client::default();
+    std::thread::sleep(Duration::from_secs(10)); // wait for the server to produce some blocks
 
     let genesis_block_hash = Hash::from_str(setup.config.genesis_block_hash()).unwrap();
     let blocks = setup
         .client
-        .pull_blocks(&[genesis_block_hash], setup.client.tip().await.id())
-        .await
+        .pull_blocks(&[genesis_block_hash], setup.client.tip().id())
         .unwrap();
 
     let blocks_hashes: Vec<Hash> = blocks.iter().map(|x| x.header.hash()).collect();
@@ -370,13 +351,12 @@ pub async fn pull_blocks_correct_hashes_all_blocks() {
 }
 
 // L1022 PullBlocks correct hashes
-#[tokio::test]
-pub async fn pull_blocks_correct_hashes_partial() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn pull_blocks_correct_hashes_partial() {
+    let setup = setup::client::default();
     setup
         .client
-        .wait_for_chain_length(10.into(), CHAIN_GROWTH_TIMEOUT)
-        .await;
+        .wait_for_chain_length(10.into(), CHAIN_GROWTH_TIMEOUT);
 
     let block_hashes_from_logs = setup.server.logger.get_created_blocks_hashes();
     let start = 2;
@@ -389,7 +369,6 @@ pub async fn pull_blocks_correct_hashes_partial() {
             &[expected_hashes[0]],
             expected_hashes.last().copied().unwrap(),
         )
-        .await
         .unwrap();
 
     let blocks_hashes: Vec<Hash> = blocks.iter().map(|x| x.header.hash()).collect();
@@ -398,27 +377,23 @@ pub async fn pull_blocks_correct_hashes_partial() {
 }
 
 // L1023 PullBlocks to and from in wrong order
-#[tokio::test]
-pub async fn pull_blocks_hashes_wrong_order() {
-    let setup = setup::client::default().await;
+#[test]
+pub fn pull_blocks_hashes_wrong_order() {
+    let setup = setup::client::default();
 
     setup
         .client
-        .wait_for_chain_length(10.into(), CHAIN_GROWTH_TIMEOUT)
-        .await;
+        .wait_for_chain_length(10.into(), CHAIN_GROWTH_TIMEOUT);
 
     let block_hashes_from_logs = setup.server.logger.get_created_blocks_hashes();
     let start = 2;
     let end = 8;
     let expected_hashes = block_hashes_from_logs[start..end].to_vec();
 
-    let result = setup
-        .client
-        .pull_blocks(
-            &[expected_hashes.last().copied().unwrap()],
-            expected_hashes[0],
-        )
-        .await;
+    let result = setup.client.pull_blocks(
+        &[expected_hashes.last().copied().unwrap()],
+        expected_hashes[0],
+    );
 
     assert!(result.is_err());
 }

--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/server_tests.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/server_tests.rs
@@ -5,9 +5,9 @@ use jormungandr_testing_utils::testing::node::{
 };
 
 // L1005 Handshake version discrepancy
-#[tokio::test]
-pub async fn wrong_protocol() {
-    let setup = setup::server::default().await;
+#[test]
+pub fn wrong_protocol() {
+    let setup = setup::server::default();
 
     let block0 = setup.server.block0_configuration().to_block();
     let genesis_hash = setup.server.genesis_block_hash().into_hash();
@@ -19,7 +19,7 @@ pub async fn wrong_protocol() {
         .with_protocol_version(ProtocolVersion::Bft)
         .build();
 
-    setup.wait_server_online().await;
+    setup.wait_server_online();
 
     let mock_result = mock_controller.finish_and_verify_that(|mock_verifier| {
         mock_verifier.method_executed_at_least_once(MethodType::Handshake)
@@ -38,9 +38,9 @@ pub async fn wrong_protocol() {
 }
 
 // L1004 Handshake hash discrepancy
-#[tokio::test]
-pub async fn wrong_genesis_hash() {
-    let setup = setup::server::default().await;
+#[test]
+pub fn wrong_genesis_hash() {
+    let setup = setup::server::default();
 
     let block0 = setup.server.block0_configuration().to_block();
 
@@ -51,7 +51,7 @@ pub async fn wrong_genesis_hash() {
         .with_protocol_version(ProtocolVersion::GenesisPraos)
         .build();
 
-    setup.wait_server_online().await;
+    setup.wait_server_online();
 
     let mock_result = mock_controller.finish_and_verify_that(|mock_verifier| {
         mock_verifier.method_executed_at_least_once(MethodType::Handshake)
@@ -75,9 +75,9 @@ pub async fn wrong_genesis_hash() {
 }
 
 // L1002 Handshake compatible
-#[tokio::test]
-pub async fn handshake_ok() {
-    let setup = setup::server::default().await;
+#[test]
+pub fn handshake_ok() {
+    let setup = setup::server::default();
 
     let block0 = setup.server.block0_configuration().to_block();
     let genesis_hash = setup.server.genesis_block_hash().into_hash();
@@ -89,7 +89,7 @@ pub async fn handshake_ok() {
         .with_protocol_version(ProtocolVersion::GenesisPraos)
         .build();
 
-    setup.wait_server_online().await;
+    setup.wait_server_online();
 
     let mock_result = mock_controller.finish_and_verify_that(|mock_verifier| {
         mock_verifier.method_executed_at_least_once(MethodType::Handshake)

--- a/testing/jormungandr-scenario-tests/Cargo.toml
+++ b/testing/jormungandr-scenario-tests/Cargo.toml
@@ -44,6 +44,6 @@ indicatif = "0.15"
 lazy_static = "1"
 
 [dependencies.reqwest]
-version = "0.10.10"
+version = "0.11"
 default-features = false
 features = ["blocking", "rustls-tls"]

--- a/testing/jormungandr-scenario-tests/src/bin/jormungandr-scenario-tests.rs
+++ b/testing/jormungandr-scenario-tests/src/bin/jormungandr-scenario-tests.rs
@@ -91,8 +91,7 @@ struct CommandArgs {
     report: bool,
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let command_args = CommandArgs::from_args();
 
     std::env::set_var("RUST_BACKTRACE", "full");

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -22,7 +22,6 @@ pub use jormungandr_testing_utils::testing::{
     FragmentNode, FragmentNodeError, MemPoolCheck,
 };
 
-use futures::executor::block_on;
 use rand_core::RngCore;
 use yaml_rust::{Yaml, YamlLoader};
 
@@ -161,7 +160,9 @@ impl LegacyNodeController {
     }
 
     pub fn blocks_to_tip(&self, from: HeaderId) -> Result<Vec<Block>> {
-        block_on(self.grpc_client.pull_blocks_to_tip(from)).map_err(Error::InvalidGrpcCall)
+        self.grpc_client
+            .pull_blocks_to_tip(from)
+            .map_err(Error::InvalidGrpcCall)
     }
 
     pub fn network_stats(&self) -> Result<Vec<PeerStats>> {
@@ -250,7 +251,7 @@ impl LegacyNodeController {
     }
 
     pub fn genesis_block_hash(&self) -> Result<HeaderId> {
-        Ok(block_on(self.grpc_client.get_genesis_block_hash()))
+        Ok(self.grpc_client.get_genesis_block_hash())
     }
 
     pub fn block(&self, header_hash: &HeaderId) -> Result<Block> {

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -30,7 +30,6 @@ pub use jormungandr_testing_utils::testing::{
 };
 use jormungandr_testing_utils::{testing::node::Explorer, Version};
 
-use futures::executor::block_on;
 use indicatif::ProgressBar;
 use rand_core::RngCore;
 
@@ -256,7 +255,9 @@ impl NodeController {
     }
 
     pub fn blocks_to_tip(&self, from: HeaderId) -> Result<Vec<Block>> {
-        block_on(self.grpc_client.pull_blocks_to_tip(from)).map_err(Error::InvalidGrpcCall)
+        self.grpc_client
+            .pull_blocks_to_tip(from)
+            .map_err(Error::InvalidGrpcCall)
     }
 
     pub fn network_stats(&self) -> Result<Vec<PeerStats>> {
@@ -311,7 +312,7 @@ impl NodeController {
     }
 
     pub fn genesis_block_hash(&self) -> Result<HeaderId> {
-        Ok(block_on(self.grpc_client.get_genesis_block_hash()))
+        Ok(self.grpc_client.get_genesis_block_hash())
     }
 
     pub fn block(&self, header_hash: &HeaderId) -> Result<Block> {

--- a/testing/jormungandr-testing-utils/Cargo.toml
+++ b/testing/jormungandr-testing-utils/Cargo.toml
@@ -64,7 +64,7 @@ tracing = "0.1"
 
 
 [dependencies.reqwest]
-version = "0.10.10"
+version = "0.11"
 default-features = false
 features = ["blocking", "json", "rustls-tls"]
 

--- a/testing/jormungandr-testing-utils/src/bin/mock_client_app.rs
+++ b/testing/jormungandr-testing-utils/src/bin/mock_client_app.rs
@@ -3,13 +3,12 @@ use rand::Rng;
 
 use std::env;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let args: Vec<String> = env::args().collect();
     let port: u16 = args[2].parse().unwrap();
     let client = JormungandrClient::new(&args[1], port);
     let mut auth_nonce = [0u8; 32];
     rand::thread_rng().fill(&mut auth_nonce[..]);
-    let response = client.handshake(&auth_nonce).await;
+    let response = client.handshake(&auth_nonce);
     println!("{:?}", response);
 }

--- a/testing/jormungandr-testing-utils/src/bin/mock_server_app.rs
+++ b/testing/jormungandr-testing-utils/src/bin/mock_server_app.rs
@@ -3,7 +3,7 @@ use chain_impl_mockchain::key::Hash;
 use jormungandr_testing_utils::testing::node::grpc::server::{header, MockBuilder};
 use std::env;
 
-fn main() ->  {
+fn main() {
     let tip_parent =
         Hash::from_str("1c3ad65daec5ccb157b439ecd5e8d0574e389077cc672dd2a256ab1af8e6a463").unwrap();
 

--- a/testing/jormungandr-testing-utils/src/bin/mock_server_app.rs
+++ b/testing/jormungandr-testing-utils/src/bin/mock_server_app.rs
@@ -3,8 +3,7 @@ use chain_impl_mockchain::key::Hash;
 use jormungandr_testing_utils::testing::node::grpc::server::{header, MockBuilder};
 use std::env;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() ->  {
     let tip_parent =
         Hash::from_str("1c3ad65daec5ccb157b439ecd5e8d0574e389077cc672dd2a256ab1af8e6a463").unwrap();
 
@@ -14,8 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut mock_controller = MockBuilder::new().with_port(port).build();
 
     std::thread::sleep(std::time::Duration::from_secs(60));
-    mock_controller.set_tip(header(30, &tip_parent)).await;
+    mock_controller.set_tip(header(30, &tip_parent));
     std::thread::sleep(std::time::Duration::from_secs(60));
     mock_controller.stop();
-    Ok(())
 }

--- a/testing/jormungandr-testing-utils/src/testing/node/grpc/server/builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/grpc/server/builder.rs
@@ -1,6 +1,4 @@
 use super::{JormungandrServerImpl, MockController, MockLogger, MockServerData, ProtocolVersion};
-use assert_fs::fixture::PathChild;
-use assert_fs::TempDir;
 use chain_impl_mockchain::{block::Header, key::Hash, testing::TestGen};
 use futures::FutureExt;
 use std::io::{Result, Write};
@@ -87,13 +85,6 @@ impl Write for ChannelWriter {
 }
 
 fn start_thread(data: Arc<RwLock<MockServerData>>, mock_port: u16) -> MockController {
-    let temp_dir = TempDir::new().unwrap();
-    let log_file = temp_dir.child("mock.log");
-    println!(
-        "mock will put logs into {}",
-        log_file.path().to_string_lossy()
-    );
-
     let (tx, rx) = sync_channel(100);
     let logger = MockLogger::new(rx);
     let (shutdown_signal, rx) = oneshot::channel::<()>();
@@ -121,5 +112,5 @@ fn start_thread(data: Arc<RwLock<MockServerData>>, mock_port: u16) -> MockContro
         });
     });
 
-    MockController::new(temp_dir, logger, shutdown_signal, data, mock_port)
+    MockController::new(logger, shutdown_signal, data, mock_port)
 }

--- a/testing/jormungandr-testing-utils/src/testing/node/grpc/server/builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/grpc/server/builder.rs
@@ -6,7 +6,8 @@ use futures::FutureExt;
 use std::io::{Result, Write};
 use std::sync::mpsc::{sync_channel, SyncSender};
 use std::sync::Arc;
-use tokio::sync::{oneshot, RwLock};
+use std::sync::RwLock;
+use tokio::sync::oneshot;
 use tonic::transport::Server;
 
 use crate::testing::node::grpc::server::NodeServer;

--- a/testing/jormungandr-testing-utils/src/testing/node/grpc/server/controller.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/grpc/server/controller.rs
@@ -1,12 +1,12 @@
 use super::{MockExitCode, MockLogger, MockServerData, MockVerifier, ProtocolVersion};
 use assert_fs::TempDir;
 use chain_impl_mockchain::{block::Header, key::Hash};
+use std::sync::RwLock;
 use std::{
     sync::Arc,
     thread,
     time::{Duration, Instant},
 };
-use tokio::sync::RwLock;
 
 pub struct MockController {
     verifier: MockVerifier,
@@ -58,18 +58,18 @@ impl MockController {
         }
     }
 
-    pub async fn set_tip(&mut self, tip: Header) {
-        let mut data = self.data.write().await;
+    pub fn set_tip(&mut self, tip: Header) {
+        let mut data = self.data.write().unwrap();
         *data.tip_mut() = tip;
     }
 
-    pub async fn set_genesis(&mut self, tip: Hash) {
-        let mut data = self.data.write().await;
+    pub fn set_genesis(&mut self, tip: Hash) {
+        let mut data = self.data.write().unwrap();
         *data.genesis_hash_mut() = tip;
     }
 
-    pub async fn set_protocol(&mut self, protocol: ProtocolVersion) {
-        let mut data = self.data.write().await;
+    pub fn set_protocol(&mut self, protocol: ProtocolVersion) {
+        let mut data = self.data.write().unwrap();
         *data.protocol_mut() = protocol;
     }
 

--- a/testing/jormungandr-testing-utils/src/testing/node/grpc/server/controller.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/grpc/server/controller.rs
@@ -1,5 +1,4 @@
 use super::{MockExitCode, MockLogger, MockServerData, MockVerifier, ProtocolVersion};
-use assert_fs::TempDir;
 use chain_impl_mockchain::{block::Header, key::Hash};
 use std::sync::RwLock;
 use std::{
@@ -11,23 +10,18 @@ use std::{
 pub struct MockController {
     verifier: MockVerifier,
     stop_signal: tokio::sync::oneshot::Sender<()>,
-    // only need to keep this for the lifetime of the fixture
-    #[allow(dead_code)]
-    temp_dir: TempDir,
     data: Arc<RwLock<MockServerData>>,
     port: u16,
 }
 
 impl MockController {
     pub fn new(
-        temp_dir: TempDir,
         logger: MockLogger,
         stop_signal: tokio::sync::oneshot::Sender<()>,
         data: Arc<RwLock<MockServerData>>,
         port: u16,
     ) -> Self {
         Self {
-            temp_dir,
             verifier: MockVerifier::new(logger),
             stop_signal,
             data,

--- a/testing/mjolnir/src/mjolnir_app/bootstrap/mod.rs
+++ b/testing/mjolnir/src/mjolnir_app/bootstrap/mod.rs
@@ -69,10 +69,9 @@ impl ClientLoadCommand {
     }
 
     fn get_block0_hash(&self) -> Hash {
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let grpc_client = JormungandrClient::from_address(&self.address).unwrap();
-            return grpc_client.get_genesis_block_hash().await;
-        })
+        JormungandrClient::from_address(&self.address)
+            .unwrap()
+            .get_genesis_block_hash()
     }
 
     fn build_config(&self) -> ClientLoadConfig {


### PR DESCRIPTION
Isolate gRPC calls that needs async in their own context so that the rest of the testing framework can use them as if they were standard blocking calls.

That also enable us to update reqwest to 0.11