### PR TITLE
Reorder fragments submitted with spending counters that are too high

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "cbor_event",
  "chain-ser",
@@ -479,7 +479,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "bech32",
  "cfg-if 1.0.0",
@@ -492,7 +492,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "chain-ser",
 ]
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "bech32",
  "cfg-if 1.0.0",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "cardano-legacy-address",
  "cfg-if 1.0.0",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "chain-network"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "async-trait",
  "chain-crypto",
@@ -567,12 +567,12 @@ dependencies = [
 [[package]]
 name = "chain-ser"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "criterion",
  "data-pile",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "chain-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "chain-core",
  "quickcheck",
@@ -595,7 +595,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "cfg-if 1.0.0",
  "chain-core",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "chain-vote"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "cryptoxide",
  "eccoxide",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 dependencies = [
  "thiserror",
 ]
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 
 [[package]]
 name = "spin"
@@ -4328,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#2650f1f27ec8c72657d87a978b22e8e5e514899c"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=explicit-spending-counter#8637bd0538f3f5a08e96c0fa0d9a382da288d6aa"
 
 [[package]]
 name = "typenum"

--- a/jcli/Cargo.toml
+++ b/jcli/Cargo.toml
@@ -25,12 +25,12 @@ bech32 = "0.7"
 hex = "0.4.2"
 rayon = "1.5"
 base64 = "0.13.0"
-chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-time    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-vote = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = ["p256k1"] }
+chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-time    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-vote = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = ["p256k1"] }
 jormungandr-lib = { path = "../jormungandr-lib" }
 gtmpl = "0.6.0"
 valico = "3.5.0"

--- a/jcli/src/jcli_lib/transaction/add_account.rs
+++ b/jcli/src/jcli_lib/transaction/add_account.rs
@@ -14,6 +14,10 @@ pub struct AddAccount {
     #[structopt(name = "ACCOUNT")]
     pub account: interfaces::Address,
 
+    /// the current spending counter of this account
+    #[structopt(name = "SPENDING_COUNTER")]
+    pub spending_counter: u32,
+
     /// the value
     #[structopt(name = "VALUE")]
     pub value: interfaces::Value,
@@ -36,7 +40,10 @@ impl AddAccount {
         };
 
         transaction.add_input(interfaces::TransactionInput {
-            input: interfaces::TransactionInputType::Account(account_id.into()),
+            input: interfaces::TransactionInputType::Account(
+                account_id.into(),
+                self.spending_counter,
+            ),
             value: self.value,
         })?;
 

--- a/jcli/src/jcli_lib/transaction/add_input.rs
+++ b/jcli/src/jcli_lib/transaction/add_input.rs
@@ -82,7 +82,7 @@ mod tests {
         );
         let input = &staging.inputs()[0];
         match input.input {
-            interfaces::TransactionInputType::Account(_) => {
+            interfaces::TransactionInputType::Account(..) => {
                 panic!("didn't create an account input")
             }
             interfaces::TransactionInputType::Utxo(fid, index) => {

--- a/jcli/src/jcli_lib/transaction/info.rs
+++ b/jcli/src/jcli_lib/transaction/info.rs
@@ -44,7 +44,7 @@ impl Info {
                     "txid": Hash::from(utxo_ptr),
                     "index": index,
                 })),
-                TransactionInputType::Account(account) => {
+                TransactionInputType::Account(account, spending_counter) => {
                     let account_id = UnspecifiedAccountIdentifier::from(account)
                         .to_single_account()
                         .ok_or(Error::InfoExpectedSingleAccount)?;
@@ -52,6 +52,7 @@ impl Info {
                         "kind": "account",
                         "value": input.value,
                         "account": account_id.to_string(),
+                        "spending_counter": spending_counter,
                     }))
                 }
             })

--- a/jcli/src/jcli_lib/transaction/staging.rs
+++ b/jcli/src/jcli_lib/transaction/staging.rs
@@ -296,7 +296,7 @@ impl Staging {
                     let balance = self.finalize_payload(&c, fee_algorithm, output_policy)?;
                     match self.inputs() {
                         [input] => match input.input {
-                            interfaces::TransactionInputType::Account(_) => (),
+                            interfaces::TransactionInputType::Account(_, _) => (),
                             interfaces::TransactionInputType::Utxo(_, _) => {
                                 return Err(Error::TxWithOwnerStakeDelegationHasUtxoInput)
                             }
@@ -580,7 +580,7 @@ mod tests {
         let mut input_ptr = [0u8; chain::transaction::INPUT_PTR_SIZE];
         input_ptr.clone_from_slice(hash.as_ref());
 
-        let result = staging.add_input(Input::new(0, Value(200), input_ptr).into());
+        let result = staging.add_input(Input::new(0, Value(200), Some(0.into()), input_ptr).into());
 
         assert!(
             result.is_err(),

--- a/jormungandr-lib/Cargo.toml
+++ b/jormungandr-lib/Cargo.toml
@@ -10,14 +10,14 @@ description = "Data structures and formats used by Jormungandr node API and conf
 bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "1.8", features = ["macros"] }
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-time           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master"}
-chain-vote = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-cardano-legacy-address = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-typed-bytes = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-time           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter"}
+chain-vote = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+cardano-legacy-address = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+typed-bytes = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
 rand = "0.8"
 rand_core = "0.6"
 rand_chacha = "0.3"
@@ -36,10 +36,10 @@ quickcheck = "0.9"
 quickcheck_macros = "0.9"
 # FIXME required to work with quickcheck 0.9. Remove after migrating another crate or newer quickcheck
 rand07 = { package = "rand", version = "0.7" }
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-core    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-core    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
 ed25519-bip32 = "0.3"
 serde_yaml = "0.8"
 serde_json = "1.0"

--- a/jormungandr-lib/src/interfaces/transaction_input.rs
+++ b/jormungandr-lib/src/interfaces/transaction_input.rs
@@ -12,16 +12,16 @@ pub struct TransactionInput {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TransactionInputType {
-    Account([u8; INPUT_PTR_SIZE]),
+    Account([u8; INPUT_PTR_SIZE], u32),
     Utxo([u8; INPUT_PTR_SIZE], u8),
 }
 
 impl From<TransactionInput> for Input {
     fn from(i: TransactionInput) -> Input {
         match i.input {
-            TransactionInputType::Account(aid) => {
-                Input::from_enum(InputEnum::AccountInput(aid.into(), i.value.into()))
-            }
+            TransactionInputType::Account(aid, spending_counter) => Input::from_enum(
+                InputEnum::AccountInput(aid.into(), spending_counter.into(), i.value.into()),
+            ),
             TransactionInputType::Utxo(txptr, txid) => {
                 Input::from_enum(InputEnum::UtxoInput(UtxoPointer {
                     output_index: txid,
@@ -36,8 +36,8 @@ impl From<TransactionInput> for Input {
 impl From<Input> for TransactionInput {
     fn from(i: Input) -> TransactionInput {
         match i.to_enum() {
-            InputEnum::AccountInput(ai, value) => TransactionInput {
-                input: TransactionInputType::Account(ai.into()),
+            InputEnum::AccountInput(ai, spending_counter, value) => TransactionInput {
+                input: TransactionInputType::Account(ai.into(), spending_counter.into()),
                 value: value.into(),
             },
             InputEnum::UtxoInput(utxoptr) => TransactionInput {

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -12,16 +12,16 @@ Midgard Serpent
 edition = "2018"
 
 [dependencies]
-chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-core = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-network = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-storage   = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-time      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-vote = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-cardano-legacy-address = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-imhamt = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-core = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-network = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-storage   = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-time      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-vote = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+cardano-legacy-address = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+imhamt = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
 
 arc-swap = "^1.1.0"
 async-trait = "=0.1.42" # https://github.com/dtolnay/async-trait/issues/144
@@ -77,9 +77,9 @@ rand_core = "0.6"
 tokio = { version = "^1.4", features = ["full"] }
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
 
 [build-dependencies]
 versionisator = "1.0.2"

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -373,7 +373,7 @@ impl ExplorerTransaction {
             .map(|i| i.to_enum())
             .zip(witnesses)
             .filter_map(|input_with_witness| match input_with_witness {
-                (InputEnum::AccountInput(id, value), Witness::Account(_)) => {
+                (InputEnum::AccountInput(id, _spending_counter, value), Witness::Account(_)) => {
                     let kind = chain_addr::Kind::Account(
                         id.to_single_account()
                             .expect("the input to be validated")
@@ -382,7 +382,7 @@ impl ExplorerTransaction {
                     let address = ExplorerAddress::New(Address(context.discrimination, kind));
                     Some(ExplorerInput { address, value })
                 }
-                (InputEnum::AccountInput(id, value), Witness::Multisig(_)) => {
+                (InputEnum::AccountInput(id, _spending_counter, value), Witness::Multisig(_)) => {
                     let kind = chain_addr::Kind::Multisig(
                         id.to_multi_account()
                             .as_ref()

--- a/modules/blockchain/Cargo.toml
+++ b/modules/blockchain/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 edition = "2018"
 
 [dependencies]
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-time           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master"}
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-time           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter"}
 thiserror = "1.0.21"
 lru       = "0.6.1"

--- a/testing/jormungandr-integration-tests/Cargo.toml
+++ b/testing/jormungandr-integration-tests/Cargo.toml
@@ -12,12 +12,12 @@ tokio = { version = "1.4", features = ["macros", "time"] }
 futures      = "0.3.14"
 base64 = "0.13"
 hex = "0.4.2"
-chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-time      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-vote      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-time      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-vote      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
 jormungandr-lib = { path = "../../jormungandr-lib" }
 jormungandr-testing-utils = { path = "../jormungandr-testing-utils" }
 jortestkit = { git = "https://github.com/input-output-hk/jortestkit.git", branch = "master" }

--- a/testing/jormungandr-integration-tests/src/common/data/witness.rs
+++ b/testing/jormungandr-integration-tests/src/common/data/witness.rs
@@ -11,7 +11,6 @@ pub struct Witness {
     pub transaction_id: Hash,
     pub addr_type: String,
     pub private_key_path: PathBuf,
-    pub spending_account_counter: Option<u32>,
     pub file: PathBuf,
 }
 
@@ -22,7 +21,6 @@ impl Witness {
         transaction_id: &Hash,
         addr_type: &str,
         private_key: &str,
-        spending_account_counter: Option<u32>,
     ) -> Witness {
         Witness {
             block_hash: *block_hash,
@@ -30,7 +28,6 @@ impl Witness {
             addr_type: addr_type.to_string(),
             private_key_path: write_witness_key(temp_dir, private_key),
             file: temp_dir.child("witness").path().into(),
-            spending_account_counter,
         }
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/command/transaction.rs
@@ -40,12 +40,14 @@ impl TransactionCommand {
     pub fn add_account<P: AsRef<Path>>(
         mut self,
         account_addr: &str,
+        spending_counter: u32,
         amount: &str,
         staging_file: P,
     ) -> Self {
         self.command
             .arg("add-account")
             .arg(account_addr.to_string())
+            .arg(spending_counter.to_string())
             .arg(amount)
             .arg("--staging")
             .arg(staging_file.as_ref());
@@ -108,12 +110,9 @@ impl TransactionCommand {
         block0_hash: &str,
         tx_id: &str,
         addr_type: &str,
-        spending_account_counter: Option<u32>,
         witness_file: P,
         witness_key: Q,
     ) -> Self {
-        let spending_counter = spending_account_counter.unwrap_or(0);
-
         self.command
             .arg("make-witness")
             .arg("--genesis-block-hash")
@@ -122,8 +121,6 @@ impl TransactionCommand {
             .arg(&addr_type)
             .arg(&tx_id)
             .arg(witness_file.as_ref())
-            .arg("--account-spending-counter")
-            .arg(spending_counter.to_string())
             .arg(witness_key.as_ref());
         self
     }

--- a/testing/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
@@ -49,8 +49,8 @@ pub fn test_utxo_transaction_with_more_than_one_witness_per_input_is_rejected() 
         .add_output(&receiver.address().to_string(), *utxo.associated_fund())
         .finalize();
 
-    let witness1 = transaction_builder.create_witness_default("utxo", None);
-    let witness2 = transaction_builder.create_witness_default("utxo", None);
+    let witness1 = transaction_builder.create_witness_default("utxo");
+    let witness2 = transaction_builder.create_witness_default("utxo");
 
     transaction_builder
         .make_witness(&witness1)
@@ -444,7 +444,7 @@ pub fn test_transaction_from_account_to_account_is_accepted_by_node() {
     let transaction_message = jcli
         .transaction_builder(block0_hash)
         .new_transaction()
-        .add_account(&sender.address().to_string(), &transfer_amount)
+        .add_account(&sender, &transfer_amount)
         .add_output(&receiver.address().to_string(), transfer_amount)
         .finalize()
         .seal_with_witness_for_address(&sender)
@@ -480,7 +480,7 @@ pub fn test_transaction_from_account_to_delegation_is_accepted_by_node() {
     let transaction_message = jcli
         .transaction_builder(block0_hash)
         .new_transaction()
-        .add_account(&sender.address().to_string(), &transfer_amount)
+        .add_account(&sender, &transfer_amount)
         .add_output(&receiver.address().to_string(), transfer_amount)
         .finalize()
         .seal_with_witness_for_address(&sender)

--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
@@ -141,7 +141,7 @@ pub fn create_new_stake_pool(
     let transaction = jcli
         .transaction_builder(block0_hash)
         .new_transaction()
-        .add_account(&account.address().to_string(), &fee_value)
+        .add_account(&account, &fee_value)
         .add_certificate(&stake_pool_certificate)
         .finalize_with_fee(&account.address().to_string(), &fees)
         .seal_with_witness_for_address(account)
@@ -195,7 +195,7 @@ pub fn delegate_stake(
     let transaction = jcli
         .transaction_builder(block0_hash)
         .new_transaction()
-        .add_account(&account.address().to_string(), &fee_value)
+        .add_account(&account, &fee_value)
         .add_certificate(&stake_pool_delegation)
         .finalize_with_fee(&account.address().to_string(), &fees)
         .seal_with_witness_for_address(account)
@@ -248,7 +248,7 @@ pub fn retire_stake_pool(
     let transaction = jcli
         .transaction_builder(block0_hash)
         .new_transaction()
-        .add_account(&account.address().to_string(), &fee_value)
+        .add_account(&account, &fee_value)
         .add_certificate(&retirement_cert)
         .finalize_with_fee(&account.address().to_string(), &fees)
         .seal_with_witness_for_address(&account)

--- a/testing/jormungandr-integration-tests/src/jormungandr/vit/private.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/vit/private.rs
@@ -106,7 +106,7 @@ pub fn jcli_e2e_flow_private_vote() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&alice.address().to_string(), &Value::zero().into())
+        .add_account(&alice, &Value::zero().into())
         .add_certificate(&vote_plan_cert)
         .finalize()
         .seal_with_witness_for_address(&alice)
@@ -155,7 +155,7 @@ pub fn jcli_e2e_flow_private_vote() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&alice.address().to_string(), &Value::zero().into())
+        .add_account(&alice, &Value::zero().into())
         .add_certificate(&yes_vote_cast)
         .finalize()
         .seal_with_witness_for_address(&alice)
@@ -170,7 +170,7 @@ pub fn jcli_e2e_flow_private_vote() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&bob.address().to_string(), &Value::zero().into())
+        .add_account(&bob, &Value::zero().into())
         .add_certificate(&yes_vote_cast)
         .finalize()
         .seal_with_witness_for_address(&bob)
@@ -183,7 +183,7 @@ pub fn jcli_e2e_flow_private_vote() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&clarice.address().to_string(), &Value::zero().into())
+        .add_account(&clarice, &Value::zero().into())
         .add_certificate(&no_vote_cast)
         .finalize()
         .seal_with_witness_for_address(&clarice)
@@ -204,7 +204,7 @@ pub fn jcli_e2e_flow_private_vote() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&alice.address().to_string(), &Value::zero().into())
+        .add_account(&alice, &Value::zero().into())
         .add_certificate(&encrypted_vote_tally_cert)
         .finalize()
         .seal_with_witness_for_address(&alice)
@@ -258,7 +258,7 @@ pub fn jcli_e2e_flow_private_vote() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&alice.address().to_string(), &Value::zero().into())
+        .add_account(&alice, &Value::zero().into())
         .add_certificate(&vote_tally_cert)
         .finalize()
         .seal_with_witness_for_address(&alice)

--- a/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
@@ -412,7 +412,7 @@ pub fn jcli_e2e_flow() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&alice.address().to_string(), &Value::zero().into())
+        .add_account(&alice, &Value::zero().into())
         .add_certificate(&vote_plan_cert)
         .finalize()
         .seal_with_witness_for_address(&alice)
@@ -449,7 +449,7 @@ pub fn jcli_e2e_flow() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&alice.address().to_string(), &Value::zero().into())
+        .add_account(&alice, &Value::zero().into())
         .add_certificate(&vote_cast)
         .finalize()
         .seal_with_witness_for_address(&alice)
@@ -464,7 +464,7 @@ pub fn jcli_e2e_flow() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&bob.address().to_string(), &Value::zero().into())
+        .add_account(&bob, &Value::zero().into())
         .add_certificate(&vote_cast)
         .finalize()
         .seal_with_witness_for_address(&bob)
@@ -477,7 +477,7 @@ pub fn jcli_e2e_flow() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&clarice.address().to_string(), &Value::zero().into())
+        .add_account(&clarice, &Value::zero().into())
         .add_certificate(&vote_cast)
         .finalize()
         .seal_with_witness_for_address(&clarice)
@@ -493,7 +493,7 @@ pub fn jcli_e2e_flow() {
     let tx = jcli
         .transaction_builder(jormungandr.genesis_block_hash())
         .new_transaction()
-        .add_account(&alice.address().to_string(), &Value::zero().into())
+        .add_account(&alice, &Value::zero().into())
         .add_certificate(&vote_tally_cert)
         .finalize()
         .seal_with_witness_for_address(&alice)

--- a/testing/jormungandr-integration-tests/src/lib.rs
+++ b/testing/jormungandr-integration-tests/src/lib.rs
@@ -10,5 +10,7 @@ pub mod jormungandr;
 pub mod networking;
 #[cfg(test)]
 pub mod non_functional;
+#[cfg(test)]
+pub mod reordered_fragments;
 
 pub mod common;

--- a/testing/jormungandr-integration-tests/src/reordered_fragments.rs
+++ b/testing/jormungandr-integration-tests/src/reordered_fragments.rs
@@ -1,0 +1,73 @@
+use std::time::Duration;
+
+use assert_fs::TempDir;
+use jormungandr_testing_utils::{
+    testing::{FragmentSender, FragmentSenderSetup, FragmentVerifier},
+    wallet::Wallet,
+};
+use rand::seq::SliceRandom;
+use rand_core::OsRng;
+
+use crate::common::jormungandr::{ConfigurationBuilder, Starter};
+
+#[test]
+fn all_reordered_fragments_are_submitted() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut rng = OsRng;
+    let mut alice = Wallet::new_account(&mut rng);
+    let mut bob = Wallet::new_account(&mut rng);
+    let clarice = Wallet::new_account(&mut rng);
+
+    let initial_fund_per_wallet = 1_000_000;
+    let wallets = [&alice, &bob, &clarice];
+    let config = ConfigurationBuilder::new()
+        .with_funds(
+            wallets
+                .iter()
+                .map(|x| x.to_initial_fund(initial_fund_per_wallet))
+                .collect(),
+        )
+        .with_committees(&wallets)
+        .with_slots_per_epoch(60)
+        .with_explorer()
+        .with_slot_duration(1)
+        .with_treasury(1_000.into())
+        .build(&temp_dir);
+
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config.clone())
+        .start()
+        .unwrap();
+
+    let block0_hash = jormungandr.genesis_block_hash();
+    let fees = jormungandr.fees();
+
+    let mut fragments = Vec::new();
+    for _i in 0..10 {
+        for wallet in &mut [&mut alice, &mut bob] {
+            let fragment = wallet
+                .transaction_to(&block0_hash, &fees, clarice.address(), 100.into())
+                .unwrap();
+            fragments.push((wallet.clone(), fragment));
+            wallet.confirm_transaction();
+        }
+    }
+    fragments.shuffle(&mut rng);
+
+    let fragment_sender = FragmentSender::new(block0_hash, fees, FragmentSenderSetup::no_verify());
+
+    let checks = fragments
+        .into_iter()
+        .map(|(mut wallet, fragment)| {
+            fragment_sender.send_fragment(&mut wallet, fragment, &jormungandr)
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let fragment_verifier = FragmentVerifier;
+    fragment_verifier
+        .wait_and_verify_all_are_in_block(Duration::from_secs(5), checks, &jormungandr)
+        .unwrap();
+}

--- a/testing/jormungandr-scenario-tests/Cargo.toml
+++ b/testing/jormungandr-scenario-tests/Cargo.toml
@@ -13,11 +13,11 @@ custom_debug = "0.5"
 dialoguer = "0.8"
 error-chain = "0.12"
 assert_fs = "1.0"
-chain-core           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-crypto         = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-addr           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-time           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-core           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-crypto         = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-addr           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-time           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
 jormungandr-testing-utils = { path = "../jormungandr-testing-utils" }
 jormungandr-lib = { path = "../../jormungandr-lib" }
 jortestkit = { git = "https://github.com/input-output-hk/jortestkit.git", branch = "master" }

--- a/testing/jormungandr-testing-utils/Cargo.toml
+++ b/testing/jormungandr-testing-utils/Cargo.toml
@@ -17,15 +17,15 @@ bech32 = "0.7"
 bytesize = "1.0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-time      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-storage   = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = ["with-bench"] }
-chain-vote      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-cardano-legacy-address = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-typed-bytes = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-time      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-storage   = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = ["with-bench"] }
+chain-vote      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+cardano-legacy-address = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+typed-bytes = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
 jormungandr-lib = { path = "../../jormungandr-lib" }
 jortestkit = { git = "https://github.com/input-output-hk/jortestkit.git", branch = "master" }
 rand = "0.8"

--- a/testing/jormungandr-testing-utils/src/testing/fragments/adversary.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/adversary.rs
@@ -338,13 +338,13 @@ impl FaultyTransactionBuilder {
     }
 
     pub fn wrong_counter(&self, from: &Wallet, to: &Wallet) -> Fragment {
+        let mut from = from.clone();
+        from.confirm_transaction();
         let input_value: Value = (self.fees.calculate(None, 1, 1) + Value(1u64)).unwrap();
         let input = from.add_input_with_value(input_value.into());
         let output = OutputAddress::from_address(to.address().into(), Value(1u64));
         self.transaction_to(&[input], &[output], |sign_data| {
-            let mut false_from = from.clone();
-            false_from.confirm_transaction();
-            vec![false_from.mk_witness(&self.block0_hash, sign_data)]
+            vec![from.mk_witness(&self.block0_hash, sign_data)]
         })
     }
 

--- a/testing/jormungandr-testing-utils/src/wallet/account.rs
+++ b/testing/jormungandr-testing-utils/src/wallet/account.rs
@@ -94,16 +94,17 @@ impl Wallet {
         block0_hash: &Hash,
         signing_data: &TransactionSignDataHash,
     ) -> Witness {
-        Witness::new_account(
-            &block0_hash.clone().into_hash(),
-            signing_data,
-            self.internal_counter(),
-            |d| self.signing_key().as_ref().sign(d),
-        )
+        Witness::new_account(&block0_hash.clone().into_hash(), signing_data, |d| {
+            self.signing_key().as_ref().sign(d)
+        })
     }
 
     pub fn add_input_with_value(&self, value: Value) -> Input {
-        Input::from_account_single(self.identifier().to_inner(), value.into())
+        Input::from_account_single(
+            self.identifier().to_inner(),
+            self.internal_counter(),
+            value.into(),
+        )
     }
 
     pub fn add_input<'a, Extra: Payload>(
@@ -128,7 +129,11 @@ impl Wallet {
             }
         };
 
-        let input = Input::from_account_single(self.identifier().to_inner(), value);
+        let input = Input::from_account_single(
+            self.identifier().to_inner(),
+            self.internal_counter(),
+            value,
+        );
         iobuilder.add_input(&input).unwrap();
         Ok(())
     }

--- a/testing/mjolnir/Cargo.toml
+++ b/testing/mjolnir/Cargo.toml
@@ -15,13 +15,13 @@ thiserror = "1.0"
 structopt = "^0.3"
 assert_fs = "1.0"
 indicatif = "0.15"
-chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
-chain-time      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chain-storage   = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = ["with-bench"] }
-chain-vote      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = [ "property-test-api" ] }
+chain-time      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
+chain-storage   = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter", features = ["with-bench"] }
+chain-vote      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "explicit-spending-counter" }
 tokio = { version = "1.4", features = ["macros"] }
 
 [build-dependencies]


### PR DESCRIPTION
Depends on https://github.com/input-output-hk/chain-libs/pull/565.

Given the explicit spending counter we can reorder fragments on the per-account basis using priority queues. This introduces breaking changes to `jcli` as the spending counter is no longer needed to build a witness, but is required for account inputs.

**TBD**:

- [ ] `insert_all`:
  - [ ] Fragments from priority queues should be included in the overall count.
  - [ ] The pool should reject fragments that are already in one of priority queues.
- [ ] Implement removal from priority queues upon calling `remove_all`.
- [ ] Evict fragments that sit in their priority queues for too long.
- [ ] Restore legacy UTXO testing API.

**Side notes**

Since witnesses no longer depend on the spending counter (e.g. ledger state) we may validate them at the time transactions come to the pool. Early validation (or removing it from here entirely) in `chain-libs` is also an option.