### PR TITLE
Entrypoint changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1623927034,
+        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "e09c320446c5c2516d430803f7b19f5833781337",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1624626397,
@@ -18,30 +38,9 @@
     },
     "root": {
       "inputs": {
+        "naersk": "naersk",
         "nixpkgs": "nixpkgs",
-        "rust-nix": "rust-nix",
         "utils": "utils"
-      }
-    },
-    "rust-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1614256663,
-        "narHash": "sha256-cFew8eXUJfmlaLh4f3Z+TxAAo2Syh2xWB/3Xa/Ebd70=",
-        "owner": "input-output-hk",
-        "repo": "rust.nix",
-        "rev": "e2d4e8e5225739c4607614f98f60d2667c794558",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "work",
-        "repo": "rust.nix",
-        "type": "github"
       }
     },
     "utils": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1624447853,
-        "narHash": "sha256-Zn+vTEa3NE9q6z6ytpcNXrr8jV7HvrKRxMYoD2E6DpE=",
+        "lastModified": 1624626397,
+        "narHash": "sha256-+h0ulo5//RqStx6g6MDqD9MzgmBfeZ1VYxwEaSmw/Zs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1905f5f2e55e0db0bb6244cfe62cb6c0dbda391d",
+        "rev": "e1f8852faac7638e88d5e8a5b9ee2a7568685e3f",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1613500319,
-        "narHash": "sha256-ybAq6pImFCSnwyhhmnnvV567JM4GuhCEG/PHBkSS86U=",
+        "lastModified": 1624650440,
+        "narHash": "sha256-BIwYENLvbSTNYdyeVJihwi7G6bXVGrPNoOgvJ1Z1SlY=",
         "owner": "kreisys",
         "repo": "flake-utils",
-        "rev": "28e72370213c9bc2cf094ab07b8ac95f3c6bb60f",
+        "rev": "026014b92b548ef130a7aebc84a3894f791370fc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,18 @@
 
                 ulimit -n 1024
 
+                nodeConfig="$NOMAD_TASK_DIR/node-config.json"
+                runConfig="$NOMAD_TASK_DIR/running.json"
+                runYaml="$NOMAD_TASK_DIR/running.yaml"
+                name="jormungandr"
+
                 chmod u+rwx -R "$NOMAD_TASK_DIR" || true
+
+                function convert () {
+                  chmod u+rwx -R "$NOMAD_TASK_DIR" || true
+                  cp "$nodeConfig" "$runConfig"
+                  remarshal --if json --of yaml "$runConfig" > "$runYaml"
+                }
 
                 if [ "$RESET" = "true" ]; then
                   echo "RESET is given, will start from scratch..."
@@ -52,13 +63,29 @@
 
                 set +x
                 echo "waiting for $REQUIRED_PEER_COUNT peers"
-                until [ "$(yq -e -r '.p2p.trusted_peers | length' < "/local/config.yaml" || echo 0)" -ge $REQUIRED_PEER_COUNT ]; do
+                until [ "$(jq -e -r '.p2p.trusted_peers | length' < "$nodeConfig" || echo 0)" -ge $REQUIRED_PEER_COUNT ]; do
                   sleep 1
                 done
                 set -x
 
-                cp /local/config.yaml /local/running.yaml
-                exec jormungandr "$@"
+                convert
+
+                if [ -n "$PRIVATE" ]; then
+                  echo "Running with node with secrets..."
+                  exec jormungandr \
+                    --storage "$STORAGE_DIR" \
+                    --config "$NOMAD_TASK_DIR/running.yaml" \
+                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
+                    --secret $NOMAD_SECRETS_DIR/bft-secret.yaml \
+                    "$@" || true
+                else
+                  echo "Running with follower node..."
+                  exec jormungandr \
+                    --storage "$STORAGE_DIR" \
+                    --config "$NOMAD_TASK_DIR/running.yaml" \
+                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
+                    "$@" || true
+                fi
               '';
             in final.symlinkJoin {
               name = "entrypoint";
@@ -75,8 +102,8 @@
                 gnugrep
                 gnused
                 htop
+                jormungandr
                 jq
-                yq
                 lsof
                 netcat
                 procps
@@ -89,13 +116,15 @@
                 tree
                 utillinux
                 vim
+                yq
               ];
             };
           };
 
       packages = { jormungandr, jcli, jormungandr-entrypoint }@pkgs: pkgs;
 
-      devShell = { mkShell, rustc, cargo, pkg-config, openssl, protobuf, rustfmt }:
+      devShell =
+        { mkShell, rustc, cargo, pkg-config, openssl, protobuf, rustfmt }:
         mkShell {
           PROTOC = "${protobuf}/bin/protoc";
           PROTOC_INCLUDE = "${protobuf}/include";

--- a/flake.nix
+++ b/flake.nix
@@ -2,21 +2,21 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     utils.url = "github:kreisys/flake-utils";
-    rust-nix.url = "github:input-output-hk/rust.nix/work";
-    rust-nix.inputs.nixpkgs.follows = "nixpkgs";
+    naersk.url = "github:nmattia/naersk";
+    naersk.inputs.nixpkgs.follows = "nixpkgs";
   };
-  outputs = { self, nixpkgs, utils, rust-nix }:
+  outputs = { self, nixpkgs, utils, naersk }:
     let
       workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
       inherit (workspaceCargo.workspace) members;
     in utils.lib.simpleFlake {
       inherit nixpkgs;
       systems = [ "x86_64-linux" "aarch64-linux" ];
-      preOverlays = [ rust-nix ];
+      preOverlays = [ naersk ];
       overlay = final: prev:
         let lib = prev.lib;
         in (lib.listToAttrs (lib.forEach members (member:
-          lib.nameValuePair member (final.rust-nix.buildPackage {
+          lib.nameValuePair member (final.naersk.buildPackage {
             inherit ((builtins.fromTOML
               (builtins.readFile (./. + "/${member}/Cargo.toml"))).package)
               name version;


### PR DESCRIPTION
This is needed to enable deploying jormungandr by simply changing the deploy.cue file in vit-ops instead of having to bump its flake input.