### PR TITLE
handle execution of time-consuming transactions

### DIFF
--- a/doc/configuration/introduction.md
+++ b/doc/configuration/introduction.md
@@ -107,6 +107,11 @@ REST endpoints `/api/v0/rewards/history/1` or `/api/v0/rewards/epoch/10`.
 
 **this is not a recommended settings as it may take memory and may trigger some latency**.
 
+### Handling of time-consuming transactions
+
+By default we allow a single transaction to delay a block by 50 slots. This can
+be changed by adjusting the `block_hard_deadline` setting.
+
 #### The following is deprecated and will be removed
 
 If you want to record the reward distributions in a directory it is possible to set

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -112,7 +112,8 @@ impl Pools {
         ledger: ApplyBlockLedger,
         ledger_params: LedgerParameters,
         selection_alg: FragmentSelectionAlgorithmParams,
-        abort_future: futures::channel::oneshot::Receiver<()>,
+        soft_deadline_future: futures::channel::oneshot::Receiver<()>,
+        hard_deadline_future: futures::channel::oneshot::Receiver<()>,
     ) -> (Contents, ApplyBlockLedger) {
         let Pools { logs, pools, .. } = self;
         let pool = &mut pools[pool_idx];
@@ -120,7 +121,14 @@ impl Pools {
             FragmentSelectionAlgorithmParams::OldestFirst => {
                 let mut selection_alg = OldestFirst::new();
                 selection_alg
-                    .select(ledger, &ledger_params, logs, pool, abort_future)
+                    .select(
+                        ledger,
+                        &ledger_params,
+                        logs,
+                        pool,
+                        soft_deadline_future,
+                        hard_deadline_future,
+                    )
                     .await
             }
         }

--- a/jormungandr/src/fragment/process.rs
+++ b/jormungandr/src/fragment/process.rs
@@ -103,10 +103,18 @@ impl Process {
                         ledger_params,
                         selection_alg,
                         reply_handle,
-                        abort_future,
+                        soft_deadline_future,
+                        hard_deadline_future,
                     } => {
                         let contents = pool
-                            .select(pool_idx, ledger, ledger_params, selection_alg, abort_future)
+                            .select(
+                                pool_idx,
+                                ledger,
+                                ledger_params,
+                                selection_alg,
+                                soft_deadline_future,
+                                hard_deadline_future,
+                            )
                             .await;
                         reply_handle.reply_ok(contents);
                     }

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -511,7 +511,8 @@ pub enum TransactionMsg {
         ledger_params: LedgerParameters,
         selection_alg: FragmentSelectionAlgorithmParams,
         reply_handle: ReplyHandle<(FragmentContents, ApplyBlockLedger)>,
-        abort_future: futures::channel::oneshot::Receiver<()>,
+        soft_deadline_future: futures::channel::oneshot::Receiver<()>,
+        hard_deadline_future: futures::channel::oneshot::Receiver<()>,
     },
 }
 

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -209,6 +209,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         let enclave = leadership::Enclave::new(enclave.clone());
         let fragment_msgbox = fragment_msgbox.clone();
         let rewards_report_all = bootstrapped_node.settings.rewards_report_all;
+        let block_hard_deadline = bootstrapped_node.settings.block_hard_deadline;
 
         services.spawn_try_future("leadership", move |info| {
             leadership::Module::new(
@@ -219,6 +220,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 enclave,
                 block_msgbox,
                 rewards_report_all,
+                block_hard_deadline,
             )
             .and_then(|module| module.run())
         });

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -44,8 +44,11 @@ pub struct Config {
 
     #[serde(default)]
     pub bootstrap_from_trusted_peers: bool,
+
     #[serde(default)]
     pub skip_bootstrap: bool,
+
+    pub block_hard_deadline: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -14,6 +14,7 @@ const DEFAULT_FILTER_LEVEL: LevelFilter = LevelFilter::TRACE;
 const DEFAULT_LOG_FORMAT: LogFormat = LogFormat::Default;
 const DEFAULT_LOG_OUTPUT: LogOutput = LogOutput::Stderr;
 const DEFAULT_NO_BLOCKCHAIN_UPDATES_WARNING_INTERVAL: u64 = 1800; // 30 min
+const DEFAULT_BLOCK_HARD_DEADLINE: u32 = 50;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -39,6 +40,7 @@ pub struct Settings {
     pub leadership: Leadership,
     pub explorer: bool,
     pub no_blockchain_updates_warning_interval: std::time::Duration,
+    pub block_hard_deadline: u32,
 }
 
 pub struct RawSettings {
@@ -205,6 +207,10 @@ impl RawSettings {
                 .unwrap_or_else(|| {
                     std::time::Duration::from_secs(DEFAULT_NO_BLOCKCHAIN_UPDATES_WARNING_INTERVAL)
                 }),
+            block_hard_deadline: config
+                .as_ref()
+                .and_then(|config| config.block_hard_deadline)
+                .unwrap_or(DEFAULT_BLOCK_HARD_DEADLINE),
         })
     }
 }


### PR DESCRIPTION
The process of building a block now has two deadline:

1. The soft deadline is equal to the end of the leadership event.
2. The hard deadline is a multiple of the slot duration. The multiplier
   is configured on the node start up.

If a single transaction was not able to complete until the hard deadline
it is forever rejected by the current node.

This patch is the 3rd and the last in the series of patches (previous: #3140, #3152) that implement the handling of time-consuming transactions, required for the successful handling of private voting.