### PR TITLE
Mempool update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "cbor_event",
  "chain-ser",
@@ -469,7 +469,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "bech32",
  "chain-core",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "chain-ser",
 ]
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "bech32",
  "cryptoxide",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "cardano-legacy-address",
  "chain-addr",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "chain-network"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "async-trait",
  "chain-crypto",
@@ -554,12 +554,12 @@ dependencies = [
 [[package]]
 name = "chain-ser"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "criterion",
  "data-pile",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "chain-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "chain-core",
  "quickcheck",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "cfg-if 1.0.0",
  "chain-core",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "chain-vote"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "chain-core",
  "cryptoxide",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 dependencies = [
  "thiserror",
 ]
@@ -3479,7 +3479,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 
 [[package]]
 name = "spin"
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a12e68d452990ddd7e2ff5980628152ac7ce2329"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#8b051298e4dd74ed7314f10b81a341439e7e219d"
 
 [[package]]
 name = "typenum"

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -354,14 +354,13 @@ pub async fn process_new_ref(
                     .storage()
                     .put_tag(MAIN_BRANCH_TAG, candidate_hash)?;
 
-                let block = blockchain.storage().get(candidate_hash)?;
-                if let Some(block) = block {
-                    let fragment_ids = block.fragments().map(|f| f.id()).collect();
-                    if let Some(ref mut tx_msg_box) = tx_msg_box {
-                        try_request_fragment_removal(tx_msg_box, fragment_ids, &block.header())?;
-                    }
-                } else {
-                    panic!();
+                // if we were able to put the main branch tag at the candidate hash
+                // it cannot happen that no block is found now
+                let block = blockchain.storage().get(candidate_hash)?.unwrap();
+
+                let fragment_ids = block.fragments().map(|f| f.id()).collect();
+                if let Some(ref mut tx_msg_box) = tx_msg_box {
+                    try_request_fragment_removal(tx_msg_box, fragment_ids, &block.header())?;
                 }
 
                 tip.update_ref(candidate).await;

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -375,6 +375,9 @@ pub async fn process_new_ref(
                     .stream_from_to(common_ancestor, candidate_hash)?;
                 tokio::pin!(stream);
 
+                // skip the first block as it is shared between the two branches
+                stream.next().await;
+
                 while let Some(block) = stream.next().await {
                     let block = block.unwrap();
                     let fragment_ids = block.fragments().map(|f| f.id()).collect();

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -193,11 +193,19 @@ impl Process {
         let tip = self.blockchain_tip.clone();
         let blockchain = self.blockchain.clone();
         let explorer = self.explorer_msgbox.clone();
+        let tx_msg_box = self.fragment_msgbox.clone();
 
         info.run_periodic_fallible(
             "branch reprocessing",
             BRANCH_REPROCESSING_INTERVAL,
-            move || reprocess_tip(blockchain.clone(), tip.clone(), explorer.clone()),
+            move || {
+                reprocess_tip(
+                    blockchain.clone(),
+                    tip.clone(),
+                    explorer.clone(),
+                    tx_msg_box.clone(),
+                )
+            },
         )
     }
 
@@ -282,6 +290,7 @@ async fn reprocess_tip(
     mut blockchain: Blockchain,
     tip: Tip,
     explorer_msg_box: Option<MessageBox<ExplorerMsg>>,
+    tx_msg_box: MessageBox<TransactionMsg>,
 ) -> Result<(), Error> {
     let branches: Vec<Arc<Ref>> = blockchain.branches().branches().await;
 
@@ -298,6 +307,7 @@ async fn reprocess_tip(
             tip.clone(),
             Arc::clone(other),
             explorer_msg_box.clone(),
+            Some(tx_msg_box.clone()),
         )
         .await?
     }
@@ -319,6 +329,7 @@ pub async fn process_new_ref(
     mut tip: Tip,
     candidate: Arc<Ref>,
     explorer_msg_box: Option<MessageBox<ExplorerMsg>>,
+    mut tx_msg_box: Option<MessageBox<TransactionMsg>>,
 ) -> Result<(), Error> {
     let candidate_hash = candidate.hash();
     let tip_ref = tip.get_ref().await;
@@ -342,6 +353,16 @@ pub async fn process_new_ref(
                 blockchain
                     .storage()
                     .put_tag(MAIN_BRANCH_TAG, candidate_hash)?;
+
+                let block = blockchain.storage().get(candidate_hash)?;
+                if let Some(block) = block {
+                    let fragment_ids = block.fragments().map(|f| f.id()).collect();
+                    if let Some(ref mut tx_msg_box) = tx_msg_box {
+                        try_request_fragment_removal(tx_msg_box, fragment_ids, &block.header())?;
+                    }
+                } else {
+                    panic!();
+                }
 
                 tip.update_ref(candidate).await;
             } else {
@@ -379,11 +400,18 @@ async fn process_and_propagate_new_ref(
     new_block_ref: Arc<Ref>,
     mut network_msg_box: MessageBox<NetworkMsg>,
     explorer_msg_box: Option<MessageBox<ExplorerMsg>>,
+    tx_msg_box: MessageBox<TransactionMsg>,
 ) -> chain::Result<()> {
     let header = new_block_ref.header().clone();
     tracing::debug!("processing the new block and propagating");
-
-    process_new_ref(blockchain, tip, new_block_ref, explorer_msg_box).await?;
+    process_new_ref(
+        blockchain,
+        tip,
+        new_block_ref,
+        explorer_msg_box,
+        Some(tx_msg_box),
+    )
+    .await?;
 
     tracing::debug!("propagating block to the network");
 
@@ -398,7 +426,7 @@ async fn process_and_propagate_new_ref(
 async fn process_leadership_block(
     mut blockchain: Blockchain,
     blockchain_tip: Tip,
-    mut tx_msg_box: MessageBox<TransactionMsg>,
+    tx_msg_box: MessageBox<TransactionMsg>,
     network_msg_box: MessageBox<NetworkMsg>,
     explorer_msg_box: Option<MessageBox<ExplorerMsg>>,
     leadership_block: LeadershipBlock,
@@ -407,17 +435,13 @@ async fn process_leadership_block(
     let block = leadership_block.block.clone();
     let new_block_ref = process_leadership_block_inner(&mut blockchain, leadership_block).await?;
 
-    let fragments = block.fragments().map(|f| f.id()).collect();
-
-    tracing::trace!("updating fragments log");
-    try_request_fragment_removal(&mut tx_msg_box, fragments, new_block_ref.header())?;
-
     process_and_propagate_new_ref(
         &mut blockchain,
         blockchain_tip,
         Arc::clone(&new_block_ref),
         network_msg_box,
         explorer_msg_box.clone(),
+        tx_msg_box,
     )
     .await?;
 
@@ -495,7 +519,7 @@ async fn process_block_announcement(
 async fn process_network_blocks(
     mut blockchain: Blockchain,
     blockchain_tip: Tip,
-    mut tx_msg_box: MessageBox<TransactionMsg>,
+    tx_msg_box: MessageBox<TransactionMsg>,
     network_msg_box: MessageBox<NetworkMsg>,
     mut explorer_msg_box: Option<MessageBox<ExplorerMsg>>,
     mut get_next_block_scheduler: GetNextBlockScheduler,
@@ -514,7 +538,6 @@ async fn process_network_blocks(
                 let res = process_network_block(
                     &blockchain,
                     block.clone(),
-                    &mut tx_msg_box,
                     explorer_msg_box.as_mut(),
                     &mut get_next_block_scheduler,
                 )
@@ -554,6 +577,7 @@ async fn process_network_blocks(
                 Arc::clone(&new_block_ref),
                 network_msg_box,
                 explorer_msg_box,
+                tx_msg_box,
             )
             .await?;
 
@@ -570,7 +594,6 @@ async fn process_network_blocks(
 async fn process_network_block(
     blockchain: &Blockchain,
     block: Block,
-    tx_msg_box: &mut MessageBox<TransactionMsg>,
     explorer_msg_box: Option<&mut MessageBox<ExplorerMsg>>,
     get_next_block_scheduler: &mut GetNextBlockScheduler,
 ) -> Result<Option<Arc<Ref>>, chain::Error> {
@@ -602,9 +625,7 @@ async fn process_network_block(
             Err(Error::MissingParentBlock(parent_hash))
         }
         PreCheckedHeader::HeaderWithCache { parent_ref, .. } => {
-            let r =
-                check_and_apply_block(blockchain, parent_ref, block, tx_msg_box, explorer_msg_box)
-                    .await;
+            let r = check_and_apply_block(blockchain, parent_ref, block, explorer_msg_box).await;
             r
         }
     }
@@ -614,7 +635,6 @@ async fn check_and_apply_block(
     blockchain: &Blockchain,
     parent_ref: Arc<Ref>,
     block: Block,
-    tx_msg_box: &mut MessageBox<TransactionMsg>,
     explorer_msg_box: Option<&mut MessageBox<ExplorerMsg>>,
 ) -> Result<Option<Arc<Ref>>, chain::Error> {
     let explorer_enabled = explorer_msg_box.is_some();
@@ -634,7 +654,6 @@ async fn check_and_apply_block(
     } else {
         None
     };
-    let fragment_ids = block.fragments().map(|f| f.id()).collect::<Vec<_>>();
     let applied_block = blockchain
         .apply_and_store_block(post_checked, block)
         .await?;
@@ -645,9 +664,6 @@ async fn check_and_apply_block(
             parent = %header.parent_id(),
             date = %header.block_date(),
             "applied block to storage"
-        );
-        try_request_fragment_removal(tx_msg_box, fragment_ids, header).unwrap_or_else(
-            |err| tracing::error!(reason = %err, "cannot remove fragments from pool"),
         );
         if let Some(msg_box) = explorer_msg_box {
             msg_box

--- a/jormungandr/src/blockchain/storage.rs
+++ b/jormungandr/src/blockchain/storage.rs
@@ -262,6 +262,23 @@ impl Storage {
         }))
     }
 
+    // This should be done better
+    pub fn find_common_ancestor(
+        &self,
+        tip_1: HeaderHash,
+        tip_2: HeaderHash,
+    ) -> Result<HeaderHash, Error> {
+        HeaderHash::deserialize(
+            self.storage
+                .find_lowest_common_ancestor(tip_1.as_ref(), tip_2.as_ref())?
+                // No common ancestor means that we accepted blocks originating from two different block0
+                .unwrap()
+                .id()
+                .as_ref(),
+        )
+        .map_err(Error::Deserialize)
+    }
+
     pub fn gc(&self, threshold_depth: u32, main_branch_tip: &[u8]) -> Result<(), Error> {
         let _enter = self.span.enter();
         let main_info = self.storage.get_block_info(main_branch_tip)?;

--- a/jormungandr/src/blockchain/storage.rs
+++ b/jormungandr/src/blockchain/storage.rs
@@ -262,7 +262,6 @@ impl Storage {
         }))
     }
 
-    // This should be done better
     pub fn find_common_ancestor(
         &self,
         tip_1: HeaderHash,

--- a/jormungandr/src/fragment/logs.rs
+++ b/jormungandr/src/fragment/logs.rs
@@ -114,6 +114,9 @@ impl Logs {
                 FragmentStatus::InABlock { date, .. } | FragmentStatus::Rejected { date, .. } => {
                     if date > &target_date {
                         to_remove.push(*log.fragment_id());
+                    } else {
+                        // iterating in most-recently used order (i.e. most recently added to block)
+                        break;
                     }
                 }
                 FragmentStatus::Pending => (),

--- a/jormungandr/src/fragment/logs.rs
+++ b/jormungandr/src/fragment/logs.rs
@@ -111,7 +111,7 @@ impl Logs {
         let mut to_remove = Vec::new();
         for log in self.logs() {
             match log.status() {
-                FragmentStatus::InABlock { date, .. } | FragmentStatus::Rejected { date, .. } => {
+                FragmentStatus::InABlock { .. } | FragmentStatus::Rejected { .. } => {
                     if date > &target_date {
                         to_remove.push(*log.fragment_id());
                     } else {

--- a/jormungandr/src/fragment/logs.rs
+++ b/jormungandr/src/fragment/logs.rs
@@ -30,7 +30,8 @@ impl Logs {
     }
 
     /// Returns true if fragment was registered
-    pub fn insert(&mut self, log: FragmentLog) -> bool {
+    pub fn insert_pending(&mut self, log: FragmentLog) -> bool {
+        assert!(log.is_pending());
         let fragment_id = *log.fragment_id();
         if self.entries.contains(&fragment_id) {
             false
@@ -41,9 +42,9 @@ impl Logs {
     }
 
     /// Returns number of registered fragments
-    pub fn insert_all(&mut self, logs: impl IntoIterator<Item = FragmentLog>) -> usize {
+    pub fn insert_all_pending(&mut self, logs: impl IntoIterator<Item = FragmentLog>) -> usize {
         logs.into_iter()
-            .map(|log| self.insert(log))
+            .map(|log| self.insert_pending(log))
             .filter(|was_modified| *was_modified)
             .count()
     }

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -13,7 +13,7 @@ use futures::channel::mpsc::SendError;
 use futures::sink::SinkExt;
 use jormungandr_lib::{
     interfaces::{
-        FragmentLog, FragmentOrigin, FragmentRejectionReason, FragmentStatus,
+        BlockDate, FragmentLog, FragmentOrigin, FragmentRejectionReason, FragmentStatus,
         FragmentsProcessingSummary, PersistentFragmentLog, RejectedFragmentInfo,
     },
     time::SecondsSinceUnixEpoch,
@@ -251,6 +251,11 @@ impl Pools {
                     .await
             }
         }
+    }
+
+    // Remove from logs fragments that were confirmed (or rejected) in a branch
+    pub fn prune_after_ledger_branch(&mut self, branch_date: BlockDate) {
+        self.logs.remove_logs_after_date(branch_date)
     }
 }
 

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -219,10 +219,17 @@ impl Pools {
     }
 
     pub fn remove_added_to_block(&mut self, fragment_ids: Vec<FragmentId>, status: FragmentStatus) {
+        let date = if let FragmentStatus::InABlock { date, .. } = status {
+            date
+        } else {
+            panic!("expected status to be in block, found {:?}", status);
+        };
+
         for pool in &mut self.pools {
             pool.remove_all(fragment_ids.iter());
         }
-        self.logs.modify_all(fragment_ids, status);
+
+        self.logs.modify_all(fragment_ids, status, date);
     }
 
     pub async fn select(

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -167,7 +167,7 @@ impl Pools {
                 .iter()
                 .map(move |fragment| FragmentLog::new(fragment.id(), origin))
                 .collect();
-            self.logs.insert_all(fragment_logs);
+            self.logs.insert_all_pending(fragment_logs);
 
             for fragment in &new_fragments {
                 let id = fragment.id();

--- a/jormungandr/src/fragment/process.rs
+++ b/jormungandr/src/fragment/process.rs
@@ -159,6 +159,9 @@ impl Process {
                                     );
                                     reply_handle.reply_ok(statuses);
                                 }
+                                TransactionMsg::BranchSwitch(fork_date) => {
+                                    pool.prune_after_ledger_branch(fork_date);
+                                }
                                 TransactionMsg::SelectTransactions {
                                     pool_idx,
                                     ledger,

--- a/jormungandr/src/fragment/selection.rs
+++ b/jormungandr/src/fragment/selection.rs
@@ -5,7 +5,7 @@ use crate::{
     fragment::FragmentId,
 };
 use chain_core::property::Fragment as _;
-use jormungandr_lib::interfaces::FragmentStatus;
+use jormungandr_lib::interfaces::{BlockDate, FragmentStatus};
 
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -66,6 +66,7 @@ impl FragmentSelectionAlgorithm for OldestFirst {
     ) -> (Contents, ApplyBlockLedger) {
         use futures::future::{select, Either};
 
+        let date: BlockDate = ledger.block_date().into();
         let mut current_total_size = 0;
         let mut contents_builder = ContentsBuilder::new();
         let mut return_to_pool = Vec::new();

--- a/jormungandr/src/fragment/selection.rs
+++ b/jormungandr/src/fragment/selection.rs
@@ -87,7 +87,7 @@ impl FragmentSelectionAlgorithm for OldestFirst {
                     fragment_size, ledger_params.block_content_max_size
                 );
                 tracing::debug!("{}", reason);
-                logs.modify(id, FragmentStatus::Rejected { reason });
+                logs.modify(id, FragmentStatus::Rejected { reason }, date);
                 continue;
             }
 
@@ -132,6 +132,7 @@ impl FragmentSelectionAlgorithm for OldestFirst {
                                 FragmentStatus::Rejected {
                                     reason: reason.to_string(),
                                 },
+                                date,
                             );
                             break;
                         }
@@ -152,7 +153,7 @@ impl FragmentSelectionAlgorithm for OldestFirst {
                         msg.push_str(&e.to_string());
                     }
                     tracing::debug!(?error, "fragment is rejected");
-                    logs.modify(id, FragmentStatus::Rejected { reason: msg })
+                    logs.modify(id, FragmentStatus::Rejected { reason: msg }, date)
                 }
             }
 

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -9,7 +9,7 @@ use crate::utils::async_msg::{self, MessageBox, MessageQueue};
 use chain_impl_mockchain::fragment::Contents as FragmentContents;
 use chain_network::error as net_error;
 use jormungandr_lib::interfaces::{
-    FragmentLog, FragmentOrigin, FragmentStatus, FragmentsProcessingSummary,
+    BlockDate, FragmentLog, FragmentOrigin, FragmentStatus, FragmentsProcessingSummary,
 };
 use poldercast::layer::Selection;
 
@@ -509,6 +509,7 @@ pub enum TransactionMsg {
         reply_handle: ReplyHandle<FragmentsProcessingSummary>,
     },
     RemoveTransactions(Vec<FragmentId>, FragmentStatus),
+    BranchSwitch(BlockDate),
     GetLogs(ReplyHandle<Vec<FragmentLog>>),
     GetStatuses(
         Vec<FragmentId>,

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -271,6 +271,7 @@ where
                         branch.clone(),
                         parent_tip.clone(),
                         None,
+                        None,
                     )
                     .await
                     {
@@ -283,7 +284,7 @@ where
     }
 
     if let Some(parent_tip) = maybe_parent_tip {
-        blockchain::process_new_ref(&mut blockchain, branch, parent_tip, None)
+        blockchain::process_new_ref(&mut blockchain, branch, parent_tip, None, None)
             .await
             .map_err(Error::ChainSelectionFailed)
     } else {


### PR DESCRIPTION
Improves mempool logic to better handle forks. 

### Changelog
* Fragments are removed from the mempool only if they are included in a block appended to our local main chain
* Introduce a date field in `FragmentStatus::Rejected`, this helps with clearing transactions that were rejected in a fork with a different history.
* Clear outdated `InABlock` and `Rejected` fragments in case of a branch switch to keep logs consistent with ledger state (in case of `InABlock`) and avoid refusing now valid transactions (`Rejected`).
Ideally, the `Pending` status could be determined by the presence in the mempool, `InABlock` fetched from the underlying ledger, and `Rejected` is the only one that needs a separate place to be saved (maybe with a time validity). On the other hand, this is meant to be fast (and only related to the last fragments), so maybe fetching the status of a fragment every time from the ledger is not feasible, and that's why I kept it this way for the moment.

Those new transitions are now possible with respect to fragment logs:
*   `Rejected` | `InABlock` (< confirmed depth)  -> not in fragment logs

