### PR TITLE
gracefully stop fragment selection

### DIFF
--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -106,19 +106,22 @@ impl Pools {
         self.logs.modify_all(fragment_ids, status);
     }
 
-    pub fn select(
+    pub async fn select(
         &mut self,
         pool_idx: usize,
         ledger: ApplyBlockLedger,
         ledger_params: LedgerParameters,
         selection_alg: FragmentSelectionAlgorithmParams,
+        abort_future: futures::channel::oneshot::Receiver<()>,
     ) -> (Contents, ApplyBlockLedger) {
         let Pools { logs, pools, .. } = self;
         let pool = &mut pools[pool_idx];
         match selection_alg {
             FragmentSelectionAlgorithmParams::OldestFirst => {
                 let mut selection_alg = OldestFirst::new();
-                selection_alg.select(ledger, &ledger_params, logs, pool)
+                selection_alg
+                    .select(ledger, &ledger_params, logs, pool, abort_future)
+                    .await
             }
         }
     }

--- a/jormungandr/src/fragment/process.rs
+++ b/jormungandr/src/fragment/process.rs
@@ -103,8 +103,11 @@ impl Process {
                         ledger_params,
                         selection_alg,
                         reply_handle,
+                        abort_future,
                     } => {
-                        let contents = pool.select(pool_idx, ledger, ledger_params, selection_alg);
+                        let contents = pool
+                            .select(pool_idx, ledger, ledger_params, selection_alg, abort_future)
+                            .await;
                         reply_handle.reply_ok(contents);
                     }
                 }

--- a/jormungandr/src/fragment/selection.rs
+++ b/jormungandr/src/fragment/selection.rs
@@ -7,6 +7,8 @@ use crate::{
 use chain_core::property::Fragment as _;
 use jormungandr_lib::interfaces::FragmentStatus;
 
+use async_trait::async_trait;
+use futures::prelude::*;
 use tracing::{span, Level};
 
 use std::error::Error;
@@ -19,13 +21,15 @@ pub enum SelectionOutput {
     Reject { reason: String },
 }
 
+#[async_trait]
 pub trait FragmentSelectionAlgorithm {
-    fn select(
+    async fn select(
         &mut self,
         ledger: ApplyBlockLedger,
         ledger_params: &LedgerParameters,
         logs: &mut Logs,
         pool: &mut Pool,
+        abort_future: futures::channel::oneshot::Receiver<()>,
     ) -> (Contents, ApplyBlockLedger);
 }
 
@@ -48,17 +52,21 @@ impl Default for OldestFirst {
     }
 }
 
+#[async_trait]
 impl FragmentSelectionAlgorithm for OldestFirst {
-    fn select(
+    async fn select(
         &mut self,
         mut ledger: ApplyBlockLedger,
         ledger_params: &LedgerParameters,
         logs: &mut Logs,
         pool: &mut Pool,
+        abort_future: futures::channel::oneshot::Receiver<()>,
     ) -> (Contents, ApplyBlockLedger) {
         let mut current_total_size = 0;
         let mut contents_builder = ContentsBuilder::new();
         let mut return_to_pool = Vec::new();
+
+        let abort_future = abort_future.shared();
 
         while let Some(fragment) = pool.remove_oldest() {
             let id = fragment.id();
@@ -79,34 +87,50 @@ impl FragmentSelectionAlgorithm for OldestFirst {
 
             let total_size = current_total_size + fragment_size;
 
-            if total_size <= ledger_params.block_content_max_size {
-                tracing::debug!("applying fragment in simulation");
-                match ledger.apply_fragment(&fragment) {
-                    Ok(ledger_new) => {
-                        contents_builder.push(fragment);
-                        ledger = ledger_new;
-                        tracing::debug!("successfully applied and committed the fragment");
-                    }
-                    Err(error) => {
-                        let mut msg = error.to_string();
-                        for e in iter::successors(error.source(), |&e| e.source()) {
-                            msg.push_str(": ");
-                            msg.push_str(&e.to_string());
-                        }
-                        tracing::debug!(?error, "fragment is rejected");
-                        logs.modify(id, FragmentStatus::Rejected { reason: msg })
-                    }
-                }
-
-                current_total_size = total_size;
-
-                if total_size == ledger_params.block_content_max_size {
-                    break;
-                }
-            } else {
+            if total_size > ledger_params.block_content_max_size {
                 // return a fragment to the pool later if does not fit the contents size limit
                 return_to_pool.push(fragment);
+                continue;
             }
+
+            tracing::debug!("applying fragment in simulation");
+
+            let fragment1 = fragment.clone();
+            let ledger1 = ledger.clone();
+            let fragment_future =
+                tokio::task::spawn_blocking(move || ledger1.apply_fragment(&fragment1));
+
+            let result = tokio::select! {
+                join_result = fragment_future => join_result.unwrap(),
+                _ = abort_future.clone() => {
+                    return_to_pool.push(fragment);
+                    break;
+                }
+            };
+
+            match result {
+                Ok(ledger_new) => {
+                    contents_builder.push(fragment);
+                    ledger = ledger_new;
+                    tracing::debug!("successfully applied and committed the fragment");
+                }
+                Err(error) => {
+                    let mut msg = error.to_string();
+                    for e in iter::successors(error.source(), |&e| e.source()) {
+                        msg.push_str(": ");
+                        msg.push_str(&e.to_string());
+                    }
+                    tracing::debug!(?error, "fragment is rejected");
+                    logs.modify(id, FragmentStatus::Rejected { reason: msg })
+                }
+            }
+
+            current_total_size = total_size;
+
+            if total_size == ledger_params.block_content_max_size {
+                break;
+            }
+
             drop(_enter);
         }
 

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -511,6 +511,7 @@ pub enum TransactionMsg {
         ledger_params: LedgerParameters,
         selection_alg: FragmentSelectionAlgorithmParams,
         reply_handle: ReplyHandle<(FragmentContents, ApplyBlockLedger)>,
+        abort_future: futures::channel::oneshot::Receiver<()>,
     },
 }
 


### PR DESCRIPTION
With this change the fragment selection operation can be interrupted.
Upon interruption the task returns already processed fragments and the
interrupted fragment is sent back to the fragment pool.

This is the second PR (after #3140) in the series of changes that would make it easier to process long-running transactions.