### PR TITLE
explorer: use thiserror instead of error-chain

### DIFF
--- a/jormungandr/src/explorer/graphql/certificates.rs
+++ b/jormungandr/src/explorer/graphql/certificates.rs
@@ -1,4 +1,4 @@
-use super::error::ErrorKind;
+use super::error::ApiError;
 use async_graphql::{Context, FieldResult, Object, Union};
 use chain_impl_mockchain::certificate;
 use std::convert::TryFrom;
@@ -58,7 +58,7 @@ impl StakeDelegation {
             .to_single_account()
             .ok_or_else(||
                 // TODO: Multisig address?
-                ErrorKind::Unimplemented.into())
+                ApiError::Unimplemented.into())
             .map(|single| {
                 chain_addr::Address(discrimination, chain_addr::Kind::Account(single.into()))
             })
@@ -254,7 +254,7 @@ impl EncryptedVoteTally {
 /*----------------------------*/
 
 impl TryFrom<chain_impl_mockchain::certificate::Certificate> for Certificate {
-    type Error = super::error::Error;
+    type Error = super::error::ApiError;
     fn try_from(
         original: chain_impl_mockchain::certificate::Certificate,
     ) -> Result<Certificate, Self::Error> {

--- a/jormungandr/src/explorer/graphql/error.rs
+++ b/jormungandr/src/explorer/graphql/error.rs
@@ -1,28 +1,17 @@
-error_chain! {
-    errors {
-        InternalError(msg: String) {
-            description("an error that shouldn't happen"),
-            display("{}", msg)
-        }
-        NotFound(msg: String) {
-            description("resource not found"),
-            display("{}", msg)
-        }
-        Unimplemented {
-            description("feature not implemented yet"),
-            display("unimplemented")
-        }
-        ArgumentError(msg: String) {
-            description("invalid argument in query"),
-            display("invalid argument: {}", msg)
-        }
-        InvalidCursor(msg: String) {
-            description("invalid cursor in pagination query"),
-            display("invalid cursor in pagination query: {}", msg)
-        }
-        InvalidAddress(address: String) {
-            description("failed to parse address"),
-            display("invalid address: {}", address)
-        }
-    }
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ApiError {
+    #[error("internal error (this shouldn't happen) {0}")]
+    InternalError(String),
+    #[error("resource not found {0}")]
+    NotFound(String),
+    #[error("feature not implemented yet")]
+    Unimplemented,
+    #[error("invalid argument {0}")]
+    ArgumentError(String),
+    #[error("invalud pagination cursor {0}")]
+    InvalidCursor(String),
+    #[error("invalid address {0}")]
+    InvalidAddress(String),
 }

--- a/jormungandr/src/explorer/graphql/scalars.rs
+++ b/jormungandr/src/explorer/graphql/scalars.rs
@@ -1,4 +1,4 @@
-use super::error::ErrorKind;
+use super::error::ApiError;
 use crate::blockcfg;
 use async_graphql::{Enum, InputValueError, InputValueResult, Scalar, ScalarType, SimpleObject};
 use chain_crypto::bech32::Bech32;
@@ -307,12 +307,12 @@ impl From<u32> for IndexCursor {
 }
 
 impl TryInto<u64> for IndexCursor {
-    type Error = super::ErrorKind;
+    type Error = ApiError;
 
     fn try_into(self) -> Result<u64, Self::Error> {
         self.0
             .parse()
-            .map_err(|_| ErrorKind::InvalidCursor("IndexCursor is not a valid number".to_string()))
+            .map_err(|_| ApiError::InvalidCursor("IndexCursor is not a valid number".to_string()))
     }
 }
 
@@ -348,10 +348,10 @@ impl From<vote::Options> for VoteOptionRange {
 }
 
 impl TryFrom<IndexCursor> for u32 {
-    type Error = ErrorKind;
+    type Error = ApiError;
     fn try_from(c: IndexCursor) -> Result<u32, Self::Error> {
         c.0.parse()
-            .map_err(|_| ErrorKind::InvalidCursor("IndexCursor is not a valid number".to_owned()))
+            .map_err(|_| ApiError::InvalidCursor("IndexCursor is not a valid number".to_owned()))
     }
 }
 
@@ -368,10 +368,10 @@ impl From<blockcfg::ChainLength> for IndexCursor {
 }
 
 impl TryFrom<IndexCursor> for blockcfg::ChainLength {
-    type Error = ErrorKind;
+    type Error = ApiError;
     fn try_from(c: IndexCursor) -> Result<blockcfg::ChainLength, Self::Error> {
         let inner: u32 = c.0.parse().map_err(|_| {
-            ErrorKind::InvalidCursor(
+            ApiError::InvalidCursor(
                 "block's pagination cursor is greater than maximum ChainLength".to_owned(),
             )
         })?;


### PR DESCRIPTION
There is no real reason to use `error-chain` there, besides that no one took the time to replace it. `thiserror` is much nicer to work with anyway (it's used in other places, though, so it can not be removed anyway).