### PR TITLE
consistent transaction fields order

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/genesis/pool_update.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/genesis/pool_update.rs
@@ -32,12 +32,12 @@ pub fn update_pool_fees_is_not_allowed() {
 
     let transaction = stake_pool_owner
         .issue_pool_update_cert(
+            &jormungandr.genesis_block_hash(),
+            &jormungandr.fees(),
             chain_impl_mockchain::block::BlockDate {
                 epoch: 3,
                 slot_id: 0,
             },
-            &jormungandr.genesis_block_hash(),
-            &jormungandr.fees(),
             stake_pool,
             &new_stake_pool,
         )

--- a/testing/jormungandr-integration-tests/src/jormungandr/legacy.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/legacy.rs
@@ -78,9 +78,9 @@ pub fn test_legacy_node_all_fragments() {
     // 2a). send pool registration certificate
     fragment = first_stake_pool_owner
         .issue_pool_registration_cert(
-            chain_impl_mockchain::block::BlockDate::first(),
             &jormungandr.genesis_block_hash(),
             &jormungandr.fees(),
+            chain_impl_mockchain::block::BlockDate::first(),
             &first_stake_pool,
         )
         .expect("cannot create pool registration fragment for first stake pool owner");
@@ -94,9 +94,9 @@ pub fn test_legacy_node_all_fragments() {
     // 2b). send pool registration certificate
     fragment = second_stake_pool_owner
         .issue_pool_registration_cert(
-            chain_impl_mockchain::block::BlockDate::first(),
             &jormungandr.genesis_block_hash(),
             &jormungandr.fees(),
+            chain_impl_mockchain::block::BlockDate::first(),
             &second_stake_pool,
         )
         .expect("cannot create pool registration fragment for second stake owner");
@@ -121,9 +121,9 @@ pub fn test_legacy_node_all_fragments() {
     // 3. send owner delegation certificate
     fragment = first_stake_pool_owner
         .issue_owner_delegation_cert(
-            chain_impl_mockchain::block::BlockDate::first(),
             &jormungandr.genesis_block_hash(),
             &jormungandr.fees(),
+            chain_impl_mockchain::block::BlockDate::first(),
             &first_stake_pool,
         )
         .unwrap();
@@ -146,9 +146,9 @@ pub fn test_legacy_node_all_fragments() {
     // 4. send full delegation certificate
     fragment = full_delegator
         .issue_full_delegation_cert(
-            chain_impl_mockchain::block::BlockDate::first(),
             &jormungandr.genesis_block_hash(),
             &jormungandr.fees(),
+            chain_impl_mockchain::block::BlockDate::first(),
             &first_stake_pool,
         )
         .expect("error while sending full delegation certificate");
@@ -170,9 +170,9 @@ pub fn test_legacy_node_all_fragments() {
     // 5. send split delegation certificate
     fragment = split_delegator
         .issue_split_delegation_cert(
-            chain_impl_mockchain::block::BlockDate::first(),
             &jormungandr.genesis_block_hash(),
             &jormungandr.fees(),
+            chain_impl_mockchain::block::BlockDate::first(),
             vec![(&first_stake_pool, 1u8), (&second_stake_pool, 1u8)],
         )
         .expect("error while sending split delegation certificate");
@@ -211,9 +211,9 @@ pub fn test_legacy_node_all_fragments() {
     startup::sleep_till_next_epoch(1, jormungandr.block0_configuration());
     fragment = first_stake_pool_owner
         .issue_pool_update_cert(
-            chain_impl_mockchain::block::BlockDate::first(),
             &jormungandr.genesis_block_hash(),
             &jormungandr.fees(),
+            chain_impl_mockchain::block::BlockDate::first(),
             &first_stake_pool,
             &new_stake_pool,
         )
@@ -227,9 +227,9 @@ pub fn test_legacy_node_all_fragments() {
     // 7. send pool retire certificate
     fragment = first_stake_pool_owner
         .issue_pool_retire_cert(
-            chain_impl_mockchain::block::BlockDate::first(),
             &jormungandr.genesis_block_hash(),
             &jormungandr.fees(),
+            chain_impl_mockchain::block::BlockDate::first(),
             &first_stake_pool,
         )
         .expect("error while sending stake pool retirement certificate");

--- a/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
@@ -163,7 +163,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         via: &A,
     ) -> Result<MemPoolCheck, FragmentSenderError> {
         let fragment =
-            from.issue_full_delegation_cert(self.date, &self.block0_hash, &self.fees, to)?;
+            from.issue_full_delegation_cert(&self.block0_hash, &self.fees, self.date, to)?;
         self.dump_fragment_if_enabled(from, &fragment, via)?;
         self.send_fragment(from, fragment, via)
     }
@@ -175,9 +175,9 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         via: &A,
     ) -> Result<MemPoolCheck, FragmentSenderError> {
         let fragment = from.issue_split_delegation_cert(
-            self.date,
             &self.block0_hash,
             &self.fees,
+            self.date,
             distribution.to_vec(),
         )?;
         self.dump_fragment_if_enabled(from, &fragment, via)?;
@@ -191,7 +191,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         via: &A,
     ) -> Result<MemPoolCheck, FragmentSenderError> {
         let fragment =
-            from.issue_owner_delegation_cert(self.date, &self.block0_hash, &self.fees, to)?;
+            from.issue_owner_delegation_cert(&self.block0_hash, &self.fees, self.date, to)?;
         self.dump_fragment_if_enabled(from, &fragment, via)?;
         self.send_fragment(from, fragment, via)
     }
@@ -203,7 +203,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         via: &A,
     ) -> Result<MemPoolCheck, FragmentSenderError> {
         let fragment =
-            from.issue_pool_registration_cert(self.date, &self.block0_hash, &self.fees, to)?;
+            from.issue_pool_registration_cert(&self.block0_hash, &self.fees, self.date, to)?;
         self.dump_fragment_if_enabled(from, &fragment, via)?;
         self.send_fragment(from, fragment, via)
     }
@@ -216,9 +216,9 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         via: &A,
     ) -> Result<MemPoolCheck, FragmentSenderError> {
         let fragment = from.issue_pool_update_cert(
-            self.date,
             &self.block0_hash,
             &self.fees,
+            self.date,
             to,
             update_stake_pool,
         )?;
@@ -232,7 +232,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         to: &StakePool,
         via: &A,
     ) -> Result<MemPoolCheck, FragmentSenderError> {
-        let fragment = from.issue_pool_retire_cert(self.date, &self.block0_hash, &self.fees, to)?;
+        let fragment = from.issue_pool_retire_cert(&self.block0_hash, &self.fees, self.date, to)?;
         self.dump_fragment_if_enabled(from, &fragment, via)?;
         self.send_fragment(from, fragment, via)
     }
@@ -244,7 +244,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         via: &A,
     ) -> Result<MemPoolCheck, FragmentSenderError> {
         let fragment =
-            from.issue_vote_plan_cert(self.date, &self.block0_hash, &self.fees, vote_plan)?;
+            from.issue_vote_plan_cert(&self.block0_hash, &self.fees, self.date, vote_plan)?;
         self.dump_fragment_if_enabled(from, &fragment, via)?;
         self.send_fragment(from, fragment, via)
     }
@@ -258,9 +258,9 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         via: &A,
     ) -> Result<MemPoolCheck, FragmentSenderError> {
         let fragment = from.issue_vote_cast_cert(
-            self.date,
             &self.block0_hash,
             &self.fees,
+            self.date,
             vote_plan,
             proposal_index,
             choice,
@@ -285,7 +285,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         via: &A,
     ) -> Result<MemPoolCheck, FragmentSenderError> {
         let fragment =
-            from.issue_encrypted_tally_cert(self.date, &self.block0_hash, &self.fees, vote_plan)?;
+            from.issue_encrypted_tally_cert(&self.block0_hash, &self.fees, self.date, vote_plan)?;
         self.dump_fragment_if_enabled(from, &fragment, via)?;
         self.send_fragment(from, fragment, via)
     }

--- a/testing/jormungandr-testing-utils/src/wallet/mod.rs
+++ b/testing/jormungandr-testing-utils/src/wallet/mod.rs
@@ -346,9 +346,9 @@ impl Wallet {
 
     pub fn issue_pool_retire_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
         stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
         Ok(FragmentBuilder::new(block0_hash, fees, date).stake_pool_retire(vec![self], stake_pool))
@@ -356,9 +356,9 @@ impl Wallet {
 
     pub fn issue_pool_registration_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
         stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
         Ok(FragmentBuilder::new(block0_hash, fees, date).stake_pool_registration(self, stake_pool))
@@ -366,9 +366,9 @@ impl Wallet {
 
     pub fn issue_pool_update_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
         stake_pool: &StakePool,
         update_stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
@@ -383,9 +383,9 @@ impl Wallet {
 
     pub fn issue_full_delegation_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
         stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
         Ok(FragmentBuilder::new(block0_hash, fees, date).delegation(self, stake_pool))
@@ -393,9 +393,9 @@ impl Wallet {
 
     pub fn issue_owner_delegation_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
         stake_pool: &StakePool,
     ) -> Result<Fragment, WalletError> {
         Ok(FragmentBuilder::new(block0_hash, fees, date).owner_delegation(self, stake_pool))
@@ -403,9 +403,9 @@ impl Wallet {
 
     pub fn issue_split_delegation_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
         distribution: Vec<(&StakePool, u8)>,
     ) -> Result<Fragment, WalletError> {
         Ok(FragmentBuilder::new(block0_hash, fees, date).delegation_to_many(self, distribution))
@@ -413,18 +413,18 @@ impl Wallet {
 
     pub fn remove_delegation_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
     ) -> Result<Fragment, WalletError> {
         Ok(FragmentBuilder::new(block0_hash, fees, date).delegation_remove(self))
     }
 
     pub fn issue_vote_plan_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
         vote_plan: &VotePlan,
     ) -> Result<Fragment, WalletError> {
         Ok(FragmentBuilder::new(block0_hash, fees, date).vote_plan(self, vote_plan))
@@ -432,9 +432,9 @@ impl Wallet {
 
     pub fn issue_vote_cast_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
         vote_plan: &VotePlan,
         proposal_index: u8,
         choice: &Choice,
@@ -457,9 +457,9 @@ impl Wallet {
 
     pub fn issue_encrypted_tally_cert(
         &mut self,
-        date: BlockDate,
         block0_hash: &Hash,
         fees: &LinearFee,
+        date: BlockDate,
         vote_plan: &VotePlan,
     ) -> Result<Fragment, WalletError> {
         Ok(FragmentBuilder::new(block0_hash, fees, date).encrypted_tally(self, vote_plan))


### PR DESCRIPTION
It was bothering me a little that different `Wallet` transactions had the block date field in different positions. 