### PR TITLE
Derive hash for interfaces::Address

### DIFF
--- a/jormungandr-lib/src/interfaces/address.rs
+++ b/jormungandr-lib/src/interfaces/address.rs
@@ -4,7 +4,7 @@ use std::{fmt, str::FromStr};
 /// Address with the appropriate implementation for Serde API and
 /// Display/FromStr interfaces.
 ///
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Address(pub String, pub chain_addr::Address);
 
 /* ---------------- Display ------------------------------------------------ */


### PR DESCRIPTION
It is handy to use addresses as dictionary keys. It is currently needed for the voter reward calculations.