### PR TITLE
Adjust quarantine tests

### DIFF
--- a/testing/jormungandr-integration-tests/src/common/network/builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/builder.rs
@@ -151,7 +151,3 @@ pub fn wallet(alias: &str) -> WalletTemplateBuilder {
         discrimination: Discrimination::Test,
     }
 }
-
-pub fn params(alias: &str) -> SpawnParams {
-    SpawnParams::new(&alias)
-}

--- a/testing/jormungandr-integration-tests/src/common/network/builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/builder.rs
@@ -2,6 +2,7 @@ use super::{Controller, ControllerError};
 use chain_addr::Discrimination;
 use chain_impl_mockchain::value::Value;
 use chain_impl_mockchain::{chaintypes::ConsensusVersion, milli::Milli};
+use jormungandr_lib::crypto::key::SigningKey;
 use jormungandr_lib::interfaces::{
     ActiveSlotCoefficient, KesUpdateSpeed, NodeSecret, NumberOfSlotsPerEpoch, SlotDuration,
 };
@@ -72,6 +73,7 @@ impl NetworkBuilder {
                             bft: None,
                             genesis: None,
                         },
+                        topology_secret: SigningKey::generate(&mut rand::thread_rng()),
                         node_topology: template,
                     },
                 )

--- a/testing/jormungandr-integration-tests/src/common/network/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/mod.rs
@@ -1,5 +1,5 @@
 mod builder;
 mod controller;
 
-pub use builder::{builder, params, wallet};
+pub use builder::{builder, wallet};
 pub use controller::{Controller, ControllerError};

--- a/testing/jormungandr-integration-tests/src/networking/p2p.rs
+++ b/testing/jormungandr-integration-tests/src/networking/p2p.rs
@@ -1,6 +1,6 @@
 use crate::common::{
     jormungandr::process::JormungandrProcess,
-    network::{self, params, wallet},
+    network::{self, wallet},
 };
 
 use jormungandr_lib::{
@@ -9,6 +9,7 @@ use jormungandr_lib::{
     },
     time::Duration,
 };
+use jormungandr_testing_utils::testing::network_builder::SpawnParams;
 use jortestkit::process as process_utils;
 const CLIENT: &str = "CLIENT";
 const SERVER: &str = "SERVER";
@@ -129,7 +130,9 @@ pub fn node_whitelist_itself() {
             wallet("delegated1").with(1_000_000).delegated_to(CLIENT),
             wallet("delegated2").with(1_000_000).delegated_to(SERVER),
         ])
-        .custom_config(vec![params(CLIENT).explorer(Explorer { enabled: true })])
+        .custom_config(vec![
+            SpawnParams::new(CLIENT).explorer(Explorer { enabled: true })
+        ])
         .build()
         .unwrap();
 
@@ -146,7 +149,12 @@ pub fn node_whitelist_itself() {
     };
 
     let client = network_controller
-        .spawn_custom(params(CLIENT).policy(policy))
+        .spawn_custom(
+            network_controller
+                .spawn_params(CLIENT)
+                .unwrap()
+                .policy(policy),
+        )
         .unwrap();
     client.assert_no_errors_in_log();
 }
@@ -159,7 +167,9 @@ pub fn node_does_not_quarantine_whitelisted_node() {
             wallet("delegated1").with(1_000_000).delegated_to(CLIENT),
             wallet("delegated2").with(1_000_000).delegated_to(SERVER),
         ])
-        .custom_config(vec![params(CLIENT).explorer(Explorer { enabled: true })])
+        .custom_config(vec![
+            SpawnParams::new(CLIENT).explorer(Explorer { enabled: true })
+        ])
         .build()
         .unwrap();
 
@@ -176,7 +186,12 @@ pub fn node_does_not_quarantine_whitelisted_node() {
     };
 
     let client = network_controller
-        .spawn_custom(params(CLIENT).policy(policy))
+        .spawn_custom(
+            network_controller
+                .spawn_params(CLIENT)
+                .unwrap()
+                .policy(policy),
+        )
         .unwrap();
 
     server.shutdown();
@@ -200,7 +215,9 @@ pub fn node_put_in_quarantine_nodes_which_are_not_whitelisted() {
             wallet("delegated1").with(1_000_000).delegated_to(CLIENT),
             wallet("delegated2").with(1_000_000).delegated_to(SERVER),
         ])
-        .custom_config(vec![params(CLIENT).explorer(Explorer { enabled: true })])
+        .custom_config(vec![
+            SpawnParams::new(CLIENT).explorer(Explorer { enabled: true })
+        ])
         .build()
         .unwrap();
 
@@ -217,7 +234,12 @@ pub fn node_put_in_quarantine_nodes_which_are_not_whitelisted() {
     };
 
     let client = network_controller
-        .spawn_custom(params(CLIENT).policy(policy))
+        .spawn_custom(
+            network_controller
+                .spawn_params(CLIENT)
+                .unwrap()
+                .policy(policy),
+        )
         .unwrap();
 
     server.shutdown();
@@ -257,7 +279,9 @@ pub fn node_trust_itself() {
             wallet("delegated1").with(1_000_000).delegated_to(CLIENT),
             wallet("delegated2").with(1_000_000).delegated_to(SERVER),
         ])
-        .custom_config(vec![params(CLIENT).explorer(Explorer { enabled: true })])
+        .custom_config(vec![
+            SpawnParams::new(CLIENT).explorer(Explorer { enabled: true })
+        ])
         .build()
         .unwrap();
 
@@ -305,7 +329,10 @@ pub fn node_put_itself_in_preffered_layers() {
 
     assert!(network_controller
         .expect_spawn_failed(
-            params(CLIENT).preferred_layer(layer),
+            network_controller
+                .spawn_params(CLIENT)
+                .unwrap()
+                .preferred_layer(layer),
             "topology tells the node to connect to itself"
         )
         .is_ok());
@@ -339,8 +366,8 @@ pub fn topic_of_interest_influences_node_sync_ability() {
                 .delegated_to(slow_client_alias),
         ])
         .custom_config(vec![
-            params(fast_client_alias).topics_of_interest(high_topic_of_interests),
-            params(slow_client_alias).topics_of_interest(low_topic_of_interests),
+            SpawnParams::new(fast_client_alias).topics_of_interest(high_topic_of_interests),
+            SpawnParams::new(slow_client_alias).topics_of_interest(low_topic_of_interests),
         ])
         .build()
         .unwrap();

--- a/testing/jormungandr-integration-tests/src/networking/p2p.rs
+++ b/testing/jormungandr-integration-tests/src/networking/p2p.rs
@@ -149,12 +149,7 @@ pub fn node_whitelist_itself() {
     };
 
     let client = network_controller
-        .spawn_custom(
-            network_controller
-                .spawn_params(CLIENT)
-                .unwrap()
-                .policy(policy),
-        )
+        .spawn_custom(network_controller.spawn_params(CLIENT).policy(policy))
         .unwrap();
     client.assert_no_errors_in_log();
 }
@@ -186,12 +181,7 @@ pub fn node_does_not_quarantine_whitelisted_node() {
     };
 
     let client = network_controller
-        .spawn_custom(
-            network_controller
-                .spawn_params(CLIENT)
-                .unwrap()
-                .policy(policy),
-        )
+        .spawn_custom(network_controller.spawn_params(CLIENT).policy(policy))
         .unwrap();
 
     server.shutdown();
@@ -234,12 +224,7 @@ pub fn node_put_in_quarantine_nodes_which_are_not_whitelisted() {
     };
 
     let client = network_controller
-        .spawn_custom(
-            network_controller
-                .spawn_params(CLIENT)
-                .unwrap()
-                .policy(policy),
-        )
+        .spawn_custom(network_controller.spawn_params(CLIENT).policy(policy))
         .unwrap();
 
     server.shutdown();
@@ -287,7 +272,7 @@ pub fn node_trust_itself() {
 
     let _server = network_controller.spawn_and_wait(SERVER);
 
-    let config = network_controller.node_config(CLIENT).unwrap().p2p.clone();
+    let config = network_controller.node_config(CLIENT).unwrap().p2p;
 
     let peer = TrustedPeer {
         address: config.public_address,
@@ -295,7 +280,9 @@ pub fn node_trust_itself() {
     };
     network_controller
         .expect_spawn_failed(
-            params(CLIENT).trusted_peers(vec![peer]),
+            network_controller
+                .spawn_params(CLIENT)
+                .trusted_peers(vec![peer]),
             "failed to retrieve the list of bootstrap peers from trusted peer",
         )
         .unwrap();
@@ -315,7 +302,7 @@ pub fn node_put_itself_in_preffered_layers() {
 
     let _server = network_controller.spawn_and_wait(SERVER);
 
-    let config = network_controller.node_config(CLIENT).unwrap().p2p.clone();
+    let config = network_controller.node_config(CLIENT).unwrap().p2p;
 
     let peer = TrustedPeer {
         address: config.public_address,
@@ -331,7 +318,6 @@ pub fn node_put_itself_in_preffered_layers() {
         .expect_spawn_failed(
             network_controller
                 .spawn_params(CLIENT)
-                .unwrap()
                 .preferred_layer(layer),
             "topology tells the node to connect to itself"
         )

--- a/testing/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -8,7 +8,7 @@ use chain_impl_mockchain::{
     vote::PayloadType,
 };
 
-use jormungandr_lib::crypto::account::Identifier;
+use jormungandr_lib::crypto::{account::Identifier, key::SigningKey};
 use jormungandr_lib::interfaces::try_initials_vec_from_messages;
 use jormungandr_lib::{
     interfaces::{
@@ -272,6 +272,7 @@ impl PrepareNodeSettings for NodeSetting {
             alias,
             config: NodeConfig::prepare(context),
             secret: NodeSecret::prepare(context),
+            topology_secret: SigningKey::generate(&mut rand::thread_rng()),
             node_topology: template.clone(),
         }
     }

--- a/testing/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
+++ b/testing/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
@@ -137,6 +137,9 @@ pub fn passive_leader_disruption_overlap(
     // 2. Only leader is up
     passive.shutdown()?;
 
+    // Wait a bit so that the leader can indeed notice that passive is offline
+    utils::wait(15);
+
     // 3. Both nodes are up
     let passive = controller.spawn_node(
         PASSIVE,
@@ -206,7 +209,7 @@ pub fn leader_leader_disruption_overlap(mut context: Context<ChaChaRng>) -> Resu
 
     // 3. second node is down
     leader2.shutdown()?;
-    utils::wait(5);
+    utils::wait(15);
 
     // 4. both nodes are up
     let leader2 = controller.spawn_node(

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
@@ -34,6 +34,8 @@ pub struct NodeSetting {
 
     pub config: NodeConfig,
 
+    pub topology_secret: SigningKey<Ed25519>,
+
     pub node_topology: NodeTemplate,
 }
 
@@ -42,12 +44,14 @@ impl NodeSetting {
         alias: NodeAlias,
         config: NodeConfig,
         secret: NodeSecret,
+        topology_secret: SigningKey<Ed25519>,
         template: NodeTemplate,
     ) -> Self {
         Self {
             alias,
             config,
             secret,
+            topology_secret,
             node_topology: template,
         }
     }

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/spawn_params.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/spawn_params.rs
@@ -28,6 +28,7 @@ pub struct SpawnParams {
     pub version: Option<Version>,
     pub bootstrap_from_peers: Option<bool>,
     pub skip_bootstrap: Option<bool>,
+    pub node_key_file: Option<PathBuf>,
 }
 
 impl SpawnParams {
@@ -50,6 +51,7 @@ impl SpawnParams {
             version: None,
             bootstrap_from_peers: None,
             skip_bootstrap: None,
+            node_key_file: None,
         }
     }
 
@@ -168,6 +170,11 @@ impl SpawnParams {
         self
     }
 
+    pub fn node_key_file(&mut self, node_key_file: PathBuf) -> &mut Self {
+        self.node_key_file = Some(node_key_file);
+        self
+    }
+
     pub fn get_jormungandr(&self) -> &Option<PathBuf> {
         &self.jormungandr
     }
@@ -233,6 +240,10 @@ impl SpawnParams {
 
         if let Some(skip_bootstrap) = &self.skip_bootstrap {
             node_config.skip_bootstrap = Some(*skip_bootstrap);
+        }
+
+        if let Some(node_key_file) = &self.node_key_file {
+            node_config.p2p.node_key_file = Some(node_key_file.clone());
         }
     }
 }


### PR DESCRIPTION
Quarantine / disruption tests were not working as expected (by that I mean that they were passing, but not testing what they were meant to test), because quarantine is now based on the node id and if a node is not provided with a node_key it will generate a random one each time, thus making a restart appear as another node joining the network.

There are now 2 failing scenario tests, `point_to_point_disruption_overlap` and `leader_leader_disruption_overlap`, where a root node without trusted peers is restarted,  for which a fix is being discussed here https://github.com/input-output-hk/jormungandr/issues/3229 .