### PR TITLE
Ignore legacy test

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
@@ -19,6 +19,7 @@ use jormungandr_testing_utils::{
 use assert_fs::TempDir;
 
 #[test]
+#[ignore]
 pub fn test_legacy_node_all_fragments() {
     let temp_dir = TempDir::new().unwrap();
     let jcli: JCli = Default::default();


### PR DESCRIPTION
We are doing quite a few breaking config changes atm and AFAIK we have no legacy compatibility commitment, let's disable it until we are interested in this again.