### PR TITLE
Set log level in scenario tests

### DIFF
--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -682,6 +682,15 @@ pub struct SpawnBuilder<'a, R: RngCore, N> {
 
 impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
     pub fn new(context: &'a Context<R>, node_settings: &'a mut NodeSetting) -> Self {
+        // Ensure that logs are set in JSON format and output to stdout
+        // when spawning a new Node.
+        let format = "json";
+        let level = context.log_level();
+        node_settings.config.log = Some(Log(LogEntry {
+            format: format.to_string(),
+            level,
+            output: LogOutput::Stdout,
+        }));
         Self {
             jormungandr: PathBuf::new(),
             context,
@@ -759,16 +768,6 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
         }
     }
 
-    fn set_log_level(&mut self) {
-        let format = "json";
-        let level = self.context.log_level();
-        self.node_settings.config.log = Some(Log(LogEntry {
-            format: format.to_string(),
-            level,
-            output: LogOutput::Stdout,
-        }));
-    }
-
     pub fn command<P: AsRef<Path>, Q: AsRef<Path>>(
         &self,
         config_file: P,
@@ -805,7 +804,6 @@ impl<'a, R: RngCore> SpawnBuilder<'a, R, Node> {
         let config_file = dir.join(NODE_CONFIG);
         let config_secret = dir.join(NODE_SECRET);
 
-        self.set_log_level();
         self.apply_persistence_setting(&dir);
         self.write_config_file(&config_file)?;
         self.write_secret_file(&config_secret)?;
@@ -843,7 +841,6 @@ impl<'a, R: RngCore> SpawnBuilder<'a, R, LegacyNode> {
         let config_file = dir.join(NODE_CONFIG);
         let config_secret = dir.join(NODE_SECRET);
 
-        self.set_log_level();
         self.apply_persistence_setting(&dir);
         self.write_config_file(&config_file)?;
         self.write_secret_file(&config_secret)?;

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -761,7 +761,7 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
     }
 
     fn set_log_level(&mut self, _log_file: &Path) {
-        let format = "plain";
+        let format = "json";
         let level = self.context.log_level();
         self.node_settings.config.log = Some(Log(LogEntry {
             format: format.to_string(),

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -760,7 +760,7 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
         }
     }
 
-    fn set_log_level(&mut self, _log_file: &Path) {
+    fn set_log_level(&mut self) {
         let format = "json";
         let level = self.context.log_level();
         self.node_settings.config.log = Some(Log(LogEntry {
@@ -807,7 +807,7 @@ impl<'a, R: RngCore> SpawnBuilder<'a, R, Node> {
         let config_secret = dir.join(NODE_SECRET);
         let log_file = dir.join(NODE_LOG);
 
-        self.set_log_level(&log_file);
+        self.set_log_level();
         self.apply_persistence_setting(&dir);
         self.write_config_file(&config_file)?;
         self.write_secret_file(&config_secret)?;
@@ -846,7 +846,7 @@ impl<'a, R: RngCore> SpawnBuilder<'a, R, LegacyNode> {
         let config_secret = dir.join(NODE_SECRET);
         let log_file = dir.join(NODE_LOG);
 
-        self.set_log_level(&log_file);
+        self.set_log_level();
         self.apply_persistence_setting(&dir);
         self.write_config_file(&config_file)?;
         self.write_secret_file(&config_secret)?;

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -179,7 +179,6 @@ pub struct Node {
 const NODE_CONFIG: &str = "node_config.yaml";
 const NODE_SECRET: &str = "node_secret.yaml";
 const NODE_STORAGE: &str = "storage.db";
-const NODE_LOG: &str = "node.log";
 
 impl NodeController {
     pub fn alias(&self) -> &NodeAlias {
@@ -805,7 +804,6 @@ impl<'a, R: RngCore> SpawnBuilder<'a, R, Node> {
 
         let config_file = dir.join(NODE_CONFIG);
         let config_secret = dir.join(NODE_SECRET);
-        let log_file = dir.join(NODE_LOG);
 
         self.set_log_level();
         self.apply_persistence_setting(&dir);
@@ -844,7 +842,6 @@ impl<'a, R: RngCore> SpawnBuilder<'a, R, LegacyNode> {
 
         let config_file = dir.join(NODE_CONFIG);
         let config_secret = dir.join(NODE_SECRET);
-        let log_file = dir.join(NODE_LOG);
 
         self.set_log_level();
         self.apply_persistence_setting(&dir);


### PR DESCRIPTION
Using "plain" as the format will make the logger crash as it only understands json. On top of that, that function is not very useful anymore, as it ignores the only argument.

This addresses missing changes from #3145 