### PR TITLE
Jcli make transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rayon",
  "reqwest",
+ "rpassword",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3175,6 +3176,16 @@ dependencies = [
  "spin 0.5.2",
  "untrusted",
  "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rpassword"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
+dependencies = [
+ "libc",
  "winapi",
 ]
 

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -35,6 +35,7 @@ gtmpl = "0.6.0"
 ed25519-bip32 = "0.3"
 thiserror = "1.0"
 bytes = "1.0"
+rpassword = "5.0"
 
 [dependencies.clap]
 version = "2.33"

--- a/jcli/src/jcli_lib/address.rs
+++ b/jcli/src/jcli_lib/address.rs
@@ -131,7 +131,7 @@ fn mk_delegation(prefix: &str, s: PublicKey<Ed25519>, testing: bool, d: PublicKe
     mk_address_2(prefix, s, d, testing, Kind::Group)
 }
 
-fn mk_account(prefix: &str, s: PublicKey<Ed25519>, testing: bool) {
+pub fn mk_account(prefix: &str, s: PublicKey<Ed25519>, testing: bool) {
     mk_address_1(prefix, s, testing, Kind::Account)
 }
 

--- a/jcli/src/jcli_lib/address.rs
+++ b/jcli/src/jcli_lib/address.rs
@@ -131,7 +131,7 @@ fn mk_delegation(prefix: &str, s: PublicKey<Ed25519>, testing: bool, d: PublicKe
     mk_address_2(prefix, s, d, testing, Kind::Group)
 }
 
-pub fn mk_account(prefix: &str, s: PublicKey<Ed25519>, testing: bool) {
+fn mk_account(prefix: &str, s: PublicKey<Ed25519>, testing: bool) {
     mk_address_1(prefix, s, testing, Kind::Account)
 }
 

--- a/jcli/src/jcli_lib/block/mod.rs
+++ b/jcli/src/jcli_lib/block/mod.rs
@@ -116,16 +116,24 @@ pub struct Input {
 
 impl Input {
     pub fn open(&self) -> Result<impl BufRead, Error> {
-        io::open_file_read(&self.input_file).map_err(|source| Error::InputInvalid {
-            source,
-            path: self.input_file.clone().unwrap_or_default(),
-        })
+        open_block_file(&self.input_file)
     }
 
     pub fn load_block(&self) -> Result<Block, Error> {
         let reader = self.open()?;
-        Block::deserialize(reader).map_err(Error::BlockFileCorrupted)
+        load_block(reader)
     }
+}
+
+pub fn open_block_file(input_file: &Option<PathBuf>) -> Result<impl BufRead, Error> {
+    io::open_file_read(input_file).map_err(|source| Error::InputInvalid {
+        source,
+        path: input_file.clone().unwrap_or_default(),
+    })
+}
+
+pub fn load_block(block_reader: impl BufRead) -> Result<Block, Error> {
+    Block::deserialize(block_reader).map_err(Error::BlockFileCorrupted)
 }
 
 #[derive(StructOpt)]

--- a/jcli/src/jcli_lib/key.rs
+++ b/jcli/src/jcli_lib/key.rs
@@ -418,6 +418,7 @@ fn bytes_to_priv_key<K: AsymmetricKey>(bytes: &[u8]) -> Result<String, Error> {
 
 #[derive(Debug)]
 struct Seed([u8; 32]);
+
 impl std::str::FromStr for Seed {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/jcli/src/jcli_lib/rest/config.rs
+++ b/jcli/src/jcli_lib/rest/config.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use thiserror::Error;
 
-#[derive(StructOpt)]
+#[derive(StructOpt, Clone)]
 pub struct RestArgs {
     /// node API address. Must always have `http://` or `https://` prefix.
     /// E.g. `-h http://127.0.0.1`, `--host https://node.com:8443/cardano/api`

--- a/jcli/src/jcli_lib/rest/config.rs
+++ b/jcli/src/jcli_lib/rest/config.rs
@@ -12,7 +12,7 @@ pub struct RestArgs {
     /// node API address. Must always have `http://` or `https://` prefix.
     /// E.g. `-h http://127.0.0.1`, `--host https://node.com:8443/cardano/api`
     #[structopt(short, long, env = "JORMUNGANDR_RESTAPI_URL")]
-    host: Url,
+    pub host: Url,
     /// print additional debug information to stderr.
     /// The output format is intentionally undocumented and unstable
     #[structopt(long)]

--- a/jcli/src/jcli_lib/rest/mod.rs
+++ b/jcli/src/jcli_lib/rest/mod.rs
@@ -1,8 +1,8 @@
 mod config;
-mod v0;
+pub mod v0;
 
 use crate::jcli_lib::utils::{io::ReadYamlError, output_format};
-use config::RestArgs;
+pub use config::RestArgs;
 use hex::FromHexError;
 use structopt::StructOpt;
 use thiserror::Error;
@@ -29,6 +29,8 @@ pub enum Error {
     InputHexMalformed(#[from] FromHexError),
     #[error("error when trying to perform an HTTP request")]
     RequestError(#[from] config::Error),
+    #[error("error loading data from response")]
+    SerdeError(#[from] serde_json::Error),
 }
 
 impl From<ReadYamlError> for Error {

--- a/jcli/src/jcli_lib/rest/v0/account/mod.rs
+++ b/jcli/src/jcli_lib/rest/v0/account/mod.rs
@@ -1,5 +1,6 @@
 use crate::jcli_lib::rest::{Error, RestArgs};
 use crate::jcli_lib::utils::{AccountId, OutputFormat};
+use jormungandr_lib::interfaces::AccountState;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -24,13 +25,20 @@ impl Account {
             output_format,
             account_id,
         } = self;
-        let state = args
-            .client()?
-            .get(&["v0", "account", &account_id.to_url_arg()])
-            .execute()?
-            .json()?;
-        let formatted = output_format.format_json(state)?;
+        let state = request_account_information(args, account_id)?;
+        let formatted = output_format.format_json(serde_json::to_value(state)?)?;
         println!("{}", formatted);
         Ok(())
     }
+}
+
+pub fn request_account_information(
+    args: RestArgs,
+    account_id: AccountId,
+) -> Result<AccountState, Error> {
+    Ok(args
+        .client()?
+        .get(&["v0", "account", &account_id.to_url_arg()])
+        .execute()?
+        .json()?)
 }

--- a/jcli/src/jcli_lib/rest/v0/account/mod.rs
+++ b/jcli/src/jcli_lib/rest/v0/account/mod.rs
@@ -36,9 +36,9 @@ pub fn request_account_information(
     args: RestArgs,
     account_id: AccountId,
 ) -> Result<AccountState, Error> {
-    Ok(args
-        .client()?
+    args.client()?
         .get(&["v0", "account", &account_id.to_url_arg()])
         .execute()?
-        .json()?)
+        .json()
+        .map_err(Into::into)
 }

--- a/jcli/src/jcli_lib/rest/v0/mod.rs
+++ b/jcli/src/jcli_lib/rest/v0/mod.rs
@@ -2,7 +2,7 @@ pub mod account;
 mod block;
 mod diagnostic;
 mod leaders;
-mod message;
+pub mod message;
 mod network;
 mod node;
 mod rewards;

--- a/jcli/src/jcli_lib/rest/v0/mod.rs
+++ b/jcli/src/jcli_lib/rest/v0/mod.rs
@@ -6,7 +6,7 @@ pub mod message;
 mod network;
 mod node;
 mod rewards;
-mod settings;
+pub mod settings;
 mod shutdown;
 mod stake;
 mod stake_pool;

--- a/jcli/src/jcli_lib/rest/v0/mod.rs
+++ b/jcli/src/jcli_lib/rest/v0/mod.rs
@@ -1,4 +1,4 @@
-mod account;
+pub mod account;
 mod block;
 mod diagnostic;
 mod leaders;

--- a/jcli/src/jcli_lib/rest/v0/settings/mod.rs
+++ b/jcli/src/jcli_lib/rest/v0/settings/mod.rs
@@ -1,5 +1,7 @@
 use crate::jcli_lib::rest::{Error, RestArgs};
 use crate::jcli_lib::utils::OutputFormat;
+use jormungandr_lib::interfaces::SettingsDto;
+
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -20,9 +22,14 @@ impl Settings {
             args,
             output_format,
         } = self;
-        let response = args.client()?.get(&["v0", "settings"]).execute()?.json()?;
-        let formatted = output_format.format_json(response)?;
+        let settings = request_settings(args)?;
+        let formatted = output_format.format_json(serde_json::to_value(&settings)?)?;
         println!("{}", formatted);
         Ok(())
     }
+}
+
+pub fn request_settings(args: RestArgs) -> Result<SettingsDto, Error> {
+    serde_json::from_str(&(args.client()?.get(&["v0", "settings"]).execute()?.text()?))
+        .map_err(Error::SerdeError)
 }

--- a/jcli/src/jcli_lib/transaction/add_account.rs
+++ b/jcli/src/jcli_lib/transaction/add_account.rs
@@ -1,7 +1,4 @@
 use crate::jcli_lib::transaction::{common, Error};
-use crate::transaction::staging::Staging;
-use chain_addr::{Address, Kind};
-use chain_impl_mockchain::transaction::UnspecifiedAccountIdentifier;
 use jormungandr_lib::interfaces;
 use structopt::StructOpt;
 
@@ -23,27 +20,7 @@ pub struct AddAccount {
 impl AddAccount {
     pub fn exec(self) -> Result<(), Error> {
         let mut transaction = self.common.load()?;
-        add_account(self.account, self.value, &mut transaction)?;
+        transaction.add_account(self.account, self.value)?;
         self.common.store(&transaction)
     }
-}
-
-pub fn add_account(
-    account: interfaces::Address,
-    value: interfaces::Value,
-    transaction: &mut Staging,
-) -> Result<(), Error> {
-    let account_id = match Address::from(self.account).kind() {
-        Kind::Account(key) => UnspecifiedAccountIdentifier::from_single_account(key.clone().into()),
-        Kind::Multisig(key) => UnspecifiedAccountIdentifier::from_multi_account((*key).into()),
-        Kind::Single(_) => return Err(Error::AccountAddressSingle),
-        Kind::Group(_, _) => return Err(Error::AccountAddressGroup),
-        Kind::Script(_) => return Err(Error::AccountAddressScript),
-    };
-
-    transaction.add_input(interfaces::TransactionInput {
-        input: interfaces::TransactionInputType::Account(account_id.into()),
-        value,
-    })?;
-    Ok(())
 }

--- a/jcli/src/jcli_lib/transaction/finalize.rs
+++ b/jcli/src/jcli_lib/transaction/finalize.rs
@@ -1,4 +1,5 @@
 use crate::jcli_lib::transaction::{common, Error};
+use crate::transaction::staging::Staging;
 use chain_impl_mockchain::transaction::OutputPolicy;
 use jormungandr_lib::interfaces;
 use structopt::StructOpt;
@@ -20,15 +21,22 @@ impl Finalize {
     pub fn exec(self) -> Result<(), Error> {
         let mut transaction = self.common.load()?;
 
-        let fee_algo = self.fee.linear_fee();
-        let output_policy = match self.change {
-            None => OutputPolicy::Forget,
-            Some(change) => OutputPolicy::One(change.into()),
-        };
-
-        let _balance = transaction.balance_inputs_outputs(&fee_algo, output_policy)?;
+        finalize(self.fee, self.change, &mut transaction)?;
 
         self.common.store(&transaction)?;
         Ok(())
     }
+}
+
+pub fn finalize(
+    fee: common::CommonFees,
+    change: Option<interfaces::Address>,
+    transaction: &mut Staging,
+) -> Result<(), Error> {
+    let fee_algo = fee.linear_fee();
+    let output_policy = match change {
+        None => OutputPolicy::Forget,
+        Some(change) => OutputPolicy::One(change.into()),
+    };
+    let _balance = transaction.balance_inputs_outputs(&fee_algo, output_policy)?;
 }

--- a/jcli/src/jcli_lib/transaction/finalize.rs
+++ b/jcli/src/jcli_lib/transaction/finalize.rs
@@ -39,4 +39,5 @@ pub fn finalize(
         Some(change) => OutputPolicy::One(change.into()),
     };
     let _balance = transaction.balance_inputs_outputs(&fee_algo, output_policy)?;
+    Ok(())
 }

--- a/jcli/src/jcli_lib/transaction/mod.rs
+++ b/jcli/src/jcli_lib/transaction/mod.rs
@@ -64,8 +64,8 @@ pub enum Transaction {
     Auth(auth::Auth),
     /// get the message format out of a sealed transaction
     ToMessage(common::CommonTransaction),
-    /// send a transaction from faucet (simplified method)
-    Simplified(simplified::SimplifiedTransaction),
+    /// send a transaction from one account to another (simplified method)
+    MakeTransaction(simplified::MakeTransaction),
 }
 
 type StaticStr = &'static str;
@@ -203,6 +203,9 @@ pub enum Error {
 
     #[error("could not generate random key")]
     RandError(#[from] rand::Error),
+
+    #[error("invalid block0 header hash")]
+    InvalidBlock0HeaderHash,
 }
 
 /*
@@ -231,7 +234,7 @@ impl Transaction {
             Transaction::MakeWitness(mk_witness) => mk_witness.exec(),
             Transaction::Auth(auth) => auth.exec(),
             Transaction::ToMessage(common) => display_message(common),
-            Transaction::Simplified(send) => send.exec(),
+            Transaction::MakeTransaction(send) => send.exec(),
         }
     }
 }

--- a/jcli/src/jcli_lib/transaction/mod.rs
+++ b/jcli/src/jcli_lib/transaction/mod.rs
@@ -64,8 +64,8 @@ pub enum Transaction {
     Auth(auth::Auth),
     /// get the message format out of a sealed transaction
     ToMessage(common::CommonTransaction),
-    /// send  a transaction from faucet (simplified method)
-    Send(simplified::SimplifiedTransaction),
+    /// send a transaction from faucet (simplified method)
+    Simplified(simplified::SimplifiedTransaction),
 }
 
 type StaticStr = &'static str;
@@ -231,7 +231,7 @@ impl Transaction {
             Transaction::MakeWitness(mk_witness) => mk_witness.exec(),
             Transaction::Auth(auth) => auth.exec(),
             Transaction::ToMessage(common) => display_message(common),
-            Transaction::Send(send) => send.exec(),
+            Transaction::Simplified(send) => send.exec(),
         }
     }
 }

--- a/jcli/src/jcli_lib/transaction/mod.rs
+++ b/jcli/src/jcli_lib/transaction/mod.rs
@@ -1,15 +1,16 @@
-mod add_account;
+pub mod add_account;
 mod add_certificate;
 mod add_input;
-mod add_output;
+pub mod add_output;
 mod add_witness;
 mod auth;
 mod common;
-mod finalize;
+pub mod finalize;
 mod info;
 mod mk_witness;
-mod new;
+pub mod new;
 mod seal;
+mod simplified;
 mod staging;
 
 use self::staging::StagingKind;
@@ -62,6 +63,8 @@ pub enum Transaction {
     Auth(auth::Auth),
     /// get the message format out of a sealed transaction
     ToMessage(common::CommonTransaction),
+    /// send  a transaction from faucet (simplified method)
+    Send(simplified::Send),
 }
 
 type StaticStr = &'static str;
@@ -215,6 +218,7 @@ impl Transaction {
             Transaction::MakeWitness(mk_witness) => mk_witness.exec(),
             Transaction::Auth(auth) => auth.exec(),
             Transaction::ToMessage(common) => display_message(common),
+            Transaction::Send(send) => send.exec(),
         }
     }
 }

--- a/jcli/src/jcli_lib/transaction/mod.rs
+++ b/jcli/src/jcli_lib/transaction/mod.rs
@@ -18,6 +18,7 @@ use crate::jcli_lib::{
     certificate,
     utils::{key_parser, output_format},
 };
+use crate::{block, rest, utils};
 use chain_core::property::Serialize as _;
 use chain_impl_mockchain as chain;
 use std::path::PathBuf;
@@ -190,6 +191,15 @@ pub enum Error {
     TxWithOwnerStakeDelegationHasUtxoInput,
     #[error("transaction has owner stake delegation, but has outputs")]
     TxWithOwnerStakeDelegationHasOutputs,
+
+    #[error(transparent)]
+    Block0Error(#[from] block::Error),
+
+    #[error(transparent)]
+    AccountIdError(#[from] utils::account_id::Error),
+
+    #[error(transparent)]
+    RestError(#[from] rest::Error),
 }
 
 /*

--- a/jcli/src/jcli_lib/transaction/mod.rs
+++ b/jcli/src/jcli_lib/transaction/mod.rs
@@ -91,7 +91,7 @@ pub enum Error {
         path: PathBuf,
     },
     #[error("could not process secret file '{0}'")]
-    SecretFileFailed(#[from] key_parser::Error),
+    SecretKeyReadFailed(#[from] key_parser::Error),
     /*
     SecretFileReadFailed { source: std::io::Error, path: PathBuf }
         = @{{ let _ = source; format_args!("could not read secret file '{}'", path.display()) }},

--- a/jcli/src/jcli_lib/transaction/mod.rs
+++ b/jcli/src/jcli_lib/transaction/mod.rs
@@ -200,6 +200,9 @@ pub enum Error {
 
     #[error(transparent)]
     RestError(#[from] rest::Error),
+
+    #[error("could not generate random key")]
+    RandError(#[from] rand::Error),
 }
 
 /*

--- a/jcli/src/jcli_lib/transaction/mod.rs
+++ b/jcli/src/jcli_lib/transaction/mod.rs
@@ -206,6 +206,12 @@ pub enum Error {
 
     #[error("invalid block0 header hash")]
     InvalidBlock0HeaderHash,
+
+    #[error("canceled by user")]
+    CancelByUser,
+
+    #[error("error requesting user input")]
+    UserInputError(#[from] std::io::Error),
 }
 
 /*

--- a/jcli/src/jcli_lib/transaction/mod.rs
+++ b/jcli/src/jcli_lib/transaction/mod.rs
@@ -64,7 +64,7 @@ pub enum Transaction {
     /// get the message format out of a sealed transaction
     ToMessage(common::CommonTransaction),
     /// send  a transaction from faucet (simplified method)
-    Send(simplified::Send),
+    Send(simplified::SimplifiedTransaction),
 }
 
 type StaticStr = &'static str;

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -1,13 +1,14 @@
 use crate::block::{load_block, open_block_file};
 use crate::jcli_lib::rest::RestArgs;
 use crate::jcli_lib::transaction::{common, Error};
-use chain_crypto::{bech32::Bech32 as _, AsymmetricKey, Ed25519Extended, SecretKey};
+use chain_crypto::{bech32::Bech32 as _, Ed25519, Ed25519Extended, PublicKey, SecretKey};
 
 use crate::transaction::mk_witness::WitnessType;
 use crate::transaction::staging::Staging;
 use crate::utils::key_parser::read_ed25519_secret_key_from_file;
 use crate::utils::AccountId;
-use crate::{address, rest, transaction};
+use crate::{rest, transaction};
+use chain_addr::Kind;
 use chain_impl_mockchain::account::SpendingCounter;
 use chain_impl_mockchain::key::EitherEd25519SecretKey;
 use chain_impl_mockchain::transaction::Output;
@@ -85,20 +86,20 @@ fn create_new_private_key() -> Result<SecretKey<Ed25519Extended>, Error> {
     Ok(key)
 }
 
-fn create_receiver_address(sk: &EitherEd25519SecretKey) -> Result<interfaces::Address, Error> {
-    let sk = create_new_private_key()?;
+fn create_receiver_address(sk: &SecretKey<Ed25519Extended>) -> interfaces::Address {
     let pk = sk.to_public();
-    let address = interfaces::Address::;
-    let address = address::mk_account(Ed25519Extended::SECRET_BECH32_HRP, pk, true)?;
-    Ok(address)
+    make_address(pk)
+}
+
+fn make_address(pk: PublicKey<Ed25519>) -> interfaces::Address {
+    chain_addr::Address(chain_addr::Discrimination::Test, Kind::Account(pk)).into()
 }
 
 fn create_receiver_secret_key_and_address(
 ) -> Result<(SecretKey<Ed25519Extended>, interfaces::Address), Error> {
-    let pk = create_new_private_key()?;
-    let key = EitherEd25519SecretKey::Extended(pk.clone());
-    let address = create_receiver_address(&key)?;
-    Ok((pk, address))
+    let sk = create_new_private_key()?;
+    let address = create_receiver_address(&sk);
+    Ok((sk, address))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -168,7 +168,7 @@ pub fn make_transaction(
     // ask for user confirmation after adding fees
     if !force {
         println!(
-            "Total value to transfer (including fees): {}\n",
+            "Total value to transfer (including fees): {}",
             transfer_value
         );
         if !ask_yes_or_no(true).map_err(Error::UserInputError)? {

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -7,9 +7,7 @@ use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
-pub struct Simplified {
-    input_address_sk: String,
-
+pub struct SimplifiedTransaction {
     /// the account to debit the funds from
     #[structopt(name = "ACCOUNT")]
     pub faucet_address: interfaces::Address,
@@ -32,7 +30,7 @@ pub struct Simplified {
     pub change: Option<interfaces::Address>,
 }
 
-impl Simplified {
+impl SimplifiedTransaction {
     pub fn exec(self) -> Result<(), Error> {
         simplified_transaction(
             self.faucet_address,
@@ -55,7 +53,7 @@ pub fn simplified_transaction(
     let mut transaction = Staging::new();
 
     // add account
-    transaction::add_account::add_account(faucet_address, value.clone(), &mut transaction)?;
+    transaction::add_account::add_account(faucet_address, value, &mut transaction)?;
 
     // add output
     transaction.add_output(Output {

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -53,7 +53,7 @@ impl MakeTransaction {
     pub fn exec(self) -> Result<(), Error> {
         let secret_key = read_ed25519_secret_key_from_file(&self.secret)?;
         let (receiver_secret_key, receiver_address) = create_receiver_secret_key_and_address()?;
-        let fragment_id = simplified_transaction(
+        let fragment_id = make_transaction(
             self.sender_account,
             receiver_address.clone(),
             secret_key,
@@ -103,7 +103,7 @@ fn create_receiver_secret_key_and_address(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn simplified_transaction(
+pub fn make_transaction(
     sender_account: interfaces::Address,
     receiver_address: interfaces::Address,
     secret_key: EitherEd25519SecretKey,

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -13,6 +13,7 @@ use chain_impl_mockchain::key::EitherEd25519SecretKey;
 use chain_impl_mockchain::transaction::Output;
 use jormungandr_lib::interfaces;
 
+use crate::rest::v0::message::post_fragment;
 use crate::transaction::common::CommonFees;
 use crate::utils::io::ask_yes_or_no;
 use jormungandr_lib::interfaces::SettingsDto;
@@ -58,6 +59,9 @@ pub struct MakeTransaction {
     // force transaction without requesting for confirmation
     #[structopt(long)]
     force: bool,
+
+    #[structopt(long)]
+    post: bool,
 }
 
 impl MakeTransaction {
@@ -79,7 +83,15 @@ impl MakeTransaction {
             self.change,
             self.force,
         )?;
+
         transaction.store(&self.common.staging_file)?;
+
+        if self.post {
+            let fragment = transaction.fragment()?;
+            let fragment_id = post_fragment(self.rest_args, fragment)?;
+            println!("{}", fragment_id);
+        }
+
         Ok(())
     }
 }

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -1,17 +1,57 @@
-use structopt::StructOpt;
 use crate::transaction;
+use crate::transaction::common;
+use crate::transaction::staging::Staging;
+use chain_impl_mockchain::transaction::Output;
+use jormungandr_lib::interfaces;
+use structopt::StructOpt;
+
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub struct Send {
     input_address_sk: String,
-    faucet_address: String,
-    amount: u64,
-    receiver_address: Option<String>,
+
+    /// the account to debit the funds from
+    #[structopt(name = "ACCOUNT")]
+    pub faucet_address: interfaces::Address,
+
+    /// the UTxO address or account address to credit funds to
+    #[structopt(name = "ADDRESS")]
+    pub receiver_address: interfaces::Address,
+
+    /// the value
+    #[structopt(name = "VALUE")]
+    pub value: interfaces::Value,
+
+    #[structopt(flatten)]
+    pub common: common::CommonTransaction,
+
+    #[structopt(flatten)]
+    pub fee: common::CommonFees,
+
+    /// Set the change in the given address
+    pub change: Option<interfaces::Address>,
 }
 
 impl Send {
-    pub fn exec(&self) -> std::io::Result<()> {
-        transaction::new::New
+    pub fn exec(self) -> std::io::Result<()> {
+        let mut transaction = Staging::new();
+
+        // add account
+        transaction::add_account::add_account(
+            self.faucet_address,
+            self.value.clone(),
+            &mut transaction,
+        )?;
+
+        // add output
+        transaction.add_output(Output {
+            address: self.receiver_address.into(),
+            value: self.value.into(),
+        })?;
+
+        //finalize
+        transaction::finalize::finalize(self.fee, self.change, &mut transaction)?;
+
         Ok(())
     }
 }

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -1,5 +1,5 @@
+use crate::jcli_lib::transaction::{common, Error};
 use crate::transaction;
-use crate::transaction::common;
 use crate::transaction::staging::Staging;
 use chain_impl_mockchain::transaction::Output;
 use jormungandr_lib::interfaces;
@@ -7,7 +7,7 @@ use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
-pub struct Send {
+pub struct Simplified {
     input_address_sk: String,
 
     /// the account to debit the funds from
@@ -32,26 +32,39 @@ pub struct Send {
     pub change: Option<interfaces::Address>,
 }
 
-impl Send {
-    pub fn exec(self) -> std::io::Result<()> {
-        let mut transaction = Staging::new();
-
-        // add account
-        transaction::add_account::add_account(
+impl Simplified {
+    pub fn exec(self) -> Result<(), Error> {
+        simplified_transaction(
             self.faucet_address,
-            self.value.clone(),
-            &mut transaction,
+            self.receiver_address,
+            self.value,
+            self.fee,
+            self.change,
         )?;
-
-        // add output
-        transaction.add_output(Output {
-            address: self.receiver_address.into(),
-            value: self.value.into(),
-        })?;
-
-        //finalize
-        transaction::finalize::finalize(self.fee, self.change, &mut transaction)?;
-
         Ok(())
     }
+}
+
+pub fn simplified_transaction(
+    faucet_address: interfaces::Address,
+    receiver_address: interfaces::Address,
+    value: interfaces::Value,
+    fee: common::CommonFees,
+    change: Option<interfaces::Address>,
+) -> Result<(), Error> {
+    let mut transaction = Staging::new();
+
+    // add account
+    transaction::add_account::add_account(faucet_address, value.clone(), &mut transaction)?;
+
+    // add output
+    transaction.add_output(Output {
+        address: receiver_address.into(),
+        value: value.into(),
+    })?;
+
+    //finalize
+    transaction::finalize::finalize(fee, change, &mut transaction)?;
+
+    Ok(())
 }

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -1,0 +1,17 @@
+use structopt::StructOpt;
+use crate::transaction;
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub struct Send {
+    input_address_sk: String,
+    faucet_address: String,
+    amount: u64,
+    receiver_address: Option<String>,
+}
+
+impl Send {
+    pub fn exec(&self) -> std::io::Result<()> {
+        transaction::new::New
+        Ok(())
+    }
+}

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -34,7 +34,7 @@ pub struct MakeTransaction {
 
     /// the account to debit the funds from
     #[structopt(long)]
-    pub receiver_account: Option<interfaces::Address>,
+    pub receiver: Option<interfaces::Address>,
 
     #[structopt(long)]
     pub block0_hash: String,
@@ -58,7 +58,7 @@ pub struct MakeTransaction {
 impl MakeTransaction {
     pub fn exec(self) -> Result<(), Error> {
         let secret_key = read_ed25519_secret_key_from_file(&self.secret)?;
-        let receiver_address = if let Some(address) = self.receiver_account {
+        let receiver_address = if let Some(address) = self.receiver {
             address
         } else {
             let (_, address) = create_receiver_secret_key_and_address()?;

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -1,15 +1,20 @@
 use crate::block::{load_block, open_block_file};
 use crate::jcli_lib::rest::RestArgs;
 use crate::jcli_lib::transaction::{common, Error};
+use chain_crypto::{bech32::Bech32 as _, AsymmetricKey, Ed25519Extended, SecretKey};
+
 use crate::transaction::mk_witness::WitnessType;
 use crate::transaction::staging::Staging;
 use crate::utils::key_parser::read_ed25519_secret_key_from_file;
 use crate::utils::AccountId;
-use crate::{rest, transaction};
+use crate::{address, rest, transaction};
 use chain_impl_mockchain::account::SpendingCounter;
 use chain_impl_mockchain::key::EitherEd25519SecretKey;
 use chain_impl_mockchain::transaction::Output;
 use jormungandr_lib::interfaces;
+use rand::rngs::OsRng;
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -23,10 +28,6 @@ pub struct SimplifiedTransaction {
     /// the account to debit the funds from
     #[structopt(name = "ACCOUNT")]
     pub faucet_address: interfaces::Address,
-
-    /// the UTxO address or account address to credit funds to
-    #[structopt(name = "ADDRESS")]
-    pub receiver_address: interfaces::Address,
 
     /// the value
     #[structopt(name = "VALUE")]
@@ -51,18 +52,53 @@ pub struct SimplifiedTransaction {
 impl SimplifiedTransaction {
     pub fn exec(self) -> Result<(), Error> {
         let secret_key = read_ed25519_secret_key_from_file(&self.secret)?;
-        simplified_transaction(
+        let (receiver_secret_key, receiver_address) = create_receiver_secret_key_and_address()?;
+        let fragment_id = simplified_transaction(
             self.faucet_address,
-            self.receiver_address,
+            receiver_address,
             secret_key,
             self.value,
             self.fee,
             self.block0_path,
-            self.rest_args,
+            self.rest_args.clone(),
             self.change,
         )?;
+        println!("{}", fragment_id);
+        println!(
+            "Private key of receiver (to revert transaction for testing purposes): {}",
+            receiver_secret_key.to_bech32_str()
+        );
+        println!("To see if transaction is in block use:");
+        println!("jcli rest v0 message logs -h {}", &self.rest_args.host);
+        println!("To check new account balance :");
+        println!(
+            "jcli  rest v0 account get  $RECEIVER_ADDR -h {}",
+            &self.rest_args.host
+        );
         Ok(())
     }
+}
+
+fn create_new_private_key() -> Result<SecretKey<Ed25519Extended>, Error> {
+    let rng = ChaChaRng::from_rng(OsRng)?;
+    let key = SecretKey::<Ed25519Extended>::generate(rng);
+    Ok(key)
+}
+
+fn create_receiver_address(sk: &EitherEd25519SecretKey) -> Result<interfaces::Address, Error> {
+    let sk = create_new_private_key()?;
+    let pk = sk.to_public();
+    let address = interfaces::Address::;
+    let address = address::mk_account(Ed25519Extended::SECRET_BECH32_HRP, pk, true)?;
+    Ok(address)
+}
+
+fn create_receiver_secret_key_and_address(
+) -> Result<(SecretKey<Ed25519Extended>, interfaces::Address), Error> {
+    let pk = create_new_private_key()?;
+    let key = EitherEd25519SecretKey::Extended(pk.clone());
+    let address = create_receiver_address(&key)?;
+    Ok((pk, address))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -75,7 +111,7 @@ pub fn simplified_transaction(
     block0_file: PathBuf,
     rest_args: RestArgs,
     change: Option<interfaces::Address>,
-) -> Result<(), Error> {
+) -> Result<String, Error> {
     let mut transaction = Staging::new();
 
     // add account
@@ -120,5 +156,5 @@ pub fn simplified_transaction(
     let fragment = transaction.fragment()?;
     let fragment_id = rest::v0::message::post_fragment(rest_args, fragment)?;
 
-    Ok(())
+    Ok(fragment_id)
 }

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -1,13 +1,25 @@
+use crate::block::{load_block, open_block_file};
+use crate::jcli_lib::rest::RestArgs;
 use crate::jcli_lib::transaction::{common, Error};
-use crate::transaction;
+use crate::transaction::mk_witness::WitnessType;
 use crate::transaction::staging::Staging;
+use crate::utils::key_parser::read_ed25519_secret_key_from_file;
+use crate::utils::AccountId;
+use crate::{rest, transaction};
+use chain_impl_mockchain::account::SpendingCounter;
+use chain_impl_mockchain::key::EitherEd25519SecretKey;
 use chain_impl_mockchain::transaction::Output;
 use jormungandr_lib::interfaces;
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub struct SimplifiedTransaction {
+    /// the file path to the file to read the signing key from.
+    /// If omitted it will be read from the standard input.
+    pub secret: Option<PathBuf>,
+
     /// the account to debit the funds from
     #[structopt(name = "ACCOUNT")]
     pub faucet_address: interfaces::Address,
@@ -28,15 +40,25 @@ pub struct SimplifiedTransaction {
 
     /// Set the change in the given address
     pub change: Option<interfaces::Address>,
+
+    #[structopt(default_value = "block-0.bin")]
+    pub block0_path: PathBuf,
+
+    #[structopt(flatten)]
+    rest_args: RestArgs,
 }
 
 impl SimplifiedTransaction {
     pub fn exec(self) -> Result<(), Error> {
+        let secret_key = read_ed25519_secret_key_from_file(&self.secret)?;
         simplified_transaction(
             self.faucet_address,
             self.receiver_address,
+            secret_key,
             self.value,
             self.fee,
+            self.block0_path,
+            self.rest_args,
             self.change,
         )?;
         Ok(())
@@ -46,14 +68,17 @@ impl SimplifiedTransaction {
 pub fn simplified_transaction(
     faucet_address: interfaces::Address,
     receiver_address: interfaces::Address,
+    secret_key: EitherEd25519SecretKey,
     value: interfaces::Value,
     fee: common::CommonFees,
+    block0_file: PathBuf,
+    rest_args: RestArgs,
     change: Option<interfaces::Address>,
 ) -> Result<(), Error> {
     let mut transaction = Staging::new();
 
     // add account
-    transaction::add_account::add_account(faucet_address, value, &mut transaction)?;
+    transaction::add_account::add_account(faucet_address.clone(), value, &mut transaction)?;
 
     // add output
     transaction.add_output(Output {
@@ -63,6 +88,26 @@ pub fn simplified_transaction(
 
     //finalize
     transaction::finalize::finalize(fee, change, &mut transaction)?;
+
+    // get transaction and block0 ids
+    let transaction_sign_data_hash = transaction.transaction_sign_data_hash();
+    let block0 = load_block(open_block_file(&Some(block0_file))?)?;
+    let block0_hash = block0.header.id();
+
+    // get spending counter
+    let account_state = rest::v0::account::request_account_information(
+        rest_args,
+        AccountId::try_from_str(&faucet_address.to_string())?,
+    )?;
+
+    //make witness
+    let witness = transaction::mk_witness::make_witness(
+        &WitnessType::Account,
+        &block0_hash,
+        &transaction_sign_data_hash,
+        Some(SpendingCounter::from(account_state.counter())),
+        &secret_key,
+    )?;
 
     Ok(())
 }

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -84,12 +84,13 @@ impl MakeTransaction {
             self.force,
         )?;
 
-        transaction.store(&self.common.staging_file)?;
-
         if self.post {
             let fragment = transaction.fragment()?;
             let fragment_id = post_fragment(self.rest_args, fragment)?;
-            println!("{}", fragment_id);
+            println!("Posted fragment id: {}", fragment_id);
+        } else {
+            // if not posted make the transaction available as a file
+            transaction.store(&self.common.staging_file)?;
         }
 
         Ok(())

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -32,6 +32,10 @@ pub struct MakeTransaction {
     #[structopt(name = "VALUE")]
     pub value: interfaces::Value,
 
+    /// the account to debit the funds from
+    #[structopt(long)]
+    pub receiver_account: Option<interfaces::Address>,
+
     #[structopt(long)]
     pub block0_hash: String,
 
@@ -54,7 +58,12 @@ pub struct MakeTransaction {
 impl MakeTransaction {
     pub fn exec(self) -> Result<(), Error> {
         let secret_key = read_ed25519_secret_key_from_file(&self.secret)?;
-        let (_receiver_secret_key, receiver_address) = create_receiver_secret_key_and_address()?;
+        let receiver_address = if let Some(address) = self.receiver_account {
+            address
+        } else {
+            let (_, address) = create_receiver_secret_key_and_address()?;
+            address
+        };
         let transaction = make_transaction(
             self.sender_account,
             receiver_address,

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -22,10 +22,6 @@ use structopt::StructOpt;
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub struct MakeTransaction {
-    /// the file path to the file to read the signing key from.
-    /// If omitted it will be read from the standard input.
-    pub secret: Option<PathBuf>,
-
     /// the account to debit the funds from
     #[structopt(name = "ACCOUNT")]
     pub sender_account: interfaces::Address,
@@ -34,16 +30,20 @@ pub struct MakeTransaction {
     #[structopt(name = "VALUE")]
     pub value: interfaces::Value,
 
+    pub block0_hash: String,
+
+    /// the file path to the file to read the signing key from.
+    /// If omitted it will be read from the standard input.
+    pub secret: Option<PathBuf>,
+
+    /// Set the change in the given address
+    pub change: Option<interfaces::Address>,
+
     #[structopt(flatten)]
     pub common: common::CommonTransaction,
 
     #[structopt(flatten)]
     pub fee: common::CommonFees,
-
-    /// Set the change in the given address
-    pub change: Option<interfaces::Address>,
-
-    pub block0_hash: String,
 
     #[structopt(flatten)]
     rest_args: RestArgs,
@@ -65,12 +65,12 @@ impl MakeTransaction {
         )?;
         println!(
             "{}
-Private key of receiver (to revert transaction for testing purposes): {}
-To see if transaction is in block use:
-    jcli rest v0 message logs -h {host}
-To check new account balance:
-    jcli  rest v0 account get  {} -h {host}
-            ",
+        Private key of receiver (to revert transaction for testing purposes): {}
+        To see if transaction is in block use:
+            jcli rest v0 message logs -h {host}
+        To check new account balance:
+            jcli  rest v0 account get  {} -h {host}
+                    ",
             fragment_id,
             receiver_secret_key.to_bech32_str(),
             receiver_address,

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -32,13 +32,16 @@ pub struct MakeTransaction {
     #[structopt(name = "VALUE")]
     pub value: interfaces::Value,
 
+    #[structopt(long)]
     pub block0_hash: String,
 
     /// the file path to the file to read the signing key from.
     /// If omitted it will be read from the standard input.
+    #[structopt(long)]
     pub secret: Option<PathBuf>,
 
     /// Set the change in the given address
+    #[structopt(long)]
     pub change: Option<interfaces::Address>,
 
     #[structopt(flatten)]

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -116,7 +116,7 @@ pub fn make_transaction(
     let mut transaction = Staging::new();
 
     // add account
-    transaction::add_account::add_account(sender_account.clone(), value, &mut transaction)?;
+    transaction.add_account(sender_account.clone(), value)?;
 
     // add output
     transaction.add_output(Output {

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -104,7 +104,7 @@ fn create_receiver_secret_key_and_address(
 
 #[allow(clippy::too_many_arguments)]
 pub fn simplified_transaction(
-    faucet_address: interfaces::Address,
+    sender_account: interfaces::Address,
     receiver_address: interfaces::Address,
     secret_key: EitherEd25519SecretKey,
     value: interfaces::Value,
@@ -116,7 +116,7 @@ pub fn simplified_transaction(
     let mut transaction = Staging::new();
 
     // add account
-    transaction::add_account::add_account(faucet_address.clone(), value, &mut transaction)?;
+    transaction::add_account::add_account(sender_account.clone(), value, &mut transaction)?;
 
     // add output
     transaction.add_output(Output {
@@ -135,7 +135,7 @@ pub fn simplified_transaction(
     // get spending counter
     let account_state = rest::v0::account::request_account_information(
         rest_args.clone(),
-        AccountId::try_from_str(&faucet_address.to_string())?,
+        AccountId::try_from_str(&sender_account.to_string())?,
     )?;
 
     // make witness

--- a/jcli/src/jcli_lib/transaction/staging.rs
+++ b/jcli/src/jcli_lib/transaction/staging.rs
@@ -124,9 +124,7 @@ impl Staging {
             Kind::Account(key) => {
                 UnspecifiedAccountIdentifier::from_single_account(key.clone().into())
             }
-            Kind::Multisig(key) => {
-                UnspecifiedAccountIdentifier::from_multi_account(key.clone().into())
-            }
+            Kind::Multisig(key) => UnspecifiedAccountIdentifier::from_multi_account((*key).into()),
             Kind::Single(_) => return Err(Error::AccountAddressSingle),
             Kind::Group(_, _) => return Err(Error::AccountAddressGroup),
             Kind::Script(_) => return Err(Error::AccountAddressScript),

--- a/jcli/src/jcli_lib/transaction/staging.rs
+++ b/jcli/src/jcli_lib/transaction/staging.rs
@@ -7,7 +7,8 @@ use crate::jcli_lib::{
     transaction::Error,
     utils::io,
 };
-use chain_addr::Address;
+use chain_addr::{Address, Kind};
+use chain_impl_mockchain::transaction::UnspecifiedAccountIdentifier;
 use chain_impl_mockchain::{
     self as chain,
     certificate::{Certificate, CertificatePayload, PoolSignature, SignedCertificate},
@@ -111,6 +112,30 @@ impl Staging {
 
         self.outputs.push(output.into());
 
+        Ok(())
+    }
+
+    pub fn add_account(
+        &mut self,
+        account: interfaces::Address,
+        value: interfaces::Value,
+    ) -> Result<(), Error> {
+        let account_id = match Address::from(account).kind() {
+            Kind::Account(key) => {
+                UnspecifiedAccountIdentifier::from_single_account(key.clone().into())
+            }
+            Kind::Multisig(key) => {
+                UnspecifiedAccountIdentifier::from_multi_account(key.clone().into())
+            }
+            Kind::Single(_) => return Err(Error::AccountAddressSingle),
+            Kind::Group(_, _) => return Err(Error::AccountAddressGroup),
+            Kind::Script(_) => return Err(Error::AccountAddressScript),
+        };
+
+        self.add_input(interfaces::TransactionInput {
+            input: interfaces::TransactionInputType::Account(account_id.into()),
+            value,
+        })?;
         Ok(())
     }
 

--- a/jcli/src/jcli_lib/utils/io.rs
+++ b/jcli/src/jcli_lib/utils/io.rs
@@ -69,6 +69,7 @@ pub fn read_yaml<D: DeserializeOwned>(path: &Option<impl AsRef<Path>>) -> Result
 pub fn ask_yes_or_no(with_output: bool) -> std::io::Result<bool> {
     if with_output {
         print!("Continue? Yes[y] or No[n]? ");
+        std::io::stdout().flush()?;
     }
     let mut buff = String::new();
     std::io::stdin().read_line(&mut buff)?;

--- a/jcli/src/jcli_lib/utils/io.rs
+++ b/jcli/src/jcli_lib/utils/io.rs
@@ -68,7 +68,7 @@ pub fn read_yaml<D: DeserializeOwned>(path: &Option<impl AsRef<Path>>) -> Result
 
 pub fn ask_yes_or_no(with_output: bool) -> std::io::Result<bool> {
     if with_output {
-        println!("Continue? Yes[y] or No[n]?");
+        printl!("Continue? Yes[y] or No[n]? ");
     }
     let mut buff = String::new();
     std::io::stdin().read_line(&mut buff)?;

--- a/jcli/src/jcli_lib/utils/io.rs
+++ b/jcli/src/jcli_lib/utils/io.rs
@@ -65,3 +65,12 @@ pub fn read_yaml<D: DeserializeOwned>(path: &Option<impl AsRef<Path>>) -> Result
     let yaml = serde_yaml::from_reader(reader)?;
     Ok(yaml)
 }
+
+pub fn ask_yes_or_no(with_output: bool) -> std::io::Result<bool> {
+    if with_output {
+        println!("Continue? Yes[y] or No[n]?");
+    }
+    let mut buff = String::new();
+    std::io::stdin().read_line(&mut buff)?;
+    Ok(matches!(buff.to_ascii_lowercase().as_str(), "yes" | "y"))
+}

--- a/jcli/src/jcli_lib/utils/io.rs
+++ b/jcli/src/jcli_lib/utils/io.rs
@@ -68,7 +68,7 @@ pub fn read_yaml<D: DeserializeOwned>(path: &Option<impl AsRef<Path>>) -> Result
 
 pub fn ask_yes_or_no(with_output: bool) -> std::io::Result<bool> {
     if with_output {
-        printl!("Continue? Yes[y] or No[n]? ");
+        print!("Continue? Yes[y] or No[n]? ");
     }
     let mut buff = String::new();
     std::io::stdin().read_line(&mut buff)?;

--- a/jcli/src/jcli_lib/utils/io.rs
+++ b/jcli/src/jcli_lib/utils/io.rs
@@ -72,5 +72,5 @@ pub fn ask_yes_or_no(with_output: bool) -> std::io::Result<bool> {
     }
     let mut buff = String::new();
     std::io::stdin().read_line(&mut buff)?;
-    Ok(matches!(buff.to_ascii_lowercase().as_str(), "yes" | "y"))
+    Ok(matches!(buff.to_ascii_lowercase().trim_end(), "yes" | "y"))
 }

--- a/jcli/src/jcli_lib/utils/mod.rs
+++ b/jcli/src/jcli_lib/utils/mod.rs
@@ -1,5 +1,4 @@
-mod account_id;
-
+pub mod account_id;
 pub mod io;
 pub mod key_parser;
 pub mod output_file;

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
@@ -279,6 +279,7 @@ impl Transaction {
         self.command.seal(staging_file).build().assert().success();
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn make_transaction(
         self,
         host: String,

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
@@ -283,13 +283,22 @@ impl Transaction {
         self,
         host: String,
         sender: jormungandr_lib::interfaces::Address,
+        receiver: Option<jormungandr_lib::interfaces::Address>,
         value: jormungandr_lib::interfaces::Value,
         block0_hash: String,
         secret: impl AsRef<Path>,
         staging_file: impl AsRef<Path>,
     ) {
         self.command
-            .make_transaction(host, sender, value, block0_hash, secret, staging_file)
+            .make_transaction(
+                host,
+                sender,
+                receiver,
+                value,
+                block0_hash,
+                secret,
+                staging_file,
+            )
             .build()
             .assert()
             .success();

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
@@ -279,6 +279,22 @@ impl Transaction {
         self.command.seal(staging_file).build().assert().success();
     }
 
+    pub fn make_transaction(
+        self,
+        host: String,
+        sender: jormungandr_lib::interfaces::Address,
+        value: jormungandr_lib::interfaces::Value,
+        block0_hash: String,
+        secret: impl AsRef<Path>,
+        staging_file: impl AsRef<Path>,
+    ) {
+        self.command
+            .make_transaction(host, sender, value, block0_hash, secret, staging_file)
+            .build()
+            .assert()
+            .success();
+    }
+
     pub fn convert_to_message<P: AsRef<Path>>(self, staging_file: P) -> String {
         self.command
             .to_message(staging_file)

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
@@ -289,6 +289,7 @@ impl Transaction {
         block0_hash: String,
         secret: impl AsRef<Path>,
         staging_file: impl AsRef<Path>,
+        post: bool,
     ) {
         self.command
             .make_transaction(
@@ -299,6 +300,7 @@ impl Transaction {
                 block0_hash,
                 secret,
                 staging_file,
+                post,
             )
             .build()
             .assert()

--- a/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
@@ -209,9 +209,7 @@ impl TransactionCommand {
             .arg(block0_hash);
 
         if let Some(receiver) = receiver {
-            self.command
-                .arg("--receiver-account")
-                .arg(receiver.to_string());
+            self.command.arg("--receiver").arg(receiver.to_string());
         };
         self.command.arg(sender.to_string()).arg(value.to_string());
         self

--- a/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
@@ -190,6 +190,7 @@ impl TransactionCommand {
         mut self,
         host: String,
         sender: jormungandr_lib::interfaces::Address,
+        receiver: Option<jormungandr_lib::interfaces::Address>,
         value: jormungandr_lib::interfaces::Value,
         block0_hash: String,
         secret: impl AsRef<Path>,
@@ -204,9 +205,14 @@ impl TransactionCommand {
             .arg("--host")
             .arg(host)
             .arg("--block0-hash")
-            .arg(block0_hash)
-            .arg(sender.to_string())
-            .arg(value.to_string());
+            .arg(block0_hash);
+
+        if let Some(receiver) = receiver {
+            self.command
+                .arg("--receiver-account")
+                .arg(receiver.to_string());
+        };
+        self.command.arg(sender.to_string()).arg(value.to_string());
         self
     }
 

--- a/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
@@ -186,6 +186,7 @@ impl TransactionCommand {
         self
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn make_transaction(
         mut self,
         host: String,

--- a/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
@@ -206,7 +206,8 @@ impl TransactionCommand {
             .arg("--host")
             .arg(host)
             .arg("--block0-hash")
-            .arg(block0_hash);
+            .arg(block0_hash)
+            .arg("--force");
 
         if let Some(receiver) = receiver {
             self.command.arg("--receiver").arg(receiver.to_string());

--- a/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
@@ -186,6 +186,30 @@ impl TransactionCommand {
         self
     }
 
+    pub fn make_transaction(
+        mut self,
+        host: String,
+        sender: jormungandr_lib::interfaces::Address,
+        value: jormungandr_lib::interfaces::Value,
+        block0_hash: String,
+        secret: impl AsRef<Path>,
+        staging_file: impl AsRef<Path>,
+    ) -> Self {
+        self.command
+            .arg("make-transaction")
+            .arg("--secret")
+            .arg(secret.as_ref())
+            .arg("--staging")
+            .arg(staging_file.as_ref())
+            .arg("--host")
+            .arg(host)
+            .arg("--block0-hash")
+            .arg(block0_hash)
+            .arg(sender.to_string())
+            .arg(value.to_string());
+        self
+    }
+
     pub fn build(self) -> Command {
         println!("{:?}", self.command);
         self.command

--- a/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
@@ -196,6 +196,7 @@ impl TransactionCommand {
         block0_hash: String,
         secret: impl AsRef<Path>,
         staging_file: impl AsRef<Path>,
+        post: bool,
     ) -> Self {
         self.command
             .arg("make-transaction")
@@ -209,9 +210,13 @@ impl TransactionCommand {
             .arg(block0_hash)
             .arg("--force");
 
+        if post {
+            self.command.arg("--post");
+        }
         if let Some(receiver) = receiver {
             self.command.arg("--receiver").arg(receiver.to_string());
         };
+
         self.command.arg(sender.to_string()).arg(value.to_string());
         self
     }

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/mod.rs
@@ -1,3 +1,4 @@
 pub mod e2e;
 pub mod finalize;
 pub mod input;
+pub mod simplified;

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
@@ -48,6 +48,7 @@ pub fn test_make_test_transaction() {
         block0_hash.to_string(),
         sk_file_path,
         staging_file,
+        false,
     );
 }
 
@@ -93,6 +94,7 @@ pub fn test_make_transaction_to_receiver_account() {
         block0_hash.to_string(),
         sk_file_path,
         staging_file,
+        false,
     );
 }
 
@@ -139,5 +141,53 @@ pub fn test_make_transaction_to_receiver_account_with_fees() {
         block0_hash.to_string(),
         sk_file_path,
         staging_file,
+        false,
+    );
+}
+
+#[test]
+pub fn test_make_transaction_to_receiver_account_with_fees_and_post() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let jcli: JCli = Default::default();
+    let sender = startup::create_new_account_address();
+    let receiver = startup::create_new_account_address();
+
+    let sk_file_path = temp_dir.join("sender.sk");
+
+    {
+        let mut sk_file = std::fs::File::create(&sk_file_path).unwrap();
+        sk_file
+            .write_all(sender.signing_key_to_string().as_bytes())
+            .unwrap();
+    }
+
+    let staging_file = temp_dir.join("staging.txt");
+
+    let config = ConfigurationBuilder::new()
+        .with_funds(vec![InitialUTxO {
+            address: sender.address(),
+            value: 111.into(),
+        }])
+        .with_linear_fees(LinearFee::new(10, 0, 0))
+        .build(&temp_dir);
+
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
+
+    let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
+
+    jcli.transaction().make_transaction(
+        jormungandr.rest_uri(),
+        sender.address(),
+        Some(receiver.address()),
+        100.into(),
+        block0_hash.to_string(),
+        sk_file_path,
+        staging_file,
+        true,
     );
 }

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
@@ -1,0 +1,50 @@
+use crate::common::jormungandr::ConfigurationBuilder;
+use crate::common::{jcli::JCli, jormungandr::starter::Starter, startup};
+use jormungandr_lib::crypto::hash::Hash;
+use jormungandr_lib::interfaces::InitialUTxO;
+
+use assert_fs::TempDir;
+use std::io::Write;
+
+#[test]
+pub fn test_make_test_transaction() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let jcli: JCli = Default::default();
+    let sender = startup::create_new_account_address();
+
+    let sk_file_path = temp_dir.join("sender.sk");
+
+    {
+        let mut sk_file = std::fs::File::create(&sk_file_path).unwrap();
+        sk_file
+            .write_all(sender.signing_key_to_string().as_bytes())
+            .unwrap();
+    }
+
+    let staging_file = temp_dir.join("staging.txt");
+
+    let config = ConfigurationBuilder::new()
+        .with_funds(vec![InitialUTxO {
+            address: sender.address(),
+            value: 100.into(),
+        }])
+        .build(&temp_dir);
+
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
+
+    let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
+
+    jcli.transaction().make_transaction(
+        jormungandr.rest_uri(),
+        sender.address(),
+        100.into(),
+        block0_hash.to_string(),
+        sk_file_path,
+        staging_file,
+    );
+}

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
@@ -118,7 +118,7 @@ pub fn test_make_transaction_to_receiver_account_with_fees() {
     let config = ConfigurationBuilder::new()
         .with_funds(vec![InitialUTxO {
             address: sender.address(),
-            value: 1000.into(),
+            value: 111.into(),
         }])
         .with_linear_fees(LinearFee::new(10, 0, 0))
         .build(&temp_dir);

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
@@ -42,6 +42,52 @@ pub fn test_make_test_transaction() {
     jcli.transaction().make_transaction(
         jormungandr.rest_uri(),
         sender.address(),
+        None,
+        100.into(),
+        block0_hash.to_string(),
+        sk_file_path,
+        staging_file,
+    );
+}
+
+#[test]
+pub fn test_make_transaction_to_receiver_account() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let jcli: JCli = Default::default();
+    let sender = startup::create_new_account_address();
+    let receiver = startup::create_new_account_address();
+
+    let sk_file_path = temp_dir.join("sender.sk");
+
+    {
+        let mut sk_file = std::fs::File::create(&sk_file_path).unwrap();
+        sk_file
+            .write_all(sender.signing_key_to_string().as_bytes())
+            .unwrap();
+    }
+
+    let staging_file = temp_dir.join("staging.txt");
+
+    let config = ConfigurationBuilder::new()
+        .with_funds(vec![InitialUTxO {
+            address: sender.address(),
+            value: 100.into(),
+        }])
+        .build(&temp_dir);
+
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
+
+    let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
+
+    jcli.transaction().make_transaction(
+        jormungandr.rest_uri(),
+        sender.address(),
+        Some(receiver.address()),
         100.into(),
         block0_hash.to_string(),
         sk_file_path,

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/simplified.rs
@@ -4,6 +4,7 @@ use jormungandr_lib::crypto::hash::Hash;
 use jormungandr_lib::interfaces::InitialUTxO;
 
 use assert_fs::TempDir;
+use chain_impl_mockchain::fee::LinearFee;
 use std::io::Write;
 
 #[test]
@@ -74,6 +75,52 @@ pub fn test_make_transaction_to_receiver_account() {
             address: sender.address(),
             value: 100.into(),
         }])
+        .build(&temp_dir);
+
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
+
+    let block0_hash = Hash::from_hex(config.genesis_block_hash()).unwrap();
+
+    jcli.transaction().make_transaction(
+        jormungandr.rest_uri(),
+        sender.address(),
+        Some(receiver.address()),
+        100.into(),
+        block0_hash.to_string(),
+        sk_file_path,
+        staging_file,
+    );
+}
+
+#[test]
+pub fn test_make_transaction_to_receiver_account_with_fees() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let jcli: JCli = Default::default();
+    let sender = startup::create_new_account_address();
+    let receiver = startup::create_new_account_address();
+
+    let sk_file_path = temp_dir.join("sender.sk");
+
+    {
+        let mut sk_file = std::fs::File::create(&sk_file_path).unwrap();
+        sk_file
+            .write_all(sender.signing_key_to_string().as_bytes())
+            .unwrap();
+    }
+
+    let staging_file = temp_dir.join("staging.txt");
+
+    let config = ConfigurationBuilder::new()
+        .with_funds(vec![InitialUTxO {
+            address: sender.address(),
+            value: 1000.into(),
+        }])
+        .with_linear_fees(LinearFee::new(10, 0, 0))
         .build(&temp_dir);
 
     let jormungandr = Starter::new()


### PR DESCRIPTION
I'm starting this as a draft. It is a close example of what jcli path to being a lib should lead to. 

The simplified transaction command uses several of the other transaction commands.
I started extracting the common code into external functions. Also stripping some functionality like reading and writing to files that shouldn't be within the reusable computations.
