### PR TITLE
Bft desync

### DIFF
--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -271,6 +271,7 @@ where
                         branch.clone(),
                         parent_tip.clone(),
                         None,
+                        None,
                     )
                     .await
                     {
@@ -283,7 +284,7 @@ where
     }
 
     if let Some(parent_tip) = maybe_parent_tip {
-        blockchain::process_new_ref(&mut blockchain, branch, parent_tip, None)
+        blockchain::process_new_ref(&mut blockchain, branch, parent_tip, None, None)
             .await
             .map_err(Error::ChainSelectionFailed)
     } else {

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -21,7 +21,8 @@ use jormungandr_lib::{
 };
 pub use jormungandr_testing_utils::testing::{
     network_builder::{
-        LeadershipMode, NodeAlias, NodeBlock0, NodeSetting, PersistenceMode, Settings,
+        FaketimeConfig, LeadershipMode, NodeAlias, NodeBlock0, NodeSetting, PersistenceMode,
+        Settings,
     },
     node::{
         grpc::{client::MockClientError, JormungandrClient},
@@ -260,6 +261,10 @@ impl NodeController {
         self.grpc_client
             .pull_blocks_to_tip(from)
             .map_err(Error::InvalidGrpcCall)
+    }
+
+    pub fn rest(&self) -> JormungandrRest {
+        self.rest_client.clone()
     }
 
     pub fn network_stats(&self) -> Result<Vec<PeerStats>> {
@@ -675,6 +680,7 @@ pub struct SpawnBuilder<'a, R: RngCore, N> {
     block0: NodeBlock0,
     working_dir: PathBuf,
     peristence_mode: PersistenceMode,
+    faketime: Option<FaketimeConfig>,
     phantom_data: PhantomData<N>,
 }
 
@@ -699,6 +705,7 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
             working_dir: PathBuf::new(),
             peristence_mode: PersistenceMode::Persistent,
             phantom_data: PhantomData,
+            faketime: None,
         }
     }
 
@@ -713,6 +720,11 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
 
     pub fn alias<S: Into<String>>(&mut self, alias: S) -> &mut Self {
         self.alias = alias.into();
+        self
+    }
+
+    pub fn faketime(&mut self, faketime: FaketimeConfig) -> &mut Self {
+        self.faketime = Some(faketime);
         self
     }
 
@@ -778,7 +790,14 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
         config_file: P,
         config_secret: Q,
     ) -> Command {
-        let mut command = Command::new(self.jormungandr.clone());
+        let mut command = if let Some(faketime) = &self.faketime {
+            let mut cmd = Command::new("faketime");
+            cmd.args(&["-f", &format!("{:+}s", faketime.offset)]);
+            cmd.arg(self.jormungandr.clone());
+            cmd
+        } else {
+            Command::new(self.jormungandr.clone())
+        };
 
         command.arg("--config");
         command.arg(config_file.as_ref());

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -792,7 +792,12 @@ impl<'a, R: RngCore, N> SpawnBuilder<'a, R, N> {
     ) -> Command {
         let mut command = if let Some(faketime) = &self.faketime {
             let mut cmd = Command::new("faketime");
-            cmd.args(&["-f", &format!("{:+}s", faketime.offset)]);
+            let arg = if faketime.drift > f32::MIN_POSITIVE {
+                format!("{:+}s x{}", faketime.offset, faketime.drift)
+            } else {
+                format!("{:+}s", faketime.offset)
+            };
+            cmd.args(&["-f", &arg]);
             cmd.arg(self.jormungandr.clone());
             cmd
         } else {

--- a/testing/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -424,6 +424,9 @@ impl Controller {
             .block0(block0_setting)
             .working_dir(self.node_dir(&params.get_alias()).path())
             .peristence_mode(params.get_persistence_mode());
+        if let Some(faketime) = params.faketime.take() {
+            spawn_builder.faketime(faketime);
+        }
         let node = spawn_builder.build()?;
 
         Ok(node.controller())

--- a/testing/jormungandr-scenario-tests/src/scenario/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/mod.rs
@@ -76,6 +76,7 @@ macro_rules! prepare_scenario {
                     $(proposal adds $action_value:tt to $action_target:tt with $proposal_options_count:tt vote options),+ $(,)*
                 ]
             )*],)?
+            $(block_content_max_size = $block_content_max_size:expr)?
         }
     ) => {{
         let mut builder = $crate::scenario::ControllerBuilder::new($title);
@@ -103,6 +104,10 @@ macro_rules! prepare_scenario {
             let node_leader = $node_leader.to_owned();
             blockchain.add_leader(node_leader);
         )*
+
+        $(
+            blockchain.set_block_max_content_size($block_content_max_size);
+        )?
 
         $(
             let wallet = {

--- a/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
@@ -176,6 +176,7 @@ fn scenarios_repository() -> Vec<Scenario> {
             transaction_to_passive,
             vec![Tag::Short],
         ),
+        Scenario::new("bft_forks", bft_forks, vec![Tag::Short]),
         Scenario::new("interactive", interactive, vec![Tag::Interactive]),
         Scenario::new("example", scenario_2, vec![Tag::Example]),
         Scenario::new(

--- a/testing/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
+++ b/testing/jormungandr-scenario-tests/src/test/non_functional/disruption.rs
@@ -9,10 +9,7 @@ use crate::{
     Context,
 };
 
-use jormungandr_testing_utils::{
-    testing::{network_builder::FaketimeConfig, FragmentSenderSetup},
-    wallet::Wallet,
-};
+use jormungandr_testing_utils::testing::{network_builder::FaketimeConfig, FragmentSenderSetup};
 
 use function_name::named;
 use rand_chacha::ChaChaRng;
@@ -225,10 +222,8 @@ pub fn bft_forks(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
 
     let num_transactions = 30;
 
-    let mut last_fragment;
     for _ in 0..num_transactions {
-        last_fragment =
-            fragment_sender.send_transaction(&mut alice, &bob, &leader_1, 1_000_000.into())?;
+        fragment_sender.send_transaction(&mut alice, &bob, &leader_1, 1_000_000.into())?;
         // Spans at least one slot for every leader
         std::thread::sleep(std::time::Duration::from_secs(1));
     }

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/blockchain.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/blockchain.rs
@@ -4,7 +4,8 @@ pub use chain_impl_mockchain::chaintypes::ConsensusVersion;
 use chain_impl_mockchain::{fee::LinearFee, testing::scenario::template::VotePlanDef};
 use jormungandr_lib::interfaces::CommitteeIdDef;
 use jormungandr_lib::interfaces::{
-    ActiveSlotCoefficient, KesUpdateSpeed, NumberOfSlotsPerEpoch, SlotDuration,
+    ActiveSlotCoefficient, BlockContentMaxSize, KesUpdateSpeed, NumberOfSlotsPerEpoch,
+    SlotDuration, DEFAULT_BLOCK_CONTENT_MAX_SIZE,
 };
 use std::collections::HashMap;
 
@@ -24,6 +25,7 @@ pub struct Blockchain {
     consensus_genesis_praos_active_slot_coeff: ActiveSlotCoefficient,
     linear_fee: LinearFee,
     discrimination: Discrimination,
+    block_content_max_size: BlockContentMaxSize,
 }
 
 impl Blockchain {
@@ -49,6 +51,7 @@ impl Blockchain {
             consensus_genesis_praos_active_slot_coeff,
             linear_fee: LinearFee::new(1, 1, 1),
             discrimination: Discrimination::Test,
+            block_content_max_size: DEFAULT_BLOCK_CONTENT_MAX_SIZE.into(),
         }
     }
 
@@ -127,6 +130,10 @@ impl Blockchain {
         self.wallets.insert(wallet.alias().clone(), wallet);
     }
 
+    pub fn set_block_max_content_size(&mut self, size: BlockContentMaxSize) {
+        self.block_content_max_size = size;
+    }
+
     pub fn consensus(&self) -> &ConsensusVersion {
         &self.consensus
     }
@@ -153,5 +160,9 @@ impl Blockchain {
 
     pub fn wallets(&self) -> impl Iterator<Item = &WalletTemplate> {
         self.wallets.values()
+    }
+
+    pub fn block_content_max_size(&self) -> BlockContentMaxSize {
+        self.block_content_max_size
     }
 }

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/mod.rs
@@ -9,7 +9,7 @@ pub use blockchain::Blockchain;
 use chain_impl_mockchain::header::HeaderId;
 pub use rng::{Random, Seed};
 pub use settings::{NodeSetting, Settings, WalletProxySettings};
-pub use spawn_params::SpawnParams;
+pub use spawn_params::{FaketimeConfig, SpawnParams};
 use std::path::PathBuf;
 pub use topology::{Node, NodeAlias, Topology, TopologyBuilder};
 pub use wallet::{

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
@@ -229,6 +229,7 @@ impl Settings {
         blockchain_configuration.kes_update_speed = *blockchain.kes_update_speed();
         blockchain_configuration.consensus_genesis_praos_active_slot_coeff =
             ActiveSlotCoefficient::MAXIMUM;
+        blockchain_configuration.block_content_max_size = blockchain.block_content_max_size();
     }
 
     fn populate_block0_blockchain_initials<'a, RNG, I>(

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/spawn_params.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/spawn_params.rs
@@ -29,6 +29,13 @@ pub struct SpawnParams {
     pub bootstrap_from_peers: Option<bool>,
     pub skip_bootstrap: Option<bool>,
     pub node_key_file: Option<PathBuf>,
+    pub faketime: Option<FaketimeConfig>,
+}
+
+#[derive(Clone)]
+pub struct FaketimeConfig {
+    pub drift: f32,
+    pub offset: i32,
 }
 
 impl SpawnParams {
@@ -52,6 +59,7 @@ impl SpawnParams {
             bootstrap_from_peers: None,
             skip_bootstrap: None,
             node_key_file: None,
+            faketime: None,
         }
     }
 
@@ -172,6 +180,11 @@ impl SpawnParams {
 
     pub fn node_key_file(&mut self, node_key_file: PathBuf) -> &mut Self {
         self.node_key_file = Some(node_key_file);
+        self
+    }
+
+    pub fn faketime(&mut self, faketime: FaketimeConfig) -> &mut Self {
+        self.faketime = Some(faketime);
         self
     }
 


### PR DESCRIPTION
This attempts to replicate possible issues in case of a fork due to unsynchronized clocks, where even transactions that are submitted to a leader that is part of the major component can be settled in fork.


 It requires the installation of faketime, if we want to include this in our tests we should take care of this dependency as well.