### PR TITLE
rest: log all requests

### DIFF
--- a/jormungandr/src/rest/mod.rs
+++ b/jormungandr/src/rest/mod.rs
@@ -32,7 +32,16 @@ pub async fn start_rest_server(config: Rest, explorer_enabled: bool, context: Co
 
     let api = warp::path!("api" / ..)
         .and(v0::filter(context.clone()).or(v1::filter(context.clone())))
-        .with(warp::filters::trace::request());
+        .with(warp::filters::trace::trace(|info| {
+            tracing::span!(
+                tracing::Level::DEBUG,
+                "rest_api_request",
+                method = %info.method(),
+                path = %info.path(),
+                version = ?info.version(),
+                remote_addr = ?info.remote_addr(),
+            )
+        }));
     if explorer_enabled {
         let explorer = explorer::filter(context);
         setup_cors(api.or(explorer), config, stopper_rx).await;

--- a/jormungandr/src/rest/mod.rs
+++ b/jormungandr/src/rest/mod.rs
@@ -30,8 +30,9 @@ pub async fn start_rest_server(config: Rest, explorer_enabled: bool, context: Co
         .await
         .set_server_stopper(ServerStopper(stopper_tx));
 
-    let api =
-        warp::path!("api" / ..).and(v0::filter(context.clone()).or(v1::filter(context.clone())));
+    let api = warp::path!("api" / ..)
+        .and(v0::filter(context.clone()).or(v1::filter(context.clone())))
+        .with(warp::filters::trace::request());
     if explorer_enabled {
         let explorer = explorer::filter(context);
         setup_cors(api.or(explorer), config, stopper_rx).await;


### PR DESCRIPTION
This produces a log that looks like:

```
Jun 02 10:53:48.423  INFO request{method=GET path=/api/v0/fragment/logs version=HTTP/1.1 remote.addr=127.0.0.1:60560}: warp::filters::trace: processing request
...
Jun 02 10:53:48.424  INFO request{method=GET path=/api/v0/fragment/logs version=HTTP/1.1 remote.addr=127.0.0.1:60560}: warp::filters::trace: finished processing with success status=200
```

Note that is automatically producing a tracing span.