### PR TITLE
replace LRU in fragment pool with the custom queue implementation & preserve the order of fragments returned to pool

### DIFF
--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -251,13 +251,13 @@ pub(super) mod internal {
 
         fn pop_back(&mut self) -> Option<(K, V)> {
             let tail = unsafe { self.tail.as_mut() }?;
-            let entry = self.index.remove(&IndexedDequeueKeyRef(&tail.key)).unwrap();
             self.tail = tail.prev;
             if let Some(prev) = unsafe { tail.prev.as_mut() } {
                 prev.next = ptr::null_mut();
             } else {
                 self.head = ptr::null_mut();
             }
+            let entry = self.index.remove(&IndexedDequeueKeyRef(&tail.key)).unwrap();
             Some((entry.key, entry.value))
         }
 

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -162,17 +162,148 @@ fn is_transaction_valid<E>(tx: &Transaction<E>) -> bool {
 }
 
 pub(super) mod internal {
+    use std::{collections::HashMap, ptr};
+
     use super::*;
-    use lru::LruCache;
+
+    struct QueueEntry<K, V> {
+        key: K,
+        value: V,
+
+        prev: *mut QueueEntry<K, V>,
+        next: *mut QueueEntry<K, V>,
+    }
+
+    struct QueueKeyRef<K>(*const K);
+
+    struct Queue<K, V> {
+        head: *mut QueueEntry<K, V>,
+        tail: *mut QueueEntry<K, V>,
+
+        index: HashMap<QueueKeyRef<K>, Box<QueueEntry<K, V>>>,
+    }
+
+    impl<K, V> Queue<K, V>
+    where
+        K: Eq + std::hash::Hash,
+    {
+        fn new() -> Self {
+            Self {
+                head: ptr::null_mut(),
+                tail: ptr::null_mut(),
+
+                index: HashMap::new(),
+            }
+        }
+
+        fn push_front(&mut self, key: K, value: V) {
+            let mut entry = Box::new(QueueEntry {
+                key,
+                value,
+                prev: ptr::null_mut(),
+                next: self.head,
+            });
+            if let Some(head) = unsafe { self.head.as_mut() } {
+                head.prev = &mut *entry;
+            }
+            if self.tail.is_null() {
+                self.tail = &mut *entry;
+            }
+            self.head = &mut *entry;
+            self.index.insert(QueueKeyRef(&entry.key), entry);
+        }
+
+        fn push_back(&mut self, key: K, value: V) {
+            let mut entry = Box::new(QueueEntry {
+                key,
+                value,
+                prev: self.tail,
+                next: ptr::null_mut(),
+            });
+            if let Some(tail) = unsafe { self.tail.as_mut() } {
+                tail.next = &mut *entry;
+            }
+            if self.head.is_null() {
+                self.head = &mut *entry;
+            }
+            self.tail = &mut *entry;
+            self.index.insert(QueueKeyRef(&entry.key), entry);
+        }
+
+        fn pop_front(&mut self) -> Option<(K, V)> {
+            let head = unsafe { self.head.as_mut() }?;
+            let entry = self.index.remove(&QueueKeyRef(&head.key)).unwrap();
+            self.head = head.next;
+            if let Some(next) = unsafe { head.next.as_mut() } {
+                next.prev = ptr::null_mut();
+            } else {
+                self.tail = ptr::null_mut();
+            }
+            Some((entry.key, entry.value))
+        }
+
+        fn pop_back(&mut self) -> Option<(K, V)> {
+            let tail = unsafe { self.tail.as_mut() }?;
+            let entry = self.index.remove(&QueueKeyRef(&tail.key)).unwrap();
+            self.tail = tail.prev;
+            if let Some(prev) = unsafe { tail.prev.as_mut() } {
+                prev.next = ptr::null_mut();
+            } else {
+                self.head = ptr::null_mut();
+            }
+            Some((entry.key, entry.value))
+        }
+
+        fn remove(&mut self, key: &K) -> Option<V> {
+            let entry = self.index.remove(&QueueKeyRef(key))?;
+            if let Some(prev) = unsafe { entry.prev.as_mut() } {
+                prev.next = entry.next;
+            } else {
+                self.head = entry.next;
+            }
+            if let Some(next) = unsafe { entry.next.as_mut() } {
+                next.prev = entry.prev;
+            } else {
+                self.tail = entry.prev;
+            }
+            Some(entry.value)
+        }
+
+        fn len(&self) -> usize {
+            self.index.len()
+        }
+
+        fn contains(&self, key: &K) -> bool {
+            self.index.contains_key(&QueueKeyRef(key))
+        }
+    }
+
+    unsafe impl<K, V> Send for Queue<K, V> {}
+
+    impl<K: PartialEq> PartialEq for QueueKeyRef<K> {
+        fn eq(&self, other: &QueueKeyRef<K>) -> bool {
+            unsafe { (*self.0).eq(&*other.0) }
+        }
+    }
+
+    impl<K: PartialEq> Eq for QueueKeyRef<K> {}
+
+    impl<K: std::hash::Hash> std::hash::Hash for QueueKeyRef<K> {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            unsafe { (*self.0).hash(state) }
+        }
+    }
 
     pub struct Pool {
-        entries: LruCache<FragmentId, Fragment>,
+        entries: Queue<FragmentId, Fragment>,
+        max_entries: usize,
     }
 
     impl Pool {
         pub fn new(max_entries: usize) -> Self {
             Pool {
-                entries: LruCache::new(max_entries),
+                entries: Queue::new(),
+                max_entries,
             }
         }
 
@@ -181,7 +312,7 @@ pub(super) mod internal {
             &mut self,
             fragments: impl IntoIterator<Item = Fragment>,
         ) -> Vec<Fragment> {
-            let max_fragments = self.entries.cap() - self.entries.len();
+            let max_fragments = self.max_entries - self.entries.len();
             fragments
                 .into_iter()
                 .filter(|fragment| {
@@ -189,7 +320,7 @@ pub(super) mod internal {
                     if self.entries.contains(&fragment_id) {
                         false
                     } else {
-                        self.entries.put(fragment_id, fragment.clone());
+                        self.entries.push_front(fragment_id, fragment.clone());
                         true
                     }
                 })
@@ -199,12 +330,12 @@ pub(super) mod internal {
 
         pub fn remove_all<'a>(&mut self, fragment_ids: impl IntoIterator<Item = &'a FragmentId>) {
             for fragment_id in fragment_ids {
-                self.entries.pop(fragment_id);
+                self.entries.remove(fragment_id);
             }
         }
 
         pub fn remove_oldest(&mut self) -> Option<Fragment> {
-            self.entries.pop_lru().map(|(_, value)| value)
+            self.entries.pop_back().map(|(_, value)| value)
         }
     }
 

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -218,9 +218,13 @@ pub(super) mod internal {
                 self.tail = &mut *entry;
             }
             self.head = &mut *entry;
-            self.index
+            if self
+                .index
                 .insert(IndexedDequeueKeyRef(&entry.key), entry)
-                .map(|_| panic!("inserted an already existing key"));
+                .is_some()
+            {
+                panic!("inserted an already existing key");
+            }
         }
 
         fn push_back(&mut self, key: K, value: V) {
@@ -236,9 +240,13 @@ pub(super) mod internal {
                 self.head = &mut *entry;
             }
             self.tail = &mut *entry;
-            self.index
+            if self
+                .index
                 .insert(IndexedDequeueKeyRef(&entry.key), entry)
-                .map(|_| panic!("inserted an already existing key"));
+                .is_some()
+            {
+                panic!("inserted an already existing key");
+            }
         }
 
         fn pop_back(&mut self) -> Option<(K, V)> {

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -285,7 +285,7 @@ pub(super) mod internal {
         }
     }
 
-    unsafe impl<K, V> Send for IndexedDeqeue<K, V> {}
+    unsafe impl<K: Send, V: Send> Send for IndexedDeqeue<K, V> {}
 
     impl<K: PartialEq> PartialEq for IndexedDequeueKeyRef<K> {
         fn eq(&self, other: &IndexedDequeueKeyRef<K>) -> bool {

--- a/jormungandr/src/fragment/selection.rs
+++ b/jormungandr/src/fragment/selection.rs
@@ -162,7 +162,8 @@ impl FragmentSelectionAlgorithm for OldestFirst {
             }
         }
 
-        pool.insert_all(return_to_pool);
+        return_to_pool.reverse();
+        pool.return_to_pool(return_to_pool);
 
         (contents_builder.into(), ledger)
     }


### PR DESCRIPTION
It fixes a possible situation when fragments are returned to pool in such a way they would executed before some other fragments depending on them.