### PR TITLE
Additional TTL Functional Tests

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
@@ -1,14 +1,12 @@
-use crate::common::jcli::JCli;
 use crate::common::jormungandr::{starter::Role, Starter};
-use crate::common::transaction_utils::TransactionHash;
 use crate::common::{jormungandr::ConfigurationBuilder, startup};
 use assert_fs::fixture::PathChild;
 use assert_fs::TempDir;
 use chain_impl_mockchain::fee::LinearFee;
 use chain_impl_mockchain::{block::BlockDate, chaintypes::ConsensusVersion};
+use jormungandr_lib::interfaces::InitialUTxO;
 use jormungandr_lib::interfaces::PersistentLog;
 use jormungandr_lib::interfaces::{BlockDate as BlockDateDto, Mempool};
-use jormungandr_lib::interfaces::{InitialUTxO, Value};
 use jormungandr_testing_utils::testing::fragments::FragmentExporter;
 use jormungandr_testing_utils::testing::fragments::PersistentLogViewer;
 use jormungandr_testing_utils::testing::{
@@ -395,7 +393,9 @@ pub fn node_should_pickup_log_after_restart() {
 }
 
 #[test]
-pub fn expired_fragment_should_be_removed() {
+/// Verifies that a node will reject a fragment that has expired, even after it's been accepted in
+/// its mempool.
+pub fn expired_fragment_should_be_rejected() {
     const N_FRAGMENTS: u32 = 10;
 
     let receiver = startup::create_new_account_address();
@@ -434,7 +434,7 @@ pub fn expired_fragment_should_be_removed() {
         .unwrap();
 
     // By the time the rest of the transactions have been placed in blocks, the epoch should be over
-    // and the transaction below have be expired.
+    // and the transaction below should have expired.
     FragmentVerifier::wait_and_verify_is_rejected(Duration::from_secs(1), check, &jormungandr)
         .unwrap();
 }

--- a/testing/jormungandr-integration-tests/src/jormungandr/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mod.rs
@@ -6,6 +6,7 @@ pub mod grpc;
 mod leadership;
 pub mod legacy;
 pub mod mempool;
+pub mod persistent_log;
 pub mod recovery;
 pub mod rest;
 pub mod tls;

--- a/testing/jormungandr-integration-tests/src/jormungandr/persistent_log.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/persistent_log.rs
@@ -10,11 +10,12 @@ use jormungandr_testing_utils::testing::fragments::PersistentLogViewer;
 pub use jortestkit::console::progress_bar::{parse_progress_bar_mode_from_str, ProgressBarMode};
 
 #[test]
+/// Verifies that no log entries are created for fragments that are already expired when received.
 fn rejected_fragments_have_no_log() {
     let receiver = startup::create_new_account_address();
     let mut sender = startup::create_new_account_address();
 
-    let persistent_log_path = TempDir::new().unwrap().child("log_path");
+    let log_path = TempDir::new().unwrap().child("log_path");
 
     let (jormungandr, _) = startup::start_stake_pool(
         &[sender.clone()],
@@ -25,7 +26,7 @@ fn rejected_fragments_have_no_log() {
                 pool_max_entries: 1_000.into(),
                 log_max_entries: 1_000.into(),
                 persistent_log: Some(PersistentLog {
-                    dir: persistent_log_path.path().to_path_buf(),
+                    dir: log_path.path().to_path_buf(),
                 }),
             }),
     )
@@ -81,7 +82,8 @@ fn rejected_fragments_have_no_log() {
         )
         .assert_rejected_summary();
 
-    let persistent_log_viewer = PersistentLogViewer::new(persistent_log_path.path().to_path_buf());
-
-    assert_eq!(persistent_log_viewer.count(), 1);
+    assert_eq!(
+        PersistentLogViewer::new(log_path.path().to_path_buf()).count(),
+        1
+    );
 }

--- a/testing/jormungandr-integration-tests/src/jormungandr/persistent_log.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/persistent_log.rs
@@ -1,0 +1,87 @@
+use crate::common::jcli::JCli;
+use crate::common::jormungandr::ConfigurationBuilder;
+use crate::common::startup;
+use crate::common::transaction_utils::TransactionHash;
+use assert_fs::fixture::PathChild;
+use assert_fs::TempDir;
+use chain_impl_mockchain::block::BlockDate;
+use jormungandr_lib::interfaces::{Mempool, PersistentLog};
+use jormungandr_testing_utils::testing::fragments::PersistentLogViewer;
+pub use jortestkit::console::progress_bar::{parse_progress_bar_mode_from_str, ProgressBarMode};
+
+#[test]
+fn rejected_fragments_have_no_log() {
+    let receiver = startup::create_new_account_address();
+    let mut sender = startup::create_new_account_address();
+
+    let persistent_log_path = TempDir::new().unwrap().child("log_path");
+
+    let (jormungandr, _) = startup::start_stake_pool(
+        &[sender.clone()],
+        &[receiver.clone()],
+        ConfigurationBuilder::new()
+            .with_slot_duration(1)
+            .with_mempool(Mempool {
+                pool_max_entries: 1_000.into(),
+                log_max_entries: 1_000.into(),
+                persistent_log: Some(PersistentLog {
+                    dir: persistent_log_path.path().to_path_buf(),
+                }),
+            }),
+    )
+    .unwrap();
+
+    let jcli = JCli::default();
+
+    // Should be rejected without a log entry
+    jcli.fragment_sender(&jormungandr)
+        .send(
+            &sender
+                .transaction_to(
+                    &jormungandr.genesis_block_hash(),
+                    &jormungandr.fees(),
+                    BlockDate::first(),
+                    receiver.address(),
+                    100.into(),
+                )
+                .unwrap()
+                .encode(),
+        )
+        .assert_rejected_summary();
+
+    // Should be accepted with a log entry
+    jcli.fragment_sender(&jormungandr)
+        .send(
+            &sender
+                .transaction_to(
+                    &jormungandr.genesis_block_hash(),
+                    &jormungandr.fees(),
+                    BlockDate::first().next_epoch(),
+                    receiver.address(),
+                    101.into(),
+                )
+                .unwrap()
+                .encode(),
+        )
+        .assert_in_block();
+
+    // Should be rejected without a log entry
+    jcli.fragment_sender(&jormungandr)
+        .send(
+            &sender
+                .transaction_to(
+                    &jormungandr.genesis_block_hash(),
+                    &jormungandr.fees(),
+                    BlockDate::first(),
+                    receiver.address(),
+                    102.into(),
+                )
+                .unwrap()
+                .encode(),
+        )
+        .assert_rejected_summary();
+
+    let persistent_log_viewer = PersistentLogViewer::new(persistent_log_path.path().to_path_buf());
+
+    assert_eq!(persistent_log_viewer.count(), 1);
+}


### PR DESCRIPTION
Addendum to #3537:

* New test to verify expired transactions do not create entries in the persistent log.
* New test to verify a node will reject transactions that expired after they've entered the mempool.