### PR TITLE
reverse order of leadership logs

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/leadership.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/leadership.rs
@@ -17,9 +17,13 @@ pub fn test_leadership_logs_parent_hash_is_correct() {
         .wait_for_bootstrap(&StartupVerificationMode::Rest, Duration::from_secs(10))
         .unwrap();
 
+    // Give the node some time to produce blocks
+    std::thread::sleep(Duration::from_secs(5));
+
     let leadership_logs = jcli.rest().v0().leadership_log(jormungandr.rest_uri());
 
-    for leadership in leadership_logs.iter().take(10) {
+    // leadership logs are fetched in reverse order (newest first)
+    for leadership in leadership_logs.iter().take(10).rev() {
         if let LeadershipLogStatus::Block {
             block,
             parent,


### PR DESCRIPTION
The test failed because leadership logs are written to before appending the new block to the chain, and it may happen that a block that is present in the leadership logs is not yet on the chain.

By reversing the order of processing logs in testing (from old to new blocks), we give the node the time to append it to the chain.