### PR TITLE
Fix concurrent tip updates

### DIFF
--- a/jormungandr/src/blockchain/branch.rs
+++ b/jormungandr/src/blockchain/branch.rs
@@ -47,7 +47,18 @@ impl Branches {
         let maybe_branch = self.apply(Arc::clone(&candidate)).await;
         match maybe_branch {
             Some(branch) => branch,
-            None => self.create(candidate).await,
+            None => {
+                let maybe_exists = self
+                    .branches()
+                    .await
+                    .into_iter()
+                    .find(|branch| branch.hash() == candidate.hash());
+
+                if let Some(branch) = maybe_exists {
+                    return Branch::new(branch);
+                }
+                self.create(candidate).await
+            }
         }
     }
 

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -1,4 +1,3 @@
-mod bootstrap;
 mod branch;
 mod candidate;
 mod chain;
@@ -26,7 +25,6 @@ mod chunk_sizes {
 // Re-exports
 
 pub use self::{
-    bootstrap::{bootstrap_from_stream, Error as BootstrapError},
     branch::Branch,
     chain::{
         new_epoch_leadership_from, Blockchain, CheckHeaderProof, EpochLeadership, Error,
@@ -38,5 +36,5 @@ pub use self::{
     process::{start, TaskData},
     reference::Ref,
     storage::{Error as StorageError, Storage},
-    tip::Tip,
+    tip::{Tip, TipUpdater}, // TODO: Remove TipUpdater as soon as the bootstrap process is refactored
 };

--- a/jormungandr/src/blockchain/mod.rs
+++ b/jormungandr/src/blockchain/mod.rs
@@ -1,3 +1,4 @@
+mod bootstrap;
 mod branch;
 mod candidate;
 mod chain;
@@ -25,6 +26,7 @@ mod chunk_sizes {
 // Re-exports
 
 pub use self::{
+    bootstrap::{bootstrap_from_stream, Error as BootstrapError},
     branch::Branch,
     chain::{
         new_epoch_leadership_from, Blockchain, CheckHeaderProof, EpochLeadership, Error,
@@ -33,7 +35,7 @@ pub use self::{
     chain_selection::{compare_against, ComparisonResult},
     checkpoints::Checkpoints,
     multiverse::Multiverse,
-    process::{process_new_ref, Process},
+    process::{start, TaskData},
     reference::Ref,
     storage::{Error as StorageError, Storage},
     tip::Tip,

--- a/jormungandr/src/blockchain/tip.rs
+++ b/jormungandr/src/blockchain/tip.rs
@@ -215,7 +215,6 @@ impl TipUpdater {
             .collect::<Vec<_>>();
 
         for other in others {
-            // TODO: avoid duplicating branches
             self.process_new_ref(Arc::clone(other)).await?
         }
 

--- a/jormungandr/src/blockchain/tip.rs
+++ b/jormungandr/src/blockchain/tip.rs
@@ -22,7 +22,7 @@ const BRANCH_REPROCESSING_INTERVAL: Duration = Duration::from_secs(60);
 /// Handles updates to the tip.
 /// Only one of this structs should be active at any given time.
 #[derive(Clone)]
-pub(super) struct TipUpdater {
+pub struct TipUpdater {
     tip: Tip,
     blockchain: Blockchain,
     explorer_mbox: Option<MessageBox<ExplorerMsg>>,
@@ -31,7 +31,7 @@ pub(super) struct TipUpdater {
 }
 
 impl TipUpdater {
-    pub(super) fn new(
+    pub fn new(
         tip: Tip,
         blockchain: Blockchain,
         fragment_mbox: Option<MessageBox<TransactionMsg>>,
@@ -73,7 +73,7 @@ impl TipUpdater {
     /// If the current tip is not the one being updated we will then trigger
     /// chain selection after updating that other branch as it may be possible that
     /// this branch just became more interesting for the current consensus algorithm.
-    pub(super) async fn process_new_ref(&mut self, candidate: Arc<Ref>) -> Result<(), Error> {
+    pub async fn process_new_ref(&mut self, candidate: Arc<Ref>) -> Result<(), Error> {
         let candidate_hash = candidate.hash();
         let storage = self.blockchain.storage();
         let tip_ref = self.tip.get_ref().await;
@@ -208,6 +208,7 @@ pub struct Tip {
 }
 
 impl Tip {
+    // TODO: make this module private as soon as the bootstrap in refactored
     pub fn new(branch: Branch) -> Self {
         Tip { branch }
     }

--- a/jormungandr/src/blockchain/tip.rs
+++ b/jormungandr/src/blockchain/tip.rs
@@ -1,5 +1,206 @@
-use crate::blockchain::{Branch, Ref};
+use crate::{
+    blockcfg::{FragmentId, Header},
+    blockchain::{
+        chain_selection::{self, ComparisonResult},
+        storage, Blockchain, Branch, Error, Ref, MAIN_BRANCH_TAG,
+    },
+    intercom::{ExplorerMsg, TransactionMsg},
+    metrics::{Metrics, MetricsBackend},
+    utils::async_msg::{self, MessageBox, MessageQueue},
+};
+use chain_core::property::{Block as _, Fragment as _, HasHeader as _};
+use jormungandr_lib::interfaces::FragmentStatus;
 use std::sync::Arc;
+use tokio::time::MissedTickBehavior;
+
+use futures::prelude::*;
+
+use std::time::Duration;
+
+const BRANCH_REPROCESSING_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Handles updates to the tip.
+/// Only one of this structs should be active at any given time.
+#[derive(Clone)]
+pub(super) struct TipUpdater {
+    tip: Tip,
+    blockchain: Blockchain,
+    explorer_mbox: Option<MessageBox<ExplorerMsg>>,
+    fragment_mbox: Option<MessageBox<TransactionMsg>>,
+    stats_counter: Metrics,
+}
+
+impl TipUpdater {
+    pub(super) fn new(
+        tip: Tip,
+        blockchain: Blockchain,
+        fragment_mbox: Option<MessageBox<TransactionMsg>>,
+        explorer_mbox: Option<MessageBox<ExplorerMsg>>,
+        stats_counter: Metrics,
+    ) -> Self {
+        Self {
+            tip,
+            blockchain,
+            fragment_mbox,
+            explorer_mbox,
+            stats_counter,
+        }
+    }
+
+    pub async fn run(&mut self, mut input: MessageQueue<Arc<Ref>>) {
+        let mut reprocessing_interval = tokio::time::interval(BRANCH_REPROCESSING_INTERVAL);
+        reprocessing_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                Some(candidate) = input.next() => {
+                    self.process_new_ref(candidate).await.unwrap_or_else(|e| tracing::error!("could not process new ref:` {}", e))
+                }
+
+                _ = reprocessing_interval.tick() => {
+                    self.reprocess_tip().await.unwrap_or_else(|e| tracing::error!("could not reprocess tip:` {}", e))
+                }
+
+            }
+        }
+    }
+
+    /// process a new candidate block on top of the blockchain, this function may:
+    ///
+    /// * update the current tip if the candidate's parent is the current tip;
+    /// * update a branch if the candidate parent is that branch's tip;
+    /// * create a new branch if none of the above;
+    ///
+    /// If the current tip is not the one being updated we will then trigger
+    /// chain selection after updating that other branch as it may be possible that
+    /// this branch just became more interesting for the current consensus algorithm.
+    pub(super) async fn process_new_ref(&mut self, candidate: Arc<Ref>) -> Result<(), Error> {
+        let candidate_hash = candidate.hash();
+        let storage = self.blockchain.storage();
+        let tip_ref = self.tip.get_ref().await;
+        let block = storage
+            .get(candidate_hash)?
+            .ok_or(storage::Error::BlockNotFound)?;
+
+        match chain_selection::compare_against(storage, &tip_ref, &candidate) {
+            ComparisonResult::PreferCurrent => {
+                tracing::info!(
+                    "create new branch with tip {} | current-tip {}",
+                    candidate.header().description(),
+                    tip_ref.header().description(),
+                );
+                self.blockchain
+                    .branches_mut()
+                    .apply_or_create(candidate.clone())
+                    .await;
+            }
+            ComparisonResult::PreferCandidate => {
+                if tip_ref.hash() == candidate.block_parent_hash() {
+                    tracing::info!(
+                        "update current branch tip: {} -> {}",
+                        tip_ref.header().description(),
+                        candidate.header().description(),
+                    );
+
+                    storage.put_tag(MAIN_BRANCH_TAG, candidate_hash)?;
+
+                    let fragment_ids = block.fragments().map(|f| f.id()).collect();
+                    self.try_request_fragment_removal(fragment_ids, &block.header())?;
+
+                    self.tip.update_ref(candidate.clone()).await;
+                } else {
+                    let common_ancestor =
+                        storage.find_common_ancestor(candidate_hash, tip_ref.hash())?;
+
+                    let stream = self
+                        .blockchain
+                        .storage()
+                        .stream_from_to(common_ancestor, candidate_hash)?;
+                    tokio::pin!(stream);
+
+                    // there is always at least one block in the stream
+                    let ancestor = stream.next().await.unwrap()?;
+                    if let Some(ref mut mbox) = self.fragment_mbox {
+                        mbox.try_send(TransactionMsg::BranchSwitch(ancestor.date().into()))?;
+                    }
+
+                    while let Some(block) = stream.next().await {
+                        let block = block?;
+                        let fragment_ids = block.fragments().map(|f| f.id()).collect();
+                        self.try_request_fragment_removal(fragment_ids, &block.header())?;
+                    }
+
+                    tracing::info!(
+                        "switching branch from {} to {}",
+                        tip_ref.header().description(),
+                        candidate.header().description(),
+                    );
+
+                    self.blockchain
+                        .storage()
+                        .put_tag(MAIN_BRANCH_TAG, candidate_hash)?;
+
+                    let branch = self
+                        .blockchain
+                        .branches_mut()
+                        .apply_or_create(candidate.clone())
+                        .await;
+                    self.tip.swap(branch).await;
+                }
+
+                self.stats_counter.set_tip_block(&block, &candidate);
+                if let Some(ref mut msg_box) = self.explorer_mbox {
+                    tracing::debug!("sending new tip to explorer {}", candidate_hash);
+                    msg_box
+                        .send(ExplorerMsg::NewTip(candidate_hash))
+                        .await
+                        .unwrap_or_else(|err| {
+                            tracing::error!("cannot send new tip to explorer: {}", err)
+                        });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn try_request_fragment_removal(
+        &mut self,
+        fragment_ids: Vec<FragmentId>,
+        header: &Header,
+    ) -> Result<(), async_msg::TrySendError<TransactionMsg>> {
+        if let Some(ref mut mbox) = self.fragment_mbox {
+            let hash = header.hash().into();
+            let date = header.block_date();
+            let status = FragmentStatus::InABlock {
+                date: date.into(),
+                block: hash,
+            };
+            mbox.try_send(TransactionMsg::RemoveTransactions(fragment_ids, status))?;
+        }
+
+        Ok(())
+    }
+
+    /// this function will re-process the tip against the different branches
+    /// this is because a branch may have become more interesting with time
+    /// moving forward and branches may have been dismissed
+    async fn reprocess_tip(&mut self) -> Result<(), Error> {
+        let branches: Vec<Arc<Ref>> = self.blockchain.branches().branches().await;
+        let tip_as_ref = self.tip.get_ref().await;
+
+        let others = branches
+            .iter()
+            .filter(|r| !Arc::ptr_eq(r, &tip_as_ref))
+            .collect::<Vec<_>>();
+
+        for other in others {
+            // TODO: avoid duplicating branches
+            self.process_new_ref(Arc::clone(other)).await?
+        }
+
+        Ok(())
+    }
+}
 
 #[derive(Clone)]
 pub struct Tip {
@@ -15,11 +216,11 @@ impl Tip {
         self.branch.get_ref().await
     }
 
-    pub async fn update_ref(&mut self, new_ref: Arc<Ref>) -> Arc<Ref> {
+    async fn update_ref(&mut self, new_ref: Arc<Ref>) -> Arc<Ref> {
         self.branch.update_ref(new_ref).await
     }
 
-    pub async fn swap(&mut self, mut branch: Branch) {
+    async fn swap(&mut self, mut branch: Branch) {
         let mut tip_branch = self.branch.clone();
         let tr = self.branch.get_ref().await;
         let br = branch.update_ref(tr).await;

--- a/jormungandr/src/explorer/error.rs
+++ b/jormungandr/src/explorer/error.rs
@@ -1,5 +1,5 @@
 use crate::blockcfg::HeaderHash;
-use crate::{blockchain::StorageError, intercom};
+use crate::{blockchain::Error as ChainError, blockchain::StorageError, intercom};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -18,6 +18,8 @@ pub enum ExplorerError {
     BootstrapError(String),
     #[error("storage error")]
     StorageError(#[from] StorageError),
+    #[error("blockchain error")]
+    ChainError(#[from] Box<ChainError>),
     #[error("streaming error")]
     StreamingError(#[from] intercom::Error),
 }

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -212,7 +212,14 @@ impl ExplorerDb {
         let addresses = apply_block_to_addresses(Addresses::new(), &block);
         let (stake_pool_data, stake_pool_blocks) =
             apply_block_to_stake_pools(StakePool::new(), StakePoolBlocks::new(), &block);
-        let vote_plans = apply_block_to_vote_plans(VotePlans::new(), &blockchain_tip, &block);
+        let block_id = block0.header.hash();
+
+        let block_ref = blockchain
+            .get_ref(block_id)
+            .await
+            .map_err(Box::new)?
+            .ok_or(Error::BlockNotFound(block_id))?;
+        let vote_plans = apply_block_to_vote_plans(VotePlans::new(), &block_ref, &block);
 
         let initial_state = State {
             transactions,
@@ -321,6 +328,14 @@ impl ExplorerDb {
         let (stake_pool_data, stake_pool_blocks) =
             apply_block_to_stake_pools(stake_pool_data, stake_pool_blocks, &explorer_block);
 
+        let block_ref = self
+            .blockchain()
+            .get_ref(block_id)
+            .await
+            .map_err(Box::new)?
+            .ok_or(Error::BlockNotFound(block_id))?;
+        let vote_plans = apply_block_to_vote_plans(vote_plans, &block_ref, &explorer_block);
+
         let state_ref = multiverse
             .insert(
                 chain_length,
@@ -334,15 +349,10 @@ impl ExplorerDb {
                     chain_lengths: apply_block_to_chain_lengths(chain_lengths, &explorer_block)?,
                     stake_pool_data,
                     stake_pool_blocks,
-                    vote_plans: apply_block_to_vote_plans(
-                        vote_plans,
-                        &self.blockchain_tip,
-                        &explorer_block,
-                    ),
+                    vote_plans,
                 },
             )
             .await;
-
         Ok(state_ref)
     }
 
@@ -705,7 +715,7 @@ fn apply_block_to_stake_pools(
 
 fn apply_block_to_vote_plans(
     mut vote_plans: VotePlans,
-    blockchain_tip: &blockchain::Tip,
+    block_ref: &Arc<blockchain::Ref>,
     block: &ExplorerBlock,
 ) -> VotePlans {
     for tx in block.transactions.values() {
@@ -798,17 +808,16 @@ fn apply_block_to_vote_plans(
                     use chain_impl_mockchain::vote::PayloadType;
                     vote_plans
                         .update(vote_tally.id(), |vote_plan| {
-                            let proposals_from_state =
-                                futures::executor::block_on(blockchain_tip.get_ref())
-                                    .active_vote_plans()
-                                    .into_iter()
-                                    .find_map(|vps| {
-                                        if vps.id != vote_plan.id {
-                                            return None;
-                                        }
-                                        Some(vps.proposals)
-                                    })
-                                    .unwrap();
+                            let proposals_from_state = block_ref
+                                .active_vote_plans()
+                                .into_iter()
+                                .find_map(|vps| {
+                                    if vps.id != vote_plan.id {
+                                        return None;
+                                    }
+                                    Some(vps.proposals)
+                                })
+                                .unwrap();
                             let proposals = vote_plan
                                 .proposals
                                 .clone()

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -57,7 +57,6 @@ pub struct ExplorerDb {
     longest_chain_tip: Tip,
     pub blockchain_config: BlockchainConfig,
     blockchain: Blockchain,
-    blockchain_tip: blockchain::Tip,
     stable_store: StableIndex,
     tip_broadcast: tokio::sync::broadcast::Sender<(HeaderHash, multiverse::Ref)>,
 }
@@ -179,11 +178,7 @@ impl ExplorerDb {
     /// Apply all the blocks in the [block0, MAIN_BRANCH_TAG], also extract the static
     /// Blockchain settings from the Block0 (Discrimination)
     /// This function is only called once on the node's bootstrap phase
-    pub async fn bootstrap(
-        block0: Block,
-        blockchain: &Blockchain,
-        blockchain_tip: blockchain::Tip,
-    ) -> Result<Self> {
+    pub async fn bootstrap(block0: Block, blockchain: &Blockchain) -> Result<Self> {
         let blockchain_config = BlockchainConfig::from_config_params(
             block0
                 .contents
@@ -254,7 +249,6 @@ impl ExplorerDb {
             longest_chain_tip: Tip::new(hash),
             blockchain_config,
             blockchain: blockchain.clone(),
-            blockchain_tip,
             stable_store: StableIndex {
                 confirmed_block_chain_length: Arc::new(AtomicU32::default()),
             },

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -500,7 +500,7 @@ async fn bootstrap_internal(
 
     let explorer_db = if settings.explorer {
         futures::select! {
-            explorer_result = explorer::ExplorerDb::bootstrap(block0_explorer, &blockchain, blockchain_tip.clone()).fuse() => {
+            explorer_result = explorer::ExplorerDb::bootstrap(block0_explorer, &blockchain).fuse() => {
                 Some(explorer_result?)
             },
             _ = cancellation_token.cancelled().fuse() => return Err(start_up::Error::Interrupted),

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -158,7 +158,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         let block_cache_ttl: Duration = Duration::from_secs(120);
         let stats_counter = stats_counter.clone();
         services.spawn_future("block", move |info| {
-            let process = blockchain::Process {
+            let task_data = blockchain::TaskData {
                 blockchain,
                 blockchain_tip,
                 stats_counter,
@@ -167,7 +167,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 explorer_msgbox,
                 garbage_collection_interval: block_cache_ttl,
             };
-            process.start(info, block_queue)
+            blockchain::start(task_data, info, block_queue)
         });
     }
 


### PR DESCRIPTION
### Problem
Concurrent updates to the tip result in invalid results and data races. See node logs in https://app.circleci.com/pipelines/github/input-output-hk/jormungandr/11546/workflows/1a631406-e672-4344-bdcc-b1dee3962d95/jobs/43478/steps?invite=true#step-110-2026

### Proposed solution
This PR introduces a new component, `TipUpdater`, which is the point of serialization for all tip update requests and is responsible for keeping it up to date (e.g. with periodic checks).
This is done to avoid locking the `Tip` (which is shared and used by pretty much all other modules) or the blockchain process with a mutex for the duration of the selection algorithm.
OTOH, the introduction of a whole new part can be seen as an over complication, but I I think this helps with separating functions (and thus readability) even more.

This has the side effect that it may happen that the tip is not updated right after a new block is received by the blockchain process, but I don't  see this as a problem since there are already no synchronization guarantees when passing messages between tasks.


### Bug fixes?
I've also fixed some of what I think are bugs in the code:
* `process_network_blocks` always setting the explorer tip to the latest received block https://github.com/input-output-hk/jormungandr/blob/a389bb69b7a97ee27b80e38f18ccfd542d1e7094/jormungandr/src/blockchain/process.rs#L611
* explorer assuming the block applied is the tip https://github.com/input-output-hk/jormungandr/blob/a389bb69b7a97ee27b80e38f18ccfd542d1e7094/jormungandr/src/explorer/mod.rs#L704
* `process_new_ref` not actually creating a new branch for non-optimal forks https://github.com/input-output-hk/jormungandr/blob/a389bb69b7a97ee27b80e38f18ccfd542d1e7094/jormungandr/src/blockchain/process.rs#L343. I traced back this as far as I could but as far as I can tell we never created a branch here and I don't understand why. If `Branches` should contains all of the forks in the chain then I think this step was missing, as this is the only place where we create branches. OTOH, I think the current process will duplicate branches every time we reprocess the tip, as `.apply_or_create` does not check for already existing branches (but can be amended rather easily). I would like some feedback on this one


### Next steps
As a result of the introduction of the `TipUpdater`, and as a way to hide unnecessary information and prevent misuse, it should be impossible for the tip be updated or created manually anymore outside of the blockchain module.
Unfortunately, it's not currently possible to do so, as part of the bootstrap process happens in the network module. I think we should refactor that and clean it up

I've tried to keep this as small as possible, but looks like I've failed :sweat_smile: