### PR TITLE
Improve rest utils

### DIFF
--- a/testing/jormungandr-testing-utils/src/testing/node/legacy/rest.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/legacy/rest.rs
@@ -46,13 +46,11 @@ impl BackwardCompatibleRest {
     }
 
     pub fn disable_logger(&mut self) {
-        self.settings.enable_debug = false;
-        self.raw.update_settings(self.settings.clone());
+        self.raw.disable_logger();
     }
 
     pub fn enable_logger(&mut self) {
-        self.settings.enable_debug = true;
-        self.raw.update_settings(self.settings.clone());
+        self.raw.enable_logger();
     }
 
     pub fn epoch_reward_history(&self, epoch: u32) -> Result<String, reqwest::Error> {

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
@@ -8,7 +8,7 @@ use chain_impl_mockchain::fragment::Fragment;
 use jormungandr_lib::interfaces::FragmentsBatch;
 use jortestkit::process::Wait;
 use reqwest::{
-    blocking::Response,
+    blocking::{Client, Response},
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
 };
 use std::fmt;
@@ -33,16 +33,44 @@ impl fmt::Display for ApiVersion {
 #[derive(Debug, Clone)]
 pub struct RawRest {
     uri: String,
-    settings: RestSettings,
+    client: Client,
+    logging_enabled: bool,
 }
 
 impl RawRest {
     pub fn new(uri: String, settings: RestSettings) -> Self {
-        Self { uri, settings }
+        let client = match &settings.certificate {
+            None => Client::new(),
+            Some(cert) => Client::builder()
+                .use_rustls_tls()
+                .add_root_certificate(cert.clone())
+                .build()
+                .unwrap(),
+        };
+        let uri = if settings.use_https {
+            let url = url::Url::parse(&uri).unwrap();
+            format!(
+                "https://{}:443/{}",
+                url.domain().unwrap(),
+                url.path_segments().unwrap().next().unwrap()
+            )
+        } else {
+            uri
+        };
+
+        Self {
+            uri,
+            client,
+            logging_enabled: settings.enable_debug,
+        }
     }
 
-    pub fn update_settings(&mut self, settings: RestSettings) {
-        self.settings = settings;
+    pub fn enable_logger(&mut self) {
+        self.logging_enabled = true;
+    }
+
+    pub fn disable_logger(&mut self) {
+        self.logging_enabled = false;
     }
 
     pub fn epoch_reward_history(&self, epoch: u32) -> Result<Response, reqwest::Error> {
@@ -64,17 +92,7 @@ impl RawRest {
     fn get(&self, path: &str) -> Result<reqwest::blocking::Response, reqwest::Error> {
         let request = self.path(path, ApiVersion::V0);
         self.print_request_path(&request);
-        match &self.settings.certificate {
-            None => reqwest::blocking::get(&request),
-            Some(cert) => {
-                let client = reqwest::blocking::Client::builder()
-                    .use_rustls_tls()
-                    .add_root_certificate(cert.clone())
-                    .build()
-                    .unwrap();
-                client.get(&request).send()
-            }
-        }
+        self.client.get(request).send()
     }
 
     fn path(&self, path: &str, api_version: ApiVersion) -> String {
@@ -168,10 +186,8 @@ impl RawRest {
         path: &str,
         body: Vec<u8>,
     ) -> Result<reqwest::blocking::Response, reqwest::Error> {
-        let builder = reqwest::blocking::Client::builder();
-        let client = builder.build()?;
-        client
-            .post(&self.path_http_or_https(path, ApiVersion::V0))
+        self.client
+            .post(&self.path(path, ApiVersion::V0))
             .headers(self.construct_headers())
             .body(body)
             .send()
@@ -193,10 +209,8 @@ impl RawRest {
         let clients: Vec<reqwest::blocking::RequestBuilder> = bodies
             .into_iter()
             .map(|body| {
-                reqwest::blocking::Client::builder()
-                    .build()
-                    .unwrap()
-                    .post(&self.path_http_or_https("message", ApiVersion::V0))
+                self.client
+                    .post(&self.path("message", ApiVersion::V0))
                     .headers(self.construct_headers())
                     .body(body)
             })
@@ -209,19 +223,14 @@ impl RawRest {
     }
 
     pub fn fragments_logs(&self) -> Result<Response, reqwest::Error> {
-        let builder = reqwest::blocking::Client::builder();
-        let client = builder.build()?;
-
-        client
-            .get(&self.path_http_or_https("fragments/logs", ApiVersion::V1))
+        self.client
+            .get(&self.path("fragments/logs", ApiVersion::V1))
             .send()
     }
 
     pub fn fragments_statuses(&self, ids: Vec<String>) -> Result<Response, reqwest::Error> {
-        let builder = reqwest::blocking::Client::builder();
-        let client = builder.build()?;
-        client
-            .get(&self.path_http_or_https("fragments/statuses", ApiVersion::V1))
+        self.client
+            .get(&self.path("fragments/statuses", ApiVersion::V1))
             .query(&[("fragment_ids", ids.join(","))])
             .send()
     }
@@ -231,11 +240,8 @@ impl RawRest {
         fragments: Vec<Fragment>,
         fail_fast: bool,
     ) -> Result<Response, reqwest::Error> {
-        let builder = reqwest::blocking::Client::builder();
-        let client = builder.build()?;
-
-        client
-            .post(&self.path_http_or_https("fragments", ApiVersion::V1))
+        self.client
+            .post(&self.path("fragments", ApiVersion::V1))
             .headers(self.construct_headers())
             .json(&FragmentsBatch {
                 fail_fast,

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
@@ -56,13 +56,13 @@ impl RawRest {
     }
 
     fn print_request_path(&self, text: &str) {
-        if self.settings.enable_debug {
+        if self.logging_enabled {
             println!("Request: {}", text);
         }
     }
 
     fn get(&self, path: &str) -> Result<reqwest::blocking::Response, reqwest::Error> {
-        let request = self.path(path);
+        let request = self.path(path, ApiVersion::V0);
         self.print_request_path(&request);
         match &self.settings.certificate {
             None => reqwest::blocking::get(&request),
@@ -77,21 +77,7 @@ impl RawRest {
         }
     }
 
-    fn path(&self, path: &str) -> String {
-        format!("{}/v0/{}", self.uri, path)
-    }
-
-    fn path_http_or_https(&self, path: &str, api_version: ApiVersion) -> String {
-        if self.settings.use_https_for_post {
-            let url = url::Url::parse(&self.uri).unwrap();
-            return format!(
-                "https://{}:443/{}/{}/{}",
-                url.domain().unwrap(),
-                url.path_segments().unwrap().next().unwrap(),
-                api_version.to_string(),
-                path
-            );
-        }
+    fn path(&self, path: &str, api_version: ApiVersion) -> String {
         format!("{}/{}/{}", self.uri, api_version, path)
     }
 

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
@@ -90,12 +90,12 @@ impl RawRest {
     }
 
     fn get(&self, path: &str) -> Result<reqwest::blocking::Response, reqwest::Error> {
-        let request = self.path(path, ApiVersion::V0);
+        let request = self.path(ApiVersion::V0, path);
         self.print_request_path(&request);
         self.client.get(request).send()
     }
 
-    fn path(&self, path: &str, api_version: ApiVersion) -> String {
+    fn path(&self, api_version: ApiVersion, path: &str) -> String {
         format!("{}/{}/{}", self.uri, api_version, path)
     }
 
@@ -187,7 +187,7 @@ impl RawRest {
         body: Vec<u8>,
     ) -> Result<reqwest::blocking::Response, reqwest::Error> {
         self.client
-            .post(&self.path(path, ApiVersion::V0))
+            .post(&self.path(ApiVersion::V0, path))
             .headers(self.construct_headers())
             .body(body)
             .send()
@@ -210,7 +210,7 @@ impl RawRest {
             .into_iter()
             .map(|body| {
                 self.client
-                    .post(&self.path("message", ApiVersion::V0))
+                    .post(&self.path(ApiVersion::V0, "message"))
                     .headers(self.construct_headers())
                     .body(body)
             })
@@ -224,13 +224,13 @@ impl RawRest {
 
     pub fn fragments_logs(&self) -> Result<Response, reqwest::Error> {
         self.client
-            .get(&self.path("fragments/logs", ApiVersion::V1))
+            .get(&self.path(ApiVersion::V1, "fragments/logs"))
             .send()
     }
 
     pub fn fragments_statuses(&self, ids: Vec<String>) -> Result<Response, reqwest::Error> {
         self.client
-            .get(&self.path("fragments/statuses", ApiVersion::V1))
+            .get(&self.path(ApiVersion::V1, "fragments/statuses"))
             .query(&[("fragment_ids", ids.join(","))])
             .send()
     }
@@ -241,7 +241,7 @@ impl RawRest {
         fail_fast: bool,
     ) -> Result<Response, reqwest::Error> {
         self.client
-            .post(&self.path("fragments", ApiVersion::V1))
+            .post(&self.path(ApiVersion::V1, "fragments"))
             .headers(self.construct_headers())
             .json(&FragmentsBatch {
                 fail_fast,

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/settings.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/settings.rs
@@ -3,15 +3,15 @@ use reqwest::Certificate;
 #[derive(Debug, Clone)]
 pub struct RestSettings {
     pub enable_debug: bool,
-    pub use_https_for_post: bool,
+    pub use_https: bool,
     pub certificate: Option<Certificate>,
 }
 
 impl RestSettings {
-    pub fn new_use_https_for_post() -> Self {
+    pub fn new_use_https() -> Self {
         RestSettings {
             enable_debug: false,
-            use_https_for_post: true,
+            use_https: true,
             certificate: None,
         }
     }
@@ -21,7 +21,7 @@ impl Default for RestSettings {
     fn default() -> Self {
         RestSettings {
             enable_debug: false,
-            use_https_for_post: false,
+            use_https: false,
             certificate: None,
         }
     }


### PR DESCRIPTION
Reuse the same client for successive requests instead of building a new one each time, which is inefficient (relevant because this is used in load tools).
One thing that I changed is that there was a config option to use https on post requests, but I changed that to apply for all requests types (I'm not sure why that was the case, but it seems better this way imo)

