### PR TITLE
ci/docs: fix permissions for mdbook-linkcheck

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,5 @@
 name: Build and publish docs
+
 on:
   push:
     branches:
@@ -23,6 +24,7 @@ jobs:
           gh release --repo Michael-F-Bryan/mdbook-linkcheck download --pattern '*x86_64-unknown-linux-gnu.zip'
           unzip *x86_64-unknown-linux-gnu.zip
           rm *x86_64-unknown-linux-gnu.zip
+          chmod +x ./mdbook-linkcheck
           echo $GITHUB_WORKSPACE/mdbook-linkcheck >> $GITHUB_PATH
 
       - name: Setup mdBook


### PR DESCRIPTION
Recent failures in the docs workflow (see
https://github.com/input-output-hk/jormungandr/runs/2506718320) were
caused by a permissions issue:

        Error: -05 06:06:26 [ERROR] (mdbook::utils): Error: Rendering failed
        Error: -05 06:06:26 [ERROR] (mdbook::utils): 	Caused By: Unable to start the backend
        Error: -05 06:06:26 [ERROR] (mdbook::utils): 	Caused By: Permission denied (os error 13)
        Error: Process completed with exit code 101.

After unzipping files do not have the permissions that allow executing
them, see example from my machine after reproducing that workflow:

        total 12212
        -rw-r--r--. 1 1070 Feb 26 17:35 LICENSE
        -rw-r--r--. 1 12489480 Feb 26 17:35 mdbook-linkcheck
        -rw-r--r--. 1 5238 Feb 26 17:35 README.md