### PR TITLE
fix number of pools spawned

### DIFF
--- a/jormungandr/src/secure/enclave.rs
+++ b/jormungandr/src/secure/enclave.rs
@@ -33,8 +33,8 @@ pub struct Schedule {
     current_slot_data: Vec<LeaderEvent>,
 }
 
-fn get_maximum_id<A>(leaders: &BTreeMap<LeaderId, A>) -> LeaderId {
-    leaders.keys().last().copied().unwrap_or_default()
+fn get_maximum_id<A>(leaders: &BTreeMap<LeaderId, A>) -> Option<LeaderId> {
+    leaders.keys().last().copied()
 }
 
 fn leader_identifier(leader: &Leader) -> String {
@@ -64,7 +64,9 @@ impl EnclaveLeadersWithCache {
         if let Some(leader_id) = self.added_leaders_cache.get(&identifier) {
             *leader_id
         } else {
-            let leader_id = get_maximum_id(&self.leaders).next();
+            let leader_id = get_maximum_id(&self.leaders)
+                .map(LeaderId::next)
+                .unwrap_or_default();
 
             self.added_leaders_cache.insert(identifier, leader_id);
             self.leaders.insert(leader_id, leader);
@@ -233,8 +235,7 @@ mod tests {
             genesis_leader: None,
         };
 
-        let init_leader_id = LeaderId::new();
-        let fst_id = init_leader_id.next();
+        let fst_id = LeaderId::new();
         let snd_id = fst_id.next();
 
         assert_eq!(enclave.add_leader(leader1).await, fst_id);
@@ -307,8 +308,7 @@ mod tests {
             }),
         };
 
-        let init_leader_id = LeaderId::new();
-        let fst_id = init_leader_id.next();
+        let fst_id = LeaderId::new();
         let snd_id = fst_id.next();
 
         assert_eq!(enclave.add_leader(leader1).await, fst_id);

--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/mempool/v1.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/mempool/v1.rs
@@ -71,16 +71,10 @@ pub fn test_mempool_pool_max_entries_limit() {
 
     let mempools = assert_accepted_rejected(
         vec![first_transaction.id()],
-        vec![
-            (
-                second_transaction.id(),
-                FragmentRejectionReason::PoolOverflow { pool_number: 0 },
-            ),
-            (
-                second_transaction.id(),
-                FragmentRejectionReason::PoolOverflow { pool_number: 1 },
-            ),
-        ],
+        vec![(
+            second_transaction.id(),
+            FragmentRejectionReason::PoolOverflow { pool_number: 0 },
+        )],
         jormungandr
             .rest()
             .send_fragment_batch(vec![first_transaction, second_transaction], false),
@@ -178,14 +172,6 @@ pub fn test_mempool_pool_max_entries_equal_0() {
                 second_transaction.id(),
                 FragmentRejectionReason::PoolOverflow { pool_number: 0 },
             ),
-            (
-                first_transaction.id(),
-                FragmentRejectionReason::PoolOverflow { pool_number: 1 },
-            ),
-            (
-                second_transaction.id(),
-                FragmentRejectionReason::PoolOverflow { pool_number: 1 },
-            ),
         ],
         jormungandr
             .rest()
@@ -259,16 +245,10 @@ pub fn test_mempool_log_max_entries_only_one_fragment() {
 
     let mempools = assert_accepted_rejected(
         vec![first_transaction.id()],
-        vec![
-            (
-                second_transaction.id(),
-                FragmentRejectionReason::PoolOverflow { pool_number: 0 },
-            ),
-            (
-                second_transaction.id(),
-                FragmentRejectionReason::PoolOverflow { pool_number: 1 },
-            ),
-        ],
+        vec![(
+            second_transaction.id(),
+            FragmentRejectionReason::PoolOverflow { pool_number: 0 },
+        )],
         jormungandr
             .rest()
             .send_fragment_batch(vec![first_transaction, second_transaction], false),
@@ -365,14 +345,6 @@ pub fn test_mempool_log_max_entries_equals_0() {
             (
                 second_transaction.id(),
                 FragmentRejectionReason::PoolOverflow { pool_number: 0 },
-            ),
-            (
-                first_transaction.id(),
-                FragmentRejectionReason::PoolOverflow { pool_number: 1 },
-            ),
-            (
-                second_transaction.id(),
-                FragmentRejectionReason::PoolOverflow { pool_number: 1 },
             ),
         ],
         jormungandr


### PR DESCRIPTION
Spawn as many pools as there are leaders, with the minimum being one for passive nodes to able to participate in the fragments dissemination protocol.