### PR TITLE
Fixed 1.54  clippy warnings

### DIFF
--- a/jcli/src/jcli_lib/certificate/mod.rs
+++ b/jcli/src/jcli_lib/certificate/mod.rs
@@ -257,7 +257,7 @@ fn read_cert(input: Option<&Path>) -> Result<interfaces::Certificate, Error> {
     use std::str::FromStr as _;
 
     let cert_str = read_input(input)?;
-    let cert = interfaces::Certificate::from_str(&cert_str.trim_end())?;
+    let cert = interfaces::Certificate::from_str(cert_str.trim_end())?;
     Ok(cert)
 }
 

--- a/jcli/src/jcli_lib/certificate/sign.rs
+++ b/jcli/src/jcli_lib/certificate/sign.rs
@@ -111,7 +111,7 @@ pub(crate) fn committee_vote_tally_sign(
     let id = private_key.to_public().as_ref().try_into().unwrap();
 
     let signature = SingleAccountBindingSignature::new(&builder.get_auth_data(), |d| {
-        private_key.sign_slice(&d.0)
+        private_key.sign_slice(d.0)
     });
 
     let proof = match vote_tally.tally_type() {
@@ -135,7 +135,7 @@ pub(crate) fn committee_encrypted_vote_tally_sign(
     let id = private_key.to_public().as_ref().try_into().unwrap();
 
     let signature = SingleAccountBindingSignature::new(&builder.get_auth_data(), |d| {
-        private_key.sign_slice(&d.0)
+        private_key.sign_slice(d.0)
     });
 
     let proof = EncryptedVoteTallyProof { id, signature };
@@ -157,7 +157,7 @@ pub(crate) fn committee_vote_plan_sign(
     let id = private_key.to_public().as_ref().try_into().unwrap();
 
     let signature = SingleAccountBindingSignature::new(&builder.get_auth_data(), |d| {
-        private_key.sign_slice(&d.0)
+        private_key.sign_slice(d.0)
     });
 
     let proof = VotePlanProof { id, signature };
@@ -191,7 +191,7 @@ pub(crate) fn stake_delegation_account_binding_sign(
     }
 
     let sig = AccountBindingSignature::new_single(&builder.get_auth_data(), |d| {
-        private_key.sign_slice(&d.0)
+        private_key.sign_slice(d.0)
     });
 
     Ok(SignedCertificate::StakeDelegation(delegation, sig))
@@ -238,7 +238,7 @@ where
 
     let mut sigs = Vec::new();
     for (i, key) in keys.iter() {
-        let sig = SingleAccountBindingSignature::new(&auth_data, |d| key.sign_slice(&d.0));
+        let sig = SingleAccountBindingSignature::new(&auth_data, |d| key.sign_slice(d.0));
         sigs.push((*i, sig))
     }
     let sig = PoolOwnersSigned { signatures: sigs };

--- a/jcli/src/jcli_lib/key.rs
+++ b/jcli/src/jcli_lib/key.rs
@@ -329,7 +329,7 @@ impl Verify {
         A: SigningAlgorithm,
         <A as AsymmetricKey>::PubAlg: VerificationAlgorithm,
     {
-        let public = A::PubAlg::public_from_binary(&public_bytes)?;
+        let public = A::PubAlg::public_from_binary(public_bytes)?;
         let (hrp, data) = read_bech32(&self.signature)?;
         if hrp != A::PubAlg::SIGNATURE_BECH32_HRP {
             return Err(Error::UnexpectedBech32SignHrp {
@@ -377,7 +377,7 @@ impl Derive {
             }
         }
 
-        let child_key_bech32 = bech32::encode(&hrp, child_key)?;
+        let child_key_bech32 = bech32::encode(hrp, child_key)?;
         let mut output = self.child_key.open()?;
         writeln!(output, "{}", child_key_bech32)?;
         Ok(())

--- a/jcli/src/jcli_lib/rest/config.rs
+++ b/jcli/src/jcli_lib/rest/config.rs
@@ -60,11 +60,11 @@ pub enum Error {
     #[error("node rejected request because of invalid parameters")]
     InvalidParams(#[source] reqwest::Error),
     #[error("node internal error")]
-    InternalError(#[source] reqwest::Error),
+    Internal(#[source] reqwest::Error),
     #[error("redirecting error while connecting with node")]
     Redirecton(#[source] reqwest::Error),
     #[error("communication with node failed in unexpected way")]
-    UnexpectedError(#[source] reqwest::Error),
+    Unexpected(#[source] reqwest::Error),
 }
 
 impl RestArgs {
@@ -203,14 +203,14 @@ impl RestRequestBuilder {
                     if status.is_client_error() {
                         Error::InvalidParams(e)
                     } else if status.is_server_error() {
-                        Error::InternalError(e)
+                        Error::Internal(e)
                     } else if status.is_redirection() {
                         Error::Redirecton(e)
                     } else {
-                        Error::UnexpectedError(e)
+                        Error::Unexpected(e)
                     }
                 } else {
-                    Error::UnexpectedError(e)
+                    Error::Unexpected(e)
                 }
             })?;
 

--- a/jcli/src/jcli_lib/utils/key_parser.rs
+++ b/jcli/src/jcli_lib/utils/key_parser.rs
@@ -64,9 +64,9 @@ pub fn read_ed25519_secret_key_from_file<P: AsRef<Path>>(
 }
 
 pub fn parse_ed25519_secret_key(bech32_str: &str) -> Result<EitherEd25519SecretKey, Error> {
-    match SecretKey::try_from_bech32_str(&bech32_str) {
+    match SecretKey::try_from_bech32_str(bech32_str) {
         Ok(sk) => Ok(EitherEd25519SecretKey::Extended(sk)),
-        Err(_) => SecretKey::try_from_bech32_str(&bech32_str)
+        Err(_) => SecretKey::try_from_bech32_str(bech32_str)
             .map(EitherEd25519SecretKey::Normal)
             .map_err(Error::SecretKeyMalformed),
     }

--- a/jormungandr-lib/src/crypto/serde.rs
+++ b/jormungandr-lib/src/crypto/serde.rs
@@ -166,7 +166,7 @@ where
         E: DeserializerError,
     {
         use chain_crypto::bech32::Error as Bech32Error;
-        match Self::Value::try_from_bech32_str(&v) {
+        match Self::Value::try_from_bech32_str(v) {
             Err(Bech32Error::DataInvalid(err)) => Err(E::custom(format!("Invalid data: {}", err))),
             Err(Bech32Error::HrpInvalid { expected, actual }) => Err(E::custom(format!(
                 "Invalid prefix: expected {} but was {}",
@@ -207,7 +207,7 @@ where
         E: DeserializerError,
     {
         use chain_crypto::bech32::Error as Bech32Error;
-        match Self::Value::try_from_bech32_str(&v) {
+        match Self::Value::try_from_bech32_str(v) {
             Err(Bech32Error::DataInvalid(err)) => Err(E::custom(format!("Invalid data: {}", err))),
             Err(Bech32Error::HrpInvalid { expected, actual }) => Err(E::custom(format!(
                 "Invalid prefix: expected {} but was {}",
@@ -251,7 +251,7 @@ where
         E: DeserializerError,
     {
         use chain_crypto::bech32::Error as Bech32Error;
-        match Self::Value::try_from_bech32_str(&v) {
+        match Self::Value::try_from_bech32_str(v) {
             Err(Bech32Error::DataInvalid(err)) => Err(E::custom(format!("Invalid data: {}", err))),
             Err(Bech32Error::HrpInvalid { expected, actual }) => Err(E::custom(format!(
                 "Invalid prefix: expected {} but was {}",

--- a/jormungandr-lib/src/interfaces/block0_configuration/active_slot_coefficient.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/active_slot_coefficient.rs
@@ -231,7 +231,7 @@ mod test {
         const VALUE: Milli = Milli::from_millis(220);
         const ACTIVE_SLOT_STR: &str = "---\n\"0.220\"";
 
-        let decoded: ActiveSlotCoefficient = serde_yaml::from_str(&ACTIVE_SLOT_STR).unwrap();
+        let decoded: ActiveSlotCoefficient = serde_yaml::from_str(ACTIVE_SLOT_STR).unwrap();
 
         assert_eq!(decoded.0, VALUE)
     }

--- a/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/initial_fragment.rs
@@ -125,9 +125,9 @@ fn extend_inits_with_legacy_utxo(initials: &mut Vec<Initial>, utxo_decl: &UtxoDe
 impl<'a> From<&'a Initial> for Fragment {
     fn from(initial: &'a Initial) -> Fragment {
         match initial {
-            Initial::Fund(utxo) => pack_utxo_in_message(&utxo),
-            Initial::Cert(cert) => pack_certificate_in_empty_tx_fragment(&cert),
-            Initial::LegacyFund(utxo) => pack_legacy_utxo_in_message(&utxo),
+            Initial::Fund(utxo) => pack_utxo_in_message(utxo),
+            Initial::Cert(cert) => pack_certificate_in_empty_tx_fragment(cert),
+            Initial::LegacyFund(utxo) => pack_legacy_utxo_in_message(utxo),
         }
     }
 }

--- a/jormungandr-lib/src/interfaces/block0_configuration/kes_update_speed.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/kes_update_speed.rs
@@ -196,7 +196,7 @@ mod test {
         const VALUE: u32 = 2 * 24 * 3600 + 6 * 3600 + 15 * 60 + 34;
         const DURATION_STR: &str = "---\n2days 6h 15m 34s";
 
-        let decoded: KesUpdateSpeed = serde_yaml::from_str(&DURATION_STR).unwrap();
+        let decoded: KesUpdateSpeed = serde_yaml::from_str(DURATION_STR).unwrap();
 
         assert_eq!(decoded.0, VALUE)
     }

--- a/jormungandr-lib/src/interfaces/block0_configuration/leader_id.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/leader_id.rs
@@ -108,7 +108,7 @@ mod test {
         const STR: &str =
             "---\n\"ed25519_pk1evu9kfx9tztez708nac569hcp0xwkvekxpwc7m8ztxu44tmq4gws3yayej\"";
 
-        let _: ConsensusLeaderId = serde_yaml::from_str(&STR).unwrap();
+        let _: ConsensusLeaderId = serde_yaml::from_str(STR).unwrap();
     }
 
     quickcheck! {

--- a/jormungandr-lib/src/interfaces/block0_configuration/slots_duration.rs
+++ b/jormungandr-lib/src/interfaces/block0_configuration/slots_duration.rs
@@ -198,7 +198,7 @@ mod test {
         const VALUE: u8 = 15;
         const DURATION_STR: &str = "---\n15s";
 
-        let decoded: SlotDuration = serde_yaml::from_str(&DURATION_STR).unwrap();
+        let decoded: SlotDuration = serde_yaml::from_str(DURATION_STR).unwrap();
 
         assert_eq!(decoded.0, VALUE)
     }

--- a/jormungandr-lib/src/interfaces/blockdate.rs
+++ b/jormungandr-lib/src/interfaces/blockdate.rs
@@ -46,7 +46,7 @@ impl BlockDate {
     pub fn shift_slot(&self, slot_shift: u32, time_era: &TimeEra) -> Self {
         let mut block_date: block::BlockDate = (*self).into();
         for _ in 0..slot_shift {
-            block_date = block_date.next(&time_era);
+            block_date = block_date.next(time_era);
         }
         block_date.into()
     }

--- a/jormungandr-lib/src/interfaces/certificate.rs
+++ b/jormungandr-lib/src/interfaces/certificate.rs
@@ -342,7 +342,7 @@ impl fmt::Display for Certificate {
 impl FromStr for Certificate {
     type Err = CertificateFromStrError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Certificate::from_bech32(&s)?)
+        Ok(Certificate::from_bech32(s)?)
     }
 }
 

--- a/jormungandr-lib/src/interfaces/fragment.rs
+++ b/jormungandr-lib/src/interfaces/fragment.rs
@@ -30,7 +30,7 @@ impl FragmentDef {
     where
         S: Serializer,
     {
-        serialize_fragment(&fragment, serializer)
+        serialize_fragment(fragment, serializer)
     }
 }
 

--- a/jormungandr-lib/src/interfaces/transaction_witness.rs
+++ b/jormungandr-lib/src/interfaces/transaction_witness.rs
@@ -26,7 +26,7 @@ impl TransactionWitness {
 
         let bytes = self.as_ref().serialize_as_vec().unwrap();
 
-        bech32::encode(&HRP, bytes.to_base32()).unwrap()
+        bech32::encode(HRP, bytes.to_base32()).unwrap()
     }
 
     pub fn from_bech32_str(s: &str) -> Result<Self, TransactionWitnessFromStrError> {

--- a/jormungandr/src/blockcfg/mod.rs
+++ b/jormungandr/src/blockcfg/mod.rs
@@ -84,7 +84,7 @@ impl Block0DataSource for Block {
 fn initial(block: &Block) -> Result<&ConfigParams, Block0Malformed> {
     for fragment in block.fragments() {
         if let Fragment::Initial(init) = fragment {
-            return Ok(&init);
+            return Ok(init);
         }
     }
     Err(Block0Malformed::NoInitialSettings)

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -896,7 +896,7 @@ pub fn new_epoch_leadership_from(
                 let (ledger, rewards_info) = ledger
                     .distribute_rewards(
                         distribution,
-                        &parent.epoch_ledger_parameters(),
+                        parent.epoch_ledger_parameters(),
                         reward_info_dist,
                     )
                     .expect("Distribution of rewards will not overflow");

--- a/jormungandr/src/blockchain/checkpoints.rs
+++ b/jormungandr/src/blockchain/checkpoints.rs
@@ -25,7 +25,7 @@ impl Checkpoints {
 
             for _ in 0..ignore_prev {
                 if let Some(prev_epoch) = current_ref.last_ref_previous_epoch() {
-                    current_ref = Arc::clone(&prev_epoch);
+                    current_ref = Arc::clone(prev_epoch);
                 } else {
                     break;
                 }

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -298,7 +298,7 @@ async fn reprocess_tip(
 
     let others = branches
         .iter()
-        .filter(|r| !Arc::ptr_eq(&r, &tip_as_ref))
+        .filter(|r| !Arc::ptr_eq(r, &tip_as_ref))
         .collect::<Vec<_>>();
 
     for other in others {

--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -381,7 +381,7 @@ impl Branch {
     ) -> FieldResult<
         Option<Connection<IndexCursor, Block, ConnectionFields<BlockCount>, EmptyFields>>,
     > {
-        let epoch_data = match extract_context(&context).await.db.get_epoch(epoch.0).await {
+        let epoch_data = match extract_context(context).await.db.get_epoch(epoch.0).await {
             Some(epoch_data) => epoch_data,
             None => return Ok(None),
         };
@@ -494,7 +494,7 @@ impl Block {
     async fn fetch_explorer_block(&self, db: &ExplorerDb) -> FieldResult<Arc<ExplorerBlock>> {
         let mut contents = self.contents.lock().await;
         if let Some(block) = &*contents {
-            Ok(Arc::clone(&block))
+            Ok(Arc::clone(block))
         } else {
             let block = db.get_block(&self.hash).await.ok_or_else(|| {
                 ApiError::InternalError("Couldn't find block's contents in explorer".to_owned())
@@ -533,7 +533,7 @@ impl Block {
 
     /// Date the Block was included in the blockchain
     pub async fn date(&self, context: &Context<'_>) -> FieldResult<BlockDate> {
-        self.fetch_explorer_block(&extract_context(&context).await.db)
+        self.fetch_explorer_block(&extract_context(context).await.db)
             .await
             .map(|b| b.date().into())
     }
@@ -548,7 +548,7 @@ impl Block {
         after: Option<String>,
     ) -> FieldResult<Connection<IndexCursor, Transaction, EmptyFields, EmptyFields>> {
         let explorer_block = self
-            .fetch_explorer_block(&extract_context(&context).await.db)
+            .fetch_explorer_block(&extract_context(context).await.db)
             .await?;
 
         let mut transactions: Vec<&ExplorerTransaction> =
@@ -621,13 +621,13 @@ impl Block {
     }
 
     pub async fn chain_length(&self, context: &Context<'_>) -> FieldResult<ChainLength> {
-        self.fetch_explorer_block(&extract_context(&context).await.db)
+        self.fetch_explorer_block(&extract_context(context).await.db)
             .await
             .map(|block| ChainLength(block.chain_length()))
     }
 
     pub async fn leader(&self, context: &Context<'_>) -> FieldResult<Option<Leader>> {
-        self.fetch_explorer_block(&extract_context(&context).await.db)
+        self.fetch_explorer_block(&extract_context(context).await.db)
             .await
             .map(|block| match block.producer() {
                 BlockProducer::StakePool(pool) => {
@@ -641,25 +641,25 @@ impl Block {
     }
 
     pub async fn previous_block(&self, context: &Context<'_>) -> FieldResult<Block> {
-        self.fetch_explorer_block(&extract_context(&context).await.db)
+        self.fetch_explorer_block(&extract_context(context).await.db)
             .await
             .map(|b| Block::from_valid_hash(b.parent_hash))
     }
 
     pub async fn total_input(&self, context: &Context<'_>) -> FieldResult<Value> {
-        self.fetch_explorer_block(&extract_context(&context).await.db)
+        self.fetch_explorer_block(&extract_context(context).await.db)
             .await
             .map(|block| Value(block.total_input))
     }
 
     pub async fn total_output(&self, context: &Context<'_>) -> FieldResult<Value> {
-        self.fetch_explorer_block(&extract_context(&context).await.db)
+        self.fetch_explorer_block(&extract_context(context).await.db)
             .await
             .map(|block| Value(block.total_output))
     }
 
     pub async fn treasury(&self, context: &Context<'_>) -> FieldResult<Option<Treasury>> {
-        let treasury = extract_context(&context)
+        let treasury = extract_context(context)
             .await
             .db
             .blockchain()
@@ -680,7 +680,7 @@ impl Block {
     }
 
     pub async fn is_confirmed(&self, context: &Context<'_>) -> bool {
-        extract_context(&context)
+        extract_context(context)
             .await
             .db
             .is_block_confirmed(&self.hash)
@@ -689,7 +689,7 @@ impl Block {
 
     pub async fn branches(&self, context: &Context<'_>) -> FieldResult<Vec<Branch>> {
         let branches = self
-            .get_branches(&extract_context(&context).await.db)
+            .get_branches(&extract_context(context).await.db)
             .await?;
 
         Ok(branches)
@@ -744,7 +744,7 @@ pub struct Transaction {
 
 impl Transaction {
     async fn from_id(id: FragmentId, context: &Context<'_>) -> FieldResult<Transaction> {
-        let block_hashes = extract_context(&context)
+        let block_hashes = extract_context(context)
             .await
             .db
             .find_blocks_by_transaction(&id)
@@ -779,7 +779,7 @@ impl Transaction {
 
     async fn get_blocks(&self, context: &Context<'_>) -> FieldResult<Vec<Arc<ExplorerBlock>>> {
         let block_ids = if self.block_hashes.is_empty() {
-            extract_context(&context)
+            extract_context(context)
                 .await
                 .db
                 .find_blocks_by_transaction(&self.id)
@@ -797,7 +797,7 @@ impl Transaction {
         let mut result = Vec::new();
 
         for block_id in block_ids {
-            let block = extract_context(&context)
+            let block = extract_context(context)
                 .await
                 .db
                 .get_block(&block_id)
@@ -938,7 +938,7 @@ impl Address {
     async fn id(&self, context: &Context<'_>) -> String {
         match &self.id {
             ExplorerAddress::New(addr) => chain_addr::AddressReadable::from_address(
-                &extract_context(&context)
+                &extract_context(context)
                     .await
                     .settings
                     .address_bech32_prefix,
@@ -1013,7 +1013,7 @@ pub struct Pool {
 
 impl Pool {
     async fn from_string_id(id: &str, db: &ExplorerDb) -> FieldResult<Pool> {
-        let id = certificate::PoolId::from_str(&id)?;
+        let id = certificate::PoolId::from_str(id)?;
         let blocks = db
             .get_stake_pool_blocks(&id)
             .await
@@ -1064,7 +1064,7 @@ impl Pool {
     ) -> FieldResult<Connection<IndexCursor, Block, ConnectionFields<BlockCount>>> {
         let blocks = match &self.blocks {
             Some(b) => b.clone(),
-            None => extract_context(&context)
+            None => extract_context(context)
                 .await
                 .db
                 .get_stake_pool_blocks(&self.id)
@@ -1133,7 +1133,7 @@ impl Pool {
     pub async fn registration(&self, context: &Context<'_>) -> FieldResult<PoolRegistration> {
         match &self.data {
             Some(data) => Ok(data.registration.clone().into()),
-            None => extract_context(&context)
+            None => extract_context(context)
                 .await
                 .db
                 .get_stake_pool_data(&self.id)
@@ -1146,7 +1146,7 @@ impl Pool {
     pub async fn retirement(&self, context: &Context<'_>) -> FieldResult<Option<PoolRetirement>> {
         match &self.data {
             Some(data) => Ok(data.retirement.clone().map(PoolRetirement::from)),
-            None => extract_context(&context)
+            None => extract_context(context)
                 .await
                 .db
                 .get_stake_pool_data(&self.id)
@@ -1172,7 +1172,7 @@ impl Settings {
             certificate,
             per_certificate_fees,
             per_vote_certificate_fees,
-        } = extract_context(&context).await.db.blockchain_config.fees;
+        } = extract_context(context).await.db.blockchain_config.fees;
 
         FeeSettings {
             constant: Value::from(constant),
@@ -1212,7 +1212,7 @@ impl Settings {
     }
 
     pub async fn epoch_stability_depth(&self, context: &Context<'_>) -> String {
-        extract_context(&context)
+        extract_context(context)
             .await
             .db
             .blockchain_config
@@ -1267,19 +1267,19 @@ impl Epoch {
     }
 
     pub async fn first_block(&self, context: &Context<'_>) -> Option<Block> {
-        self.get_epoch_data(&extract_context(&context).await.db)
+        self.get_epoch_data(&extract_context(context).await.db)
             .await
             .map(|data| Block::from_valid_hash(data.first_block))
     }
 
     pub async fn last_block(&self, context: &Context<'_>) -> Option<Block> {
-        self.get_epoch_data(&extract_context(&context).await.db)
+        self.get_epoch_data(&extract_context(context).await.db)
             .await
             .map(|data| Block::from_valid_hash(data.last_block))
     }
 
     pub async fn total_blocks(&self, context: &Context<'_>) -> BlockCount {
-        self.get_epoch_data(&extract_context(&context).await.db)
+        self.get_epoch_data(&extract_context(context).await.db)
             .await
             .map_or(0u32.into(), |data| data.total_blocks.into())
     }
@@ -1369,7 +1369,7 @@ impl VotePlanStatus {
     ) -> FieldResult<Self> {
         let vote_plan_id = chain_impl_mockchain::certificate::VotePlanId::from_str(&vote_plan_id.0)
             .map_err(|err| -> FieldError { ApiError::InvalidAddress(err.to_string()).into() })?;
-        if let Some(vote_plan) = extract_context(&context)
+        if let Some(vote_plan) = extract_context(context)
             .await
             .db
             .get_vote_plan_by_id(&vote_plan_id)
@@ -1551,7 +1551,7 @@ pub struct Query;
 #[Object]
 impl Query {
     async fn block(&self, context: &Context<'_>, id: String) -> FieldResult<Block> {
-        Block::from_string_hash(id, &extract_context(&context).await.db).await
+        Block::from_string_hash(id, &extract_context(context).await.db).await
     }
 
     async fn blocks_by_chain_length(
@@ -1559,7 +1559,7 @@ impl Query {
         context: &Context<'_>,
         length: ChainLength,
     ) -> FieldResult<Vec<Block>> {
-        let blocks = extract_context(&context)
+        let blocks = extract_context(context)
             .await
             .db
             .find_blocks_by_chain_length(length.0)
@@ -1580,7 +1580,7 @@ impl Query {
 
     /// get all current tips, sorted (descending) by their length
     pub async fn branches(&self, context: &Context<'_>) -> Vec<Branch> {
-        extract_context(&context)
+        extract_context(context)
             .await
             .db
             .get_branches()
@@ -1594,7 +1594,7 @@ impl Query {
     /// get the block that the ledger currently considers as the main branch's
     /// tip
     async fn tip(&self, context: &Context<'_>) -> Branch {
-        let (hash, state_ref) = extract_context(&context).await.db.get_tip().await;
+        let (hash, state_ref) = extract_context(context).await.db.get_tip().await;
         Branch::from_id_and_state(hash, state_ref)
     }
 
@@ -1612,7 +1612,7 @@ impl Query {
     }
 
     pub async fn stake_pool(&self, context: &Context<'_>, id: PoolId) -> FieldResult<Pool> {
-        Pool::from_string_id(&id.0.to_string(), &extract_context(&context).await.db).await
+        Pool::from_string_id(&id.0.to_string(), &extract_context(context).await.db).await
     }
 
     pub async fn settings(&self, _context: &Context<'_>) -> FieldResult<Settings> {

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -402,7 +402,7 @@ impl ExplorerTransaction {
                         .and_then(|block_id| {
                             context
                                 .prev_blocks
-                                .lookup(&block_id)
+                                .lookup(block_id)
                                 .map(|block| &block.transactions[&tx].outputs[index as usize])
                         })
                         .or_else(|| {

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -346,7 +346,7 @@ impl ExplorerDb {
 
     pub async fn get_block(&self, block_id: &HeaderHash) -> Option<Arc<ExplorerBlock>> {
         for (_hash, state_ref) in self.multiverse.tips().await.iter() {
-            if let Some(b) = state_ref.state().blocks.lookup(&block_id) {
+            if let Some(b) = state_ref.state().blocks.lookup(block_id) {
                 return Some(Arc::clone(b));
             }
         }
@@ -405,7 +405,7 @@ impl ExplorerDb {
         let mut tips = Vec::new();
 
         for (hash, state_ref) in self.multiverse.tips().await.drain(..) {
-            if let Some(b) = state_ref.state().blocks.lookup(&block_id) {
+            if let Some(b) = state_ref.state().blocks.lookup(block_id) {
                 block = block.or_else(|| Some(Arc::clone(b)));
                 tips.push((hash, state_ref));
             }
@@ -432,7 +432,7 @@ impl ExplorerDb {
             .await
             .unwrap();
 
-        if let Some(block) = current_branch.state().blocks.lookup(&block_id) {
+        if let Some(block) = current_branch.state().blocks.lookup(block_id) {
             let confirmed_block_chain_length: ChainLength = self
                 .stable_store
                 .confirmed_block_chain_length
@@ -469,7 +469,7 @@ impl ExplorerDb {
                 state_ref
                     .state()
                     .transactions
-                    .lookup(&transaction_id)
+                    .lookup(transaction_id)
                     .map(|arc| *arc.clone())
             })
             .collect();
@@ -520,7 +520,7 @@ impl ExplorerDb {
         vote_plan_id: &VotePlanId,
     ) -> Option<Arc<ExplorerVotePlan>> {
         for (_hash, state_ref) in self.multiverse.tips().await.iter() {
-            if let Some(b) = state_ref.state().vote_plans.lookup(&vote_plan_id) {
+            if let Some(b) = state_ref.state().vote_plans.lookup(vote_plan_id) {
                 return Some(Arc::clone(b));
             }
         }
@@ -653,7 +653,7 @@ fn apply_block_to_stake_pools(
     let mut blocks = match &block.producer() {
         indexing::BlockProducer::StakePool(id) => blocks
             .update(
-                &id,
+                id,
                 |array: &Arc<PersistentSequence<HeaderHash>>| -> std::result::Result<_, Infallible> {
                     Ok(Some(Arc::new(array.append(block.id()))))
                 },

--- a/jormungandr/src/explorer/multiverse.rs
+++ b/jormungandr/src/explorer/multiverse.rs
@@ -55,7 +55,7 @@ impl Multiverse {
 
     pub(super) async fn get_ref(&self, hash: &HeaderHash) -> Option<multiverse::Ref<State>> {
         let guard = self.inner.read().await;
-        guard.multiverse.get_ref(&hash)
+        guard.multiverse.get_ref(hash)
     }
 
     /// run the garbage collection of the multiverse

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -225,7 +225,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
             let secret = secure::NodeSecret::load_from_file(secret_path.as_path())?;
             if let (Some(leaders), Some(leader)) = (&bft_leaders, secret.bft()) {
                 let public_key = &leader.sig_key.to_public();
-                if !leaders.contains(&public_key) {
+                if !leaders.contains(public_key) {
                     tracing::warn!(
                         "node was started with a BFT secret key but the corresponding \
                         public key {} is not listed among consensus leaders",

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -59,7 +59,7 @@ const MAX_BOOTSTRAP_PEERS: u32 = 32;
 pub async fn peers_from_trusted_peer(peer: &Peer) -> Result<Vec<topology::Peer>, Error> {
     tracing::info!("getting peers from bootstrap peer {}", peer.connection);
 
-    let mut client = grpc::connect(&peer).await.map_err(Error::Connect)?;
+    let mut client = grpc::connect(peer).await.map_err(Error::Connect)?;
     let gossip = client
         .peers(MAX_BOOTSTRAP_PEERS)
         .await
@@ -99,7 +99,7 @@ pub async fn bootstrap_from_peer(
 
     tracing::debug!("connecting to bootstrap peer {}", peer.connection);
 
-    let mut client = with_cancellation_token(grpc::connect(&peer).boxed(), &cancellation_token)
+    let mut client = with_cancellation_token(grpc::connect(peer).boxed(), &cancellation_token)
         .await?
         .map_err(Error::Connect)?;
 

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -107,7 +107,7 @@ pub fn connect(state: ConnectionState, channels: Channels) -> (ConnectHandle, Co
 
 // Validate the server peer's node ID
 fn validate_peer_auth(auth: AuthenticatedNodeId, nonce: &[u8]) -> Result<NodeId, ConnectError> {
-    auth.verify(&nonce)
+    auth.verify(nonce)
         .map_err(ConnectError::PeerSignatureVerificationFailed)?;
     Ok(auth.into())
 }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -721,7 +721,7 @@ pub async fn fetch_block(
 
     let span = span!(Level::TRACE, "fetch_block", block = %hash.to_string());
     async {
-        for address in trusted_peers_shuffled(&config) {
+        for address in trusted_peers_shuffled(config) {
             let peer_span = span!(Level::TRACE, "peer_address", address = %address.to_string());
             let peer = Peer::new(address);
             match grpc::fetch_block(&peer, hash)

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -95,7 +95,7 @@ impl PeerMap {
     }
 
     pub fn refresh_peer(&mut self, id: &Address) -> Option<&mut PeerStats> {
-        self.map.get_refresh(&id).map(|data| &mut data.stats)
+        self.map.get_refresh(id).map(|data| &mut data.stats)
     }
 
     pub fn peer_comms(&mut self, id: &Address) -> Option<&mut PeerComms> {

--- a/jormungandr/src/rest/v0/logic.rs
+++ b/jormungandr/src/rest/v0/logic.rs
@@ -158,7 +158,7 @@ pub async fn get_tip(context: &Context) -> Result<String, Error> {
 }
 
 pub async fn get_stats_counter(context: &Context) -> Result<NodeStatsDto, Error> {
-    let stats = create_stats(&context).await?;
+    let stats = create_stats(context).await?;
     Ok(NodeStatsDto {
         version: env!("SIMPLE_VERSION").to_string(),
         state: context.node_state().clone(),
@@ -231,8 +231,8 @@ async fn create_stats(context: &Context) -> Result<Option<NodeStats>, Error> {
             Ok(())
         })?;
 
-    let peer_available_cnt = get_network_p2p_view(&context).await?.len();
-    let peer_quarantined_cnt = get_network_p2p_quarantined(&context).await?.len();
+    let peer_available_cnt = get_network_p2p_view(context).await?.len();
+    let peer_quarantined_cnt = get_network_p2p_quarantined(context).await?.len();
     let peer_total_cnt = peer_available_cnt + peer_quarantined_cnt;
     let tip_header = tip.header();
     let stats = &full_context.stats_counter;
@@ -262,7 +262,7 @@ pub async fn get_block_id(context: &Context, block_id_hex: &str) -> Result<Optio
     context
         .blockchain()?
         .storage()
-        .get(parse_block_hash(&block_id_hex)?)?
+        .get(parse_block_hash(block_id_hex)?)?
         .map(|b| b.serialize_as_vec().map_err(Error::Serialize))
         .transpose()
 }
@@ -273,7 +273,7 @@ pub async fn get_block_next_id(
     count: usize,
 ) -> Result<Option<Vec<u8>>, Error> {
     let blockchain = context.blockchain()?;
-    let block_id = parse_block_hash(&block_id_hex)?;
+    let block_id = parse_block_hash(block_id_hex)?;
     let tip = context.blockchain_tip()?.get_ref().await;
     let maybe_stream = blockchain
         .storage()

--- a/jormungandr/src/rest/v1/logic.rs
+++ b/jormungandr/src/rest/v1/logic.rs
@@ -18,15 +18,15 @@ use tracing_futures::Instrument;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
-    ContextError(#[from] crate::rest::context::Error),
+    Context(#[from] crate::rest::context::Error),
     #[error(transparent)]
     PublicKey(#[from] PublicKeyFromStrError),
     #[error(transparent)]
-    IntercomError(#[from] intercom::Error),
+    Intercom(#[from] intercom::Error),
     #[error(transparent)]
-    TxMsgSendError(#[from] TrySendError<TransactionMsg>),
+    TxMsgSend(#[from] TrySendError<TransactionMsg>),
     #[error(transparent)]
-    MsgSendError(#[from] SendError),
+    MsgSend(#[from] SendError),
     #[error("Block value calculation error")]
     Value(#[from] ValueError),
     #[error(transparent)]
@@ -59,7 +59,7 @@ pub async fn get_fragment_statuses<'a>(
             .await
             .map_err(|e| {
                 tracing::debug!(reason = %e, "error getting message statuses");
-                Error::MsgSendError(e)
+                Error::MsgSend(e)
             })?;
         reply_future
             .await
@@ -107,7 +107,7 @@ pub async fn get_fragment_logs(context: &Context) -> Result<Vec<FragmentLog>, Er
             .await
             .map_err(|e| {
                 tracing::debug!(reason = %e, "error getting fragment logs");
-                Error::MsgSendError(e)
+                Error::MsgSend(e)
             })?;
         reply_future.await.map_err(Into::into)
     }

--- a/jormungandr/src/secure/enclave.rs
+++ b/jormungandr/src/secure/enclave.rs
@@ -186,7 +186,7 @@ impl Schedule {
             let leaders = &self.enclave.leaders_data.read().await.leaders;
             let date = self.leadership.date_at_slot(self.current_slot);
             for (id, leader) in leaders {
-                match self.leadership.is_leader_for_date(&leader, date) {
+                match self.leadership.is_leader_for_date(leader, date) {
                     LeaderOutput::None => (),
                     leader_output => self.current_slot_data.push(LeaderEvent {
                         id: *id,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -164,7 +164,7 @@ impl RawSettings {
             config,
         } = self;
         let command_arguments = &command_line.start_arguments;
-        let network = generate_network(&command_arguments, &config)?;
+        let network = generate_network(command_arguments, &config)?;
 
         let storage = match (
             command_arguments.storage.as_ref(),

--- a/modules/blockchain/src/block0.rs
+++ b/modules/blockchain/src/block0.rs
@@ -15,6 +15,7 @@ pub enum Block0Error {
 }
 
 #[derive(Debug, Error)]
+#[allow(clippy::enum_variant_names)]
 pub enum Block0Malformed {
     #[error("missing its initial settings")]
     NoInitialSettings,
@@ -49,7 +50,7 @@ pub fn start_time(block0: &Block) -> Result<SystemTime, Block0Error> {
 fn initial(block0: &Block) -> Result<&ConfigParams, Block0Malformed> {
     for fragment in block0.fragments() {
         if let Fragment::Initial(init) = fragment {
-            return Ok(&init);
+            return Ok(init);
         }
     }
     Err(Block0Malformed::NoInitialSettings)

--- a/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/api/transaction.rs
@@ -66,7 +66,7 @@ impl Transaction {
         staging_file: P,
     ) {
         self.add_input(
-            &utxo.transaction_id(),
+            utxo.transaction_id(),
             utxo.index_in_transaction(),
             &amount.to_string(),
             staging_file,
@@ -75,7 +75,7 @@ impl Transaction {
 
     pub fn add_input_from_utxo<P: AsRef<Path>>(self, utxo: &UTxOInfo, staging_file: P) {
         self.add_input(
-            &utxo.transaction_id(),
+            utxo.transaction_id(),
             utxo.index_in_transaction(),
             &utxo.associated_fund().to_string(),
             staging_file,
@@ -92,7 +92,7 @@ impl Transaction {
 
     pub fn add_account<P: AsRef<Path>>(self, account_addr: &str, amount: &str, staging_file: P) {
         self.command
-            .add_account(&account_addr, amount, staging_file)
+            .add_account(account_addr, amount, staging_file)
             .build()
             .assert()
             .success();
@@ -123,7 +123,7 @@ impl Transaction {
 
     pub fn add_output<P: AsRef<Path>>(self, addr: &str, amount: Value, staging_file: P) {
         self.command
-            .add_output(&addr, &amount.to_string(), staging_file)
+            .add_output(addr, &amount.to_string(), staging_file)
             .build()
             .assert()
             .success();
@@ -144,7 +144,7 @@ impl Transaction {
         staging_file: P,
     ) {
         self.command
-            .finalize_with_fee(&address, &linear_fee, staging_file)
+            .finalize_with_fee(address, linear_fee, staging_file)
             .build()
             .assert()
             .success();
@@ -210,7 +210,7 @@ impl Transaction {
                 staging_dir,
                 genesis_hash,
                 &account.signing_key().to_bech32_str(),
-                &"account",
+                "account",
                 Some(account.internal_counter().into()),
                 staging_file,
             ),
@@ -218,7 +218,7 @@ impl Transaction {
                 staging_dir,
                 genesis_hash,
                 &utxo.last_signing_key().to_bech32_str(),
-                &"utxo",
+                "utxo",
                 None,
                 staging_file,
             ),
@@ -226,7 +226,7 @@ impl Transaction {
                 staging_dir,
                 genesis_hash,
                 &delegation.last_signing_key().to_bech32_str(),
-                &"utxo",
+                "utxo",
                 None,
                 staging_file,
             ),
@@ -247,7 +247,7 @@ impl Transaction {
             staging_dir,
             &genesis_hash,
             &transaction_id,
-            &addr_type,
+            addr_type,
             private_key,
             spending_key,
         )

--- a/testing/jormungandr-integration-tests/src/common/jcli/services/fragment_check.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/services/fragment_check.rs
@@ -44,7 +44,7 @@ impl<'a> FragmentCheck<'a> {
     pub fn assert_rejected(self, expected_reason: &str) {
         let wait: Wait = Default::default();
         self.wait_until_processed(&wait).unwrap();
-        self.assert_log_shows_rejected(&expected_reason);
+        self.assert_log_shows_rejected(expected_reason);
     }
 
     pub fn wait_until_processed(&self, wait: &Wait) -> Result<FragmentId, Error> {

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -349,7 +349,7 @@ impl ConfigurationBuilder {
         };
 
         fn write_secret(secret: &NodeSecret, output_file: ChildPath) -> PathBuf {
-            configuration::write_secret(&secret, &output_file);
+            configuration::write_secret(secret, &output_file);
             output_file.path().to_path_buf()
         }
 

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -93,7 +93,7 @@ impl JormungandrProcess {
                     log_content: self.logger.get_log_content(),
                 });
             }
-            match self.status(&verification_mode) {
+            match self.status(verification_mode) {
                 Status::Running => {
                     println!("jormungandr is up");
                     return Ok(());

--- a/testing/jormungandr-integration-tests/src/common/network/controller.rs
+++ b/testing/jormungandr-integration-tests/src/common/network/controller.rs
@@ -120,7 +120,7 @@ impl Controller {
         spawn_params: &SpawnParams,
         expected_msg: &str,
     ) -> Result<(), ControllerError> {
-        let mut starter = self.make_starter_for(&spawn_params)?;
+        let mut starter = self.make_starter_for(spawn_params)?;
         starter.start_with_fail_in_logs(expected_msg)?;
         Ok(())
     }
@@ -129,7 +129,7 @@ impl Controller {
         &mut self,
         spawn_params: &SpawnParams,
     ) -> Result<JormungandrProcess, ControllerError> {
-        let mut starter = self.make_starter_for(&spawn_params)?;
+        let mut starter = self.make_starter_for(spawn_params)?;
         let process = starter.start()?;
         Ok(process)
     }

--- a/testing/jormungandr-integration-tests/src/common/startup/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/startup/mod.rs
@@ -27,7 +27,7 @@ pub fn build_genesis_block(
     temp_dir: &impl PathChild,
 ) -> PathBuf {
     let config_file = temp_dir.child("genesis.yaml");
-    write_block0_config(&block0_config, &config_file);
+    write_block0_config(block0_config, &config_file);
     let output_block_file = temp_dir.child("block-0.bin");
     let jcli: JCli = Default::default();
     jcli.genesis()
@@ -74,7 +74,7 @@ pub fn start_stake_pool(
 
     let stake_pool_registration_certs: Vec<SignedCertificate> = stake_pools
         .iter()
-        .map(|x| signed_stake_pool_cert(&x).into())
+        .map(|x| signed_stake_pool_cert(x).into())
         .collect();
     let stake_pool_owner_delegation_certs: Vec<SignedCertificate> = stake_pools
         .iter()

--- a/testing/jormungandr-integration-tests/src/jcli/address/single.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/address/single.rs
@@ -25,7 +25,7 @@ pub fn test_delegation_address_made_of_ed25519_extended_seed_key() {
 
     let private_key = jcli
         .key()
-        .generate_with_seed("ed25519Extended", &correct_seed);
+        .generate_with_seed("ed25519Extended", correct_seed);
     println!("private key: {}", &private_key);
 
     let public_key = jcli.key().convert_to_public_string(&private_key);
@@ -33,7 +33,7 @@ pub fn test_delegation_address_made_of_ed25519_extended_seed_key() {
 
     let private_key = jcli
         .key()
-        .generate_with_seed("ed25519Extended", &correct_seed);
+        .generate_with_seed("ed25519Extended", correct_seed);
     println!("private delegation key: {}", &private_key);
     let delegation_key = jcli.key().convert_to_public_string(&private_key);
     println!("delegation key: {}", &delegation_key);
@@ -55,7 +55,7 @@ pub fn test_delegation_address_is_the_same_as_public() {
 
     let private_key = jcli
         .key()
-        .generate_with_seed("ed25519Extended", &correct_seed);
+        .generate_with_seed("ed25519Extended", correct_seed);
     println!("private key: {}", &private_key);
 
     let public_key = jcli.key().convert_to_public_string(&private_key);
@@ -78,7 +78,7 @@ pub fn test_delegation_address_for_prod_discrimination() {
 
     let private_key = jcli
         .key()
-        .generate_with_seed("ed25519Extended", &correct_seed);
+        .generate_with_seed("ed25519Extended", correct_seed);
     println!("private key: {}", &private_key);
 
     let public_key = jcli.key().convert_to_public_string(&private_key);
@@ -101,7 +101,7 @@ pub fn test_single_address_for_prod_discrimination() {
 
     let private_key = jcli
         .key()
-        .generate_with_seed("ed25519Extended", &correct_seed);
+        .generate_with_seed("ed25519Extended", correct_seed);
     println!("private key: {}", &private_key);
 
     let public_key = jcli.key().convert_to_public_string(&private_key);
@@ -121,7 +121,7 @@ pub fn test_account_address_for_prod_discrimination() {
 
     let private_key = jcli
         .key()
-        .generate_with_seed("ed25519Extended", &correct_seed);
+        .generate_with_seed("ed25519Extended", correct_seed);
     println!("private key: {}", &private_key);
 
     let public_key = jcli.key().convert_to_public_string(&private_key);

--- a/testing/jormungandr-integration-tests/src/jcli/certificate/retirement.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/certificate/retirement.rs
@@ -44,7 +44,7 @@ pub fn jcli_creates_correct_retirement_certificate() {
 }
 
 pub fn assert_new_stake_pool_retirement(stake_pool_id: &str) -> String {
-    let pool_id = PoolId::from_str(&stake_pool_id).unwrap();
+    let pool_id = PoolId::from_str(stake_pool_id).unwrap();
     let start_validity = 0u64;
     let certificate = build_stake_pool_retirement_cert(pool_id, start_validity);
     Certificate::from(certificate).to_bech32().unwrap()

--- a/testing/jormungandr-integration-tests/src/jcli/key/generate.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/key/generate.rs
@@ -55,27 +55,27 @@ pub fn test_key_with_seed_generation() {
     let correct_seed = "73855612722627931e20c850f8ad53eb04c615c7601a95747be073dcada3e135";
     let generated_key = jcli
         .key()
-        .generate_with_seed("Ed25519Extended", &correct_seed);
+        .generate_with_seed("Ed25519Extended", correct_seed);
     assert_ne!(generated_key, "", "generated key is empty");
 }
 
 #[test]
 pub fn test_key_with_too_short_seed_generation() {
     let too_short_seed = "73855612722627931e20c850f8ad53eb04c615c7601a95747be073dcadaa";
-    test_key_invalid_seed_length(&too_short_seed);
+    test_key_invalid_seed_length(too_short_seed);
 }
 
 #[test]
 pub fn test_key_with_too_long_seed_generation() {
     let too_long_seed = "73855612722627931e20c850f8ad53eb04c615c7601a95747be073dcada0234212";
-    test_key_invalid_seed_length(&too_long_seed);
+    test_key_invalid_seed_length(too_long_seed);
 }
 
 fn test_key_invalid_seed_length(seed: &str) {
     let jcli: JCli = Default::default();
     jcli.key().generate_with_seed_expect_fail(
         "Ed25519Extended",
-        &seed,
+        seed,
         "invalid seed length, expected 32 bytes but received",
     );
 }
@@ -86,7 +86,7 @@ pub fn test_key_with_seed_with_unknown_symbol_generation() {
     let incorrect_seed = "73855612722627931e20c850f8ad53eb04c615c7601a95747be073dcay";
     jcli.key().generate_with_seed_expect_fail(
         "Ed25519Extended",
-        &incorrect_seed,
+        incorrect_seed,
         "invalid Hexadecimal",
     );
 }

--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/fragments.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/fragments.rs
@@ -119,7 +119,7 @@ pub fn test_all_fragments() {
     let mut stake_pool_info = new_stake_pool.info_mut();
     stake_pool_info.serial = 100u128;
 
-    startup::sleep_till_next_epoch(1, &jormungandr.block0_configuration());
+    startup::sleep_till_next_epoch(1, jormungandr.block0_configuration());
 
     transaction_sender
         .send_pool_update(

--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/pool_update.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/pool_update.rs
@@ -28,13 +28,13 @@ pub fn update_pool_fees_is_not_allowed() {
     stake_pool_info.rewards = TaxType::zero();
 
     // 6. send pool update certificate
-    startup::sleep_till_next_epoch(1, &jormungandr.block0_configuration());
+    startup::sleep_till_next_epoch(1, jormungandr.block0_configuration());
 
     let transaction = stake_pool_owner
         .issue_pool_update_cert(
             &jormungandr.genesis_block_hash(),
             &jormungandr.fees(),
-            &stake_pool,
+            stake_pool,
             &new_stake_pool,
         )
         .unwrap()

--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_distribution.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_distribution.rs
@@ -77,7 +77,7 @@ pub fn stake_distribution() {
         jormungandr.rest_uri(),
     );
 
-    startup::sleep_till_epoch(3, 10, &jormungandr.block0_configuration());
+    startup::sleep_till_epoch(3, 10, jormungandr.block0_configuration());
 
     jcli.rest().v0().account_stats(
         stake_pool_owner_1.address().to_string(),

--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
@@ -149,9 +149,9 @@ pub fn create_new_stake_pool(
         .to_message();
 
     account.confirm_transaction();
-    jcli.fragment_sender(&jormungandr)
+    jcli.fragment_sender(jormungandr)
         .send(&transaction)
-        .assert_in_block_with_wait(&wait);
+        .assert_in_block_with_wait(wait);
 
     let stake_pool_id = jcli
         .certificate()
@@ -203,16 +203,16 @@ pub fn delegate_stake(
         .to_message();
 
     account.confirm_transaction();
-    jcli.fragment_sender(&jormungandr)
+    jcli.fragment_sender(jormungandr)
         .send(&transaction)
-        .assert_in_block_with_wait(&wait);
+        .assert_in_block_with_wait(wait);
 
     let account_state_after_delegation = jcli
         .rest()
         .v0()
         .account_stats(account.address().to_string(), jormungandr.rest_uri());
 
-    let stake_pool_id_hash = Hash::from_str(&stake_pool_id).unwrap();
+    let stake_pool_id_hash = Hash::from_str(stake_pool_id).unwrap();
     assert!(
         account_state_after_delegation
             .delegation()
@@ -238,7 +238,7 @@ pub fn retire_stake_pool(
         .write_str(&account.signing_key_to_string())
         .unwrap();
 
-    let retirement_cert = jcli.certificate().new_stake_pool_retirement(&stake_pool_id);
+    let retirement_cert = jcli.certificate().new_stake_pool_retirement(stake_pool_id);
 
     let settings = jcli.rest().v0().settings(jormungandr.rest_uri());
     let fees: LinearFee = settings.fees;
@@ -251,21 +251,21 @@ pub fn retire_stake_pool(
         .add_account(&account.address().to_string(), &fee_value)
         .add_certificate(&retirement_cert)
         .finalize_with_fee(&account.address().to_string(), &fees)
-        .seal_with_witness_for_address(&account)
+        .seal_with_witness_for_address(account)
         .add_auth(owner_stake_key.path())
         .to_message();
 
     account.confirm_transaction();
-    jcli.fragment_sender(&jormungandr)
+    jcli.fragment_sender(jormungandr)
         .send(&transaction)
-        .assert_in_block_with_wait(&wait);
+        .assert_in_block_with_wait(wait);
 
     let account_state_after_stake_pool_retire = jcli
         .rest()
         .v0()
         .account_stats(account.address().to_string(), jormungandr.rest_uri());
 
-    let stake_pool_id_hash = Hash::from_str(&stake_pool_id).unwrap();
+    let stake_pool_id_hash = Hash::from_str(stake_pool_id).unwrap();
 
     assert!(
         account_state_after_stake_pool_retire

--- a/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/legacy/mod.rs
@@ -201,7 +201,7 @@ pub fn test_legacy_node_all_fragments() {
 
     // 6. send pool update certificate
 
-    startup::sleep_till_next_epoch(1, &jormungandr.block0_configuration());
+    startup::sleep_till_next_epoch(1, jormungandr.block0_configuration());
     fragment = first_stake_pool_owner
         .issue_pool_update_cert(
             &jormungandr.genesis_block_hash(),

--- a/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/recovery.rs
@@ -64,11 +64,11 @@ pub fn do_simple_transaction(
         .add_output(&account_receiver.address().to_string(), TX_VALUE.into())
         .add_output(&utxo_receiver.address().to_string(), TX_VALUE.into())
         .finalize()
-        .seal_with_witness_for_address(&sender)
+        .seal_with_witness_for_address(sender)
         .to_message();
     let tx_id = tx.fragment_id();
 
-    jcli.fragment_sender(&jormungandr)
+    jcli.fragment_sender(jormungandr)
         .send(&transaction_message)
         .assert_in_block();
 

--- a/testing/jormungandr-integration-tests/src/networking/testnet.rs
+++ b/testing/jormungandr-integration-tests/src/networking/testnet.rs
@@ -142,12 +142,12 @@ impl TestnetConfig {
 
 fn create_actor_account(private_key: &str, jormungandr: &JormungandrProcess) -> Wallet {
     let jcli: JCli = Default::default();
-    let actor_account = Wallet::from_existing_account(&private_key, None);
+    let actor_account = Wallet::from_existing_account(private_key, None);
     let account_state = jcli
         .rest()
         .v0()
         .account_stats(actor_account.address().to_string(), jormungandr.rest_uri());
-    Wallet::from_existing_account(&private_key, Some(account_state.counter()))
+    Wallet::from_existing_account(private_key, Some(account_state.counter()))
 }
 
 fn bootstrap_current(testnet_config: TestnetConfig, network_alias: &str) {
@@ -283,7 +283,7 @@ pub fn itn_bootstrap_current() {
 fn get_legacy_app(temp_dir: &TempDir) -> (PathBuf, Version) {
     let releases = download_last_n_releases(1);
     let last_release = releases.get(0).unwrap();
-    let jormungandr = get_jormungandr_bin(&last_release, temp_dir);
+    let jormungandr = get_jormungandr_bin(last_release, temp_dir);
     (jormungandr, last_release.version())
 }
 

--- a/testing/jormungandr-integration-tests/src/non_functional/mod.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/mod.rs
@@ -82,7 +82,7 @@ pub fn send_transaction_and_ensure_block_was_produced(
     let block_tip_before_transaction = jcli.rest().v0().tip(&jormungandr.rest_uri());
     let block_counter_before_transaction = jormungandr.logger.get_created_blocks_counter();
 
-    jcli.fragment_sender(&jormungandr)
+    jcli.fragment_sender(jormungandr)
         .send_many(transation_messages)
         .wait_until_all_processed(&Default::default())
         .map_err(NodeStuckError::InternalJcliError)?;
@@ -113,9 +113,9 @@ pub fn check_transaction_was_processed(
     value: u64,
     jormungandr: &JormungandrProcess,
 ) -> Result<(), NodeStuckError> {
-    send_transaction_and_ensure_block_was_produced(&[transaction], &jormungandr)?;
+    send_transaction_and_ensure_block_was_produced(&[transaction], jormungandr)?;
 
-    check_funds_transferred_to(&receiver.address().to_string(), value.into(), &jormungandr)?;
+    check_funds_transferred_to(&receiver.address().to_string(), value.into(), jormungandr)?;
 
     jormungandr
         .check_no_errors_in_log()

--- a/testing/jormungandr-scenario-tests/src/interactive/args/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/mod.rs
@@ -70,7 +70,7 @@ impl UserInteractionController {
         vote_plan_alias: &str,
         node_alias: &str,
     ) -> Result<jormungandr_testing_utils::testing::MemPoolCheck> {
-        let committee_address = self.controller.wallet(&committee_alias)?.address();
+        let committee_address = self.controller.wallet(committee_alias)?.address();
         let vote_plan_def = self.controller.vote_plan(vote_plan_alias)?;
 
         let mut temp_wallets = self.wallets_mut().clone();
@@ -114,7 +114,7 @@ impl UserInteractionController {
         proposal_index: usize,
         choice: u8,
     ) -> Result<jormungandr_testing_utils::testing::MemPoolCheck> {
-        let address = self.controller.wallet(&wallet_alias)?.address();
+        let address = self.controller.wallet(wallet_alias)?.address();
         let vote_plan_def = self.controller.vote_plan(vote_plan_alias)?;
 
         let mut temp_wallets = self.wallets_mut().clone();
@@ -161,8 +161,8 @@ impl UserInteractionController {
         node_alias: &str,
         value: Value,
     ) -> Result<jormungandr_testing_utils::testing::MemPoolCheck> {
-        let from_address = self.controller.wallet(&from_str)?.address();
-        let to_address = self.controller.wallet(&to_str)?.address();
+        let from_address = self.controller.wallet(from_str)?.address();
+        let to_address = self.controller.wallet(to_str)?.address();
 
         let to = self
             .wallets()

--- a/testing/jormungandr-scenario-tests/src/interactive/args/spawn.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/spawn.rs
@@ -44,7 +44,7 @@ impl SpawnPassiveNode {
             LeadershipMode::Passive,
             self.storage,
             &self.alias,
-            self.legacy.as_ref().map(|x| Version::parse(&x).unwrap()),
+            self.legacy.as_ref().map(|x| Version::parse(x).unwrap()),
             self.wait,
         )
     }
@@ -145,7 +145,7 @@ impl SpawnLeaderNode {
             LeadershipMode::Leader,
             self.storage,
             &self.alias,
-            self.legacy.as_ref().map(|x| Version::parse(&x).unwrap()),
+            self.legacy.as_ref().map(|x| Version::parse(x).unwrap()),
             self.wait,
         )
     }

--- a/testing/jormungandr-scenario-tests/src/legacy/node.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/node.rs
@@ -303,7 +303,7 @@ impl LegacyNodeController {
         for _ in 0..max_try {
             let logs = self.fragment_logs()?;
 
-            if let Some(log) = logs.get(&check.fragment_id()) {
+            if let Some(log) = logs.get(check.fragment_id()) {
                 use jormungandr_lib::interfaces::FragmentStatus::*;
                 let status = log.status().clone();
                 match log.status() {
@@ -534,7 +534,7 @@ impl LegacyNode {
         context: &'a Context<R>,
         node_settings: &'a mut NodeSetting,
     ) -> SpawnBuilder<'a, R, LegacyNode> {
-        SpawnBuilder::new(&context, node_settings)
+        SpawnBuilder::new(context, node_settings)
     }
     pub fn capture_logs(&mut self) {
         let stderr = self.process.stderr.take().unwrap();

--- a/testing/jormungandr-scenario-tests/src/node.rs
+++ b/testing/jormungandr-scenario-tests/src/node.rs
@@ -541,7 +541,7 @@ impl Node {
         context: &'a Context<R>,
         node_settings: &'a mut NodeSetting,
     ) -> SpawnBuilder<'a, R, Node> {
-        SpawnBuilder::new(&context, node_settings)
+        SpawnBuilder::new(context, node_settings)
     }
 
     pub fn progress_bar(&self) -> &ProgressBarController {

--- a/testing/jormungandr-scenario-tests/src/scenario/context.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/context.rs
@@ -146,7 +146,7 @@ impl<RNG: RngCore> Context<RNG> {
     /// retrieve the original seed of the pseudo random generator
     #[inline]
     pub fn seed(&self) -> &Seed {
-        &self.rng.seed()
+        self.rng.seed()
     }
 
     pub fn progress_bar_mode(&self) -> ProgressBarMode {

--- a/testing/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -147,7 +147,7 @@ impl ControllerBuilder {
             let file = std::fs::File::create(&path.join("initial_setup.dot"))?;
 
             let dotifier = Dotifier;
-            dotifier.dottify(&settings, file)?;
+            dotifier.dottify(settings, file)?;
 
             for wallet in settings.network_settings.wallets.values() {
                 wallet.save_to(path)?;

--- a/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/repository/mod.rs
@@ -108,7 +108,7 @@ impl ScenariosRepository {
             }
             suite_result.push(self.run_single_scenario(
                 &scenario_to_run.name(),
-                &available_scenarios,
+                available_scenarios,
                 &mut context,
             ));
         }

--- a/testing/jormungandr-scenario-tests/src/scenario/settings.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/settings.rs
@@ -173,7 +173,7 @@ impl Dotifier {
 "###
         )?;
         for node in settings.network_settings.nodes.values() {
-            let label = self.dot_node_label(&node);
+            let label = self.dot_node_label(node);
             writeln!(&mut w, "    {}", &label)?;
 
             for trusted_peer in node.node_topology.trusted_peers() {
@@ -190,7 +190,7 @@ impl Dotifier {
 
         for wallet in settings.network_settings.wallets.values() {
             let template = wallet.template();
-            let label = self.dot_wallet_label(&template);
+            let label = self.dot_wallet_label(template);
             writeln!(&mut w, "  {}", &label)?;
 
             if let Some(node) = template.delegate() {

--- a/testing/jormungandr-scenario-tests/src/test/non_functional/soak.rs
+++ b/testing/jormungandr-scenario-tests/src/test/non_functional/soak.rs
@@ -19,7 +19,7 @@ use function_name::named;
 pub fn relay_soak(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     let name = function_name!();
     let scenario_settings = prepare_scenario! {
-        &name,
+        name,
         &mut context,
         topology [
             CORE_NODE,

--- a/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -43,7 +43,7 @@ pub fn measure_single_transaction_propagation_speed<A: SyncNode + FragmentNode +
     let node = leaders.iter().next().unwrap();
     let check = controller.fragment_sender().send_transaction(
         &mut wallet1,
-        &wallet2,
+        wallet2,
         *node,
         1_000.into(),
     )?;

--- a/testing/jormungandr-testing-utils/src/qr_code/hash.rs
+++ b/testing/jormungandr-testing-utils/src/qr_code/hash.rs
@@ -12,7 +12,7 @@ pub enum Error {
     #[error("invalid secret key")]
     SecretKey(#[from] SecretKeyError),
     #[error("failed to decode hex")]
-    HexDecodeError(#[from] hex::FromHexError),
+    HexDecode(#[from] hex::FromHexError),
 }
 
 pub fn generate(key: SecretKey<Ed25519Extended>, password: &[u8]) -> String {

--- a/testing/jormungandr-testing-utils/src/testing/fragments/adversary.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/adversary.rs
@@ -260,7 +260,7 @@ impl<'a, S: SyncNode + Send> AdversaryFragmentSender<'a, S> {
         self.send_faulty_transactions_with_iteration_delay(
             n,
             &mut wallet1,
-            &wallet2,
+            wallet2,
             node,
             std::time::Duration::from_secs(0),
         )
@@ -278,7 +278,7 @@ impl<'a, S: SyncNode + Send> AdversaryFragmentSender<'a, S> {
     ) -> Result<Vec<MemPoolCheck>, AdversaryFragmentSenderError> {
         let mut mem_checks = Vec::new();
         for _ in 0..n {
-            mem_checks.push(self.send_random_faulty_transaction(&mut wallet1, &wallet2, node)?);
+            mem_checks.push(self.send_random_faulty_transaction(&mut wallet1, wallet2, node)?);
             std::thread::sleep(duration);
         }
         Ok(mem_checks)

--- a/testing/jormungandr-testing-utils/src/testing/fragments/export.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/export.rs
@@ -72,7 +72,7 @@ impl FragmentExporter {
         let mut file = fs::File::create(&file_path)
             .map_err(|_| FragmentExporterError::CannotCreateDumpFile(file_path))?;
 
-        file.write_all(&self.format_fragment(fragment).as_bytes())
+        file.write_all(self.format_fragment(fragment).as_bytes())
             .map_err(|_| {
                 FragmentExporterError::CannotWriteFragmentToDumpFile(self.dump_folder.clone())
             })?;

--- a/testing/jormungandr-testing-utils/src/testing/fragments/generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/generator.rs
@@ -74,7 +74,7 @@ impl<'a, S: SyncNode + Send> FragmentGenerator<'a, S> {
 
         for stake_pool in stake_pools.iter() {
             self.fragment_sender
-                .send_pool_registration(&mut self.sender, &stake_pool, &self.node)
+                .send_pool_registration(&mut self.sender, stake_pool, &self.node)
                 .unwrap();
         }
 
@@ -101,7 +101,7 @@ impl<'a, S: SyncNode + Send> FragmentGenerator<'a, S> {
 
         for vote_plan in vote_plans_for_tally.iter() {
             self.fragment_sender
-                .send_vote_plan(&mut self.sender, &vote_plan, &self.node)
+                .send_vote_plan(&mut self.sender, vote_plan, &self.node)
                 .unwrap();
         }
         self.vote_plan_for_casting = Some(vote_plan_for_casting);

--- a/testing/jormungandr-testing-utils/src/testing/fragments/load/adversary_generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/load/adversary_generator.rs
@@ -86,7 +86,7 @@ impl<'a, S: SyncNode + Send> AdversaryFragmentGenerator<'a, S> {
         let reciever = recievers.get(0).unwrap();
 
         self.adversary_fragment_sender
-            .send_random_faulty_transaction(&mut sender, &reciever, &self.jormungandr)
+            .send_random_faulty_transaction(&mut sender, reciever, &self.jormungandr)
             .map(|x| *x.fragment_id())
             .map_err(|e| RequestFailure::General(format!("{:?}", e)))
     }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/load/transaction_generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/load/transaction_generator.rs
@@ -82,7 +82,7 @@ impl<'a, S: SyncNode + Send> TransactionGenerator<'a, S> {
         let reciever = recievers.get(0).unwrap();
 
         self.fragment_sender
-            .send_transaction(&mut sender, &reciever, &self.jormungandr, 1.into())
+            .send_transaction(&mut sender, reciever, &self.jormungandr, 1.into())
             .map(|x| *x.fragment_id())
             .map_err(|e| RequestFailure::General(format!("{:?}", e)))
     }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/mod.rs
@@ -136,7 +136,7 @@ impl FragmentBuilder {
         let mut inner_distribution: Vec<(&StakePoolLib, u8)> = Vec::new();
 
         for (inner_stake_pool, (_, factor)) in inner_stake_pools.iter().zip(distribution) {
-            inner_distribution.push((&inner_stake_pool, factor));
+            inner_distribution.push((inner_stake_pool, factor));
         }
 
         self.fragment_factory()

--- a/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
@@ -293,7 +293,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         }
 
         for _ in 0..n {
-            self.send_transaction(&mut wallet1, &wallet2, node, value)?;
+            self.send_transaction(&mut wallet1, wallet2, node, value)?;
         }
         Ok(())
     }
@@ -312,7 +312,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         }
 
         for _ in 0..n {
-            self.send_transaction(&mut wallet1, &wallet2, node, value)?;
+            self.send_transaction(&mut wallet1, wallet2, node, value)?;
             std::thread::sleep(duration);
         }
         Ok(())
@@ -331,8 +331,8 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         }
 
         for _ in 0..n {
-            self.send_transaction(&mut wallet1, &wallet2, node, value)?;
-            self.send_transaction(&mut wallet2, &wallet1, node, value)?;
+            self.send_transaction(&mut wallet1, wallet2, node, value)?;
+            self.send_transaction(&mut wallet2, wallet1, node, value)?;
         }
         Ok(())
     }

--- a/testing/jormungandr-testing-utils/src/testing/node/logger.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/logger.rs
@@ -67,7 +67,7 @@ impl fmt::Display for LogEntry {
         if let Some(spans) = &self.spans {
             for span in spans {
                 let span_name = span.get("name").cloned().unwrap_or_default();
-                write!(f, "{}{{{}}}: ", span_name, flatten_fields(&span, "name"))?;
+                write!(f, "{}{{{}}}: ", span_name, flatten_fields(span, "name"))?;
             }
         }
         write!(f, " {}: ", self.target)?;
@@ -153,7 +153,7 @@ impl LogEntry {
     pub fn block_date(&self) -> Option<BlockDate> {
         self.fields
             .get("block_date")
-            .map(|block| block::BlockDate::from_str(&block).unwrap().into())
+            .map(|block| block::BlockDate::from_str(block).unwrap().into())
     }
 
     pub fn is_later_than(&self, reference_time: &SystemTime) -> bool {
@@ -264,14 +264,14 @@ impl JormungandrLogger {
 
     pub fn get_created_blocks_hashes(&self) -> Vec<Hash> {
         self.filter_entries_with_block_creation()
-            .map(|item| Hash::from_str(&item.span.unwrap().get("hash").unwrap()).unwrap())
+            .map(|item| Hash::from_str(item.span.unwrap().get("hash").unwrap()).unwrap())
             .collect()
     }
 
     pub fn get_created_blocks_hashes_after(&self, reference_time: SystemTime) -> Vec<Hash> {
         self.filter_entries_with_block_creation()
             .filter(|item| item.is_later_than(&reference_time))
-            .map(|item| Hash::from_str(&item.span.unwrap().get("hash").unwrap()).unwrap())
+            .map(|item| Hash::from_str(item.span.unwrap().get("hash").unwrap()).unwrap())
             .collect()
     }
 
@@ -327,7 +327,7 @@ impl JormungandrLogger {
                 .collect()
         }
 
-        let mut value: Value = serde_json::from_str(&line).unwrap();
+        let mut value: Value = serde_json::from_str(line).unwrap();
         value["fields"] = stringify_map(&value, "fields");
         if value.get("span").is_some() {
             value["span"] = stringify_map(&value, "span");

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
@@ -274,7 +274,7 @@ impl RawRest {
         F: Fn(&RawRest) -> Result<Response, reqwest::Error>,
     {
         loop {
-            let response = action(&self);
+            let response = action(self);
             println!("Waiting for 200... {:?}", response);
             if let Ok(response) = response {
                 if response.status().is_success() {

--- a/testing/jormungandr-testing-utils/src/testing/node/verifier/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/verifier/mod.rs
@@ -46,8 +46,8 @@ impl JormungandrStateVerifier {
         to: &Wallet,
         value: Value,
     ) -> Result<(), StateVerifierError> {
-        self.wallet_lost_value(&from, value)?;
-        self.wallet_gain_value(&to, value)?;
+        self.wallet_lost_value(from, value)?;
+        self.wallet_gain_value(to, value)?;
         Ok(())
     }
 

--- a/testing/jormungandr-testing-utils/src/wallet/committee.rs
+++ b/testing/jormungandr-testing-utils/src/wallet/committee.rs
@@ -116,7 +116,7 @@ impl ElectionPublicKeyExtension for ElectionPublicKey {
 }
 
 pub fn election_key_from_base32(key: &str) -> Result<ElectionPublicKey, Error> {
-    let (hrp, data) = bech32::decode(&key).map_err(Error::InvalidBech32)?;
+    let (hrp, data) = bech32::decode(key).map_err(Error::InvalidBech32)?;
     if hrp != ENCRYPTING_VOTE_PK_HRP {
         return Err(Error::InvalidBech32Key {
             expected: ENCRYPTING_VOTE_PK_HRP.to_string(),

--- a/testing/jormungandr-testing-utils/src/wallet/delegation.rs
+++ b/testing/jormungandr-testing-utils/src/wallet/delegation.rs
@@ -55,7 +55,7 @@ impl Wallet {
     }
 
     pub fn delegation(&self, i: usize) -> &AccountIdentifier {
-        &self.delegations.get(i).unwrap()
+        self.delegations.get(i).unwrap()
     }
 
     pub fn address(&self) -> Address {

--- a/testing/jormungandr-testing-utils/src/wallet/mod.rs
+++ b/testing/jormungandr-testing-utils/src/wallet/mod.rs
@@ -225,7 +225,7 @@ impl Wallet {
 
     pub fn sign_slice(&self, data: &[u8]) -> Signature<TransactionBindingAuthDataPhantom, Ed25519> {
         match self {
-            Wallet::Account(account) => account.signing_key().as_ref().sign_slice(&data),
+            Wallet::Account(account) => account.signing_key().as_ref().sign_slice(data),
             _ => unimplemented!(),
         }
     }
@@ -307,7 +307,7 @@ impl Wallet {
     }
 
     pub fn delegation_cert_for_block0(&self, pool_id: PoolId) -> Initial {
-        FragmentBuilder::full_delegation_cert_for_block0(&self, pool_id)
+        FragmentBuilder::full_delegation_cert_for_block0(self, pool_id)
     }
 
     pub fn transaction_to(
@@ -318,7 +318,7 @@ impl Wallet {
         value: Value,
     ) -> Result<Fragment, WalletError> {
         FragmentBuilder::new(block0_hash, fees)
-            .transaction(&self, address, value)
+            .transaction(self, address, value)
             .map_err(WalletError::FragmentError)
     }
 
@@ -330,7 +330,7 @@ impl Wallet {
         value: Value,
     ) -> Result<Fragment, WalletError> {
         FragmentBuilder::new(block0_hash, fees)
-            .transaction_to_many(&self, address, value)
+            .transaction_to_many(self, address, value)
             .map_err(WalletError::FragmentError)
     }
 
@@ -340,7 +340,7 @@ impl Wallet {
         fees: &LinearFee,
         stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
-        Ok(FragmentBuilder::new(block0_hash, fees).stake_pool_retire(vec![&self], stake_pool))
+        Ok(FragmentBuilder::new(block0_hash, fees).stake_pool_retire(vec![self], stake_pool))
     }
 
     pub fn issue_pool_registration_cert(
@@ -349,7 +349,7 @@ impl Wallet {
         fees: &LinearFee,
         stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
-        Ok(FragmentBuilder::new(block0_hash, fees).stake_pool_registration(&self, stake_pool))
+        Ok(FragmentBuilder::new(block0_hash, fees).stake_pool_registration(self, stake_pool))
     }
 
     pub fn issue_pool_update_cert(
@@ -360,7 +360,7 @@ impl Wallet {
         update_stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
         Ok(FragmentBuilder::new(block0_hash, fees).stake_pool_update(
-            vec![&self],
+            vec![self],
             stake_pool,
             update_stake_pool,
         ))
@@ -372,7 +372,7 @@ impl Wallet {
         fees: &LinearFee,
         stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
-        Ok(FragmentBuilder::new(block0_hash, fees).delegation(&self, stake_pool))
+        Ok(FragmentBuilder::new(block0_hash, fees).delegation(self, stake_pool))
     }
 
     pub fn issue_owner_delegation_cert(
@@ -381,7 +381,7 @@ impl Wallet {
         fees: &LinearFee,
         stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
-        Ok(FragmentBuilder::new(block0_hash, fees).owner_delegation(&self, stake_pool))
+        Ok(FragmentBuilder::new(block0_hash, fees).owner_delegation(self, stake_pool))
     }
 
     pub fn issue_split_delegation_cert(
@@ -390,7 +390,7 @@ impl Wallet {
         fees: &LinearFee,
         distribution: Vec<(&StakePool, u8)>,
     ) -> Result<Fragment, WalletError> {
-        Ok(FragmentBuilder::new(block0_hash, fees).delegation_to_many(&self, distribution))
+        Ok(FragmentBuilder::new(block0_hash, fees).delegation_to_many(self, distribution))
     }
 
     pub fn remove_delegation_cert(
@@ -398,7 +398,7 @@ impl Wallet {
         block0_hash: &Hash,
         fees: &LinearFee,
     ) -> Result<Fragment, WalletError> {
-        Ok(FragmentBuilder::new(block0_hash, fees).delegation_remove(&self))
+        Ok(FragmentBuilder::new(block0_hash, fees).delegation_remove(self))
     }
 
     pub fn issue_vote_plan_cert(
@@ -407,7 +407,7 @@ impl Wallet {
         fees: &LinearFee,
         vote_plan: &VotePlan,
     ) -> Result<Fragment, WalletError> {
-        Ok(FragmentBuilder::new(block0_hash, fees).vote_plan(&self, vote_plan))
+        Ok(FragmentBuilder::new(block0_hash, fees).vote_plan(self, vote_plan))
     }
 
     pub fn issue_vote_cast_cert(
@@ -423,12 +423,12 @@ impl Wallet {
                 block0_hash,
                 fees,
             )
-            .public_vote_cast(&self, vote_plan, proposal_index, choice)),
+            .public_vote_cast(self, vote_plan, proposal_index, choice)),
             chain_impl_mockchain::vote::PayloadType::Private => Ok(FragmentBuilder::new(
                 block0_hash,
                 fees,
             )
-            .private_vote_cast(&self, vote_plan, proposal_index, choice)),
+            .private_vote_cast(self, vote_plan, proposal_index, choice)),
         }
     }
 
@@ -438,7 +438,7 @@ impl Wallet {
         fees: &LinearFee,
         vote_plan: &VotePlan,
     ) -> Result<Fragment, WalletError> {
-        Ok(FragmentBuilder::new(block0_hash, fees).encrypted_tally(&self, vote_plan))
+        Ok(FragmentBuilder::new(block0_hash, fees).encrypted_tally(self, vote_plan))
     }
 
     pub fn issue_vote_tally_cert(
@@ -448,7 +448,7 @@ impl Wallet {
         vote_plan: &VotePlan,
         tally_type: VoteTallyPayload,
     ) -> Result<Fragment, WalletError> {
-        Ok(FragmentBuilder::new(block0_hash, fees).vote_tally(&self, vote_plan, tally_type))
+        Ok(FragmentBuilder::new(block0_hash, fees).vote_tally(self, vote_plan, tally_type))
     }
 
     pub fn to_committee_id(&self) -> CommitteeIdDef {

--- a/testing/mjolnir/src/mjolnir_app/bootstrap/scenario/mod.rs
+++ b/testing/mjolnir/src/mjolnir_app/bootstrap/scenario/mod.rs
@@ -34,7 +34,7 @@ pub fn start_node(
     storage_folder_name: &str,
     temp_dir: &TempDir,
 ) -> Result<JormungandrProcess, StartupError> {
-    copy_initial_storage_if_used(client_config, &storage_folder_name, temp_dir);
+    copy_initial_storage_if_used(client_config, storage_folder_name, temp_dir);
 
     let config = ConfigurationBuilder::new()
         .with_trusted_peers(vec![client_config.trusted_peer()])


### PR DESCRIPTION
Rust `1.54.0` is [out](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html), along with new clippy [lints](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-154).

Most of them are unnecessary borrows so I ran a `cargo clippy --fix`. Some of them are related to [enum variants](https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names) – with `Error` enum variants named `SomeVariantError`. I applied common sense but these things can be a matter of preference.