### PR TITLE
Pack logs for failed tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,10 +121,11 @@ commands:
       - run:
           name: Compress Artifacts
           command: tar -cvzf logs.tar /tmp/logs/
-
+          when: on_fail
       - store_artifacts: 
           path: /tmp/logs.tar
           destination: failed_logs
+          when: on_fail
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ commands:
               -- --test-threads=1
       - run:
           name: Compress Artifacts
-          command: tar -cvzf logs.tar /tmp/logs/
+          command: tar -cvzf logs.tar /tmp/jormungandr-logs/
           when: on_fail
       - store_artifacts: 
           path: /tmp/logs.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ commands:
               -- --test-threads=1
       - run:
           name: Compress Artifacts
-          command: tar -cvzf /tmp/jormungandr-logs.tar /tmp/jormungandr-logs/
+          command: tar -cvzf /tmp/jormungandr-logs.tar /tmp/jormungandr_*
           when: on_fail
       - store_artifacts: 
           path: /tmp/jormungandr-logs.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,10 +120,10 @@ commands:
               -- --test-threads=1
       - run:
           name: Compress Artifacts
-          command: tar -cvzf logs.tar /tmp/jormungandr-logs/
+          command: tar -cvzf /tmp/jormungandr-logs.tar /tmp/jormungandr-logs/
           when: on_fail
       - store_artifacts: 
-          path: /tmp/logs.tar
+          path: /tmp/jormungandr-logs.tar
           destination: failed_logs
           when: on_fail
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,13 @@ commands:
             cargo test --workspace --doc \
               << parameters.mode >> << parameters.cargo_behavior >> \
               -- --test-threads=1
+      - run:
+          name: Compress Artifacts
+          command: tar -cvzf logs.tar /tmp/logs/
+
+      - store_artifacts: 
+          path: /tmp/logs.tar
+          destination: failed_logs
 
 workflows:
   version: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,6 +183,9 @@ jobs:
           command: build
           args: -p jormungandr-scenario-tests ${{ env.CARGO_FLAGS }}
 
+      - shell: bash
+        run: mkdir ${{ runner.temp }}/logs
+
       - name: Run tests
         uses: actions-rs/cargo@v1
         timeout-minutes: 30
@@ -192,6 +195,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TMPDIR: ${{ runner.temp }}/logs
+
+      - name: Pack logs from failed tests
+        uses: actions/upload-artifact@v2
+        with:
+          name: node-logs-from-failed-tests
+          path: ${{ runner.temp }}/logs
 
   lints:
     name: Lints

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,11 +204,6 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.profile }}-node-logs-from-failed-tests
           path: ${{ runner.temp }}/logs
 
-      - name: Download logs from failed tests
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.os }}-${{ matrix.profile }}-node-logs-from-failed-tests
-
   lints:
     name: Lints
     needs: [cache_info, update_deps]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,7 @@ jobs:
           args: --tests ${{ env.CARGO_FLAGS }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TMPDIR and TMP are used respectively on unix and windows
           TMPDIR: ${{ runner.temp }}
           TMP: ${{ runner.temp }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,6 +203,11 @@ jobs:
           name: node-logs-from-failed-tests
           path: ${{ runner.temp }}/logs
 
+      - name: Download logs from failed tests
+        uses: actions/download-artifact@v2
+        with:
+          name: node-logs-from-failed-tests
+
   lints:
     name: Lints
     needs: [cache_info, update_deps]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,8 +184,8 @@ jobs:
           args: -p jormungandr-scenario-tests ${{ env.CARGO_FLAGS }}
 
       - name: Create artifact for failed logs
-        shell: bash
-        run: mkdir ${{ runner.temp }}/logs
+        run: mkdir logs
+        working-directory: ${{ runner.temp }}
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Download logs from failed tests
         uses: actions/download-artifact@v2
         with:
-          name: node-logs-from-failed-tests
+          name: ${{ matrix.os }}-${{ matrix.profile }}-node-logs-from-failed-tests
 
   lints:
     name: Lints

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,7 @@ jobs:
           args: --tests ${{ env.CARGO_FLAGS }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TMPDIR: ${{ runner.temp }}/logs
 
   lints:
     name: Lints

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-${{ matrix.profile }}-node-logs-from-failed-tests
-          path: ${{ runner.temp }}/jormungandr-*
+          path: ${{ runner.temp }}/jormungandr-logs/
+          retention-days: 30
 
   lints:
     name: Lints

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
           command: build
           args: -p jormungandr-scenario-tests ${{ env.CARGO_FLAGS }}
 
-      - name: Create artifact for failed logs
+      - name: Create directory to store failed logs
         run: mkdir logs
         working-directory: ${{ runner.temp }}
 
@@ -201,7 +201,7 @@ jobs:
       - name: Pack logs from failed tests
         uses: actions/upload-artifact@v2
         with:
-          name: node-logs-from-failed-tests
+          name: ${{ matrix.os }}-${{ matrix.profile }}-node-logs-from-failed-tests
           path: ${{ runner.temp }}/logs
 
       - name: Download logs from failed tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,6 +196,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TMPDIR: ${{ runner.temp }}/logs
+          TMP: ${{ runner.temp }}\logs
 
       - name: Pack logs from failed tests
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.os }}-${{ matrix.profile }}-node-logs-from-failed-tests
+          name: ${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.toolchain }}-node-logs-from-failed-tests
           path: ${{ runner.temp }}/jormungandr-logs/
           retention-days: 30
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,8 @@ jobs:
           command: build
           args: -p jormungandr-scenario-tests ${{ env.CARGO_FLAGS }}
 
-      - shell: bash
+      - name: Create artifact for failed logs
+        shell: bash
         run: mkdir ${{ runner.temp }}/logs
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,10 +183,6 @@ jobs:
           command: build
           args: -p jormungandr-scenario-tests ${{ env.CARGO_FLAGS }}
 
-      - name: Create directory to store failed logs
-        run: mkdir logs
-        working-directory: ${{ runner.temp }}
-
       - name: Run tests
         uses: actions-rs/cargo@v1
         timeout-minutes: 30
@@ -195,6 +191,8 @@ jobs:
           args: --tests ${{ env.CARGO_FLAGS }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TMPDIR: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
 
       - name: Pack logs from failed tests
         if: ${{ failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,14 +195,13 @@ jobs:
           args: --tests ${{ env.CARGO_FLAGS }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TMPDIR: ${{ runner.temp }}/logs
-          TMP: ${{ runner.temp }}\logs
 
       - name: Pack logs from failed tests
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-${{ matrix.profile }}-node-logs-from-failed-tests
-          path: ${{ runner.temp }}/logs
+          path: ${{ runner.temp }}/jormungandr-*
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,6 +2092,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "structopt",
+ "tempfile",
  "thiserror",
  "tokio 1.3.0",
  "tonic",

--- a/testing/jormungandr-integration-tests/Cargo.toml
+++ b/testing/jormungandr-integration-tests/Cargo.toml
@@ -40,6 +40,7 @@ url = "2.2.0"
 yaml-rust = "0.4.4"
 indicatif = "0.15.0"
 fs_extra = "1.1.0"
+tempfile = "3"
 json = "0.12.4"
 
 [dependencies.reqwest]

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -255,8 +255,7 @@ impl Drop for JormungandrProcess {
         // FIXME: These should be better done in a test harness
         self.child.wait().unwrap();
 
-        if self.temp_dir.is_some() {
-            let temp_dir = self.steal_temp_dir().unwrap();
+        if let Some(temp_dir) = self.steal_temp_dir() {
             if panicking() {
                 println!(
                     "persisting node temp_dir after panic: {:?}",

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -255,13 +255,18 @@ impl Drop for JormungandrProcess {
         // FIXME: These should be better done in a test harness
         self.child.wait().unwrap();
 
-        if panicking() && self.temp_dir.is_some() {
+        if self.temp_dir.is_some() {
             let temp_dir = self.steal_temp_dir().unwrap();
-            println!(
-                "persisting node temp_dir after panic: {:?}",
-                temp_dir.path()
-            );
-            temp_dir.into_persistent();
+            if panicking() {
+                println!(
+                    "persisting node temp_dir after panic: {:?}",
+                    temp_dir.path()
+                );
+                temp_dir.into_persistent();
+            } else {
+                // Ensure deletion happens.
+                temp_dir.close().unwrap();
+            }
         }
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -255,15 +255,13 @@ impl Drop for JormungandrProcess {
         // FIXME: These should be better done in a test harness
         self.child.wait().unwrap();
 
-        if panicking() {
-            if self.temp_dir.is_some() {
-                let temp_dir = self.steal_temp_dir().unwrap();
-                println!(
-                    "persisting node temp_dir after panic: {:?}",
-                    temp_dir.path()
+        if panicking() && self.temp_dir.is_some() {
+            let temp_dir = self.steal_temp_dir().unwrap();
+            println!(
+                "persisting node temp_dir after panic: {:?}",
+                temp_dir.path()
                 );
-                temp_dir.into_persistent();
-            }
+            temp_dir.into_persistent();
         }
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -260,7 +260,7 @@ impl Drop for JormungandrProcess {
             println!(
                 "persisting node temp_dir after panic: {:?}",
                 temp_dir.path()
-                );
+            );
             temp_dir.into_persistent();
         }
     }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -251,8 +251,12 @@ impl Drop for JormungandrProcess {
                 .take(8)
                 .map(char::from)
                 .collect::<String>();
-            let logs_dir = std::env::temp_dir().join(format!("jormungandr-{}", dir_name));
-            std::fs::create_dir(&logs_dir).unwrap();
+
+            let logs_dir = std::env::temp_dir()
+                .join("jormungandr-logs")
+                .join(format!("jormungandr-{}", dir_name));
+
+            std::fs::create_dir_all(&logs_dir).unwrap();
 
             println!(
                 "persisting node temp_dir after panic: {}",

--- a/testing/jormungandr-integration-tests/src/jcli/rest/utxo.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/rest/utxo.rs
@@ -30,7 +30,11 @@ pub fn test_correct_utxos_are_read_from_node() {
         .with_funds(funds)
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let rest_addr = jormungandr.rest_uri();
 
     let sender_block0_utxo = config.block0_utxo_for_address(&sender_utxo_address);

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
@@ -34,7 +34,11 @@ pub fn test_utxo_transaction_with_more_than_one_witness_per_input_is_rejected() 
         }])
         .build(&temp_dir);
 
-    let _jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let _jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
 
@@ -74,7 +78,11 @@ pub fn test_two_correct_utxo_to_utxo_transactions_are_accepted_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = jcli.genesis().hash(config.genesis_block_path());
@@ -123,7 +131,11 @@ pub fn test_correct_utxo_transaction_is_accepted_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
@@ -158,7 +170,11 @@ pub fn test_correct_utxo_transaction_replaces_old_utxo_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let rest_addr = jormungandr.rest_uri();
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
@@ -209,7 +225,11 @@ pub fn test_account_is_created_if_transaction_out_is_account() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
 
@@ -267,7 +287,11 @@ pub fn test_transaction_from_delegation_to_delegation_is_accepted_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
     let transaction_message = jcli
@@ -300,7 +324,11 @@ pub fn test_transaction_from_delegation_to_account_is_accepted_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
     let transaction_message = jcli
@@ -333,7 +361,11 @@ pub fn test_transaction_from_delegation_to_utxo_is_accepted_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
 
@@ -366,7 +398,11 @@ pub fn test_transaction_from_utxo_to_account_is_accepted_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
     let transaction_message = jcli
@@ -399,7 +435,11 @@ pub fn test_transaction_from_account_to_account_is_accepted_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
     let transaction_message = jcli
         .transaction_builder(block0_hash)
@@ -431,7 +471,11 @@ pub fn test_transaction_from_account_to_delegation_is_accepted_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
     let transaction_message = jcli
         .transaction_builder(block0_hash)
@@ -462,7 +506,11 @@ pub fn test_transaction_from_utxo_to_delegation_is_accepted_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let transaction_message = jcli
@@ -493,7 +541,11 @@ pub fn test_input_with_smaller_value_than_initial_utxo_is_rejected_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let block0_hash = jcli.genesis().hash(&config.genesis_block_path());
     let utxo = config.block0_utxo_for_address(&sender);
     let transaction_message = jcli
@@ -519,7 +571,11 @@ pub fn test_transaction_with_non_existing_id_should_be_rejected_by_node() {
             value: 100.into(),
         }])
         .build(&temp_dir);
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let block0_hash = jcli.genesis().hash(&config.genesis_block_path());
     let transaction_message = jcli.transaction_builder(block0_hash).build_transaction(
         &FAKE_INPUT_TRANSACTION_ID,
@@ -548,7 +604,11 @@ pub fn test_transaction_with_input_address_equal_to_output_is_accepted_by_node()
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let block = Hash::from_hex(config.genesis_block_hash()).unwrap();
     let transaction_message = jcli.transaction_builder(block).build_transaction_from_utxo(
@@ -578,7 +638,11 @@ pub fn test_input_with_no_spending_utxo_is_rejected_by_node() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
 
@@ -607,7 +671,11 @@ pub fn test_transaction_with_non_zero_linear_fees() {
         .with_linear_fees(fee.clone())
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
     let utxo = config.block0_utxo_for_address(&sender);
     let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
     let mut tx = jcli.transaction_builder(block0_hash);

--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/start_node.rs
@@ -47,6 +47,7 @@ pub fn test_jormungandr_passive_node_without_trusted_peers_fails_to_start() {
         .build(&temp_dir);
 
     Starter::new()
+        .temp_dir(temp_dir)
         .config(config)
         .passive()
         .start_fail("no trusted peers specified")
@@ -58,7 +59,11 @@ pub fn test_jormungandr_without_initial_funds_starts_sucessfully() {
     let mut config = ConfigurationBuilder::new().build(&temp_dir);
     let block0_configuration = config.block0_configuration_mut();
     block0_configuration.initial.clear();
-    let _jormungandr = Starter::new().config(config).start().unwrap();
+    let _jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config)
+        .start()
+        .unwrap();
 }
 
 #[test]
@@ -67,7 +72,11 @@ pub fn test_jormungandr_with_no_trusted_peers_starts_succesfully() {
     let config = ConfigurationBuilder::new()
         .with_trusted_peers(vec![])
         .build(&temp_dir);
-    let _jormungandr = Starter::new().config(config).start().unwrap();
+    let _jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config)
+        .start()
+        .unwrap();
 }
 
 #[test]
@@ -81,6 +90,7 @@ pub fn test_jormungandr_with_wrong_logger_fails_to_start() {
         }]))
         .build(&temp_dir);
     Starter::new()
+        .temp_dir(temp_dir)
         .config(config)
         .start_fail(r"Error in the overall configuration of the node");
 }
@@ -89,5 +99,9 @@ pub fn test_jormungandr_with_wrong_logger_fails_to_start() {
 pub fn test_jormungandr_without_logger_starts_successfully() {
     let temp_dir = TempDir::new().unwrap();
     let config = ConfigurationBuilder::new().without_log().build(&temp_dir);
-    let _jormungandr = Starter::new().config(config).start().unwrap();
+    let _jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config)
+        .start()
+        .unwrap();
 }

--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
@@ -72,7 +72,11 @@ pub fn create_delegate_retire_stake_pool() {
         }])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     let stake_pool_id = create_new_stake_pool(
         &mut actor_account,

--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/setup.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/setup.rs
@@ -34,7 +34,6 @@ pub mod client {
         pub client: JormungandrClient,
         pub server: JormungandrProcess,
         pub config: JormungandrParams,
-        _dir: TempDir, // deleted on drop
     }
 
     pub fn default() -> ClientBootstrap {
@@ -48,14 +47,17 @@ pub mod client {
     pub fn bootstrap(config: ConfigurationBuilder) -> ClientBootstrap {
         let dir = TempDir::new().unwrap();
         let config = config.build(&dir);
-        let server = Starter::new().config(config.clone()).start_async().unwrap();
+        let server = Starter::new()
+            .temp_dir(dir)
+            .config(config.clone())
+            .start_async()
+            .unwrap();
         std::thread::sleep(Duration::from_secs(4));
         let client = Config::attach_to_local_node(config.get_p2p_listen_port()).client();
         ClientBootstrap {
             client,
             server,
             config,
-            _dir: dir,
         }
     }
 }
@@ -70,7 +72,6 @@ pub mod server {
         pub server: JormungandrProcess,
         pub config: JormungandrParams,
         pub mock_port: u16,
-        _dir: TempDir, // deleted on drop
     }
 
     pub fn default() -> ServerBootstrap {
@@ -92,12 +93,15 @@ pub mod server {
             id: None,
         };
         let config = config.with_trusted_peers(vec![trusted_peer]).build(&dir);
-        let server = Starter::new().config(config.clone()).start_async().unwrap();
+        let server = Starter::new()
+            .temp_dir(dir)
+            .config(config.clone())
+            .start_async()
+            .unwrap();
         ServerBootstrap {
             server,
             config,
             mock_port,
-            _dir: dir,
         }
     }
 

--- a/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
@@ -41,6 +41,7 @@ pub fn test_legacy_node_all_fragments() {
         .build(&temp_dir);
 
     let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
         .jormungandr_app(jormungandr)
         .legacy(legacy_release.version())
         .config(config)

--- a/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -108,6 +108,7 @@ pub fn test_node_recovers_from_node_restart() {
     std::thread::sleep(std::time::Duration::from_secs(2));
 
     let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
         .config(config)
         .role(Role::Leader)
         .start()
@@ -163,6 +164,7 @@ pub fn test_node_recovers_kill_signal() {
     jormungandr.stop();
 
     let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
         .config(config)
         .role(Role::Leader)
         .start()

--- a/testing/jormungandr-integration-tests/src/jormungandr/tls.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/tls.rs
@@ -21,6 +21,7 @@ pub fn test_rest_tls_config() {
         .build(&temp_dir);
 
     let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
         .config(config)
         .verify_by(StartupVerificationMode::Log)
         .start()

--- a/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
@@ -65,7 +65,11 @@ pub fn test_get_committee_id() {
         .with_committee_ids(expected_committee_ids.clone())
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     expected_committee_ids.insert(
         0,
@@ -99,7 +103,11 @@ pub fn test_get_initial_vote_plan() {
         .with_certs(vec![vote_plan_cert])
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     let vote_plans = jormungandr.rest().vote_plan_statuses().unwrap();
     assert!(vote_plans.len() == 1);
@@ -156,7 +164,11 @@ pub fn test_vote_flow_bft() {
         .with_treasury(1_000.into())
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     let transaction_sender = FragmentSender::new(
         jormungandr.genesis_block_hash(),
@@ -386,10 +398,14 @@ pub fn jcli_e2e_flow() {
         .with_slots_per_epoch(10)
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config).start().unwrap();
-
     let alice_sk = temp_dir.child("alice_sk");
     alice.save_to_path(alice_sk.path()).unwrap();
+
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config)
+        .start()
+        .unwrap();
 
     let vote_plan_cert = jcli.certificate().new_vote_plan(vote_plan_json.path());
 

--- a/testing/jormungandr-integration-tests/src/networking/testnet.rs
+++ b/testing/jormungandr-integration-tests/src/networking/testnet.rs
@@ -323,6 +323,7 @@ fn e2e_stake_pool(testnet_config: TestnetConfig) {
     let block0_hash = testnet_config.block0_hash();
 
     let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
         .config(testnet_config.make_leader_config(&temp_dir))
         .timeout(Duration::from_secs(8000))
         .passive()

--- a/testing/jormungandr-integration-tests/src/non_functional/voting/private/mod.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/voting/private/mod.rs
@@ -99,7 +99,11 @@ pub fn private_vote_load_scenario(quick_config: PrivateVotingLoadTestConfig) {
         .with_treasury(1_000.into())
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     let transaction_sender = FragmentSender::new(
         jormungandr.genesis_block_hash(),
@@ -267,7 +271,11 @@ pub fn adversary_private_vote_load_scenario(
         .with_treasury(1_000.into())
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     let transaction_sender = FragmentSender::new(
         jormungandr.genesis_block_hash(),

--- a/testing/jormungandr-integration-tests/src/non_functional/voting/public/mod.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/voting/public/mod.rs
@@ -78,7 +78,11 @@ pub fn public_vote_load_scenario(quick_config: PublicVotingLoadTestConfig) {
         .with_treasury(1_000.into())
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     let transaction_sender = FragmentSender::new(
         jormungandr.genesis_block_hash(),
@@ -210,7 +214,11 @@ pub fn adversary_public_vote_load_scenario(
         .with_treasury(1_000.into())
         .build(&temp_dir);
 
-    let jormungandr = Starter::new().config(config.clone()).start().unwrap();
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
 
     let transaction_sender = FragmentSender::new(
         jormungandr.genesis_block_hash(),


### PR DESCRIPTION
Reading failed tests output from the web UI of GitHub Actions is not very user friendly. We should pack logs of failed tests in an artifact published at the end of the workflow.

Ok, I'm implementing this in the following steps:

- [X] make temp_dir persistent using std::thread:panicking in the Drop impl for JormungandrProcess
- [X] in `.github/workflows/test.yml` add `TMPDIR: ${{ runner.temp }}/logs` to the action that runs tests as root TempDir (the auto-generated directories are still made in dirs with names like `.tmp*****`) to generate the artifact of the contents of TMPDIR.
- [ ] Once that's working, hook up the test name (using the `function_name` crate) with the JormungandrProcess `temp_dir`, maybe by printing it to stdout during tests, maybe by `touch`ing a file with the test name for filename.