### PR TITLE
Update config documentation about logs

### DIFF
--- a/doc/configuration/introduction.md
+++ b/doc/configuration/introduction.md
@@ -15,13 +15,9 @@ Example Configuration - 1:
 ```YAML
 ---
 log:
-  - output: stderr
-    level:  info
-    format: plain
-  - output:
-      file: example.log
-    level: info
-    format: json
+  output: stderr
+  level:  info
+  format: plain
 
 http_fetch_block0_service:
   - https://url/jormungandr-block0/raw/master/data

--- a/doc/configuration/logging.md
+++ b/doc/configuration/logging.md
@@ -22,6 +22,8 @@ The following options are available in the `log` section:
 
 A single configurable backend is supported.
 
+
+### Output to stdout
 ```yaml
 log:
   output: stdout
@@ -29,6 +31,7 @@ log:
   format: plain
 ```
 
+### Output to a file
 ```yaml
 log:
   output:

--- a/doc/configuration/logging.md
+++ b/doc/configuration/logging.md
@@ -24,14 +24,15 @@ A single configurable backend is supported.
 
 ```yaml
 log:
-  - output: stdout
-    level:  trace
-    format: plain
+  output: stdout
+  level:  trace
+  format: plain
 ```
 
 ```yaml
-  - output:
+log:
+  output:
     file: example.log
-    level: info
-    format: json
+  level: info
+  format: json
 ```


### PR DESCRIPTION
This updates docs that were missing after changes were made to use a single backend for logging (see #3145 )

This addresses the bug reported in #3235.