### PR TITLE
Clean up serialization of vote plans

### DIFF
--- a/jormungandr-lib/src/interfaces/blockdate.rs
+++ b/jormungandr-lib/src/interfaces/blockdate.rs
@@ -109,9 +109,36 @@ impl<'de> Deserialize<'de> for BlockDate {
     where
         D: Deserializer<'de>,
     {
+        use serde::de::{self, MapAccess, Visitor};
+
+        struct StringOrStruct;
+        impl<'de> Visitor<'de> for StringOrStruct {
+            type Value = BlockDate;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("string or map")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<BlockDate, E>
+            where
+                E: de::Error,
+            {
+                let bd = BlockDate::from_str(value).map_err(E::custom)?;
+                Ok(bd)
+            }
+
+            fn visit_map<M>(self, map: M) -> Result<BlockDate, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let d = de::value::MapAccessDeserializer::new(map);
+                let bd = BlockDateStructural::deserialize(d)?;
+                Ok(BlockDate(bd))
+            }
+        }
+
         if deserializer.is_human_readable() {
-            let s = String::deserialize(deserializer)?;
-            BlockDate::from_str(&s).map_err(<D::Error as serde::de::Error>::custom)
+            deserializer.deserialize_any(StringOrStruct)
         } else {
             let (epoch, slot_id): (u32, u32) = Deserialize::deserialize(deserializer)?;
             Ok(BlockDate(block::BlockDate { epoch, slot_id }))
@@ -119,10 +146,9 @@ impl<'de> Deserialize<'de> for BlockDate {
     }
 }
 
-/// This type implements serde::{Serialize, Deserialize} for the remote block:BlockDate
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "chain_impl_mockchain::block::BlockDate")]
-pub struct BlockDateDef {
+struct BlockDateStructural {
     pub epoch: u32,
     pub slot_id: u32,
 }

--- a/jormungandr-lib/src/interfaces/blockdate.rs
+++ b/jormungandr-lib/src/interfaces/blockdate.rs
@@ -180,6 +180,22 @@ mod test {
         assert_eq!(date.to_string(), "12.928")
     }
 
+    #[test]
+    fn deserialize_structured_json() {
+        let json = r#"{
+            "epoch": 12,
+            "slot_id": 928
+        }"#;
+        let decoded: BlockDate = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            decoded,
+            BlockDate(block::BlockDate {
+                epoch: 12,
+                slot_id: 928,
+            })
+        );
+    }
+
     quickcheck! {
         fn display_and_from_str(date: BlockDate) -> TestResult {
             let encoded = date.to_string();

--- a/jormungandr-lib/src/interfaces/mod.rs
+++ b/jormungandr-lib/src/interfaces/mod.rs
@@ -73,6 +73,6 @@ pub use self::transaction_witness::TransactionWitness;
 pub use self::utxo_info::{UTxOInfo, UTxOOutputInfo};
 pub use self::value::{Value, ValueDef};
 pub use self::vote::{
-    serde_base64_bytes, Payload, PrivateTallyState, Tally, TallyResult, VotePlanDef, VotePlanId,
+    serde_base64_bytes, Payload, PrivateTallyState, Tally, TallyResult, VotePlan, VotePlanId,
     VotePlanStatus, VoteProposalStatus, MEMBER_PUBLIC_KEY_BECH32_HRP,
 };

--- a/jormungandr-lib/src/interfaces/vote.rs
+++ b/jormungandr-lib/src/interfaces/vote.rs
@@ -8,7 +8,7 @@ use chain_impl_mockchain::{
     header::BlockDate,
     ledger::governance::{ParametersGovernanceAction, TreasuryGovernanceAction},
     value::Value,
-    vote::{self, Options, PayloadType},
+    vote::{self, Options},
 };
 use chain_vote::MemberPublicKey;
 use core::ops::Range;
@@ -19,8 +19,12 @@ use std::convert::TryInto;
 use std::str;
 use vote::{Choice, Weight};
 
+/// Serializable wrapper for the payload type enum.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct PayloadType(#[serde(with = "PayloadTypeDef")] pub vote::PayloadType);
+
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[serde(remote = "PayloadType", rename_all = "snake_case")]
+#[serde(remote = "vote::PayloadType", rename_all = "snake_case")]
 enum PayloadTypeDef {
     Public,
     Private,
@@ -141,7 +145,7 @@ fn committee_keys(v: &VotePlan) -> Vec<chain_vote::MemberPublicKey> {
 #[serde(remote = "VotePlan")]
 pub struct VotePlanDef {
     #[serde(with = "PayloadTypeDef", getter = "VotePlan::payload_type")]
-    payload_type: PayloadType,
+    payload_type: vote::PayloadType,
     #[serde(with = "BlockDateDef", getter = "VotePlan::vote_start")]
     vote_start: BlockDate,
     #[serde(with = "BlockDateDef", getter = "VotePlan::vote_end")]
@@ -418,7 +422,7 @@ pub type VotePlanId = Hash;
 pub struct VotePlanStatus {
     pub id: VotePlanId,
     #[serde(with = "PayloadTypeDef")]
-    pub payload: PayloadType,
+    pub payload: vote::PayloadType,
     #[serde(with = "BlockDateDef")]
     pub vote_start: BlockDate,
     #[serde(with = "BlockDateDef")]
@@ -779,7 +783,7 @@ mod test {
             bd,
             bd,
             proposals,
-            PayloadType::Private,
+            vote::PayloadType::Private,
             vec![member_key],
         ));
 


### PR DESCRIPTION
Deduplicate code in serde impls. VotePlan DTO is defined as a struct
with its own serde trait impls and From conversions from/to
the chain-libs VotePlan struct.

Use the BlockDate DTO and serialization consistently everywhere,
meaning that the string format will be used in all human-readable
serializations.
To support deserializing existing vote plan JSON data with object format
for blockdates, define adaptive serialization with a Visitor.