### PR TITLE
add discrimination to settings endpoint

### DIFF
--- a/jormungandr-lib/src/interfaces/settings.rs
+++ b/jormungandr-lib/src/interfaces/settings.rs
@@ -2,6 +2,7 @@ use crate::{
     interfaces::{LinearFeeDef, ValueDef},
     time::SystemTime,
 };
+use chain_addr::Discrimination;
 use chain_impl_mockchain::block::Epoch;
 use chain_impl_mockchain::fee::LinearFee;
 use chain_impl_mockchain::rewards::{CompoundingType, Limit, Parameters, Ratio, TaxType};
@@ -26,6 +27,8 @@ pub struct SettingsDto {
     pub treasury_tax: TaxType,
     #[serde(with = "ParametersDef")]
     pub reward_params: Parameters,
+    #[serde(with = "DiscriminationDef")]
+    pub discrimination: Discrimination,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,6 +82,13 @@ pub struct ParametersDef {
 pub enum CompoundingTypeDef {
     Linear,
     Halvening,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", remote = "Discrimination")]
+enum DiscriminationDef {
+    Test,
+    Production,
 }
 
 impl PartialEq<SettingsDto> for SettingsDto {

--- a/jormungandr/src/rest/v0/logic.rs
+++ b/jormungandr/src/rest/v0/logic.rs
@@ -399,6 +399,7 @@ pub async fn get_settings(context: &Context) -> Result<SettingsDto, Error> {
         slots_per_epoch,
         treasury_tax: current_params.treasury_tax,
         reward_params: current_params.reward_params.clone(),
+        discrimination: static_params.discrimination,
     })
 }
 


### PR DESCRIPTION
It is not really needed anymore in the mobile app (it was before when we used utxo), but I found a bit strange for the discrimination to not be present in the settings endpoint. 

Feel free to close if you think it shouldn't belong there though, it's just a few lines of code anyway.