### PR TITLE
basic xtask usage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run -p xtask -- "

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ name = "chain-vote"
 version = "0.1.0"
 source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#73a4b6cd8d64c9844200c70f86a7d18c519ce8a2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "chain-core",
  "chain-crypto",
  "cryptoxide",
@@ -4572,6 +4572,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xshell"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c640362f1b150e186b76e88606e4b01a7b2f1d56cc50fcc184ddb683fb567c23"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0607c095c96c1d8420ce4a018a0954fb15d73d5eb59b521a05a0f04cffc05059"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "structopt",
+ "xshell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
   "testing/jormungandr-integration-tests",
   "testing/jormungandr-scenario-tests",
   "testing/mjolnir",
+  "xtask",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+structopt = "^0.3"
+xshell = "0.1"

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -1,0 +1,9 @@
+use xshell::cmd;
+
+pub fn ci() {
+    cmd!("cargo fmt -- --check").run().unwrap();
+    cmd!("cargo clippy --all-features --all-targets -- -D warnings")
+        .run()
+        .unwrap();
+    crate::test::test();
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,25 @@
+//! See <https://github.com/matklad/cargo-xtask/>.
+//!
+//! This binary defines various auxiliary build commands, which are not
+//! expressible with just `cargo`.
+//!
+//! This binary is integrated into the `cargo` command line by using an alias in
+//! `.cargo/config`.
+
+use structopt::StructOpt;
+
+mod ci;
+mod test;
+
+#[derive(StructOpt)]
+enum Command {
+    Test,
+    Ci,
+}
+
+fn main() {
+    match Command::from_args() {
+        Command::Test => test::test(),
+        Command::Ci => ci::ci(),
+    }
+}

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -1,0 +1,7 @@
+use xshell::cmd;
+
+pub fn test() {
+    cmd!("cargo build -p jormungandr").run().unwrap();
+    cmd!("cargo build -p jcli").run().unwrap();
+    cmd!("cargo test").run().unwrap();
+}


### PR DESCRIPTION
This commit introduces the basic use of `xtask` approach as described in

https://github.com/matklad/cargo-xtask/

The idea is to bring better development workflow while keeping
everything within the scope of `cargo` and not introducing any
additional scripting like bash/PowerShell/Python.

If we find this approach interesting, I would also suggest porting some
parts of our release pipelines to Rust. This would give us access to
libraries like `cargo-metadata` producing better/easier to understand
scripts.