### PR TITLE
fix editorconfig action version to be less strict

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: editorconfig-checker/action-editorconfig-checker@v1.0.0
+      - uses: editorconfig-checker/action-editorconfig-checker@v1


### PR DESCRIPTION
I convinced them to do "proper" tagging of actions like in actions and
actions-rs.