### PR TITLE
use rest for remaining rewards in tests

### DIFF
--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -1159,7 +1159,7 @@ paths:
                       },
                     ]
 
-  '/api/v0/rewards/remaining/':
+  '/api/v0/rewards/remaining':
     get:
       description: 'returns the remaining funds to be distributed as rewards'
       operationId: RewardsRemaining

--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -1159,6 +1159,25 @@ paths:
                       },
                     ]
 
+  '/api/v0/rewards/remaining/':
+    get:
+      description: 'returns the remaining funds to be distributed as rewards'
+      operationId: RewardsRemaining
+      tags:
+        - rewards
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: integer
+                minimum: 0
+              examples:
+                remaining rewards:
+                  value:
+                    1000000
+
   '/api/v0/stake_pool/{pool_id}':
     get:
       description: Gets stake pool details

--- a/jormungandr/src/rest/v0/handlers.rs
+++ b/jormungandr/src/rest/v0/handlers.rs
@@ -159,6 +159,14 @@ pub async fn get_rewards_info_history(
         .map_err(warp::reject::custom)
 }
 
+pub async fn get_rewards_remaining(context: ContextLock) -> Result<impl Reply, Rejection> {
+    let context = context.read().await;
+    logic::get_rewards_remaining(&context)
+        .await
+        .map(|r| warp::reply::json(&r))
+        .map_err(warp::reject::custom)
+}
+
 pub async fn get_utxo(
     fragment_id_hex: String,
     output_index: u8,

--- a/jormungandr/src/rest/v0/logic.rs
+++ b/jormungandr/src/rest/v0/logic.rs
@@ -32,7 +32,7 @@ use jormungandr_lib::{
         AccountState, EpochRewardsInfo, FragmentLog, FragmentOrigin, FragmentsProcessingSummary,
         LeadershipLog, NodeStatsDto, PeerStats, Rewards as StakePoolRewards, SettingsDto,
         StakeDistribution, StakeDistributionDto, StakePoolStats, TaxTypeSerde, TransactionOutput,
-        VotePlanStatus,
+        Value, VotePlanStatus,
     },
     time::SystemTime,
 };
@@ -422,6 +422,13 @@ pub async fn get_rewards_info_history(
     }
 
     Ok(vec)
+}
+
+pub async fn get_rewards_remaining(context: &Context) -> Result<Value, Error> {
+    let tip_ref = context.blockchain_tip()?.get_ref().await;
+    let ledger = tip_ref.ledger();
+
+    Ok(ledger.remaining_rewards().into())
 }
 
 pub async fn get_utxo(

--- a/jormungandr/src/rest/v0/mod.rs
+++ b/jormungandr/src/rest/v0/mod.rs
@@ -191,7 +191,13 @@ pub fn filter(
             .and_then(handlers::get_rewards_info_epoch)
             .boxed();
 
-        root.and(history.or(epoch)).boxed()
+        let remaining = warp::path!("remaining")
+            .and(warp::get())
+            .and(with_context.clone())
+            .and_then(handlers::get_rewards_remaining)
+            .boxed();
+
+        root.and(history.or(epoch).or(remaining)).boxed()
     };
 
     let utxo = warp::path!("utxo" / String / u8)

--- a/testing/jormungandr-integration-tests/src/jormungandr/vit/private.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/vit/private.rs
@@ -121,7 +121,7 @@ pub fn jcli_e2e_flow_private_vote() {
 
     alice.confirm_transaction();
 
-    let rewards_before = jormungandr.explorer().last_block().unwrap().rewards();
+    let rewards_before: u64 = jormungandr.rest().remaining_rewards().unwrap().into();
 
     time::wait_for_epoch(1, jormungandr.rest());
 
@@ -266,7 +266,8 @@ pub fn jcli_e2e_flow_private_vote() {
 
     time::wait_for_epoch(3, jormungandr.rest());
 
-    let rewards_after = jormungandr.explorer().last_block().unwrap().rewards();
+    let rewards_after: u64 = jormungandr.rest().remaining_rewards().unwrap().into();
+
     // We want to make sure that our small rewards increase is reflexed in current rewards amount
     assert!(
         rewards_after == rewards_before + rewards_increase,

--- a/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
@@ -206,7 +206,7 @@ pub fn test_vote_flow_bft() {
         .send_vote_cast(&mut bob, &vote_plan, 0, &favorable_choice, &jormungandr)
         .unwrap();
 
-    let rewards_before = jormungandr.explorer().last_block().unwrap().rewards();
+    let rewards_before: u64 = jormungandr.rest().remaining_rewards().unwrap().into();
 
     wait_for_epoch(1, jormungandr.rest());
 
@@ -271,7 +271,7 @@ pub fn test_vote_flow_bft() {
         jormungandr.rest().vote_plan_statuses().unwrap(),
     );
 
-    let rewards_after = jormungandr.explorer().last_block().unwrap().rewards();
+    let rewards_after: u64 = jormungandr.rest().remaining_rewards().unwrap().into();
 
     assert!(
         rewards_after == (rewards_before + rewards_increase),
@@ -442,7 +442,7 @@ pub fn test_vote_flow_praos() {
 
     wait_for_epoch(3, jormungandr.rest());
 
-    let rewards_after = jormungandr.explorer().last_block().unwrap().rewards();
+    let rewards_after: u64 = jormungandr.rest().remaining_rewards().unwrap().into();
 
     // We want to make sure that our small rewards increase is reflexed in current rewards amount
     assert!(
@@ -532,7 +532,7 @@ pub fn jcli_e2e_flow() {
 
     alice.confirm_transaction();
 
-    let rewards_before = jormungandr.explorer().last_block().unwrap().rewards();
+    let rewards_before: u64 = jormungandr.rest().remaining_rewards().unwrap().into();
 
     time::wait_for_epoch(1, jormungandr.rest());
 
@@ -631,7 +631,7 @@ pub fn jcli_e2e_flow() {
         3
     );
 
-    let rewards_after = jormungandr.explorer().last_block().unwrap().rewards();
+    let rewards_after: u64 = jormungandr.rest().remaining_rewards().unwrap().into();
 
     // We want to make sure that our small rewards increase is reflexed in current rewards amount
     assert!(

--- a/testing/jormungandr-testing-utils/src/testing/node/legacy/rest.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/legacy/rest.rs
@@ -72,6 +72,12 @@ impl BackwardCompatibleRest {
         Ok(response_text)
     }
 
+    pub fn remaining_rewards(&self) -> Result<String, reqwest::Error> {
+        let response_text = self.raw().remaining_rewards()?.text()?;
+        self.print_response_text(&response_text);
+        Ok(response_text)
+    }
+
     pub fn stake_distribution(&self) -> Result<String, reqwest::Error> {
         let response_text = self.raw().stake_distribution()?.text()?;
         self.print_response_text(&response_text);

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/mod.rs
@@ -7,7 +7,7 @@ use chain_impl_mockchain::block::Block;
 use chain_impl_mockchain::fragment::{Fragment, FragmentId};
 use chain_impl_mockchain::header::HeaderId;
 use jormungandr_lib::interfaces::{
-    AccountVotes, Address, FragmentStatus, FragmentsProcessingSummary, VotePlanId,
+    AccountVotes, Address, FragmentStatus, FragmentsProcessingSummary, Value, VotePlanId,
 };
 use jormungandr_lib::{
     crypto::hash::Hash,
@@ -114,6 +114,10 @@ impl JormungandrRest {
     pub fn reward_history(&self, length: u32) -> Result<Vec<EpochRewardsInfo>, RestError> {
         serde_json::from_str(&self.inner.reward_history(length)?)
             .map_err(RestError::CannotDeserialize)
+    }
+
+    pub fn remaining_rewards(&self) -> Result<Value, RestError> {
+        serde_json::from_str(&self.inner.remaining_rewards()?).map_err(RestError::CannotDeserialize)
     }
 
     pub fn stake_distribution(&self) -> Result<StakeDistributionDto, RestError> {

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
@@ -93,6 +93,11 @@ impl RawRest {
         self.get(&request)
     }
 
+    pub fn remaining_rewards(&self) -> Result<Response, reqwest::Error> {
+        let request = "rewards/remaining".to_string();
+        self.get(&request)
+    }
+
     fn print_request_path(&self, text: &str) {
         if self.rest_settings().enable_debug {
             println!("Request: {}", text);


### PR DESCRIPTION
Same reasoning than #3322 

This is the more straight forward way of doing this that I could think of, but I'm open to alternatives. 

There are a couple of tests for the reward pot increase that I think we introduced at the end of the ITN. Those use the explorer right now, so this replaces it by a _new_ rest endpoint, as I didn't find a way to do it with the current ones.