### PR TITLE
Fix leadership_logs_parent_hash_is_correct

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/leadership.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/leadership.rs
@@ -1,6 +1,10 @@
-use crate::common::{jcli::JCli, jormungandr::ConfigurationBuilder, startup};
+use crate::common::{
+    jcli::JCli,
+    jormungandr::{ConfigurationBuilder, StartupVerificationMode},
+    startup,
+};
 use jormungandr_lib::interfaces::LeadershipLogStatus;
-use jortestkit::process::sleep;
+use std::time::Duration;
 
 #[test]
 pub fn test_leadership_logs_parent_hash_is_correct() {
@@ -9,7 +13,9 @@ pub fn test_leadership_logs_parent_hash_is_correct() {
     let (jormungandr, _) =
         startup::start_stake_pool(&[faucet], &[], &mut ConfigurationBuilder::new()).unwrap();
 
-    sleep(5);
+    jormungandr
+        .wait_for_bootstrap(&StartupVerificationMode::Rest, Duration::from_secs(10))
+        .unwrap();
 
     let leadership_logs = jcli.rest().v0().leadership_log(jormungandr.rest_uri());
 


### PR DESCRIPTION
The test was optimistically waiting 5 seconds before querying the node, and that caused some failures in https://github.com/input-output-hk/jormungandr/pull/3177/checks?check_run_id=2325095347

This pr adds a function to `JormungandrProcess` to help wait for it to bootstrap