### PR TITLE
Concurrent tip update

### DIFF
--- a/jormungandr/src/blockchain/bootstrap.rs
+++ b/jormungandr/src/blockchain/bootstrap.rs
@@ -1,0 +1,209 @@
+use super::tip::TipUpdater;
+use crate::blockcfg::{Block, HeaderDesc, HeaderHash};
+use crate::blockchain::{self, Blockchain, PreCheckedHeader, Ref, Tip};
+use crate::metrics::Metrics;
+use chain_core::property::{Deserialize, HasHeader};
+use chain_network::data as net_data;
+use chain_network::error::Error as NetworkError;
+use futures::{prelude::*, stream, task::Poll};
+use tokio_util::sync::CancellationToken;
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    BlockchainError(#[from] super::Error),
+    #[error(
+        "received block {0} is already present, but does not descend from any of the checkpoints"
+    )]
+    BlockNotOnBranch(HeaderHash),
+    #[error("received block {0} is not connected to the block chain")]
+    BlockMissingParent(HeaderHash),
+    #[error("bootstrap pull stream failed")]
+    PullStreamFailed(#[source] NetworkError),
+    #[error("failures while deserializing block from stream")]
+    BlockDeserialize(#[from] std::io::Error),
+    #[error("the bootstrap process was interrupted")]
+    Interrupted,
+}
+
+pub async fn bootstrap_from_stream<S>(
+    blockchain: Blockchain,
+    branch: Tip,
+    stream: S,
+    cancellation_token: CancellationToken,
+) -> Result<Option<Arc<Ref>>, Error>
+where
+    S: Stream<Item = Result<net_data::Block, NetworkError>> + Unpin,
+{
+    const PROCESS_LOGGING_DISTANCE: u64 = 2500;
+    let block0 = *blockchain.block0();
+    let mut tip_updater = TipUpdater::new(
+        branch,
+        blockchain.clone(),
+        None,
+        None,
+        Metrics::builder().build(),
+    );
+
+    let mut bootstrap_info = BootstrapInfo::new();
+    let mut maybe_parent_tip = None;
+
+    // This stream will either end when the block stream is exhausted or when
+    // the cancellation signal arrives. Building such stream allows us to
+    // correctly write all blocks and update the block tip upon the arrival of
+    // the cancellation signal.
+    let mut cancel = cancellation_token.cancelled().boxed();
+    let mut stream = stream.map_err(Error::PullStreamFailed);
+
+    let mut stream = stream::poll_fn(move |cx| {
+        let cancel = Pin::new(&mut cancel);
+        match cancel.poll(cx) {
+            Poll::Pending => {
+                let stream = Pin::new(&mut stream);
+                stream.poll_next(cx)
+            }
+            Poll::Ready(()) => Poll::Ready(Some(Err(Error::Interrupted))),
+        }
+    });
+
+    while let Some(block_result) = stream.next().await {
+        let result = match block_result {
+            Ok(block) => {
+                let block = Block::deserialize(block.as_bytes())?;
+
+                if block.header.hash() == block0 {
+                    continue;
+                }
+
+                bootstrap_info.append_block(&block);
+
+                if bootstrap_info.block_received % PROCESS_LOGGING_DISTANCE == 0 {
+                    bootstrap_info.report();
+                }
+
+                handle_block(&blockchain, block).await
+            }
+            Err(err) => Err(err),
+        };
+
+        match result {
+            Ok(parent_tip) => {
+                maybe_parent_tip = Some(parent_tip);
+            }
+            Err(err) => {
+                if let Some(bootstrap_tip) = maybe_parent_tip {
+                    tip_updater.process_new_ref(bootstrap_tip).await?;
+                }
+                return Err(err);
+            }
+        }
+    }
+
+    if let Some(ref bootstrap_tip) = maybe_parent_tip {
+        tip_updater.process_new_ref(bootstrap_tip.clone()).await?;
+    } else {
+        tracing::info!("no new blocks in bootstrap stream");
+    }
+
+    Ok(maybe_parent_tip)
+}
+
+async fn handle_block(blockchain: &Blockchain, block: Block) -> Result<Arc<Ref>, Error> {
+    let header = block.header();
+    let pre_checked = blockchain.pre_check_header(header, true).await?;
+    match pre_checked {
+        PreCheckedHeader::AlreadyPresent {
+            cached_reference: Some(block_ref),
+            ..
+        } => Ok(block_ref),
+        PreCheckedHeader::AlreadyPresent {
+            cached_reference: None,
+            header,
+        } => Err(Error::BlockNotOnBranch(header.hash())),
+        PreCheckedHeader::MissingParent { header, .. } => {
+            Err(Error::BlockMissingParent(header.hash()))
+        }
+        PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
+            let post_checked = blockchain
+                .post_check_header(header, parent_ref, blockchain::CheckHeaderProof::Enabled)
+                .await?;
+
+            tracing::debug!(
+                hash = %post_checked.header().hash(),
+                block_date = %post_checked.header().block_date(),
+                "validated block"
+            );
+            let applied = blockchain
+                .apply_and_store_block(post_checked, block)
+                .await?;
+            Ok(applied.cached_ref())
+        }
+    }
+}
+
+struct BootstrapInfo {
+    last_reported: std::time::SystemTime,
+    last_bytes_received: u64,
+    bytes_received: u64,
+    block_received: u64,
+    last_block_description: Option<HeaderDesc>,
+}
+
+impl BootstrapInfo {
+    pub fn new() -> Self {
+        let now = std::time::SystemTime::now();
+        let lbd: Option<HeaderDesc> = None;
+        BootstrapInfo {
+            last_reported: now,
+            last_bytes_received: 0,
+            bytes_received: 0,
+            block_received: 0,
+            last_block_description: lbd,
+        }
+    }
+
+    pub fn append_block(&mut self, b: &Block) {
+        use chain_core::property::Serialize;
+        self.bytes_received += b.serialize_as_vec().unwrap().len() as u64; // TODO sad serialization back
+        self.block_received += 1;
+        self.last_block_description = Some(b.header.description());
+    }
+
+    pub fn report(&mut self) {
+        fn print_sz(n: f64) -> String {
+            if n > 1_000_000.0 {
+                format!("{:.2}mb", n / (1024 * 1024) as f64)
+            } else if n > 1_000.0 {
+                format!("{:.2}kb", n / 1024_f64)
+            } else {
+                format!("{:.2}b", n)
+            }
+        }
+        let current = std::time::SystemTime::now();
+        let time_diff = current.duration_since(self.last_reported);
+        let bytes_diff = self.bytes_received - self.last_bytes_received;
+
+        let bytes = print_sz(bytes_diff as f64);
+        let kbs = time_diff
+            .map(|td| {
+                let v = (bytes_diff as f64) / td.as_secs_f64();
+                print_sz(v)
+            })
+            .unwrap_or_else(|_| "N/A".to_string());
+
+        self.last_reported = current;
+        self.last_bytes_received = self.bytes_received;
+        tracing::info!(
+            "receiving from network bytes={} {}/s, blockchain {}",
+            bytes,
+            kbs,
+            self.last_block_description
+                .as_ref()
+                .map(|lbd| lbd.to_string())
+                .expect("append_block should always be called before report")
+        )
+    }
+}

--- a/jormungandr/src/blockchain/bootstrap.rs
+++ b/jormungandr/src/blockchain/bootstrap.rs
@@ -1,8 +1,11 @@
 use super::tip::TipUpdater;
-use crate::blockcfg::{Block, HeaderDesc, HeaderHash};
-use crate::blockchain::{self, Blockchain, PreCheckedHeader, Ref, Tip};
+use crate::blockcfg::{Block, HeaderHash};
+use crate::blockchain::{
+    chain::{CheckHeaderProof, StreamInfo, StreamReporter},
+    Blockchain, Ref, Tip,
+};
 use crate::metrics::Metrics;
-use chain_core::property::{Deserialize, HasHeader};
+use chain_core::property::Deserialize;
 use chain_network::data as net_data;
 use chain_network::error::Error as NetworkError;
 use futures::{prelude::*, stream, task::Poll};
@@ -15,10 +18,6 @@ use std::sync::Arc;
 pub enum Error {
     #[error(transparent)]
     BlockchainError(#[from] super::Error),
-    #[error(
-        "received block {0} is already present, but does not descend from any of the checkpoints"
-    )]
-    BlockNotOnBranch(HeaderHash),
     #[error("received block {0} is not connected to the block chain")]
     BlockMissingParent(HeaderHash),
     #[error("bootstrap pull stream failed")]
@@ -38,7 +37,6 @@ pub async fn bootstrap_from_stream<S>(
 where
     S: Stream<Item = Result<net_data::Block, NetworkError>> + Unpin,
 {
-    const PROCESS_LOGGING_DISTANCE: u64 = 2500;
     let block0 = *blockchain.block0();
     let mut tip_updater = TipUpdater::new(
         branch,
@@ -48,7 +46,7 @@ where
         Metrics::builder().build(),
     );
 
-    let mut bootstrap_info = BootstrapInfo::new();
+    let mut bootstrap_info = StreamReporter::new(report);
     let mut maybe_parent_tip = None;
 
     // This stream will either end when the block stream is exhausted or when
@@ -79,12 +77,9 @@ where
                 }
 
                 bootstrap_info.append_block(&block);
-
-                if bootstrap_info.block_received % PROCESS_LOGGING_DISTANCE == 0 {
-                    bootstrap_info.report();
-                }
-
-                handle_block(&blockchain, block).await
+                Ok(blockchain
+                    .handle_stream_block(block, CheckHeaderProof::Enabled)
+                    .await?)
             }
             Err(err) => Err(err),
         };
@@ -111,99 +106,37 @@ where
     Ok(maybe_parent_tip)
 }
 
-async fn handle_block(blockchain: &Blockchain, block: Block) -> Result<Arc<Ref>, Error> {
-    let header = block.header();
-    let pre_checked = blockchain.pre_check_header(header, true).await?;
-    match pre_checked {
-        PreCheckedHeader::AlreadyPresent {
-            cached_reference: Some(block_ref),
-            ..
-        } => Ok(block_ref),
-        PreCheckedHeader::AlreadyPresent {
-            cached_reference: None,
-            header,
-        } => Err(Error::BlockNotOnBranch(header.hash())),
-        PreCheckedHeader::MissingParent { header, .. } => {
-            Err(Error::BlockMissingParent(header.hash()))
-        }
-        PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
-            let post_checked = blockchain
-                .post_check_header(header, parent_ref, blockchain::CheckHeaderProof::Enabled)
-                .await?;
-
-            tracing::debug!(
-                hash = %post_checked.header().hash(),
-                block_date = %post_checked.header().block_date(),
-                "validated block"
-            );
-            let applied = blockchain
-                .apply_and_store_block(post_checked, block)
-                .await?;
-            Ok(applied.cached_ref())
-        }
-    }
-}
-
-struct BootstrapInfo {
-    last_reported: std::time::SystemTime,
-    last_bytes_received: u64,
-    bytes_received: u64,
-    block_received: u64,
-    last_block_description: Option<HeaderDesc>,
-}
-
-impl BootstrapInfo {
-    pub fn new() -> Self {
-        let now = std::time::SystemTime::now();
-        let lbd: Option<HeaderDesc> = None;
-        BootstrapInfo {
-            last_reported: now,
-            last_bytes_received: 0,
-            bytes_received: 0,
-            block_received: 0,
-            last_block_description: lbd,
+fn report(stream_info: &StreamInfo) {
+    fn print_sz(n: f64) -> String {
+        if n > 1_000_000.0 {
+            format!("{:.2}mb", n / (1024 * 1024) as f64)
+        } else if n > 1_000.0 {
+            format!("{:.2}kb", n / 1024_f64)
+        } else {
+            format!("{:.2}b", n)
         }
     }
 
-    pub fn append_block(&mut self, b: &Block) {
-        use chain_core::property::Serialize;
-        self.bytes_received += b.serialize_as_vec().unwrap().len() as u64; // TODO sad serialization back
-        self.block_received += 1;
-        self.last_block_description = Some(b.header.description());
-    }
+    let current = std::time::SystemTime::now();
+    let time_diff = current.duration_since(stream_info.last_reported);
+    let bytes_diff = stream_info.bytes_received - stream_info.last_bytes_received;
 
-    pub fn report(&mut self) {
-        fn print_sz(n: f64) -> String {
-            if n > 1_000_000.0 {
-                format!("{:.2}mb", n / (1024 * 1024) as f64)
-            } else if n > 1_000.0 {
-                format!("{:.2}kb", n / 1024_f64)
-            } else {
-                format!("{:.2}b", n)
-            }
-        }
-        let current = std::time::SystemTime::now();
-        let time_diff = current.duration_since(self.last_reported);
-        let bytes_diff = self.bytes_received - self.last_bytes_received;
+    let bytes = print_sz(bytes_diff as f64);
+    let kbs = time_diff
+        .map(|td| {
+            let v = (bytes_diff as f64) / td.as_secs_f64();
+            print_sz(v)
+        })
+        .unwrap_or_else(|_| "N/A".to_string());
 
-        let bytes = print_sz(bytes_diff as f64);
-        let kbs = time_diff
-            .map(|td| {
-                let v = (bytes_diff as f64) / td.as_secs_f64();
-                print_sz(v)
-            })
-            .unwrap_or_else(|_| "N/A".to_string());
-
-        self.last_reported = current;
-        self.last_bytes_received = self.bytes_received;
-        tracing::info!(
-            "receiving from network bytes={} {}/s, blockchain {}",
-            bytes,
-            kbs,
-            self.last_block_description
-                .as_ref()
-                .map(|lbd| lbd.to_string())
-                .expect("append_block should always be called before report")
-        )
-    }
+    tracing::info!(
+        "receiving from network bytes={} {}/s, blockchain {}",
+        bytes,
+        kbs,
+        stream_info
+            .last_block_description
+            .as_ref()
+            .map(|lbd| lbd.to_string())
+            .expect("append_block should always be called before report")
+    )
 }

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -723,13 +723,8 @@ impl Blockchain {
                 Ok(applied.cached_ref())
             }
             PreCheckedHeader::AlreadyPresent {
-                cached_reference: Some(block_ref),
-                ..
-            } => Ok(block_ref),
-            PreCheckedHeader::AlreadyPresent {
-                cached_reference: None,
-                ..
-            } => unreachable!("block ref was force loaded"),
+                cached_reference, ..
+            } => Ok(cached_reference.expect("block ref was force loaded")),
             PreCheckedHeader::MissingParent { header } => {
                 Err(Error::MissingParentBlock(header.block_parent_hash()))
             }

--- a/jormungandr/src/blockchain/chain.rs
+++ b/jormungandr/src/blockchain/chain.rs
@@ -52,10 +52,10 @@ See Internal documentation for more details: doc/internal_design.md
 use super::{branch::Branches, reference_cache::RefCache};
 use crate::{
     blockcfg::{
-        Block, Block0Error, BlockDate, ChainLength, Epoch, EpochRewardsInfo, Header, HeaderHash,
-        Leadership, Ledger, LedgerParameters, RewardsInfoParameters,
+        Block, Block0Error, BlockDate, ChainLength, Epoch, EpochRewardsInfo, Header, HeaderDesc,
+        HeaderHash, Leadership, Ledger, LedgerParameters, RewardsInfoParameters,
     },
-    blockchain::{Branch, Checkpoints, Multiverse, Ref, Storage, StorageError},
+    blockchain::{Branch, Checkpoints, Multiverse, Ref, Storage, StorageError, Tip},
 };
 use chain_core::property::HasHeader;
 use chain_impl_mockchain::{leadership::Verification, ledger};
@@ -686,7 +686,7 @@ impl Blockchain {
     /// * the block0 does build a valid `Ledger`: `Error::Block0InitialLedgerError`;
     /// * other errors while interacting with the storage (IO errors)
     ///
-    pub async fn load_from_block0(&self, block0: Block) -> Result<Branch> {
+    pub async fn load_from_block0(&self, block0: Block) -> Result<Tip> {
         use chain_core::property::Block;
 
         let block0_id = block0.id();
@@ -701,7 +701,41 @@ impl Blockchain {
 
         self.storage.put_block(&block0)?;
         self.storage.put_tag(MAIN_BRANCH_TAG, block0_id)?;
-        Ok(block0_branch)
+        Ok(Tip::new(block0_branch))
+    }
+
+    pub(super) async fn handle_stream_block(
+        &self,
+        block: Block,
+        check_header: CheckHeaderProof,
+    ) -> Result<Arc<Ref>> {
+        let header = block.header.clone();
+
+        let pre_checked_header: PreCheckedHeader = self.pre_check_header(header, true).await?;
+
+        let new_ref = match pre_checked_header {
+            PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
+                let post_checked = self
+                    .post_check_header(header, parent_ref, check_header)
+                    .await?;
+
+                let applied = self.apply_and_store_block(post_checked, block).await?;
+                Ok(applied.cached_ref())
+            }
+            PreCheckedHeader::AlreadyPresent {
+                cached_reference: Some(block_ref),
+                ..
+            } => Ok(block_ref),
+            PreCheckedHeader::AlreadyPresent {
+                cached_reference: None,
+                ..
+            } => unreachable!("block ref was force loaded"),
+            PreCheckedHeader::MissingParent { header } => {
+                Err(Error::MissingParentBlock(header.block_parent_hash()))
+            }
+        }?;
+
+        Ok(new_ref)
     }
 
     /// returns a future that will propagate the initial states and leadership
@@ -718,7 +752,7 @@ impl Blockchain {
     /// * the block0 does build a valid `Ledger`: `Error::Block0InitialLedgerError`;
     /// * other errors while interacting with the storage (IO errors)
     ///
-    pub async fn load_from_storage(&self, block0: Block) -> Result<Branch> {
+    pub async fn load_from_storage(&self, block0: Block) -> Result<Tip> {
         let block0_id = block0.header.hash();
         let already_exist = self.storage.block_exists(block0_id)?;
 
@@ -734,70 +768,36 @@ impl Blockchain {
             return Err(Error::NoTag(MAIN_BRANCH_TAG.to_owned()));
         };
 
-        let block0_branch = self.apply_block0(&block0).await?;
+        let mut branch = self.apply_block0(&block0).await?;
+        let mut reporter = StreamReporter::new(|stream_info| {
+            let elapsed = stream_info
+                .last_reported
+                .elapsed()
+                .expect("time went backward");
+            tracing::info!(
+                "loading from storage, currently at {} processing={:?} ({:?} per block) ...",
+                stream_info.last_block_description.as_ref().unwrap(),
+                elapsed,
+                elapsed / PROCESS_LOGGING_DISTANCE as u32,
+            )
+        });
 
         let mut block_stream = self
             .storage
             .stream_from_to(block0_id, head_hash)
             .map(Box::pin)?;
 
-        let mut branch = block0_branch;
-        let mut count = 0u64;
-
-        let mut block_processing = std::time::Duration::from_secs(0);
-
         while let Some(r) = block_stream.next().await {
             let block = r?;
-
-            let header = block.header.clone();
-
-            const PROCESS_LOGGING_DISTANCE: u64 = 2500;
-            if count % PROCESS_LOGGING_DISTANCE == 0 {
-                tracing::info!(
-                    "loading from storage, currently at {} processing={:?} ({:?} per block) ...",
-                    header.description(),
-                    block_processing,
-                    block_processing / PROCESS_LOGGING_DISTANCE as u32,
-                );
-                block_processing = std::time::Duration::from_secs(0);
-            }
-
-            let block_process_start = std::time::SystemTime::now();
-
-            let pre_checked_header: PreCheckedHeader = self.pre_check_header(header, true).await?;
-
-            let post_checked_header = match pre_checked_header {
-                PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
-                    self.post_check_header(header, parent_ref, CheckHeaderProof::SkipFromStorage)
-                        .await?
-                }
-                PreCheckedHeader::AlreadyPresent {
-                    header,
-                    cached_reference: _cached_reference,
-                } => unreachable!(
-                    "block already present, this should not happen. {:#?}",
-                    header
-                ),
-                PreCheckedHeader::MissingParent { header } => {
-                    return Err(Error::MissingParentBlock(header.block_parent_hash()))
-                }
-            };
-
-            let new_ledger = self.apply_block_dry_run(&post_checked_header, &block)?;
-            let new_ref = self
-                .apply_block_finalize(post_checked_header, new_ledger)
+            reporter.append_block(&block);
+            branch
+                .update_ref(
+                    self.handle_stream_block(block, CheckHeaderProof::SkipFromStorage)
+                        .await?,
+                )
                 .await;
-
-            count += 1;
-            let _: Arc<Ref> = branch.update_ref(new_ref).await;
-
-            let block_process_end = std::time::SystemTime::now();
-            let duration = block_process_end
-                .duration_since(block_process_start)
-                .unwrap_or_else(|_| std::time::Duration::from_secs(0));
-            block_processing += duration;
         }
-        Ok(branch)
+        Ok(Tip::new(branch))
     }
 
     pub async fn get_checkpoints(&self, branch: &Branch) -> Checkpoints {
@@ -941,6 +941,53 @@ pub fn new_epoch_leadership_from(
             rewards_info: parent_epoch_rewards_info,
             time_frame: parent_time_frame,
             previous_state: parent.last_ref_previous_epoch().map(Arc::clone),
+        }
+    }
+}
+
+pub struct StreamReporter<R> {
+    stream_info: StreamInfo,
+    report: R,
+}
+
+pub struct StreamInfo {
+    pub start: std::time::SystemTime,
+    pub last_reported: std::time::SystemTime,
+    pub last_bytes_received: u64,
+    pub bytes_received: u64,
+    pub block_received: u64,
+    pub last_block_description: Option<HeaderDesc>,
+}
+
+const PROCESS_LOGGING_DISTANCE: u64 = 2500;
+
+impl<R: Fn(&StreamInfo)> StreamReporter<R> {
+    pub fn new(report: R) -> Self {
+        let now = std::time::SystemTime::now();
+        let lbd: Option<HeaderDesc> = None;
+        StreamReporter {
+            stream_info: StreamInfo {
+                start: now,
+                last_reported: now,
+                last_bytes_received: 0,
+                bytes_received: 0,
+                block_received: 0,
+                last_block_description: lbd,
+            },
+            report,
+        }
+    }
+
+    pub fn append_block(&mut self, b: &Block) {
+        use chain_core::property::Serialize;
+        self.stream_info.bytes_received += b.serialize_as_vec().unwrap().len() as u64; // TODO sad serialization back
+        self.stream_info.block_received += 1;
+        self.stream_info.last_block_description = Some(b.header.description());
+
+        if self.stream_info.block_received % PROCESS_LOGGING_DISTANCE == 0 {
+            (self.report)(&self.stream_info);
+            self.stream_info.last_reported = std::time::SystemTime::now();
+            self.stream_info.last_bytes_received = self.stream_info.bytes_received;
         }
     }
 }

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -1,3 +1,4 @@
+mod bootstrap;
 mod branch;
 mod candidate;
 mod chain;
@@ -25,6 +26,7 @@ mod chunk_sizes {
 // Re-exports
 
 pub use self::{
+    bootstrap::{bootstrap_from_stream, Error as BootstrapError},
     branch::Branch,
     chain::{
         new_epoch_leadership_from, Blockchain, CheckHeaderProof, EpochLeadership, Error,
@@ -33,7 +35,7 @@ pub use self::{
     chain_selection::{compare_against, ComparisonResult},
     checkpoints::Checkpoints,
     multiverse::Multiverse,
-    process::{process_new_ref, Process},
+    process::{start, TaskData},
     reference::Ref,
     storage::{Error as StorageError, Storage},
     tip::Tip,

--- a/jormungandr/src/blockchain/tip.rs
+++ b/jormungandr/src/blockchain/tip.rs
@@ -1,5 +1,206 @@
-use crate::blockchain::{Branch, Ref};
+use crate::{
+    blockcfg::{FragmentId, Header},
+    blockchain::{
+        chain_selection::{self, ComparisonResult},
+        storage, Blockchain, Branch, Error, Ref, MAIN_BRANCH_TAG,
+    },
+    intercom::{ExplorerMsg, TransactionMsg},
+    metrics::{Metrics, MetricsBackend},
+    utils::async_msg::{self, MessageBox, MessageQueue},
+};
+use chain_core::property::{Block as _, Fragment as _, HasHeader as _};
+use jormungandr_lib::interfaces::FragmentStatus;
 use std::sync::Arc;
+use tokio::time::MissedTickBehavior;
+
+use futures::prelude::*;
+
+use std::time::Duration;
+
+const BRANCH_REPROCESSING_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Handles updates to the tip.
+/// Only one of this structs should be active at any given time.
+#[derive(Clone)]
+pub(super) struct TipUpdater {
+    tip: Tip,
+    blockchain: Blockchain,
+    explorer_mbox: Option<MessageBox<ExplorerMsg>>,
+    fragment_mbox: Option<MessageBox<TransactionMsg>>,
+    stats_counter: Metrics,
+}
+
+impl TipUpdater {
+    pub(super) fn new(
+        tip: Tip,
+        blockchain: Blockchain,
+        fragment_mbox: Option<MessageBox<TransactionMsg>>,
+        explorer_mbox: Option<MessageBox<ExplorerMsg>>,
+        stats_counter: Metrics,
+    ) -> Self {
+        Self {
+            tip,
+            blockchain,
+            fragment_mbox,
+            explorer_mbox,
+            stats_counter,
+        }
+    }
+
+    pub async fn run(&mut self, mut input: MessageQueue<Arc<Ref>>) {
+        let mut reprocessing_interval = tokio::time::interval(BRANCH_REPROCESSING_INTERVAL);
+        reprocessing_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                Some(candidate) = input.next() => {
+                    self.process_new_ref(candidate).await.unwrap_or_else(|e| tracing::error!("could not process new ref:` {}", e))
+                }
+
+                _ = reprocessing_interval.tick() => {
+                    self.reprocess_tip().await.unwrap_or_else(|e| tracing::error!("could not reprocess tip:` {}", e))
+                }
+
+            }
+        }
+    }
+
+    /// process a new candidate block on top of the blockchain, this function may:
+    ///
+    /// * update the current tip if the candidate's parent is the current tip;
+    /// * update a branch if the candidate parent is that branch's tip;
+    /// * create a new branch if none of the above;
+    ///
+    /// If the current tip is not the one being updated we will then trigger
+    /// chain selection after updating that other branch as it may be possible that
+    /// this branch just became more interesting for the current consensus algorithm.
+    pub(super) async fn process_new_ref(&mut self, candidate: Arc<Ref>) -> Result<(), Error> {
+        let candidate_hash = candidate.hash();
+        let storage = self.blockchain.storage();
+        let tip_ref = self.tip.get_ref().await;
+        let block = storage
+            .get(candidate_hash)?
+            .ok_or(storage::Error::BlockNotFound)?;
+
+        match chain_selection::compare_against(storage, &tip_ref, &candidate) {
+            ComparisonResult::PreferCurrent => {
+                tracing::info!(
+                    "create new branch with tip {} | current-tip {}",
+                    candidate.header().description(),
+                    tip_ref.header().description(),
+                );
+                self.blockchain
+                    .branches_mut()
+                    .apply_or_create(candidate.clone())
+                    .await;
+            }
+            ComparisonResult::PreferCandidate => {
+                if tip_ref.hash() == candidate.block_parent_hash() {
+                    tracing::info!(
+                        "update current branch tip: {} -> {}",
+                        tip_ref.header().description(),
+                        candidate.header().description(),
+                    );
+
+                    storage.put_tag(MAIN_BRANCH_TAG, candidate_hash)?;
+
+                    let fragment_ids = block.fragments().map(|f| f.id()).collect();
+                    self.try_request_fragment_removal(fragment_ids, &block.header())?;
+
+                    self.tip.update_ref(candidate.clone()).await;
+                } else {
+                    let common_ancestor =
+                        storage.find_common_ancestor(candidate_hash, tip_ref.hash())?;
+
+                    let stream = self
+                        .blockchain
+                        .storage()
+                        .stream_from_to(common_ancestor, candidate_hash)?;
+                    tokio::pin!(stream);
+
+                    // there is always at least one block in the stream
+                    let ancestor = stream.next().await.unwrap()?;
+                    if let Some(ref mut mbox) = self.fragment_mbox {
+                        mbox.try_send(TransactionMsg::BranchSwitch(ancestor.date().into()))?;
+                    }
+
+                    while let Some(block) = stream.next().await {
+                        let block = block?;
+                        let fragment_ids = block.fragments().map(|f| f.id()).collect();
+                        self.try_request_fragment_removal(fragment_ids, &block.header())?;
+                    }
+
+                    tracing::info!(
+                        "switching branch from {} to {}",
+                        tip_ref.header().description(),
+                        candidate.header().description(),
+                    );
+
+                    self.blockchain
+                        .storage()
+                        .put_tag(MAIN_BRANCH_TAG, candidate_hash)?;
+
+                    let branch = self
+                        .blockchain
+                        .branches_mut()
+                        .apply_or_create(candidate.clone())
+                        .await;
+                    self.tip.swap(branch).await;
+                }
+
+                self.stats_counter.set_tip_block(&block, &candidate);
+                if let Some(ref mut msg_box) = self.explorer_mbox {
+                    tracing::debug!("sending new tip to explorer {}", candidate_hash);
+                    msg_box
+                        .send(ExplorerMsg::NewTip(candidate_hash))
+                        .await
+                        .unwrap_or_else(|err| {
+                            tracing::error!("cannot send new tip to explorer: {}", err)
+                        });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn try_request_fragment_removal(
+        &mut self,
+        fragment_ids: Vec<FragmentId>,
+        header: &Header,
+    ) -> Result<(), async_msg::TrySendError<TransactionMsg>> {
+        if let Some(ref mut mbox) = self.fragment_mbox {
+            let hash = header.hash().into();
+            let date = header.block_date();
+            let status = FragmentStatus::InABlock {
+                date: date.into(),
+                block: hash,
+            };
+            mbox.try_send(TransactionMsg::RemoveTransactions(fragment_ids, status))?;
+        }
+
+        Ok(())
+    }
+
+    /// this function will re-process the tip against the different branches
+    /// this is because a branch may have become more interesting with time
+    /// moving forward and branches may have been dismissed
+    async fn reprocess_tip(&mut self) -> Result<(), Error> {
+        let branches: Vec<Arc<Ref>> = self.blockchain.branches().branches().await;
+        let tip_as_ref = self.tip.get_ref().await;
+
+        let others = branches
+            .iter()
+            .filter(|r| !Arc::ptr_eq(r, &tip_as_ref))
+            .collect::<Vec<_>>();
+
+        for other in others {
+            // TODO: avoid duplicating branches
+            self.process_new_ref(Arc::clone(other)).await?
+        }
+
+        Ok(())
+    }
+}
 
 #[derive(Clone)]
 pub struct Tip {
@@ -15,11 +216,11 @@ impl Tip {
         self.branch.get_ref().await
     }
 
-    pub async fn update_ref(&mut self, new_ref: Arc<Ref>) -> Arc<Ref> {
+    async fn update_ref(&mut self, new_ref: Arc<Ref>) -> Arc<Ref> {
         self.branch.update_ref(new_ref).await
     }
 
-    pub async fn swap(&mut self, mut branch: Branch) {
+    async fn swap(&mut self, mut branch: Branch) {
         let mut tip_branch = self.branch.clone();
         let tr = self.branch.get_ref().await;
         let br = branch.update_ref(tr).await;

--- a/jormungandr/src/blockchain/tip.rs
+++ b/jormungandr/src/blockchain/tip.rs
@@ -208,7 +208,7 @@ pub struct Tip {
 }
 
 impl Tip {
-    pub fn new(branch: Branch) -> Self {
+    pub(super) fn new(branch: Branch) -> Self {
         Tip { branch }
     }
 

--- a/jormungandr/src/explorer/error.rs
+++ b/jormungandr/src/explorer/error.rs
@@ -1,5 +1,5 @@
 use crate::blockcfg::HeaderHash;
-use crate::{blockchain::StorageError, intercom};
+use crate::{blockchain::Error as ChainError, blockchain::StorageError, intercom};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -18,6 +18,8 @@ pub enum ExplorerError {
     BootstrapError(String),
     #[error("storage error")]
     StorageError(#[from] StorageError),
+    #[error("blockchain error")]
+    ChainError(#[from] Box<ChainError>),
     #[error("streaming error")]
     StreamingError(#[from] intercom::Error),
 }

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -57,7 +57,6 @@ pub struct ExplorerDb {
     longest_chain_tip: Tip,
     pub blockchain_config: BlockchainConfig,
     blockchain: Blockchain,
-    blockchain_tip: blockchain::Tip,
     stable_store: StableIndex,
     tip_broadcast: tokio::sync::broadcast::Sender<(HeaderHash, multiverse::Ref)>,
 }
@@ -177,11 +176,7 @@ impl ExplorerDb {
     /// Apply all the blocks in the [block0, MAIN_BRANCH_TAG], also extract the static
     /// Blockchain settings from the Block0 (Discrimination)
     /// This function is only called once on the node's bootstrap phase
-    pub async fn bootstrap(
-        block0: Block,
-        blockchain: &Blockchain,
-        blockchain_tip: blockchain::Tip,
-    ) -> Result<Self> {
+    pub async fn bootstrap(block0: Block, blockchain: &Blockchain) -> Result<Self> {
         let blockchain_config = BlockchainConfig::from_config_params(
             block0
                 .contents
@@ -252,7 +247,6 @@ impl ExplorerDb {
             longest_chain_tip: Tip::new(hash),
             blockchain_config,
             blockchain: blockchain.clone(),
-            blockchain_tip,
             stable_store: StableIndex {
                 confirmed_block_chain_length: Arc::new(AtomicU32::default()),
             },

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -158,7 +158,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         let block_cache_ttl: Duration = Duration::from_secs(120);
         let stats_counter = stats_counter.clone();
         services.spawn_future("block", move |info| {
-            let process = blockchain::Process {
+            let task_data = blockchain::TaskData {
                 blockchain,
                 blockchain_tip,
                 stats_counter,
@@ -167,7 +167,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 explorer_msgbox,
                 garbage_collection_interval: block_cache_ttl,
             };
-            process.start(info, block_queue)
+            blockchain::start(task_data, info, block_queue)
         });
     }
 

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -503,7 +503,7 @@ async fn bootstrap_internal(
 
     let explorer_db = if settings.explorer {
         futures::select! {
-            explorer_result = explorer::ExplorerDb::bootstrap(block0_explorer, &blockchain, blockchain_tip.clone()).fuse() => {
+            explorer_result = explorer::ExplorerDb::bootstrap(block0_explorer, &blockchain).fuse() => {
                 Some(explorer_result?)
             },
             _ = cancellation_token.cancelled().fuse() => return Err(start_up::Error::Interrupted),

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -1,18 +1,16 @@
 use super::grpc;
-use crate::blockcfg::{Block, HeaderDesc, HeaderHash};
-use crate::blockchain::{self, Blockchain, Error as BlockchainError, PreCheckedHeader, Ref, Tip};
+use crate::blockcfg::Block;
+use crate::blockchain::{self, Blockchain, BootstrapError, Error as BlockchainError, Tip};
 use crate::network::convert::Decode;
 use crate::settings::start::network::Peer;
 use crate::topology;
-use chain_core::property::{Deserialize, HasHeader};
+use chain_core::property::Deserialize;
 use chain_network::data as net_data;
 use chain_network::error::Error as NetworkError;
-use futures::{prelude::*, stream, task::Poll};
+use futures::prelude::*;
 use tokio_util::sync::CancellationToken;
 
 use std::fmt::Debug;
-use std::pin::Pin;
-use std::sync::Arc;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -24,34 +22,22 @@ pub enum Error {
     PeersNotAvailable(#[source] NetworkError),
     #[error("bootstrap pull request failed")]
     PullRequestFailed(#[source] NetworkError),
-    #[error("bootstrap pull stream failed")]
-    PullStreamFailed(#[source] NetworkError),
     #[error("could not get the blockchain tip from a peer")]
     TipFailed(#[source] NetworkError),
     #[error("decoding of a peer failed")]
     PeerDecodingFailed(#[source] NetworkError),
     #[error("decoding of a block failed")]
     BlockDecodingFailed(#[source] <Block as Deserialize>::Error),
-    #[error("block header check failed")]
-    HeaderCheckFailed(#[source] BlockchainError),
-    #[error(
-        "received block {0} is already present, but does not descend from any of the checkpoints"
-    )]
-    BlockNotOnBranch(HeaderHash),
-    #[error("received block {0} is not connected to the block chain")]
-    BlockMissingParent(HeaderHash),
-    #[error("failed to fetch checkpoints from storage")]
-    GetCheckpointsFailed(#[source] BlockchainError),
-    #[error("failed to apply block to the blockchain")]
-    ApplyBlockFailed(#[source] BlockchainError),
-    #[error("failed to select the new tip")]
-    ChainSelectionFailed(#[source] BlockchainError),
+    #[error(transparent)]
+    Blockchain(#[from] Box<BootstrapError>),
     #[error("failed to collect garbage and flush blocks to the permanent storage")]
-    GcFailed(#[source] BlockchainError),
-    #[error("the bootstrap process was interrupted")]
-    Interrupted,
+    GcFailed(#[source] Box<BlockchainError>),
+    #[error("bootstrap pull stream failed")]
+    PullStreamFailed(#[source] NetworkError),
     #[error("Trusted peers cannot be empty. To avoid bootstrap use `skip_bootstrap: true`")]
     EmptyTrustedPeers,
+    #[error("the bootstrap process was interrupted")]
+    Interrupted,
 }
 
 const MAX_BOOTSTRAP_PEERS: u32 = 32;
@@ -132,201 +118,13 @@ pub async fn bootstrap_from_peer(
         .await?
         .map_err(Error::PullRequestFailed)?;
 
-        bootstrap_from_stream(
+        blockchain::bootstrap_from_stream(
             blockchain.clone(),
             tip.clone(),
             stream,
             cancellation_token.clone(),
         )
-        .await?;
-    }
-}
-
-struct BootstrapInfo {
-    last_reported: std::time::SystemTime,
-    last_bytes_received: u64,
-    bytes_received: u64,
-    block_received: u64,
-    last_block_description: Option<HeaderDesc>,
-}
-
-impl BootstrapInfo {
-    pub fn new() -> Self {
-        let now = std::time::SystemTime::now();
-        let lbd: Option<HeaderDesc> = None;
-        BootstrapInfo {
-            last_reported: now,
-            last_bytes_received: 0,
-            bytes_received: 0,
-            block_received: 0,
-            last_block_description: lbd,
-        }
-    }
-
-    pub fn append_block(&mut self, b: &Block) {
-        use chain_core::property::Serialize;
-        self.bytes_received += b.serialize_as_vec().unwrap().len() as u64; // TODO sad serialization back
-        self.block_received += 1;
-        self.last_block_description = Some(b.header.description());
-    }
-
-    pub fn report(&mut self) {
-        fn print_sz(n: f64) -> String {
-            if n > 1_000_000.0 {
-                format!("{:.2}mb", n / (1024 * 1024) as f64)
-            } else if n > 1_000.0 {
-                format!("{:.2}kb", n / 1024_f64)
-            } else {
-                format!("{:.2}b", n)
-            }
-        }
-        let current = std::time::SystemTime::now();
-        let time_diff = current.duration_since(self.last_reported);
-        let bytes_diff = self.bytes_received - self.last_bytes_received;
-
-        let bytes = print_sz(bytes_diff as f64);
-        let kbs = time_diff
-            .map(|td| {
-                let v = (bytes_diff as f64) / td.as_secs_f64();
-                print_sz(v)
-            })
-            .unwrap_or_else(|_| "N/A".to_string());
-
-        self.last_reported = current;
-        self.last_bytes_received = self.bytes_received;
-        tracing::info!(
-            "receiving from network bytes={} {}/s, blockchain {}",
-            bytes,
-            kbs,
-            self.last_block_description
-                .as_ref()
-                .map(|lbd| lbd.to_string())
-                .expect("append_block should always be called before report")
-        )
-    }
-}
-
-async fn bootstrap_from_stream<S>(
-    mut blockchain: Blockchain,
-    branch: Tip,
-    stream: S,
-    cancellation_token: CancellationToken,
-) -> Result<(), Error>
-where
-    S: Stream<Item = Result<net_data::Block, NetworkError>> + Unpin,
-{
-    const PROCESS_LOGGING_DISTANCE: u64 = 2500;
-    let block0 = *blockchain.block0();
-
-    let mut bootstrap_info = BootstrapInfo::new();
-    let mut maybe_parent_tip = None;
-
-    let mut stream = stream.map_err(Error::PullStreamFailed);
-    let mut cancel = cancellation_token.cancelled().boxed();
-
-    // This stream will either end when the block stream is exhausted or when
-    // the cancellation signal arrives. Building such stream allows us to
-    // correctly write all blocks and update the block tip upon the arrival of
-    // the cancellation signal.
-    let mut stream = stream::poll_fn(move |cx| {
-        let cancel = Pin::new(&mut cancel);
-        match cancel.poll(cx) {
-            Poll::Pending => {
-                let stream = Pin::new(&mut stream);
-                stream.poll_next(cx)
-            }
-            Poll::Ready(()) => Poll::Ready(Some(Err(Error::Interrupted))),
-        }
-    });
-
-    while let Some(block_result) = stream.next().await {
-        let result = match block_result {
-            Ok(block) => {
-                let block =
-                    Block::deserialize(block.as_bytes()).map_err(Error::BlockDecodingFailed)?;
-
-                if block.header.hash() == block0 {
-                    continue;
-                }
-
-                bootstrap_info.append_block(&block);
-
-                if bootstrap_info.block_received % PROCESS_LOGGING_DISTANCE == 0 {
-                    bootstrap_info.report();
-                }
-
-                handle_block(&blockchain, block).await
-            }
-            Err(err) => Err(err),
-        };
-
-        match result {
-            Ok(parent_tip) => {
-                maybe_parent_tip = Some(parent_tip);
-            }
-            Err(err) => {
-                if let Some(parent_tip) = maybe_parent_tip {
-                    if let Err(err) = blockchain::process_new_ref(
-                        &mut blockchain,
-                        branch.clone(),
-                        parent_tip.clone(),
-                        None,
-                        None,
-                    )
-                    .await
-                    {
-                        tracing::warn!(error = ?err, "couldn't gracefully exit from failed netboot");
-                    }
-                }
-                return Err(err);
-            }
-        }
-    }
-
-    if let Some(parent_tip) = maybe_parent_tip {
-        blockchain::process_new_ref(&mut blockchain, branch, parent_tip, None, None)
-            .await
-            .map_err(Error::ChainSelectionFailed)
-    } else {
-        tracing::info!("no new blocks in bootstrap stream");
-        Ok(())
-    }
-}
-
-async fn handle_block(blockchain: &Blockchain, block: Block) -> Result<Arc<Ref>, Error> {
-    let header = block.header();
-    let pre_checked = blockchain
-        .pre_check_header(header, true)
         .await
-        .map_err(Error::HeaderCheckFailed)?;
-    match pre_checked {
-        PreCheckedHeader::AlreadyPresent {
-            cached_reference: Some(block_ref),
-            ..
-        } => Ok(block_ref),
-        PreCheckedHeader::AlreadyPresent {
-            cached_reference: None,
-            header,
-        } => Err(Error::BlockNotOnBranch(header.hash())),
-        PreCheckedHeader::MissingParent { header, .. } => {
-            Err(Error::BlockMissingParent(header.hash()))
-        }
-        PreCheckedHeader::HeaderWithCache { header, parent_ref } => {
-            let post_checked = blockchain
-                .post_check_header(header, parent_ref, blockchain::CheckHeaderProof::Enabled)
-                .await
-                .map_err(Error::HeaderCheckFailed)?;
-
-            tracing::debug!(
-                hash = %post_checked.header().hash(),
-                block_date = %post_checked.header().block_date(),
-                "validated block"
-            );
-            let applied = blockchain
-                .apply_and_store_block(post_checked, block)
-                .await
-                .map_err(Error::ApplyBlockFailed)?;
-            Ok(applied.cached_ref())
-        }
+        .map_err(Box::new)?;
     }
 }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -695,7 +695,7 @@ pub async fn bootstrap(
     blockchain
         .gc(branch.get_ref().await)
         .await
-        .map_err(bootstrap::Error::GcFailed)?;
+        .map_err(|e| bootstrap::Error::GcFailed(Box::new(e)))?;
 
     Ok(NetworkBootstrapResult {
         initial_peers: bootstrap_peers

--- a/jormungandr/src/start_up/error.rs
+++ b/jormungandr/src/start_up/error.rs
@@ -42,7 +42,7 @@ pub enum Error {
     #[error("Storage error")]
     StorageError(#[from] StorageError),
     #[error("Error while loading the legacy blockchain state")]
-    Blockchain(#[from] blockchain::Error),
+    Blockchain(#[from] Box<blockchain::Error>),
     #[error("Error in the genesis-block")]
     Block0(#[from] blockcfg::Block0Error),
     #[error("Error fetching the genesis block from the network")]

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -159,7 +159,7 @@ pub async fn load_blockchain(
         rewards_report_all,
     );
 
-    let main_branch = match blockchain.load_from_block0(block0.clone()).await {
+    let tip = match blockchain.load_from_block0(block0.clone()).await {
         Err(error) => match error {
             BlockchainError::Block0AlreadyInStorage => blockchain.load_from_storage(block0).await,
             error => Err(error),
@@ -167,7 +167,6 @@ pub async fn load_blockchain(
         Ok(branch) => Ok(branch),
     }
     .map_err(Box::new)?;
-    let tip = Tip::new(main_branch);
     let tip_ref = tip.get_ref().await;
     tracing::info!(
         "Loaded from storage tip is : {}",

--- a/jormungandr/src/start_up/mod.rs
+++ b/jormungandr/src/start_up/mod.rs
@@ -165,7 +165,8 @@ pub async fn load_blockchain(
             error => Err(error),
         },
         Ok(branch) => Ok(branch),
-    }?;
+    }
+    .map_err(Box::new)?;
     let tip = Tip::new(main_branch);
     let tip_ref = tip.get_ref().await;
     tracing::info!(


### PR DESCRIPTION
### Problem
Concurrent updates to the tip result in invalid results and data races. See node logs in https://app.circleci.com/pipelines/github/input-output-hk/jormungandr/11546/workflows/1a631406-e672-4344-bdcc-b1dee3962d95/jobs/43478/steps?invite=true#step-110-2026

### Proposed solution
This PR introduces a new component, `TipUpdater`, which is the point of serialization for all tip update requests and is responsible for keeping it up to date (e.g. with periodic checks).
This is done to avoid locking the `Tip` (which is shared and used by pretty much all other modules) or the blockchain process with a mutex for the duration of the selection algorithm.
OTOH, the introduction of a whole new part can be seen as an over complication, but I I think this helps with separating functions (and thus readability) even more.

This has the side effect that it may happen that the tip is not updated right after a new block is received by the blockchain process, but I don't  see this as a problem since there are already no synchronization guarantees when passing messages between tasks.


### Other changes
As a result of the introduction of the `TipUpdater`, and as a way to hide unnecessary information and prevent misuse, the tip cannot be updated or created manually anymore outside of the blockchain module.

Since it needed to be updated anyway following the aforementioned changes, the part of the bootstrap process that was dealing with internals of the blockchain has been moved to the blockchain module from the network one, to better separate functionalities and reuse code. In this regard, the code handling addition of new blocks to the chain from storage and network has been unified, even though doing so made loading from storage a bit less efficient.

### Bug fixes?
I've also fixed some of what I think are bugs in the code:
* `process_network_blocks` always setting the explorer tip to the latest received block https://github.com/input-output-hk/jormungandr/blob/a389bb69b7a97ee27b80e38f18ccfd542d1e7094/jormungandr/src/blockchain/process.rs#L611
* explorer assuming the block applied is the tip https://github.com/input-output-hk/jormungandr/blob/a389bb69b7a97ee27b80e38f18ccfd542d1e7094/jormungandr/src/explorer/mod.rs#L704
* `process_new_ref` not actually creating a new branch for non-optimal forks https://github.com/input-output-hk/jormungandr/blob/a389bb69b7a97ee27b80e38f18ccfd542d1e7094/jormungandr/src/blockchain/process.rs#L343. I traced back this as far as I could but as far as I can tell we never created a branch here and I don't understand why. If `Branches` should contains all of the forks in the chain then I think this step was missing, as this is the only place where we create branches. OTOH, I think the current process will duplicate branches every time we reprocess the tip, as `.apply_or_create` does not check for already existing branches (but can be amended rather easily). I would like some feedback on this one


I've tried to keep this as small as possible, but looks like I've failed :sweat_smile: