### PR TITLE
[Tests] Remove waits

### DIFF
--- a/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jormungandr/configuration_builder.rs
@@ -49,6 +49,7 @@ pub struct ConfigurationBuilder {
     leader_key_pair: Option<KeyPair<Ed25519>>,
     discrimination: Discrimination,
     tx_max_expiry_epochs: Option<u8>,
+    log_level: String,
 }
 
 impl Default for ConfigurationBuilder {
@@ -83,6 +84,7 @@ impl ConfigurationBuilder {
             total_reward_supply: None,
             discrimination: Discrimination::Test,
             tx_max_expiry_epochs: None,
+            log_level: "trace".into(),
         }
     }
 
@@ -213,12 +215,17 @@ impl ConfigurationBuilder {
         self
     }
 
-    pub fn with_log_path(&mut self, path: PathBuf) -> &mut Self {
+    pub fn with_log_path(&mut self, path: PathBuf, level: String) -> &mut Self {
         self.with_log(Log(LogEntry {
             format: "json".to_string(),
-            level: "debug".to_string(),
+            level,
             output: LogOutput::File(path),
         }))
+    }
+
+    pub fn with_log_level(&mut self, level: String) -> &mut Self {
+        self.log_level = level;
+        self
     }
 
     pub fn without_log(&mut self) -> &mut Self {
@@ -309,7 +316,7 @@ impl ConfigurationBuilder {
             (None, true) => {
                 let path = default_log_file();
                 node_config.log = Some(Log(LogEntry {
-                    level: "trace".to_string(),
+                    level: self.log_level.clone(),
                     format: "json".to_string(),
                     output: LogOutput::Stdout,
                 }));

--- a/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
@@ -1,4 +1,3 @@
-use crate::common::jormungandr::StartupVerificationMode;
 use crate::common::jormungandr::{starter::Role, Starter};
 use crate::common::{jormungandr::ConfigurationBuilder, startup};
 use assert_fs::fixture::{PathChild, PathCreateDir};
@@ -476,14 +475,6 @@ fn expired_fragment_should_be_rejected_by_passive_bft_node() {
         )
         .passive()
         .start()
-        .unwrap();
-
-    leader
-        .wait_for_bootstrap(&StartupVerificationMode::Rest, Duration::from_secs(30))
-        .unwrap();
-
-    passive
-        .wait_for_bootstrap(&StartupVerificationMode::Rest, Duration::from_secs(30))
         .unwrap();
 
     let fragment_sender = FragmentSender::new(

--- a/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
@@ -413,7 +413,8 @@ pub fn expired_fragment_should_be_rejected_by_leader_praos_node() {
                 pool_max_entries: 1000.into(),
                 log_max_entries: 1000.into(),
                 persistent_log: None,
-            }),
+            })
+            .with_log_level("debug".into()),
     )
     .unwrap();
 
@@ -459,7 +460,8 @@ fn expired_fragment_should_be_rejected_by_passive_bft_node() {
                 pool_max_entries: 1000.into(),
                 log_max_entries: 1000.into(),
                 persistent_log: None,
-            }),
+            })
+            .with_log_level("debug".into()),
     )
     .unwrap();
 
@@ -471,6 +473,7 @@ fn expired_fragment_should_be_rejected_by_passive_bft_node() {
             ConfigurationBuilder::new()
                 .with_trusted_peers(vec![leader.to_trusted_peer()])
                 .with_block_hash(&leader.genesis_block_hash().to_string())
+                .with_log_level("debug".into())
                 .build(&passive_dir),
         )
         .passive()


### PR DESCRIPTION
There were a bunch of unnecessary waits in `expired_fragment_should_be_rejected_by_{passive_bft, leader_praos}_node` which, along with a non-ideal implementation and slow runners, were causing the test to fail on CircleCI. This hopefully fixes it