### PR TITLE
TTL Performance Tests

### DIFF
--- a/jormungandr-lib/src/interfaces/fragments_processing_summary.rs
+++ b/jormungandr-lib/src/interfaces/fragments_processing_summary.rs
@@ -54,6 +54,15 @@ impl FragmentsProcessingSummary {
     pub fn is_error(&self) -> bool {
         self.rejected.iter().any(|info| info.reason.is_error())
     }
+
+    pub fn fragment_ids(&self) -> Vec<FragmentId> {
+        self.rejected
+            .iter()
+            .map(|info| &info.id)
+            .chain(self.accepted.iter())
+            .cloned()
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/testing/jormungandr-integration-tests/src/common/jormungandr/mod.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/mod.rs
@@ -8,6 +8,7 @@ pub use configuration_builder::ConfigurationBuilder;
 use jormungandr_lib::crypto::hash::Hash;
 use jormungandr_lib::interfaces::BlockDate;
 use jormungandr_lib::interfaces::FragmentLog;
+use jormungandr_lib::interfaces::FragmentsProcessingSummary;
 use jormungandr_testing_utils::testing::MemPoolCheck;
 pub use process::*;
 pub use starter::*;
@@ -49,7 +50,7 @@ impl FragmentNode for JormungandrProcess {
         &self,
         fragments: Vec<Fragment>,
         fail_fast: bool,
-    ) -> Result<Vec<MemPoolCheck>, FragmentNodeError> {
+    ) -> Result<FragmentsProcessingSummary, FragmentNodeError> {
         self.rest()
             .send_fragment_batch(fragments.clone(), fail_fast)
             .map_err(|e| FragmentNodeError::CannotSendFragmentBatch {

--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/mempool/v1.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/mempool/v1.rs
@@ -435,7 +435,7 @@ pub fn test_mempool_pool_max_entries_overrides_log_max_entries() {
         )
         .unwrap();
 
-    let mempools = fragment_sender
+    let summary = fragment_sender
         .send_batch_fragments(
             vec![first_transaction, second_transaction],
             false,
@@ -446,7 +446,7 @@ pub fn test_mempool_pool_max_entries_overrides_log_max_entries() {
     // Wait until the fragment enters the mempool
     FragmentVerifier::wait_fragment(
         Duration::from_millis(100),
-        mempools[1].clone(),
+        summary.fragment_ids()[0].into(),
         VerifyExitStrategy::OnPending,
         &jormungandr,
     )

--- a/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
@@ -1,6 +1,7 @@
+use crate::common::jormungandr::StartupVerificationMode;
 use crate::common::jormungandr::{starter::Role, Starter};
 use crate::common::{jormungandr::ConfigurationBuilder, startup};
-use assert_fs::fixture::PathChild;
+use assert_fs::fixture::{PathChild, PathCreateDir};
 use assert_fs::TempDir;
 use chain_impl_mockchain::fee::LinearFee;
 use chain_impl_mockchain::{block::BlockDate, chaintypes::ConsensusVersion};
@@ -393,9 +394,9 @@ pub fn node_should_pickup_log_after_restart() {
 }
 
 #[test]
-/// Verifies that a node will reject a fragment that has expired, even after it's been accepted in
-/// its mempool.
-pub fn expired_fragment_should_be_rejected() {
+/// Verifies that a leader node will reject a fragment that has expired, even after it's been
+/// accepted in its mempool.
+pub fn expired_fragment_should_be_rejected_by_leader_node() {
     const N_FRAGMENTS: u32 = 10;
 
     let receiver = startup::create_new_account_address();
@@ -437,4 +438,72 @@ pub fn expired_fragment_should_be_rejected() {
     // and the transaction below should have expired.
     FragmentVerifier::wait_and_verify_is_rejected(Duration::from_secs(1), check, &jormungandr)
         .unwrap();
+}
+
+#[test]
+/// Verifies that a passive node will reject a fragment that has expired, even after it's been
+/// accepted in its mempool.
+fn expired_fragment_should_be_rejected_by_passive_node() {
+    const N_FRAGMENTS: u32 = 10;
+
+    let receiver = startup::create_new_account_address();
+    let mut sender = startup::create_new_account_address();
+
+    let (leader, _) = startup::start_stake_pool(
+        &[sender.clone()],
+        &[receiver.clone()],
+        ConfigurationBuilder::new()
+            .with_block_content_max_size(256) // This should only fit 1 transaction
+            .with_slots_per_epoch(N_FRAGMENTS)
+            .with_slot_duration(1)
+            .with_mempool(Mempool {
+                pool_max_entries: 1000.into(),
+                log_max_entries: 1000.into(),
+                persistent_log: None,
+            }),
+    )
+    .unwrap();
+
+    let passive_dir = TempDir::new().unwrap().child("passive");
+    passive_dir.create_dir_all().unwrap();
+
+    let passive = Starter::new()
+        .config(
+            ConfigurationBuilder::new()
+                .with_trusted_peers(vec![leader.to_trusted_peer()])
+                .with_block_hash(&leader.genesis_block_hash().to_string())
+                .build(&passive_dir),
+        )
+        .passive()
+        .start()
+        .unwrap();
+
+    leader
+        .wait_for_bootstrap(&StartupVerificationMode::Rest, Duration::from_secs(30))
+        .unwrap();
+
+    passive
+        .wait_for_bootstrap(&StartupVerificationMode::Rest, Duration::from_secs(30))
+        .unwrap();
+
+    let fragment_sender = FragmentSender::new(
+        passive.genesis_block_hash(),
+        LinearFee::new(0, 0, 0),
+        BlockDate::first().next_epoch(),
+        FragmentSenderSetup::no_verify(),
+    );
+
+    for i in 0..N_FRAGMENTS as u64 {
+        fragment_sender
+            .send_transaction(&mut sender, &receiver, &passive, (100 + i).into())
+            .unwrap();
+    }
+
+    let check = fragment_sender
+        .send_transaction(&mut sender, &receiver, &passive, 1.into())
+        .unwrap();
+
+    // By the time the rest of the transactions have been placed in blocks, the epoch should be over
+    // and the transaction below should have expired.
+    FragmentVerifier::wait_and_verify_is_rejected(Duration::from_secs(1), check, &passive).unwrap();
 }

--- a/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
@@ -396,7 +396,7 @@ pub fn node_should_pickup_log_after_restart() {
 #[test]
 /// Verifies that a leader node will reject a fragment that has expired, even after it's been
 /// accepted in its mempool.
-pub fn expired_fragment_should_be_rejected_by_leader_node() {
+pub fn expired_fragment_should_be_rejected_by_leader_praos_node() {
     const N_FRAGMENTS: u32 = 10;
 
     let receiver = startup::create_new_account_address();
@@ -443,15 +443,14 @@ pub fn expired_fragment_should_be_rejected_by_leader_node() {
 #[test]
 /// Verifies that a passive node will reject a fragment that has expired, even after it's been
 /// accepted in its mempool.
-fn expired_fragment_should_be_rejected_by_passive_node() {
+fn expired_fragment_should_be_rejected_by_passive_bft_node() {
     const N_FRAGMENTS: u32 = 10;
 
     let receiver = startup::create_new_account_address();
     let mut sender = startup::create_new_account_address();
 
-    let (leader, _) = startup::start_stake_pool(
-        &[sender.clone()],
-        &[receiver.clone()],
+    let leader = startup::start_bft(
+        vec![&receiver, &sender],
         ConfigurationBuilder::new()
             .with_block_content_max_size(256) // This should only fit 1 transaction
             .with_slots_per_epoch(N_FRAGMENTS)

--- a/testing/jormungandr-integration-tests/src/jormungandr/rest/v1/statuses.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/rest/v1/statuses.rs
@@ -1,7 +1,7 @@
 use crate::common::jormungandr::JormungandrProcess;
 use crate::common::{jormungandr::ConfigurationBuilder, startup};
 use chain_impl_mockchain::{block::BlockDate, fragment::FragmentId};
-use jormungandr_testing_utils::testing::FragmentSenderSetup;
+use jormungandr_testing_utils::testing::{FragmentSenderSetup, MemPoolCheck};
 use rstest::*;
 
 #[fixture]
@@ -44,9 +44,15 @@ fn world() -> (JormungandrProcess, FragmentId, FragmentId, FragmentId) {
         .send_transaction(&mut clarice, &bob, &jormungandr, 100.into())
         .unwrap();
 
-    let tx_ids = transaction_sender
+    let summary = transaction_sender
         .send_batch_fragments(vec![alice_fragment, bob_fragment], false, &jormungandr)
         .unwrap();
+
+    let tx_ids: Vec<MemPoolCheck> = summary
+        .fragment_ids()
+        .into_iter()
+        .map(MemPoolCheck::from)
+        .collect();
 
     tx_ids
         .iter()

--- a/testing/jormungandr-scenario-tests/src/scenario/fragment_node.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/fragment_node.rs
@@ -1,7 +1,7 @@
 use crate::node::NodeController;
 use chain_impl_mockchain::fragment::{Fragment, FragmentId};
 use jormungandr_lib::crypto::hash::Hash;
-use jormungandr_lib::interfaces::{BlockDate, FragmentLog};
+use jormungandr_lib::interfaces::{BlockDate, FragmentLog, FragmentsProcessingSummary};
 use jormungandr_testing_utils::testing::{FragmentNode, FragmentNodeError, MemPoolCheck};
 use std::collections::HashMap;
 
@@ -24,7 +24,7 @@ impl FragmentNode for NodeController {
         &self,
         _fragments: Vec<Fragment>,
         _fail_fast: bool,
-    ) -> std::result::Result<Vec<MemPoolCheck>, FragmentNodeError> {
+    ) -> std::result::Result<FragmentsProcessingSummary, FragmentNodeError> {
         //TODO implement
         unimplemented!()
     }

--- a/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/utils/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     scenario::Controller,
     test::Result,
 };
+use jormungandr_lib::interfaces::FragmentsProcessingSummary;
 pub use jormungandr_testing_utils::testing::{SyncNode, SyncWaitParams};
 
 use jormungandr_lib::{
@@ -121,7 +122,7 @@ impl FragmentNode for LegacyNodeController {
         &self,
         _fragments: Vec<Fragment>,
         _fail_fast: bool,
-    ) -> std::result::Result<Vec<MemPoolCheck>, FragmentNodeError> {
+    ) -> std::result::Result<FragmentsProcessingSummary, FragmentNodeError> {
         //TODO implement
         unimplemented!()
     }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/load/batch_generator.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/load/batch_generator.rs
@@ -122,10 +122,11 @@ impl<'a, S: SyncNode + Send> BatchFragmentGenerator<'a, S> {
         let start = Instant::now();
         self.fragment_sender
             .send_batch_fragments(transactions, false, &self.jormungandr)
-            .map(|checks| Request {
-                ids: checks
+            .map(|summary| Request {
+                ids: summary
+                    .fragment_ids()
                     .iter()
-                    .map(|x| Some(x.fragment_id().to_string()))
+                    .map(|x| Some(x.to_string()))
                     .collect(),
                 duration: start.elapsed(),
             })

--- a/testing/jormungandr-testing-utils/src/testing/fragments/node.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/node.rs
@@ -1,7 +1,7 @@
 use chain_impl_mockchain::fragment::{Fragment, FragmentId};
 use jormungandr_lib::{
     crypto::hash::Hash,
-    interfaces::{BlockDate, FragmentLog},
+    interfaces::{BlockDate, FragmentLog, FragmentsProcessingSummary},
 };
 
 use std::collections::HashMap;
@@ -57,7 +57,7 @@ pub trait FragmentNode {
         &self,
         fragments: Vec<Fragment>,
         fail_fast: bool,
-    ) -> Result<Vec<MemPoolCheck>, FragmentNodeError>;
+    ) -> Result<FragmentsProcessingSummary, FragmentNodeError>;
     fn log_pending_fragment(&self, fragment_id: FragmentId);
     fn log_rejected_fragment(&self, fragment_id: FragmentId, reason: String);
     fn log_in_block_fragment(&self, fragment_id: FragmentId, valid_until: BlockDate, block: Hash);
@@ -76,5 +76,11 @@ impl MemPoolCheck {
 
     pub fn fragment_id(&self) -> &FragmentId {
         &self.fragment_id
+    }
+}
+
+impl From<FragmentId> for MemPoolCheck {
+    fn from(from: FragmentId) -> Self {
+        Self::new(from)
     }
 }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
@@ -16,7 +16,7 @@ use chain_impl_mockchain::{
     fragment::Fragment,
     vote::Choice,
 };
-use jormungandr_lib::interfaces::Address;
+use jormungandr_lib::interfaces::{Address, FragmentsProcessingSummary};
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{FragmentStatus, Value},
@@ -124,7 +124,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
         fragments: Vec<Fragment>,
         fail_fast: bool,
         node: &A,
-    ) -> Result<Vec<MemPoolCheck>, FragmentSenderError> {
+    ) -> Result<FragmentsProcessingSummary, FragmentSenderError> {
         self.wait_for_node_sync_if_enabled(node)
             .map_err(FragmentSenderError::SyncNodeError)?;
         node.send_batch_fragments(fragments, fail_fast)

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/mod.rs
@@ -8,7 +8,9 @@ pub use settings::RestSettings;
 
 use crate::{testing::node::legacy, testing::MemPoolCheck, wallet::Wallet};
 use chain_impl_mockchain::fragment::{Fragment, FragmentId};
-use jormungandr_lib::interfaces::{Address, FragmentStatus, VotePlanId};
+use jormungandr_lib::interfaces::{
+    Address, FragmentStatus, FragmentsProcessingSummary, VotePlanId,
+};
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{
@@ -220,7 +222,7 @@ impl JormungandrRest {
         &self,
         fragments: Vec<Fragment>,
         fail_fast: bool,
-    ) -> Result<Vec<MemPoolCheck>, RestError> {
+    ) -> Result<FragmentsProcessingSummary, RestError> {
         self.inner
             .send_fragment_batch(fragments, fail_fast)
             .map_err(Into::into)

--- a/testing/jormungandr-testing-utils/src/testing/node/verifier/fragment_log.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/verifier/fragment_log.rs
@@ -173,7 +173,7 @@ impl FragmentLogVerifier {
 pub fn assert_accepted_rejected(
     accepted: Vec<FragmentId>,
     rejected: Vec<(FragmentId, FragmentRejectionReason)>,
-    result: Result<Vec<MemPoolCheck>, RestError>,
+    result: Result<FragmentsProcessingSummary, RestError>,
 ) -> Vec<MemPoolCheck> {
     match result.err().unwrap() {
         RestError::NonSuccessErrorCode {
@@ -201,7 +201,9 @@ pub fn assert_accepted_rejected(
     }
 }
 
-pub fn assert_bad_request(result: Result<Vec<MemPoolCheck>, RestError>) -> Vec<MemPoolCheck> {
+pub fn assert_bad_request(
+    result: Result<FragmentsProcessingSummary, RestError>,
+) -> Vec<MemPoolCheck> {
     match result.err().unwrap() {
         RestError::NonSuccessErrorCode { status, checks, .. } => {
             assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);

--- a/testing/jormungandr-testing-utils/src/testing/remote/node.rs
+++ b/testing/jormungandr-testing-utils/src/testing/remote/node.rs
@@ -9,7 +9,7 @@ use chain_core::property::Fragment as _;
 use chain_impl_mockchain::{fragment::Fragment, fragment::FragmentId};
 use jormungandr_lib::{
     crypto::hash::Hash,
-    interfaces::{BlockDate, FragmentLog, NodeConfig},
+    interfaces::{BlockDate, FragmentLog, FragmentsProcessingSummary, NodeConfig},
 };
 use std::process::Child;
 use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
@@ -129,7 +129,7 @@ impl FragmentNode for RemoteJormungandr {
         &self,
         fragments: Vec<Fragment>,
         fail_fast: bool,
-    ) -> Result<Vec<MemPoolCheck>, FragmentNodeError> {
+    ) -> Result<FragmentsProcessingSummary, FragmentNodeError> {
         self.rest()
             .send_fragment_batch(fragments.clone(), fail_fast)
             .map_err(|e| FragmentNodeError::CannotSendFragmentBatch {


### PR DESCRIPTION
* Added a benchmark test to measure the speed at which expired transactions are handled.
* Added a benchmark test to measure the speed at which transactions with long TTL are handled.
* Added a node test to ensure passive nodes remove expired transactions from their fragment pools.