### PR TITLE
Quote path filters

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,9 @@ on:
     branches:
       - master
     paths:
-      - book.toml
-      - doc/**
-      - !doc/api/**.yaml
+      - 'book.toml'
+      - 'doc/**'
+      - '!doc/api/**.yaml'
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
The configuration is broken and doc actions always fail. Quote paths as in https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths quote 