### PR TITLE
Add buffer zone for candidate block time check

### DIFF
--- a/jormungandr/src/blockchain/chain_selection.rs
+++ b/jormungandr/src/blockchain/chain_selection.rs
@@ -1,4 +1,7 @@
 use crate::blockchain::{Ref, Storage};
+use std::time::Duration;
+
+const ALLOWED_TIME_DISCREPANCY: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
 pub enum ComparisonResult {
@@ -9,29 +12,33 @@ pub enum ComparisonResult {
 /// chose which of the two Ref is the most interesting to keep as a branch
 ///
 /// i.e. if the two Ref points to the same block date: this allows to make a choice
-/// as to which Ref ought to be our preferred choice for a tip. Being two ref
-/// on the same block date is to a requirement to call this function as it will still
-/// work to make a choice as to which of these two Ref is the right choice.
-///
+/// as to which Ref ought to be our preferred choice for a tip.
 pub fn compare_against(storage: &Storage, current: &Ref, candidate: &Ref) -> ComparisonResult {
     let epoch_stability_depth = current.epoch_ledger_parameters().epoch_stability_depth;
 
     let rollback_possible =
         check_rollback_up_to(epoch_stability_depth, storage, current, candidate);
 
-    let not_in_future = !is_in_future(candidate);
+    // returns `true` if the candidate is set in what appears to be in the future
+    // relative to this node, with a little buffer to accomodate for small inconsistencies
+    // in time
+    let in_future = match candidate.elapsed() {
+        Err(duration) if duration.duration() > ALLOWED_TIME_DISCREPANCY => {
+            tracing::debug!(
+                "candidate block {} appear to be in the future by {}s, will not consider it for updating our current tip",
+                candidate.header().description(),
+                duration.duration().as_secs()
+            );
+            true
+        }
+        _ => false,
+    };
 
-    if rollback_possible && not_in_future && current.chain_length() < candidate.chain_length() {
+    if rollback_possible && !in_future && current.chain_length() < candidate.chain_length() {
         ComparisonResult::PreferCandidate
     } else {
         ComparisonResult::PreferCurrent
     }
-}
-
-/// returns `true` is the Ref is set in what appears to be in the future
-/// relative to this node.
-fn is_in_future(node: &Ref) -> bool {
-    node.elapsed().is_err()
 }
 
 fn check_rollback_up_to(


### PR DESCRIPTION
The current candidate block selection algorithm is overly precise
in the check for blocks that appear to be in the future.
A small skew between nodes clocks could make a block appear to be
in the future with respect to the current node and cause it to
start its own fork.

Add a buffer zone (1 sec) to allow small discrepancies in the
clocks of participants, and warn when we receive a block that
appears to be in the future.