### PR TITLE
Fix schedule missing epoch

### DIFF
--- a/jormungandr/src/leadership/process.rs
+++ b/jormungandr/src/leadership/process.rs
@@ -155,7 +155,7 @@ impl Module {
 
         match epoch_time.as_ref().duration_since(SystemTime::now().into()) {
             Err(err) => {
-                // only possible if `next_epoch_time` is earlier than now. I.e. if the next
+                // only possible if `epoch_time` is earlier than now. I.e. if the next
                 // epoch is in the past.
 
                 unreachable!(

--- a/jormungandr/src/secure/enclave.rs
+++ b/jormungandr/src/secure/enclave.rs
@@ -3,6 +3,7 @@ use crate::blockcfg::{
     HeaderSetConsensusSignature,
 };
 use chain_impl_mockchain::leadership::{Leader, LeaderOutput, Leadership};
+use chain_time::Epoch;
 use jormungandr_lib::interfaces::EnclaveLeaderId as LeaderId;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -207,6 +208,10 @@ impl Schedule {
     pub async fn peek(&mut self) -> Option<&LeaderEvent> {
         self.fill().await;
         self.current_slot_data.last()
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        Epoch(self.leadership.epoch())
     }
 }
 


### PR DESCRIPTION
Re-use the schedule epoch when waiting for the next one to avoid
missing a whole new epoch when doing the check at epoch boundaries

I'm not sure how to go about testing, adding a unit test is a bit of a mess because I would basically need to bootstrap a whole node and adding an integration test has its challenges in dealing with tricky time logic.

One way to approach this could be to use libfaketime and add a test in scenario tests, but it won't be tested by the CI.