### PR TITLE
Change tracing to single configurable backend subscriber

### DIFF
--- a/doc/configuration/logging.md
+++ b/doc/configuration/logging.md
@@ -10,10 +10,6 @@ The following options are available in the `log` section:
 - `output`: Log output destination (multiple destinations are supported). Possible values are:
   - `stdout`: standard output
   - `stderr`: standard error
-  - `syslog`: syslog (only available on Unix systems)
-  - `syslogudp`: remote syslog  (only available on Unix systems)
-    - `host`: address and port of a syslog server
-    - `hostname`: hostname to attach to syslog messages
   - `journald`: journald service (only available on Linux with systemd,
     (if jormungandr is built with the `systemd` feature)
   - `gelf`: Configuration fields for GELF (Graylog) network logging protocol

--- a/doc/configuration/logging.md
+++ b/doc/configuration/logging.md
@@ -24,15 +24,18 @@ The following options are available in the `log` section:
 
 ## Example
 
-Multiple logging backends are supported.
+A single configurable backend is supported.
 
 ```yaml
 log:
   - output: stdout
     level:  trace
     format: plain
+```
+
+```yaml
   - output:
-      file: example.log
+    file: example.log
     level: info
     format: json
 ```

--- a/jormungandr-lib/src/interfaces/config/log.rs
+++ b/jormungandr-lib/src/interfaces/config/log.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Log(pub Vec<LogEntry>);
+pub struct Log(pub LogEntry);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogEntry {
@@ -21,9 +21,9 @@ pub enum LogOutput {
 
 impl Log {
     pub fn file_path(&self) -> Option<&Path> {
-        self.0.iter().find_map(|log_entry| match &log_entry.output {
+        match &self.0.output {
             LogOutput::File(path) => Some(path.as_path()),
             _ => None,
-        })
+        }
     }
 }

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -549,17 +549,19 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     let raw_settings = RawSettings::load(command_line)?;
 
     let log_settings = raw_settings.log_settings();
-    let (_logger_guards, log_info_msg) = log_settings.init_log()?;
+    let (_logger_guards, log_info_msgs) = log_settings.init_log()?;
 
     let init_span = span!(Level::TRACE, "task", kind = "init");
     let async_span = init_span.clone();
     let _enter = init_span.enter();
     tracing::info!("Starting {}", env!("FULL_VERSION"),);
 
-    if let Some(msg) = log_info_msg {
+    if let Some(msgs) = log_info_msgs {
         // if log settings were overriden, we will have an info
         // message which we can unpack at this point.
-        tracing::info!("{}", msg);
+        for msg in &msgs {
+            tracing::info!("{}", msg);
+        }
     }
 
     let diagnostic = Diagnostic::new()?;

--- a/jormungandr/src/network/service.rs
+++ b/jormungandr/src/network/service.rs
@@ -329,11 +329,7 @@ impl GossipService for NodeService {
         let parent_span = self.subscription_span(subscriber, "gossip");
         let subscriber = Address::tcp(addr);
         parent_span.in_scope(|| {
-            let span = span!(
-                Level::TRACE,
-                "fragment_subscription",
-                direction = "in"
-            );
+            let span = span!(Level::TRACE, "fragment_subscription", direction = "in");
 
             self.global_state.spawn(
                 subscription::process_gossip(

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -202,12 +202,14 @@ impl LogSettings {
                 match settings.format {
                     LogFormat::Default | LogFormat::Plain => {
                         // create a reloadable layer, and return the handle
+                        // FIXME: use this handle to reload layer
                         let (layer, _handle) = reload::Layer::new(
                             tracing_subscriber::fmt::Layer::new().with_writer(non_blocking),
                         );
                         (Some(layer), None)
                     }
                     LogFormat::Json => {
+                        // FIXME: use this handle to reload layer
                         let (layer, _handle) = reload::Layer::new(
                             tracing_subscriber::fmt::Layer::new()
                                 .json()

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 use std::fs;
-use std::io::{self};
+use std::io;
 #[cfg(feature = "gelf")]
 use std::net::SocketAddr;
 use std::path::PathBuf;

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -13,7 +13,10 @@ use tracing::subscriber::SetGlobalDefaultError;
 #[allow(unused_imports)]
 use tracing_subscriber::layer::SubscriberExt;
 
-pub struct LogSettings(pub Vec<LogSettingsEntry>, pub LogInfoMsg);
+pub struct LogSettings {
+    pub entries: Vec<LogSettingsEntry>,
+    pub msgs: LogInfoMsg,
+}
 
 /// A wrapper to return an optional string message that we
 /// have to manually log with `info!`, we need this because
@@ -175,7 +178,7 @@ impl LogSettings {
         // Parse which settings are present for possible outputs
         let mut layer_settings = LogOutputLayerSettings::default();
         let mut info_msgs: Vec<String> = Vec::new();
-        for config in self.0.into_iter() {
+        for config in self.entries.into_iter() {
             layer_settings.read_setting(config, &mut info_msgs);
         }
         let (std_out_layer, std_out_layer_json) = if let Some(settings) = layer_settings.stdout {
@@ -297,7 +300,7 @@ impl LogSettings {
         // panics if something goes wrong.
         registry.init();
 
-        let log_msgs = match (self.1, info_msgs.is_empty()) {
+        let log_msgs = match (self.msgs, info_msgs.is_empty()) {
             (None, true) => None,
             (None, false) => Some(info_msgs),
             (Some(msgs), true) => Some(msgs),

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -215,15 +215,15 @@ impl LogSettings {
             (None, None)
         };
         #[cfg(feature = "systemd")]
-        let journald_layer = if let Some(entry) = layer_settings.journald {
-            entry.format.require_default()?;
+        let journald_layer = if let Some(settings) = layer_settings.journald {
+            settings.format.require_default()?;
             let layer = tracing_journald::layer().map_err(Error::Journald)?;
             Some(layer)
         } else {
             None
         };
         #[cfg(feature = "gelf")]
-        let gelf_layer = if let Some(entry) = layer_settings.gelf {
+        let gelf_layer = if let Some(settings) = layer_settings.gelf {
             // have to use if let because it's an enum
             if let LogOutput::Gelf { backend, .. } = settings.output {
                 let (layer, task) = tracing_gelf::Logger::builder()

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -169,6 +169,7 @@ impl LogSettings {
             for layer in layer_iter {
                 init_layer = BoxedSubscriber(Box::new(init_layer.with(layer)));
             }
+            // FIXME: this should only be run once
             tracing::subscriber::set_global_default(init_layer)
                 .map_err(Error::SetGlobalSubscriberError)?;
         }
@@ -191,8 +192,8 @@ impl LogSettingsEntry {
 
         match output {
             LogOutput::Stdout => {
-                let (subscriber, guard) = tracing_appender::non_blocking(std::io::stdout());
-                let builder = builder.with_writer(subscriber).with_max_level(*level);
+                let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
+                let builder = builder.with_writer(non_blocking).with_max_level(*level);
                 let subscriber: Box<dyn Subscriber + Send + Sync> = match format {
                     LogFormat::Default | LogFormat::Plain => Box::new(builder.finish()),
                     LogFormat::Json => Box::new(builder.json().finish()),
@@ -200,8 +201,8 @@ impl LogSettingsEntry {
                 Ok((subscriber, Some(guard)))
             }
             LogOutput::Stderr => {
-                let (subscriber, guard) = tracing_appender::non_blocking(std::io::stderr());
-                let builder = builder.with_writer(subscriber).with_max_level(*level);
+                let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stderr());
+                let builder = builder.with_writer(non_blocking).with_max_level(*level);
                 let subscriber: Box<dyn Subscriber + Send + Sync> = match format {
                     LogFormat::Default | LogFormat::Plain => Box::new(builder.finish()),
                     LogFormat::Json => Box::new(builder.json().finish()),
@@ -218,8 +219,8 @@ impl LogSettingsEntry {
                         path: path.clone(),
                         cause,
                     })?;
-                let (subscriber, guard) = tracing_appender::non_blocking(file);
-                let builder = builder.with_writer(subscriber).with_max_level(*level);
+                let (non_blocking, guard) = tracing_appender::non_blocking(file);
+                let builder = builder.with_writer(non_blocking).with_max_level(*level);
                 let subscriber: Box<dyn Subscriber + Send + Sync> = match format {
                     LogFormat::Default | LogFormat::Plain => Box::new(builder.finish()),
                     LogFormat::Json => Box::new(builder.json().finish()),

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -183,12 +183,15 @@ impl LogSettings {
             guards.push(guard);
             match settings.format {
                 LogFormat::Default | LogFormat::Plain => {
-                    let layer = tracing_subscriber::fmt::Layer::new().with_writer(non_blocking);
+                    let layer = tracing_subscriber::fmt::Layer::new()
+                        .with_level(true)
+                        .with_writer(non_blocking);
                     (Some(layer), None)
                 }
                 LogFormat::Json => {
                     let layer = tracing_subscriber::fmt::Layer::new()
                         .json()
+                        .with_level(true)
                         .with_writer(non_blocking);
                     (None, Some(layer))
                 }
@@ -201,12 +204,15 @@ impl LogSettings {
             guards.push(guard);
             match settings.format {
                 LogFormat::Default | LogFormat::Plain => {
-                    let layer = tracing_subscriber::fmt::Layer::new().with_writer(non_blocking);
+                    let layer = tracing_subscriber::fmt::Layer::new()
+                        .with_level(true)
+                        .with_writer(non_blocking);
                     (Some(layer), None)
                 }
                 LogFormat::Json => {
                     let layer = tracing_subscriber::fmt::Layer::new()
                         .json()
+                        .with_level(true)
                         .with_writer(non_blocking);
                     (None, Some(layer))
                 }
@@ -231,12 +237,15 @@ impl LogSettings {
 
                 match settings.format {
                     LogFormat::Default | LogFormat::Plain => {
-                        let layer = tracing_subscriber::fmt::Layer::new().with_writer(non_blocking);
+                        let layer = tracing_subscriber::fmt::Layer::new()
+                            .with_level(true)
+                            .with_writer(non_blocking);
                         (Some(layer), None)
                     }
                     LogFormat::Json => {
                         let layer = tracing_subscriber::fmt::Layer::new()
                             .json()
+                            .with_level(true)
                             .with_writer(non_blocking);
                         (None, Some(layer))
                     }

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -18,7 +18,7 @@ pub struct LogSettings(pub Vec<LogSettingsEntry>, pub LogInfoMsg);
 /// A wrapper to return an optional string message that we
 /// have to manually log with `info!`, we need this because
 /// some code executes before the logs are initialized.
-pub type LogInfoMsg = Option<String>;
+pub type LogInfoMsg = Option<Vec<String>>;
 
 #[derive(Clone, Debug)]
 pub struct LogSettingsEntry {

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -14,7 +14,7 @@ use tracing::subscriber::SetGlobalDefaultError;
 use tracing_subscriber::layer::SubscriberExt;
 
 pub struct LogSettings {
-    pub entries: Vec<LogSettingsEntry>,
+    pub config: LogSettingsEntry,
     pub msgs: LogInfoMsg,
 }
 
@@ -23,7 +23,7 @@ pub struct LogSettings {
 /// some code executes before the logs are initialized.
 pub type LogInfoMsg = Option<Vec<String>>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LogSettingsEntry {
     pub level: LevelFilter,
     pub format: LogFormat,
@@ -178,9 +178,7 @@ impl LogSettings {
         // Parse which settings are present for possible outputs
         let mut layer_settings = LogOutputLayerSettings::default();
         let mut info_msgs: Vec<String> = Vec::new();
-        for config in self.entries.into_iter() {
-            layer_settings.read_setting(config, &mut info_msgs);
-        }
+        layer_settings.read_setting(self.config, &mut info_msgs);
         let (std_out_layer, std_out_layer_json) = if let Some(settings) = layer_settings.stdout {
             let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
             guards.push(guard);

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -135,6 +135,19 @@ impl Layer<BoxedSubscriber> for BoxedSubscriber {}
 
 impl LogSettings {
     pub fn init_log(self) -> Result<(Vec<WorkerGuard>, LogInfoMsg), Error> {
+        // WIP: Replacing this code
+        //
+        // * Use tracing_subscriber::registry::Registry instead of
+        //   boxing subscribers
+        // * Create specific layer types for each output format, implement
+        //   ````
+        //   impl<S> tracing_subscriber::Layer<S> for OutputLayer
+        //   where
+        //       S: Subscriber + for<'span> LookupSpan<'span>
+        //   ```
+        //   * expand code from LogSettingsEntry::to_subscriber, to remove
+        //   * implement uniform process of composing Layer and Subscriber types
+        //     for each output format
         use tracing_subscriber::prelude::*;
         let mut guards = Vec::new();
         let mut layers: Vec<Layered<_, BoxedSubscriber>> = Vec::new();

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -224,11 +224,16 @@ impl LogSettings {
         };
         #[cfg(feature = "gelf")]
         let gelf_layer = if let Some(entry) = layer_settings.gelf {
-            let (layer, task) = tracing_gelf::Logger::builder()
-                .connect_tcp(entry.output.backend.clone())
-                .map_err(Error::Gelf)?;
-            tokio::spawn(task);
-            Some(layer)
+            // have to use if let because it's an enum
+            if let LogOutput::Gelf { backend, .. } = settings.output {
+                let (layer, task) = tracing_gelf::Logger::builder()
+                    .connect_tcp(backend)
+                    .map_err(Error::Gelf)?;
+                tokio::spawn(task);
+                Some(layer)
+            } else {
+                None
+            }
         } else {
             None
         };

--- a/jormungandr/src/settings/logging.rs
+++ b/jormungandr/src/settings/logging.rs
@@ -249,23 +249,3 @@ pub enum Error {
     #[error("failed to set global subscriber")]
     SetGlobalSubscriberError(#[source] SetGlobalDefaultError),
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn log_settings_have_a_single_optional_entry_to_configure_tracing_subscribers() {
-        let yml = "\
-log:\
-  - output: stdout\
-    level:  trace\
-    format: plain\
-  - output:\
-      file: example.log\
-    level: info\
-    format: json"
-            .to_string();
-        assert!(true);
-    }
-}

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -53,15 +53,12 @@ pub struct Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct ConfigLogSettingsEntry {
+pub struct ConfigLogSettings {
     #[serde(with = "filter_level_opt_serde")]
     pub level: Option<LevelFilter>,
     pub format: Option<LogFormat>,
     pub output: Option<LogOutput>,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ConfigLogSettings(pub Vec<ConfigLogSettingsEntry>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -74,6 +74,12 @@ impl RawSettings {
         //  Read log settings from the config file path.
         if let Some(log) = self.config.as_ref().and_then(|cfg| cfg.log.as_ref()) {
             if let Some(cfg) = log.0.first() {
+                if log.0.len() > 1 {
+                    info_msgs.push(format!(
+                        "only one entry for log settings allowed, ignoring these: {:?}",
+                        &log.0[1..],
+                    ));
+                }
                 if let Some(level) = cfg.level {
                     log_config.level = level;
                 }

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -63,7 +63,7 @@ impl RawSettings {
 
     pub fn log_settings(&self) -> LogSettings {
         let mut entries = Vec::new();
-        let mut log_info_msg: LogInfoMsg = None;
+        let mut info_msgs: Vec<String> = Vec::new();
 
         //  Read log settings from the config file path.
         if let Some(log) = self.config.as_ref().and_then(|cfg| cfg.log.as_ref()) {
@@ -94,7 +94,7 @@ impl RawSettings {
                 // log to info! that the output was overriden,
                 // we send this as a message because tracing Subscribers
                 // do not get initiated until after this code runs
-                log_info_msg = Some(format!(
+                info_msgs.push(format!(
                     "log settings overriden from command line: {:?} replaced with {:?}",
                     entries, command_line_entry
                 ));
@@ -114,6 +114,11 @@ impl RawSettings {
             });
         }
 
+        let log_info_msg: LogInfoMsg = if info_msgs.is_empty() {
+            None
+        } else {
+            Some(info_msgs)
+        };
         LogSettings(entries, log_info_msg)
     }
 

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -119,7 +119,10 @@ impl RawSettings {
         } else {
             Some(info_msgs)
         };
-        LogSettings(entries, log_info_msg)
+        LogSettings {
+            entries,
+            msgs: log_info_msg,
+        }
     }
 
     fn rest_config(&self) -> Option<Rest> {

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -72,23 +72,15 @@ impl RawSettings {
         let mut info_msgs: Vec<String> = Vec::new();
 
         //  Read log settings from the config file path.
-        if let Some(log) = self.config.as_ref().and_then(|cfg| cfg.log.as_ref()) {
-            if let Some(cfg) = log.0.first() {
-                if log.0.len() > 1 {
-                    info_msgs.push(format!(
-                        "only one entry for log settings allowed, ignoring these: {:?}",
-                        &log.0[1..],
-                    ));
-                }
-                if let Some(level) = cfg.level {
-                    log_config.level = level;
-                }
-                if let Some(format) = cfg.format {
-                    log_config.format = format;
-                }
-                if let Some(output) = &cfg.output {
-                    log_config.output = output.clone();
-                }
+        if let Some(cfg) = self.config.as_ref().and_then(|cfg| cfg.log.as_ref()) {
+            if let Some(level) = cfg.level {
+                log_config.level = level;
+            }
+            if let Some(format) = cfg.format {
+                log_config.format = format;
+            }
+            if let Some(output) = &cfg.output {
+                log_config.output = output.clone();
             }
         }
 

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -73,7 +73,7 @@ impl RawSettings {
 
         //  Read log settings from the config file path.
         if let Some(log) = self.config.as_ref().and_then(|cfg| cfg.log.as_ref()) {
-            if let Some(cfg) = log.0.last() {
+            if let Some(cfg) = log.0.first() {
                 if let Some(level) = cfg.level {
                     log_config.level = level;
                 }

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -203,17 +203,16 @@ impl Services {
     {
         let handle = self.runtime.handle().clone();
         let now = Instant::now();
-        let tracing_span = span!(Level::TRACE, "service", kind = name);
+        let parent_span = span!(Level::TRACE, "service", kind = name);
         let future_service_info = TokioServiceInfo {
             name,
             up_time: now,
-            span: tracing_span,
+            span: parent_span.clone(),
             handle,
         };
-        let parent_span = future_service_info.span.clone();
         self.runtime
             .block_on(f(future_service_info).instrument(span!(
-                parent: parent_span,
+                parent: parent_span.clone(),
                 Level::TRACE,
                 "service",
                 kind = name

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -210,13 +210,14 @@ impl Services {
             span: parent_span.clone(),
             handle,
         };
-        self.runtime
-            .block_on(f(future_service_info).instrument(span!(
-                parent: parent_span,
-                Level::TRACE,
-                "service",
-                kind = name
-            )))
+        parent_span.in_scope(|| {
+            self.runtime
+                .block_on(f(future_service_info).instrument(span!(
+                    Level::TRACE,
+                    "service",
+                    kind = name
+                )))
+        })
     }
 }
 

--- a/jormungandr/src/utils/task.rs
+++ b/jormungandr/src/utils/task.rs
@@ -212,7 +212,7 @@ impl Services {
         };
         self.runtime
             .block_on(f(future_service_info).instrument(span!(
-                parent: parent_span.clone(),
+                parent: parent_span,
                 Level::TRACE,
                 "service",
                 kind = name

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -301,18 +301,11 @@ impl ConfigurationBuilder {
             (None, false) => default_log_file(),
             (None, true) => {
                 let path = default_log_file();
-                node_config.log = Some(Log(vec![
-                    LogEntry {
-                        level: "trace".to_string(),
-                        format: "json".to_string(),
-                        output: LogOutput::Stdout,
-                    },
-                    LogEntry {
-                        level: "trace".to_string(),
-                        format: "json".to_string(),
-                        output: LogOutput::File(path.clone()),
-                    },
-                ]));
+                node_config.log = Some(Log(LogEntry {
+                    level: "trace".to_string(),
+                    format: "json".to_string(),
+                    output: LogOutput::File(path.clone()),
+                }));
                 path
             }
         };

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -304,7 +304,7 @@ impl ConfigurationBuilder {
                 node_config.log = Some(Log(LogEntry {
                     level: "trace".to_string(),
                     format: "json".to_string(),
-                    output: LogOutput::File(path.clone()),
+                    output: LogOutput::Stdout,
                 }));
                 path
             }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -212,11 +212,11 @@ impl ConfigurationBuilder {
     }
 
     pub fn with_log_path(&mut self, path: PathBuf) -> &mut Self {
-        self.with_log(Log(vec![LogEntry {
+        self.with_log(Log(LogEntry {
             format: "json".to_string(),
             level: "debug".to_string(),
             output: LogOutput::File(path),
-        }]))
+        }))
     }
 
     pub fn without_log(&mut self) -> &mut Self {

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
@@ -293,6 +293,7 @@ impl<'a> ConfiguredStarter<'a, legacy::NodeConfig> {
         temp_dir: Option<TempDir>,
     ) -> Result<Self, StartupError> {
         let params = LegacyConfigConverter::new(version).convert(params)?;
+        params.write_node_config();
         Ok(ConfiguredStarter {
             starter,
             temp_dir,

--- a/testing/jormungandr-integration-tests/src/common/network/controller.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/controller.rs
@@ -130,18 +130,11 @@ impl Controller {
         }
 
         let log_file_path = dir.child("node.log").path().to_path_buf();
-        config.log = Some(Log(vec![
-            LogEntry {
-                format: "json".into(),
-                level: "debug".into(),
-                output: LogOutput::Stdout,
-            },
-            LogEntry {
-                format: "json".into(),
-                level: "debug".into(),
-                output: LogOutput::File(log_file_path.clone()),
-            },
-        ]));
+        config.log = Some(Log(LogEntry {
+            format: "json".into(),
+            level: "debug".into(),
+            output: LogOutput::File(log_file_path.clone()),
+        }));
 
         if let PersistenceMode::Persistent = spawn_params.get_persistence_mode() {
             let path_to_storage = dir.child("storage").path().into();

--- a/testing/jormungandr-integration-tests/src/common/network/controller.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/controller.rs
@@ -133,7 +133,7 @@ impl Controller {
         config.log = Some(Log(LogEntry {
             format: "json".into(),
             level: "debug".into(),
-            output: LogOutput::File(log_file_path.clone()),
+            output: LogOutput::Stdout,
         }));
 
         if let PersistenceMode::Persistent = spawn_params.get_persistence_mode() {

--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
@@ -74,11 +74,11 @@ pub fn test_jormungandr_with_no_trusted_peers_starts_succesfully() {
 pub fn test_jormungandr_with_wrong_logger_fails_to_start() {
     let temp_dir = TempDir::new().unwrap();
     let config = ConfigurationBuilder::new()
-        .with_log(Log(vec![LogEntry {
+        .with_log(Log(LogEntry {
             format: "xml".to_string(),
             level: "info".to_string(),
             output: LogOutput::Stderr,
-        }]))
+        }))
         .build(&temp_dir);
     Starter::new()
         .config(config)

--- a/testing/jormungandr-integration-tests/src/networking/testnet.rs
+++ b/testing/jormungandr-integration-tests/src/networking/testnet.rs
@@ -113,11 +113,11 @@ impl TestnetConfig {
         ConfigurationBuilder::new()
             .with_block_hash(self.block0_hash())
             .with_storage(&temp_dir.child("storage"))
-            .with_log(Log(vec![LogEntry {
+            .with_log(Log(LogEntry {
                 format: "json".to_string(),
                 level: "info".to_string(),
                 output: LogOutput::File(temp_dir.child("leader.log").path().to_path_buf()),
-            }]))
+            }))
             .with_trusted_peers(self.trusted_peers.clone())
             .with_public_address(format!("/ip4/{}/tcp/{}", self.public_ip, self.public_port))
             .build(temp_dir)
@@ -127,11 +127,11 @@ impl TestnetConfig {
         ConfigurationBuilder::new()
             .with_block_hash(self.block0_hash())
             .with_storage(&temp_dir.child("storage"))
-            .with_log(Log(vec![LogEntry {
+            .with_log(Log(LogEntry {
                 format: "json".to_string(),
                 level: "info".to_string(),
                 output: LogOutput::File(temp_dir.child("passive.log").path().to_path_buf()),
-            }]))
+            }))
             .with_trusted_peers(self.trusted_peers.clone())
             .build(temp_dir)
     }

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -760,13 +760,13 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
         }
     }
 
-    fn set_log_level(&mut self, log_file: &Path) {
+    fn set_log_level(&mut self, _log_file: &Path) {
         let format = "plain";
         let level = self.context.log_level();
         self.node_settings.config.log = Some(Log(LogEntry {
             format: format.to_string(),
             level,
-            output: LogOutput::File(log_file.to_path_buf()),
+            output: LogOutput::Stdout,
         }));
     }
 

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -763,18 +763,11 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
     fn set_log_level(&mut self, log_file: &Path) {
         let format = "plain";
         let level = self.context.log_level();
-        self.node_settings.config.log = Some(Log(vec![
-            LogEntry {
-                format: format.to_string(),
-                level: level.to_string(),
-                output: LogOutput::Stderr,
-            },
-            LogEntry {
-                format: format.to_string(),
-                level,
-                output: LogOutput::File(log_file.to_path_buf()),
-            },
-        ]));
+        self.node_settings.config.log = Some(Log(LogEntry {
+            format: format.to_string(),
+            level,
+            output: LogOutput::File(log_file.to_path_buf()),
+        }));
     }
 
     pub fn command<P: AsRef<Path>, Q: AsRef<Path>>(

--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/legacy/config.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/legacy/config.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 use jormungandr_lib::interfaces::{
-    Explorer, LayersConfig, Log, Mempool, Policy, Rest, TopicsOfInterest,
+    Explorer, LayersConfig, LogEntry, LogOutput, Mempool, Policy, Rest, TopicsOfInterest,
 };
 
 use serde::{Deserialize, Serialize};
@@ -41,6 +41,24 @@ pub struct TrustedPeer {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub address: poldercast::Address,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Log(pub Vec<LogEntry>);
+
+impl From<jormungandr_lib::interfaces::Log> for Log {
+    fn from(log: jormungandr_lib::interfaces::Log) -> Self {
+        Self(vec![log.0])
+    }
+}
+
+impl Log {
+    pub fn file_path(&self) -> Option<&std::path::Path> {
+        self.0.iter().find_map(|log_entry| match &log_entry.output {
+            LogOutput::File(path) => Some(path.as_path()),
+            _ => None,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/legacy/configuration_builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/legacy/configuration_builder.rs
@@ -85,7 +85,7 @@ impl LegacyNodeConfigConverter {
 
         NodeConfig {
             storage: source.storage.clone(),
-            log: source.log.clone(),
+            log: source.log.clone().map(Into::into),
             rest: Rest {
                 listen: source.rest.listen,
                 cors: None,
@@ -140,7 +140,7 @@ impl LegacyNodeConfigConverter {
 
         NodeConfig {
             storage: source.storage.clone(),
-            log: source.log.clone(),
+            log: source.log.clone().map(Into::into),
             rest: Rest {
                 listen: source.rest.listen,
                 cors: None,


### PR DESCRIPTION
This should close #3142 , implementing a single subscriber from any of the expected LogOutput variants.

* adds a DEFAULT_LOG_SETTINGS_ENTRY, which is the default configuration
* changes the code to import log settings from yaml, reading only the last
entry (ignoring the rest)
* command-line settings override anything else
* updates `LogSettings::init_log` method