### PR TITLE
Split explorer storage in stable and unstable

### DIFF
--- a/jormungandr/src/explorer/error.rs
+++ b/jormungandr/src/explorer/error.rs
@@ -1,3 +1,4 @@
+use super::stable_storage::StableIndexError;
 use crate::blockcfg::HeaderHash;
 use crate::{blockchain::StorageError, intercom};
 use thiserror::Error;
@@ -10,6 +11,8 @@ pub enum ExplorerError {
     AncestorNotFound(HeaderHash),
     #[error("transaction '{0}' is already indexed")]
     TransactionAlreadyExists(crate::blockcfg::FragmentId),
+    #[error("transaction '{0}' not found")]
+    TransactionNotFound(crate::blockcfg::FragmentId),
     #[error("tried to index block '{0}' twice")]
     BlockAlreadyExists(HeaderHash),
     #[error("block with {0} chain length already exists in explorer branch")]
@@ -20,6 +23,8 @@ pub enum ExplorerError {
     StorageError(#[from] StorageError),
     #[error("streaming error")]
     StreamingError(#[from] intercom::Error),
+    #[error("stable storage error")]
+    StableIndexError(#[from] StableIndexError),
 }
 
 pub type Result<T> = std::result::Result<T, ExplorerError>;

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -18,7 +18,6 @@ use chain_impl_mockchain::vote::{
 };
 use futures::stream::{self, StreamExt};
 use std::{convert::TryInto, sync::Arc};
-use tracing::trace;
 
 pub type Hamt<K, V> = imhamt::Hamt<DefaultHasher, K, Arc<V>>;
 
@@ -426,8 +425,6 @@ impl ExplorerTransaction {
                     (InputEnum::UtxoInput(utxo_pointer), _witness) => {
                         let tx = utxo_pointer.transaction_id;
                         let index = utxo_pointer.output_index;
-
-                        trace!("found utxo inupt, processing, {}", &tx);
 
                         let output = match context
                             .prev_transactions

--- a/jormungandr/src/explorer/persistent_sequence.rs
+++ b/jormungandr/src/explorer/persistent_sequence.rs
@@ -1,12 +1,28 @@
 use imhamt::Hamt;
+use std::convert::Infallible;
 use std::{collections::hash_map::DefaultHasher, sync::Arc};
 
-// Use a Hamt to store a sequence, the indexes can be used for pagination
-// XXX: Maybe there is a better data structure for this?
+/// Use a Hamt to store a sequence, the indexes can be used for pagination
+
+// TODO:
+// this data structure may be better served by either
+//   a persistent linked list (although pagination will be suffer)
+//   a persistent btree
+//   a persistent prefix tree (which would be like the hamt, I think, but without
+//   hashing the keys before, so we don't lose locality)
+// but it is used by different things now, and maybe some would benefit more
+// from one of the options than the others
+
 #[derive(Clone)]
 pub struct PersistentSequence<T> {
     len: u64,
     elements: Hamt<DefaultHasher, u64, Arc<T>>,
+    /// this is the first valid index, as the sequence doesn't need to start from
+    /// 0, we need this to remove from the beginning, which is useful to undo
+    /// blocks, because we are always undoing blocks from the back sequentially,
+    /// in the opposite order they were applied, so we never need to remove from
+    /// the beginning
+    first: Option<u64>,
 }
 
 impl<T> PersistentSequence<T> {
@@ -14,15 +30,40 @@ impl<T> PersistentSequence<T> {
         PersistentSequence {
             len: 0,
             elements: Hamt::new(),
+            first: None,
         }
     }
 
     pub fn append(&self, t: T) -> Self {
         let len = self.len + 1;
+        let first = self.first.or_else(|| Some(0)).map(|first| first + 1);
+
         PersistentSequence {
             len,
             elements: self.elements.insert(len - 1, Arc::new(t)).unwrap(),
+            first,
         }
+    }
+
+    pub fn remove_first(&self) -> Option<(Self, Arc<T>)> {
+        self.first.and_then(|first| {
+            let mut deleted = None;
+            let elements = self
+                .elements
+                .update::<_, Infallible>(&first, |elem| Ok(deleted.replace(Arc::clone(elem))))
+                .ok()?;
+
+            deleted.map(|deleted| {
+                (
+                    PersistentSequence {
+                        elements,
+                        len: self.len - 1,
+                        first: Some(first + 1),
+                    },
+                    deleted,
+                )
+            })
+        })
     }
 
     pub fn get<I: Into<u64>>(&self, i: I) -> Option<&Arc<T>> {

--- a/jormungandr/src/explorer/stable_storage.rs
+++ b/jormungandr/src/explorer/stable_storage.rs
@@ -1,0 +1,142 @@
+use super::indexing::ExplorerAddress;
+use super::{EpochData, ExplorerBlock};
+use crate::blockcfg::{ChainLength, Epoch, FragmentId, HeaderHash};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use tracing::debug;
+
+#[derive(Error, Debug)]
+pub enum StableIndexError {
+    #[error("block is already indexed in stable explorer storage: {0}")]
+    BlockAlreadyExists(HeaderHash),
+    #[error("there is already a block with given chain_length: {0}")]
+    DuplicatedChainLength(ChainLength),
+    #[error("transaction is already indexed in stable explorer storage")]
+    TransactionAlreadyExists,
+}
+
+#[derive(Clone, Default)]
+pub struct StableIndexShared(pub Arc<RwLock<StableIndex>>);
+
+impl StableIndexShared {
+    pub async fn write<'a>(&'a self) -> RwLockWriteGuard<'a, StableIndex> {
+        self.0.write().await
+    }
+
+    pub async fn read<'a>(&'a self) -> RwLockReadGuard<'a, StableIndex> {
+        self.0.read().await
+    }
+}
+
+/// in memory non-versioned version of the explorer indexes
+/// this is mostly a *naive* version, because the final step would be to have
+/// something backed by an on-disk database
+/// ideally just reimplementing this would be enough to introduce a database
+/// in practice, the api may need to be adapted to use database cursors or some
+/// sort of offsets
+#[derive(Default)]
+pub struct StableIndex {
+    transactions_by_address: HashMap<ExplorerAddress, Vec<FragmentId>>,
+    block_by_chain_length: BTreeMap<ChainLength, HeaderHash>,
+    epochs: BTreeMap<Epoch, EpochData>,
+    blocks: HashMap<HeaderHash, ExplorerBlock>,
+    transaction_to_block: HashMap<FragmentId, HeaderHash>,
+}
+
+impl StableIndex {
+    pub fn apply_block(&mut self, block: ExplorerBlock) -> Result<(), StableIndexError> {
+        debug!("applying block to explorer's stable index {}", block.id());
+
+        if self
+            .block_by_chain_length
+            .insert(block.chain_length, block.id())
+            .is_some()
+        {
+            return Err(StableIndexError::DuplicatedChainLength(block.chain_length));
+        }
+
+        for (hash, tx) in &block.transactions {
+            let included_addresses: std::collections::HashSet<ExplorerAddress> = tx
+                .outputs()
+                .iter()
+                .map(|output| output.address.clone())
+                .chain(tx.inputs().iter().map(|input| input.address.clone()))
+                .collect();
+
+            for address in included_addresses {
+                self.transactions_by_address
+                    .entry(address)
+                    .or_insert(vec![])
+                    .push(*hash)
+            }
+
+            if self.transaction_to_block.insert(*hash, block.id).is_some() {
+                return Err(StableIndexError::TransactionAlreadyExists);
+            }
+        }
+
+        self.epochs
+            .entry(block.date.epoch)
+            .and_modify(|epoch_data| {
+                epoch_data.last_block = block.id;
+                epoch_data.total_blocks += 1;
+            })
+            .or_insert(EpochData {
+                first_block: block.id,
+                last_block: block.id,
+                total_blocks: 1,
+            });
+
+        let id = block.id.clone();
+
+        if self.blocks.insert(block.id, block).is_some() {
+            return Err(StableIndexError::BlockAlreadyExists(id));
+        }
+
+        Ok(())
+    }
+
+    pub fn last_block_length(&self) -> Option<ChainLength> {
+        self.block_by_chain_length
+            .keys()
+            .last()
+            .map(ChainLength::clone)
+    }
+
+    pub fn get_block(&self, block_id: &HeaderHash) -> Option<&ExplorerBlock> {
+        self.blocks.get(block_id)
+    }
+
+    pub fn transactions_by_address(
+        &self,
+        address: &ExplorerAddress,
+    ) -> Option<impl Iterator<Item = &FragmentId>> {
+        self.transactions_by_address
+            .get(address)
+            .map(|inner| inner.iter())
+    }
+
+    pub fn get_block_by_chain_length(&self, chain_length: &ChainLength) -> Option<&HeaderHash> {
+        self.block_by_chain_length.get(chain_length)
+    }
+
+    pub fn get_epoch_data(&self, epoch: &Epoch) -> Option<&EpochData> {
+        self.epochs.get(epoch)
+    }
+
+    pub fn transaction_to_block(&self, fragment_id: &FragmentId) -> Option<&HeaderHash> {
+        self.transaction_to_block.get(fragment_id)
+    }
+
+    pub fn get_block_hash_range(
+        &self,
+        from: ChainLength,
+        to: ChainLength,
+    ) -> impl Iterator<Item = (HeaderHash, ChainLength)> + '_ {
+        self.block_by_chain_length
+            .range(from..to)
+            .map(|(length, hash)| (hash.clone(), length.clone()))
+    }
+}

--- a/testing/jormungandr-testing-utils/src/testing/node/time.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/time.rs
@@ -1,4 +1,5 @@
 use crate::testing::node::explorer::Explorer;
+use chain_impl_mockchain::block::ChainLength;
 use jormungandr_lib::interfaces::BlockDate;
 
 pub fn wait_for_epoch(epoch_id: u64, mut explorer: Explorer) {
@@ -37,5 +38,26 @@ pub fn wait_for_date(target_block_date: BlockDate, mut explorer: Explorer) {
         }
 
         std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
+pub fn wait_n_blocks(start: ChainLength, n: u32, explorer: &Explorer) {
+    loop {
+        let current = explorer
+            .last_block()
+            .unwrap()
+            .data
+            .unwrap()
+            .tip
+            .block
+            .chain_length;
+
+        let current: u32 = current.parse().unwrap();
+
+        if u32::from(start) + n <= current {
+            return;
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(2));
     }
 }


### PR DESCRIPTION
# Motivation

Intermediate step to introduce use a non-volatile database for the explorer. It doesn't change any behavior by itself, so it could be merged individually, it's mostly to prepare things.

## About

This PR

- Adds a simple in-memory representation of what the explorer would need to persist the indices. Each time the chain_length of the *tip* increases by one, a new block passes the epoch stability depth threshold and gets inserted there.
- Adds a wrapper type to make queries first looking in the multiverse and then looking in the _stable storage_.
- Undo the `apply_block` operation from blocks moved to the stable storage, in any incoming multiverse State.
- (WIP) Improves the explorer sanity test a bit, to account for the fact that blocks will be removed from 'memory'.

The last point requires some explanation. Currently the explorer has a multiverse of `State`, which is entirely a persistent data structure. This means we have an immutable version of the indexes for each block that we have, and there is no way to simply _forget_ things in there, but if we don't remove things that we move to the stable storage, then there will be no point in doing it. 

Because of this, I took the approach of applying delayed deletes. Each time we add a `State`, we also _unapply_ a block from the past (the one epoch_stability_depth blocks behind), before inserting.

See the following graph of the multiverse for a graphical illustration. 

For the notation:

- B{id} represents a block.
- S{id} means the `State` in the multiverse, which in this case represents a snapshot of the explorer index. This is what's used to answer queries by providing a branch id through the api.
- *+* means applying a block to the index.
- *-* means un-applying a block from the index. (which was previously applied)
![image](https://user-images.githubusercontent.com/48031343/114256648-18c7ff80-9991-11eb-8778-3657ef85fa03.png)

**Important:** this is just partial, although it can be merged as it is, this is still missing the `undo` operations for the vote tally indices (mostly because I don't quite understand that one entirely).

_Note_: I wrote something about this in #2759, but is better to read this first, because I still need to update that one with more up-to-date thoughts.