### PR TITLE
[Test] Adjust test tools in preparation for vote check tool

### DIFF
--- a/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/process.rs
@@ -59,20 +59,20 @@ impl JormungandrProcess {
         params: &JormungandrParams<Conf>,
         temp_dir: Option<TempDir>,
         alias: String,
-    ) -> Self {
+    ) -> Result<Self, StartupError> {
         let node_config = params.node_config();
         let stdout = child.stdout.take().unwrap();
-        JormungandrProcess {
+        Ok(JormungandrProcess {
             child,
             temp_dir,
             alias,
             logger: JormungandrLogger::new(stdout),
             p2p_public_address: node_config.p2p_public_address(),
             rest_socket_addr: node_config.rest_socket_addr(),
-            genesis_block_hash: Hash::from_str(params.genesis_block_hash()).unwrap(),
+            genesis_block_hash: Hash::from_str(params.genesis_block_hash())?,
             block0_configuration: params.block0_configuration().clone(),
             fees: params.fees(),
-        }
+        })
     }
 
     pub fn fragment_sender<'a, S: SyncNode + Send>(

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/commands.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/commands.rs
@@ -96,7 +96,6 @@ impl<'a> CommandBuilder<'a> {
         command.stderr(std::process::Stdio::piped());
         command.stdout(std::process::Stdio::piped());
 
-        println!("Running start jormungandr command: {:?}", &command);
         command
     }
 }

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
@@ -86,7 +86,7 @@ impl From<LeadershipMode> for FromGenesis {
 
 pub struct Starter {
     timeout: Duration,
-    jormungandr_app_path: PathBuf,
+    jormungandr_app_path: Option<PathBuf>,
     sleep: u64,
     role: Role,
     alias: String,
@@ -119,7 +119,7 @@ impl Starter {
             legacy: None,
             config: None,
             benchmark: None,
-            jormungandr_app_path: get_jormungandr_app(),
+            jormungandr_app_path: None,
         }
     }
 
@@ -129,7 +129,7 @@ impl Starter {
     }
 
     pub fn jormungandr_app(&mut self, path: PathBuf) -> &mut Self {
-        self.jormungandr_app_path = path;
+        self.jormungandr_app_path = Some(path);
         self
     }
 
@@ -329,7 +329,11 @@ where
     fn start_with_fail_in_stderr(self, expected_msg: &str) {
         get_command(
             &self.params,
-            &self.starter.jormungandr_app_path,
+            &self
+                .starter
+                .jormungandr_app_path
+                .clone()
+                .unwrap_or_else(get_jormungandr_app),
             self.starter.role,
             self.starter.from_genesis,
         )
@@ -353,7 +357,10 @@ where
 
         let mut command = get_command(
             &self.params,
-            self.starter.jormungandr_app_path.clone(),
+            self.starter
+                .jormungandr_app_path
+                .clone()
+                .unwrap_or_else(get_jormungandr_app),
             self.starter.role,
             self.starter.from_genesis,
         );

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/starter/mod.rs
@@ -42,6 +42,8 @@ pub enum StartupError {
     JormungandrError(#[from] JormungandrError),
     #[error("expected message not found: {entry} in logs: {log_content}")]
     EntryNotFoundInLogs { entry: String, log_content: String },
+    #[error("too many failures while attempting to start jormungandr")]
+    TooManyAttempts,
 }
 
 const DEFAULT_SLEEP_BETWEEN_ATTEMPTS: u64 = 2;
@@ -449,7 +451,7 @@ where
             }
 
             if retry_counter < 0 {
-                panic!("Jormungandr node cannot start despites retry attempts. see logs for more details");
+                return Err(StartupError::TooManyAttempts);
             }
 
             self.temp_dir = jormungandr.steal_temp_dir();

--- a/testing/jormungandr-testing-utils/src/testing/node/explorer/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/explorer/mod.rs
@@ -202,7 +202,17 @@ impl Explorer {
         self.last_block().unwrap().block_date()
     }
 
-    fn print_log<T: std::fmt::Debug>(&self, response: &Response<T>) {
+    pub fn run<T: Serialize>(
+        &self,
+        query: QueryBody<T>,
+    ) -> Result<reqwest::blocking::Response, ExplorerError> {
+        self.print_request(&query);
+        let response = self.client.run(query).map_err(ExplorerError::ClientError)?;
+        self.print_log(&response);
+        Ok(response)
+    }
+
+    fn print_log<T: std::fmt::Debug>(&self, response: &T) {
         if self.print_log {
             println!("Response: {:?}", &response);
         }


### PR DESCRIPTION
This PR adjust some of the tools the are currently used in testing to be able to reuse them for the vote check tool.
In particular, it contains: 
* a quick change to make `Starter` more binary friendly by:
  * adding a verbose flag to suppress unwanted output
  * lazily get the local jormungandr binary
  * remove unnecessary panics

  If we plan to use such struct more broadly I think it would be better to refactor it (and some of its dependencies, like `JormungandrProcess`) in some shared tool space (e.g. jormungandr-(testing)-utils).

  Due to the challenges of such refactor and the close deadline for code freeze I chose to go with this simpler solution for now. 
* an addition to be able to run arbitrary queries with the explorer interface tool