### PR TITLE
Poldercast [3/3]: Add custom layers

### DIFF
--- a/jormungandr-lib/src/interfaces/config/node.rs
+++ b/jormungandr-lib/src/interfaces/config/node.rs
@@ -112,8 +112,6 @@ pub struct P2p {
 
     pub allow_private_addresses: bool,
 
-    pub topics_of_interest: Option<TopicsOfInterest>,
-
     pub policy: Option<Policy>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -142,8 +140,10 @@ pub struct Explorer {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct LayersConfig {
-    #[serde(default)]
-    pub preferred_list: PreferredListConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preferred_list: Option<PreferredListConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topics_of_interest: Option<TopicsOfInterest>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -1,10 +1,9 @@
-use super::config::{self, InterestLevel, Topic};
+use super::config;
 use crate::network::p2p::Address;
 use crate::topology::{layers::LayersConfig, NodeId, QuarantineConfig};
 
 use chain_crypto::Ed25519;
 use jormungandr_lib::{crypto::key::SigningKey, multiaddr};
-use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::str;
 use std::time::Duration;
@@ -62,13 +61,6 @@ pub struct Configuration {
 
     pub public_address: Option<Address>,
 
-    /// the topic subscriptions
-    ///
-    /// When connecting to different nodes we will expose these too in order to
-    /// help the different modules of the P2P topology engine to determine the
-    /// best possible neighborhood.
-    pub topics_of_interest: BTreeMap<Topic, InterestLevel>,
-
     // Secret key used to authenticate gossips, the public part is used as an identifier of the node
     pub node_key: SigningKey<Ed25519>,
 
@@ -110,7 +102,7 @@ pub struct Configuration {
 }
 
 /// Trusted peer with DNS address resolved.
-#[derive(Clone)]
+#[derive(Clone, Hash)]
 pub struct TrustedPeer {
     pub addr: SocketAddr,
     // This will need to become compulsory if we want to check validity of keys/ids

--- a/jormungandr/src/topology/layers/mod.rs
+++ b/jormungandr/src/topology/layers/mod.rs
@@ -1,1 +1,13 @@
-pub use jormungandr_lib::interfaces::LayersConfig;
+mod preferred_list;
+mod rings;
+
+pub use self::preferred_list::PreferredListConfig;
+pub(super) use self::preferred_list::PreferredListLayer;
+pub(super) use self::rings::Rings;
+pub use self::rings::{ParseError, RingsConfig};
+
+#[derive(Clone)]
+pub struct LayersConfig {
+    pub preferred_list: PreferredListConfig,
+    pub rings: RingsConfig,
+}

--- a/jormungandr/src/topology/layers/preferred_list.rs
+++ b/jormungandr/src/topology/layers/preferred_list.rs
@@ -1,0 +1,86 @@
+use crate::settings::start::network::TrustedPeer;
+use crate::topology::NodeId;
+use poldercast::{
+    layer::{Layer, ViewBuilder},
+    InterestLevel, PriorityMap, Profile, Topic,
+};
+use rand::seq::IteratorRandom;
+use rand_chacha::ChaChaRng;
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+
+#[derive(Clone)]
+pub struct PreferredListConfig {
+    pub view_max: usize,
+    pub peers: Vec<TrustedPeer>,
+}
+
+/// This layer always return a view containing only a subset
+/// of the preferred peers that are known to the topology
+pub struct PreferredListLayer {
+    /// the max number of entries to add in the list of the view
+    view_max: usize,
+    /// the preferred peers list
+    peers: HashMap<SocketAddr, Option<NodeId>>,
+    /// actual peers that are known to the topology
+    current_peers: HashSet<keynesis::key::ed25519::PublicKey>,
+    /// a pseudo random number generator, this will help with
+    /// testing and reproducing issues.
+    ///
+    /// Do not let a user seed the value, while having a secure
+    /// RNG is not necessary it is functionally important to allow
+    /// for randomness to make its course.
+    prng: rand_chacha::ChaChaRng,
+}
+
+impl PreferredListLayer {
+    pub fn new(config: &PreferredListConfig, prng: ChaChaRng) -> Self {
+        Self {
+            view_max: config.view_max,
+            peers: config
+                .peers
+                .iter()
+                .map(|peer| (peer.addr, peer.id.clone()))
+                .collect(),
+            current_peers: HashSet::new(),
+            prng,
+        }
+    }
+}
+
+impl Layer for PreferredListLayer {
+    fn name(&self) -> &'static str {
+        "custom::preferred_list"
+    }
+
+    fn view(&mut self, builder: &mut ViewBuilder) {
+        self.current_peers
+            .iter()
+            .choose_multiple(&mut self.prng, self.view_max)
+            .into_iter()
+            .for_each(|id| builder.add(id));
+    }
+
+    // Preferred nodes will never be quarantined
+    fn remove(&mut self, _: &keynesis::key::ed25519::PublicKey) {}
+
+    fn reset(&mut self) {
+        self.current_peers.clear();
+    }
+
+    fn subscribe(&mut self, _: Topic) {}
+
+    fn unsubscribe(&mut self, _: &Topic) {}
+
+    fn subscriptions(&self, _: &mut PriorityMap<InterestLevel, Topic>) {}
+
+    fn populate(&mut self, _: &Profile, new_profile: &Profile) {
+        let addr = new_profile.address();
+        let id = new_profile.id();
+        if let Some(trusted_id) = self.peers.get(&addr) {
+            if trusted_id.is_none() || trusted_id.as_ref().map(AsRef::as_ref) == Some(&id) {
+                self.current_peers.insert(id);
+            }
+        }
+    }
+}

--- a/jormungandr/src/topology/layers/rings.rs
+++ b/jormungandr/src/topology/layers/rings.rs
@@ -1,0 +1,104 @@
+use crate::topology::topic;
+use jormungandr_lib::interfaces::TopicsOfInterest;
+use poldercast::{
+    layer::{Layer, ViewBuilder},
+    InterestLevel, PriorityMap, Profile, Topic,
+};
+use std::convert::TryFrom;
+use thiserror::Error;
+
+const LOW_INTERESET: InterestLevel = InterestLevel::new(1);
+const NORMAL_INTEREST: InterestLevel = InterestLevel::new(3);
+const HIGH_INTEREST: InterestLevel = InterestLevel::new(5);
+
+#[derive(Clone)]
+pub struct RingsConfig {
+    messages: InterestLevel,
+    blocks: InterestLevel,
+}
+
+impl Default for RingsConfig {
+    fn default() -> Self {
+        Self {
+            messages: NORMAL_INTEREST,
+            blocks: NORMAL_INTEREST,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("expected interest level to be one of: 'low', 'normal', 'high', found {0}")]
+pub struct ParseError(String);
+
+impl TryFrom<TopicsOfInterest> for RingsConfig {
+    type Error = ParseError;
+
+    fn try_from(topics: TopicsOfInterest) -> Result<Self, Self::Error> {
+        fn parse_interest(interest: String) -> Result<InterestLevel, ParseError> {
+            match interest.as_str() {
+                "low" => Ok(LOW_INTERESET),
+                "normal" => Ok(NORMAL_INTEREST),
+                "high" => Ok(HIGH_INTEREST),
+                _ => Err(ParseError(interest)),
+            }
+        }
+
+        Ok(Self {
+            messages: parse_interest(topics.messages)?,
+            blocks: parse_interest(topics.blocks)?,
+        })
+    }
+}
+
+/// This layer is very similar to poldercast::Rings,
+/// but allows to set a fixed interest for topics, instead
+/// of calculating it based current topology
+pub struct Rings {
+    /// the max number of entries to add in the list of the view
+    rings: poldercast::layer::Rings,
+    interest_levels: RingsConfig,
+}
+
+impl Rings {
+    pub fn new(interest_levels: RingsConfig, rings: poldercast::layer::Rings) -> Self {
+        Self {
+            interest_levels,
+            rings,
+        }
+    }
+}
+
+impl Layer for Rings {
+    fn name(&self) -> &'static str {
+        "custom::rings"
+    }
+
+    fn view(&mut self, builder: &mut ViewBuilder) {
+        self.rings.view(builder)
+    }
+
+    fn remove(&mut self, id: &keynesis::key::ed25519::PublicKey) {
+        self.rings.remove(id)
+    }
+
+    fn reset(&mut self) {
+        self.rings.reset()
+    }
+
+    fn subscribe(&mut self, topic: Topic) {
+        self.rings.subscribe(topic)
+    }
+
+    fn unsubscribe(&mut self, topic: &Topic) {
+        self.rings.unsubscribe(topic)
+    }
+
+    fn subscriptions(&self, output: &mut PriorityMap<InterestLevel, Topic>) {
+        output.put(self.interest_levels.blocks, topic::BLOCKS);
+        output.put(self.interest_levels.messages, topic::MESSAGES);
+    }
+
+    fn populate(&mut self, our_profile: &Profile, new_profile: &Profile) {
+        self.rings.populate(our_profile, new_profile)
+    }
+}

--- a/testing/jormungandr-integration-tests/src/networking/p2p.rs
+++ b/testing/jormungandr-integration-tests/src/networking/p2p.rs
@@ -5,8 +5,7 @@ use crate::common::{
 
 use jormungandr_lib::{
     interfaces::{
-        Explorer, LayersConfig, PeerRecord, Policy, PreferredListConfig, TopicsOfInterest,
-        TrustedPeer,
+        Explorer, PeerRecord, Policy, PreferredListConfig, TopicsOfInterest, TrustedPeer,
     },
     time::Duration,
 };
@@ -306,11 +305,9 @@ pub fn node_put_itself_in_preffered_layers() {
         id: None,
     };
 
-    let layer = LayersConfig {
-        preferred_list: PreferredListConfig {
-            view_max: Default::default(),
-            peers: vec![peer],
-        },
+    let layer = PreferredListConfig {
+        view_max: Default::default(),
+        peers: vec![peer],
     };
 
     assert!(network_controller

--- a/testing/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -11,7 +11,10 @@ use chain_impl_mockchain::{
 use jormungandr_lib::crypto::account::Identifier;
 use jormungandr_lib::interfaces::try_initials_vec_from_messages;
 use jormungandr_lib::{
-    interfaces::{Explorer, Mempool, NodeConfig, NodeSecret, P2p, Policy, Rest, TopicsOfInterest},
+    interfaces::{
+        Explorer, LayersConfig, Mempool, NodeConfig, NodeSecret, P2p, Policy, Rest,
+        TopicsOfInterest,
+    },
     time::Duration,
 };
 use jormungandr_testing_utils::testing::network_builder::Random;
@@ -347,9 +350,11 @@ impl Prepare for P2p {
             listen_address: None,
             max_connections: None,
             max_inbound_connections: None,
-            topics_of_interest: Some(TopicsOfInterest::prepare(context)),
             policy: Some(Policy::prepare(context)),
-            layers: None,
+            layers: Some(LayersConfig {
+                preferred_list: None,
+                topics_of_interest: Some(TopicsOfInterest::prepare(context)),
+            }),
             node_key_file: None,
         }
     }

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/spawn_params.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/spawn_params.rs
@@ -1,5 +1,6 @@
 use jormungandr_lib::interfaces::{
-    Explorer, LayersConfig, Mempool, NodeConfig, Policy, TopicsOfInterest, TrustedPeer,
+    Explorer, LayersConfig, Mempool, NodeConfig, Policy, PreferredListConfig, TopicsOfInterest,
+    TrustedPeer,
 };
 use multiaddr::Multiaddr;
 use std::net::SocketAddr;
@@ -17,7 +18,7 @@ pub struct SpawnParams {
     pub jormungandr: Option<PathBuf>,
     pub listen_address: Option<Option<SocketAddr>>,
     pub trusted_peers: Option<Vec<TrustedPeer>>,
-    pub preferred_layer: Option<LayersConfig>,
+    pub preferred_layer: Option<PreferredListConfig>,
     pub leadership_mode: LeadershipMode,
     pub persistence_mode: PersistenceMode,
     pub max_connections: Option<u32>,
@@ -127,7 +128,7 @@ impl SpawnParams {
         self
     }
 
-    pub fn preferred_layer(&mut self, preferred_layer: LayersConfig) -> &mut Self {
+    pub fn preferred_layer(&mut self, preferred_layer: PreferredListConfig) -> &mut Self {
         self.preferred_layer = Some(preferred_layer);
         self
     }
@@ -173,7 +174,14 @@ impl SpawnParams {
 
     pub fn override_settings(&self, node_config: &mut NodeConfig) {
         if let Some(topics_of_interest) = &self.topics_of_interest {
-            node_config.p2p.topics_of_interest = Some(topics_of_interest.clone());
+            if let Some(ref mut config) = node_config.p2p.layers {
+                config.topics_of_interest = Some(topics_of_interest.clone());
+            } else {
+                node_config.p2p.layers = Some(LayersConfig {
+                    preferred_list: None,
+                    topics_of_interest: Some(topics_of_interest.clone()),
+                });
+            }
         }
 
         if let Some(explorer) = &self.explorer {
@@ -209,7 +217,14 @@ impl SpawnParams {
         }
 
         if let Some(preferred_layer) = &self.preferred_layer {
-            node_config.p2p.layers = Some(preferred_layer.clone());
+            if let Some(ref mut config) = node_config.p2p.layers {
+                config.preferred_list = Some(preferred_layer.clone());
+            } else {
+                node_config.p2p.layers = Some(LayersConfig {
+                    preferred_list: Some(preferred_layer.clone()),
+                    topics_of_interest: None,
+                });
+            }
         }
 
         if let Some(bootstrap_from_peers) = &self.bootstrap_from_peers {

--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/legacy/configuration_builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/legacy/configuration_builder.rs
@@ -97,7 +97,11 @@ impl LegacyNodeConfigConverter {
                 listen_address: None,
                 max_inbound_connections: None,
                 max_connections: None,
-                topics_of_interest: source.p2p.topics_of_interest.clone(),
+                topics_of_interest: source
+                    .p2p
+                    .layers
+                    .as_ref()
+                    .and_then(|c| c.topics_of_interest.clone()),
                 allow_private_addresses: source.p2p.allow_private_addresses,
                 policy: source.p2p.policy.clone(),
                 layers: None,
@@ -152,7 +156,11 @@ impl LegacyNodeConfigConverter {
                 listen_address: None,
                 max_inbound_connections: None,
                 max_connections: None,
-                topics_of_interest: source.p2p.topics_of_interest.clone(),
+                topics_of_interest: source
+                    .p2p
+                    .layers
+                    .as_ref()
+                    .and_then(|c| c.topics_of_interest.clone()),
                 allow_private_addresses: source.p2p.allow_private_addresses,
                 policy: source.p2p.policy.clone(),
                 layers: None,

--- a/testing/jormungandr-testing-utils/src/testing/node/configuration/node_config_builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/configuration/node_config_builder.rs
@@ -2,7 +2,8 @@
 
 use jormungandr_lib::{
     interfaces::{
-        Explorer, Log, Mempool, NodeConfig, P2p, Policy, Rest, Tls, TopicsOfInterest, TrustedPeer,
+        Explorer, LayersConfig, Log, Mempool, NodeConfig, P2p, Policy, Rest, Tls, TopicsOfInterest,
+        TrustedPeer,
     },
     time::Duration,
 };
@@ -56,16 +57,18 @@ impl NodeConfigBuilder {
                 listen_address: None,
                 max_inbound_connections: None,
                 max_connections: None,
-                topics_of_interest: Some(TopicsOfInterest {
-                    messages: String::from("high"),
-                    blocks: String::from("high"),
-                }),
                 allow_private_addresses: true,
                 policy: Some(Policy {
                     quarantine_duration: Some(Duration::new(1, 0)),
                     quarantine_whitelist: None,
                 }),
-                layers: None,
+                layers: Some(LayersConfig {
+                    preferred_list: Default::default(),
+                    topics_of_interest: Some(TopicsOfInterest {
+                        messages: String::from("high"),
+                        blocks: String::from("high"),
+                    }),
+                }),
             },
             mempool: Some(Mempool::default()),
             explorer: Explorer { enabled: false },


### PR DESCRIPTION
Last part of the poldercast update.

This PR adds a breaking change by moving configs for rings layer under `layers` in config.