### PR TITLE
Removed max_unreachable_nodes_to_connect_per_event

### DIFF
--- a/doc/configuration/introduction.md
+++ b/doc/configuration/introduction.md
@@ -35,7 +35,6 @@ p2p:
   allow_private_addresses: false
   max_connections: 256
   max_client_connections: 192
-  max_unreachable_nodes_to_connect_per_event: 20
   gossip_interval: 10s
   max_bootstrap_attempts: # Default is not set
   trusted_peers:

--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -112,11 +112,6 @@ Use the CA certificate with `jcli`.
     It should be a list of valid addresses, for example: `["/ip4/127.0.0.1/tcp/3000"]`.
     By default this list is empty, `[default: []]`.
 - `layers`: (optional) set the settings for some of the poldercast custom layers (see below)
-- `max_unreachable_nodes_to_connect_per_event`: (optional) set the maximum number of unreachable nodes
-  to contact at a time for every new notification.
-  Every time a new propagation event is triggered, the node will select
-  randomly a certain amount of unreachable nodes to connect to in addition
-  to the one selected by other p2p topology layer `[default: 20]`
 - `gossip_interval`: (optional) interval to start gossiping with new nodes,
   changing the value will affect the bandwidth. The more often the node will
   gossip the more bandwidth the node will need. The less often the node gossips

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -105,15 +105,6 @@ pub struct P2pConfig {
     #[serde(default)]
     pub layers: LayersConfig,
 
-    /// set the maximum number of unreachable nodes to contact at a time for every
-    /// new notification. The default value is 20.
-    ///
-    /// Every time a new propagation event is triggered, the node will select
-    /// randomly a certain amount of unreachable nodes to connect to in addition
-    /// to the one selected by other p2p topology layer.
-    #[serde(default)]
-    pub max_unreachable_nodes_to_connect_per_event: Option<usize>,
-
     /// interval to start gossiping with new nodes, changing the value will
     /// affect the bandwidth. The more often the node will gossip the more
     /// bandwidth the node will need. The less often the node gossips the less
@@ -170,7 +161,6 @@ impl Default for P2pConfig {
             allow_private_addresses: false,
             policy: QuarantineConfig::default(),
             layers: LayersConfig::default(),
-            max_unreachable_nodes_to_connect_per_event: None,
             gossip_interval: None,
             network_stuck_check: None,
             max_bootstrap_attempts: None,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -341,7 +341,6 @@ fn generate_network(
             .unwrap_or(network::DEFAULT_MAX_INBOUND_CONNECTIONS),
         timeout: std::time::Duration::from_secs(15),
         allow_private_addresses: p2p.allow_private_addresses,
-        max_unreachable_nodes_to_connect_per_event: p2p.max_unreachable_nodes_to_connect_per_event,
         gossip_interval: p2p
             .gossip_interval
             .map(|d| d.into())

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -86,8 +86,6 @@ pub struct Configuration {
     /// Whether to allow non-public IP addresses in gossip
     pub allow_private_addresses: bool,
 
-    pub max_unreachable_nodes_to_connect_per_event: Option<usize>,
-
     pub gossip_interval: Duration,
 
     pub network_stuck_check: Duration,


### PR DESCRIPTION
`max_unreachable_nodes_to_connect_per_event` is not used anywhere in our codebase.