### PR TITLE
enable all-features flag when building tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ commands:
       - run:
           name: Build tests
           command: |
-            cargo build --workspace --tests << parameters.mode >> << parameters.cargo_behavior >>
+            cargo build --workspace --tests --all-features << parameters.mode >> << parameters.cargo_behavior >>
       - run:
           name: Build scenario tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ commands:
             RUST_BACKTRACE: 1
           command: |
             cargo test --workspace --tests << parameters.mode >> << parameters.cargo_behavior >>
+          no_output_timeout: 30m
       - run:
           name: Run doc tests
           environment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Run tests
         uses: actions-rs/cargo@v1
-        timeout-minutes: 30
+        timeout-minutes: 90
         with:
           command: test
           args: --tests ${{ env.CARGO_FLAGS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,7 @@ jobs:
         timeout-minutes: 30
         with:
           command: build
-          args: --tests ${{ env.CARGO_FLAGS }}
+          args: --tests --all-features ${{ env.CARGO_FLAGS }}
 
       - name: Build scenario tests
         uses: actions-rs/cargo@v1

--- a/testing/jormungandr-integration-tests/src/networking/testnet.rs
+++ b/testing/jormungandr-integration-tests/src/networking/testnet.rs
@@ -27,7 +27,6 @@ pub struct TestnetConfig {
     block0_hash: String,
     public_ip: String,
     public_port: String,
-    listen_port: String,
     trusted_peers: Vec<TrustedPeer>,
 }
 
@@ -61,10 +60,6 @@ impl TestnetConfig {
         let public_port = env::var(public_port_var_name)
             .unwrap_or_else(|_| panic!("{} env is not set", public_port_var_name));
 
-        let listen_port_var_name = "LISTEN_PORT";
-        let listen_port = env::var(listen_port_var_name)
-            .unwrap_or_else(|_| panic!("{} env is not set", listen_port_var_name));
-
         let trusted_peers = Self::initialize_trusted_peers(prefix);
 
         TestnetConfig {
@@ -72,7 +67,6 @@ impl TestnetConfig {
             block0_hash,
             public_ip,
             public_port,
-            listen_port,
             trusted_peers,
         }
     }


### PR DESCRIPTION
We have many test features (load/soak etc.) which often failed to compile after some refactoring. This PR is an attempt to fix this problem by enabling `all-features` when building tests