### PR TITLE
ci: was using the wrong key in Slack notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,7 +336,7 @@ jobs:
       - name: Produce action-slack-notify variables
         run: |
           status="${{ needs.publish_release.outputs.status }}"
-          release="${{ needs.create_release.outputs.release }}"
+          release="${{ needs.create_release.outputs.tag }}"
           if [ "$status" == "success" ]; then
             SLACK_COLOR="success"
             SLACK_MESSAGE=":rocket: Published release $release."


### PR DESCRIPTION
It is just beautification, it did not display the tag correctly.