### PR TITLE
Filter in-use ports when assigning a new one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,6 +2009,7 @@ dependencies = [
  "jortestkit",
  "json",
  "lazy_static",
+ "netstat2",
  "os_info 3.0.1",
  "poldercast",
  "prost",
@@ -2443,6 +2444,20 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "netstat2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0faa3f4ad230fd2bf2a5dad71476ecbaeaed904b3c7e7e5b1f266c415c03761f"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "libc",
+ "num-derive",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]

--- a/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -5,6 +5,7 @@ use crate::common::{
 };
 
 use jormungandr_lib::interfaces::{AccountState, InitialUTxO, SettingsDto, UTxOInfo};
+use jormungandr_testing_utils::testing::SyncNode;
 use jormungandr_testing_utils::wallet::Wallet;
 
 use assert_fs::prelude::*;
@@ -174,7 +175,10 @@ pub fn test_node_recovers_kill_signal() {
             |raw| raw.account_state(&account_receiver),
             Default::default(),
         )
-        .expect("timeout occured when pooling address endpoint");
+        .expect(&format!(
+            "timeout occured when pooling address endpoint. \nNode logs: {}",
+            jormungandr.log_content()
+        ));
 
     let snapshot_after = take_snapshot(&account_receiver, &jormungandr, new_utxo);
 

--- a/testing/jormungandr-testing-utils/Cargo.toml
+++ b/testing/jormungandr-testing-utils/Cargo.toml
@@ -61,6 +61,7 @@ strum = { version = "0.20", features = ["derive"] }
 tracing-appender = "0.1"
 tracing-subscriber = "0.2"
 tracing = "0.1"
+netstat2 = "0.9"
 
 
 [dependencies.reqwest]

--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/mod.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
-use rand::Rng;
+use netstat2::{get_sockets_info, AddressFamilyFlags, ProtocolFlags};
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicU16, Ordering};
 
 mod block0_config_builder;
@@ -17,12 +18,23 @@ pub use node_config_builder::NodeConfigBuilder;
 pub use secret_model_factory::{write_secret, SecretModelFactory};
 
 lazy_static! {
-    static ref NEXT_AVAILABLE_PORT_NUMBER: AtomicU16 = {
-        let initial_port = rand::thread_rng().gen_range(6000, 10999);
-        AtomicU16::new(initial_port)
+    static ref NEXT_AVAILABLE_PORT_NUMBER: AtomicU16 = AtomicU16::new(10000);
+    static ref OCCUPIED_PORTS: HashSet<u16> = {
+        let af_flags = AddressFamilyFlags::IPV4;
+        let proto_flags = ProtocolFlags::TCP | ProtocolFlags::UDP;
+        get_sockets_info(af_flags, proto_flags)
+            .unwrap()
+            .into_iter()
+            .map(|s| s.local_port())
+            .collect::<HashSet<_>>()
     };
 }
 
 pub fn get_available_port() -> u16 {
-    NEXT_AVAILABLE_PORT_NUMBER.fetch_add(1, Ordering::SeqCst)
+    loop {
+        let candidate_port = NEXT_AVAILABLE_PORT_NUMBER.fetch_add(1, Ordering::SeqCst);
+        if !(*OCCUPIED_PORTS).contains(&candidate_port) {
+            return candidate_port;
+        }
+    }
 }


### PR DESCRIPTION
There are some ports in use in the range that we use for nodes (e.g. mono on 8084 on ubuntu https://github.com/actions/virtual-environments/issues/2821)
Let's check before assigning ports that they are indeed free