### PR TITLE
add possibility to define tx_max_expiry_epochs settings

### DIFF
--- a/testing/jormungandr-testing-utils/src/testing/network_builder/blockchain.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/blockchain.rs
@@ -23,6 +23,7 @@ pub struct Blockchain {
     kes_update_speed: KesUpdateSpeed,
     block_content_max_size: BlockContentMaxSize,
     consensus_genesis_praos_active_slot_coeff: ActiveSlotCoefficient,
+    tx_max_expiry_epochs: Option<u8>,
     linear_fee: LinearFee,
     discrimination: Discrimination,
 }
@@ -51,6 +52,7 @@ impl Blockchain {
             linear_fee: LinearFee::new(1, 1, 1),
             discrimination: Discrimination::Test,
             block_content_max_size: 102400.into(),
+            tx_max_expiry_epochs: None,
         }
     }
 
@@ -60,6 +62,14 @@ impl Blockchain {
 
     pub fn external_committees(&self) -> Vec<CommitteeIdDef> {
         self.external_committees.clone()
+    }
+
+    pub fn tx_max_expiry_epochs(&self) -> Option<u8> {
+        self.tx_max_expiry_epochs
+    }
+
+    pub fn set_tx_max_expiry_epochs(&mut self, tx_max_expiry_epochs: Option<u8>) {
+        self.tx_max_expiry_epochs = tx_max_expiry_epochs;
     }
 
     pub fn set_external_committees(&mut self, external_committees: Vec<CommitteeIdDef>) {

--- a/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network_builder/settings.rs
@@ -225,6 +225,7 @@ impl Settings {
         };
         blockchain_configuration.slots_per_epoch = *blockchain.slots_per_epoch();
         blockchain_configuration.slot_duration = *blockchain.slot_duration();
+        blockchain_configuration.tx_max_expiry_epochs = blockchain.tx_max_expiry_epochs();
         blockchain_configuration.treasury = Some(1_000_000.into());
         blockchain_configuration.block_content_max_size = *blockchain.block_content_max_size();
         blockchain_configuration.kes_update_speed = *blockchain.kes_update_speed();


### PR DESCRIPTION
After enabling transaction expiry policy, tx_max_expiry_epochs need to be exposed so network builder framework will have possibility to define it. This is common setup for jormungandr-scenario-tests and catalyst related projects