### PR TITLE
Use longer epoch in send_all_fragments

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/fragments.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/fragments.rs
@@ -23,7 +23,7 @@ pub fn send_all_fragments() {
         &[receiver.clone()],
         ConfigurationBuilder::new()
             .with_block0_consensus(ConsensusType::GenesisPraos)
-            .with_slots_per_epoch(30)
+            .with_slots_per_epoch(60)
             .with_consensus_genesis_praos_active_slot_coeff(ActiveSlotCoefficient::MAXIMUM)
             .with_slot_duration(3)
             .with_linear_fees(LinearFee::new(1, 1, 1))


### PR DESCRIPTION
When runners are particularly slow to start up, only a few slots remain
usable to settle transactions before the change of the epoch and
of rules (voting period / tally /ecc).

This commits adjust the epoch duration to accommodate such slow
runners.