### PR TITLE
ci: remove draft release on non-build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,10 +314,10 @@ jobs:
 
   remove_failed_release:
     name: Remove the release upon a build failure
-    needs: [create_release, build_assets]
+    needs: [create_release, publish_release]
     runs-on: ubuntu-latest
     # we need always() to force the check to run even if one of the needed jobs fails
-    if: ${{ always() && needs.build_assets.outputs.status == 'failure' }}
+    if: ${{ always() && needs.publish_release.outputs.status != 'success' }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2


### PR DESCRIPTION
With the previous condition releases were removed only when one of
`build_assets` jobs was failing. However, this condition would not apply
if the failure occurred before launching this job. Instead, we check the
status of `publish_release` to be `success`. Except for a failure during
publishing, if one of the earlier jobs failed, the status of
`publish_release` would be `cancelled` which also trigger
`remove_failed_release`.