### PR TITLE
[Tests] increase default slot duration in tests to 2 secs

### DIFF
--- a/testing/jormungandr-integration-tests/src/jcli/rest/vote.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/rest/vote.rs
@@ -38,7 +38,6 @@ pub fn test_correct_proposal_number_is_returned() {
         .with_slots_per_epoch(60)
         .with_certs(vec![vote_plan_cert])
         .with_explorer()
-        .with_slot_duration(1)
         .with_treasury(1_000.into())
         .build(&temp_dir);
 

--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/mempool/v0.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/mempool/v0.rs
@@ -103,7 +103,6 @@ pub fn test_mempool_pool_max_entries_equal_0() {
                 value: 100.into(),
             },
         ])
-        .with_slot_duration(1)
         .with_mempool(Mempool {
             pool_max_entries: 0.into(),
             log_max_entries: 100.into(),
@@ -233,7 +232,6 @@ pub fn test_mempool_log_max_entries_equals_0() {
                 value: 100.into(),
             },
         ])
-        .with_slot_duration(1)
         .with_mempool(Mempool {
             pool_max_entries: 0.into(),
             log_max_entries: 0.into(),
@@ -289,7 +287,6 @@ pub fn test_mempool_pool_max_entries_overrides_log_max_entries() {
                 value: 100.into(),
             },
         ])
-        .with_slot_duration(1)
         .with_mempool(Mempool {
             pool_max_entries: 2.into(),
             log_max_entries: 0.into(),

--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/mempool/v1.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/mempool/v1.rs
@@ -128,7 +128,6 @@ pub fn test_mempool_pool_max_entries_equal_0() {
                 value: 100.into(),
             },
         ])
-        .with_slot_duration(1)
         .with_mempool(Mempool {
             pool_max_entries: 0.into(),
             log_max_entries: 100.into(),
@@ -212,7 +211,6 @@ pub fn test_mempool_log_max_entries_only_one_fragment() {
                 value: 100.into(),
             },
         ])
-        .with_slot_duration(1)
         .with_mempool(Mempool {
             pool_max_entries: 1.into(),
             log_max_entries: 1.into(),
@@ -308,7 +306,6 @@ pub fn test_mempool_log_max_entries_equals_0() {
                 value: 100.into(),
             },
         ])
-        .with_slot_duration(1)
         .with_mempool(Mempool {
             pool_max_entries: 0.into(),
             log_max_entries: 0.into(),
@@ -393,7 +390,6 @@ pub fn test_mempool_pool_max_entries_overrides_log_max_entries() {
                 value: 100.into(),
             },
         ])
-        .with_slot_duration(1)
         .with_mempool(Mempool {
             pool_max_entries: 2.into(),
             log_max_entries: 0.into(),

--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/client_tests.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/client_tests.rs
@@ -264,7 +264,6 @@ pub fn upload_block_incompatible_protocol() {
 pub fn upload_block_nonexisting_stake_pool() {
     let setup = setup::client::bootstrap(
         ConfigurationBuilder::new()
-            .with_slot_duration(1)
             .with_block0_consensus(ConsensusVersion::GenesisPraos)
             .to_owned(),
     );

--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/setup.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/setup.rs
@@ -9,7 +9,7 @@ use jormungandr_testing_utils::testing::{
 };
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
-const DEFAULT_SLOT_DURATION: u8 = 1;
+const DEFAULT_SLOT_DURATION: u8 = 2;
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 pub struct Config {
     addr: SocketAddr,

--- a/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
@@ -35,7 +35,6 @@ pub fn dump_send_correct_fragments() {
         ConfigurationBuilder::new()
             .with_slots_per_epoch(60)
             .with_block_content_max_size(10000)
-            .with_slot_duration(1)
             .with_explorer()
             .with_mempool(Mempool {
                 pool_max_entries: 1_000_000usize.into(),
@@ -101,7 +100,6 @@ pub fn dump_send_invalid_fragments() {
         vec![&sender, &receiver],
         ConfigurationBuilder::new()
             .with_slots_per_epoch(60)
-            .with_slot_duration(1)
             .with_explorer()
             .with_mempool(Mempool {
                 pool_max_entries: 1_000_000usize.into(),
@@ -150,7 +148,6 @@ pub fn non_existing_folder() {
         vec![&sender, &receiver],
         ConfigurationBuilder::new()
             .with_slots_per_epoch(60)
-            .with_slot_duration(1)
             .with_explorer()
             .with_mempool(Mempool {
                 pool_max_entries: 1_000_000usize.into(),
@@ -410,7 +407,6 @@ pub fn expired_fragment_should_be_rejected_by_leader_praos_node() {
         ConfigurationBuilder::new()
             .with_block_content_max_size(256) // This should only fit 1 transaction
             .with_slots_per_epoch(N_FRAGMENTS)
-            .with_slot_duration(1)
             .with_mempool(Mempool {
                 pool_max_entries: 1000.into(),
                 log_max_entries: 1000.into(),
@@ -457,7 +453,6 @@ fn expired_fragment_should_be_rejected_by_passive_bft_node() {
         ConfigurationBuilder::new()
             .with_block_content_max_size(256) // This should only fit 1 transaction
             .with_slots_per_epoch(N_FRAGMENTS)
-            .with_slot_duration(1)
             .with_mempool(Mempool {
                 pool_max_entries: 1000.into(),
                 log_max_entries: 1000.into(),

--- a/testing/jormungandr-integration-tests/src/jormungandr/persistent_log.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/persistent_log.rs
@@ -20,15 +20,13 @@ fn rejected_fragments_have_no_log() {
     let (jormungandr, _) = startup::start_stake_pool(
         &[sender.clone()],
         &[receiver.clone()],
-        ConfigurationBuilder::new()
-            .with_slot_duration(1)
-            .with_mempool(Mempool {
-                pool_max_entries: 1_000.into(),
-                log_max_entries: 1_000.into(),
-                persistent_log: Some(PersistentLog {
-                    dir: log_path.path().to_path_buf(),
-                }),
+        ConfigurationBuilder::new().with_mempool(Mempool {
+            pool_max_entries: 1_000.into(),
+            log_max_entries: 1_000.into(),
+            persistent_log: Some(PersistentLog {
+                dir: log_path.path().to_path_buf(),
             }),
+        }),
     )
     .unwrap();
 

--- a/testing/jormungandr-integration-tests/src/jormungandr/transactions.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/transactions.rs
@@ -105,7 +105,6 @@ fn expired_transactions_rejected() {
         ConfigurationBuilder::new()
             .with_slots_per_epoch(30)
             .with_consensus_genesis_praos_active_slot_coeff(ActiveSlotCoefficient::MAXIMUM)
-            .with_slot_duration(1)
             .with_linear_fees(LinearFee::new(0, 0, 0))
             .with_mempool(Mempool {
                 pool_max_entries: 1_000.into(),
@@ -165,7 +164,6 @@ fn transactions_with_long_time_to_live_rejected() {
         ConfigurationBuilder::new()
             .with_slots_per_epoch(30)
             .with_consensus_genesis_praos_active_slot_coeff(ActiveSlotCoefficient::MAXIMUM)
-            .with_slot_duration(1)
             .with_linear_fees(LinearFee::new(0, 0, 0))
             .with_mempool(Mempool {
                 pool_max_entries: 1_000.into(),

--- a/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
@@ -181,7 +181,6 @@ pub fn test_vote_flow_bft() {
         .with_slots_per_epoch(60)
         .with_certs(vec![vote_plan_cert])
         .with_explorer()
-        .with_slot_duration(1)
         .with_treasury(1_000.into())
         .build(&temp_dir);
 
@@ -314,8 +313,7 @@ pub fn test_vote_flow_praos() {
             ActiveSlotCoefficient::new(Milli::from_millis(1_000)).unwrap(),
         )
         .with_certs(vec![vote_plan_cert])
-        .with_total_rewards_supply(1_000_000.into())
-        .with_slot_duration(1);
+        .with_total_rewards_supply(1_000_000.into());
 
     let (jormungandr, _stake_pools) = start_stake_pool(
         &[alice.clone()],

--- a/testing/jormungandr-integration-tests/src/non_functional/persistent_log.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/persistent_log.rs
@@ -22,7 +22,6 @@ pub fn persistent_log_load_test() {
         vec![&faucet],
         ConfigurationBuilder::new()
             .with_slots_per_epoch(60)
-            .with_slot_duration(1)
             .with_explorer()
             .with_mempool(Mempool {
                 pool_max_entries: 1_000_000usize.into(),

--- a/testing/jormungandr-testing-utils/src/testing/jormungandr/configuration_builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/jormungandr/configuration_builder.rs
@@ -20,6 +20,7 @@ use jormungandr_lib::interfaces::{
     Value,
 };
 use std::path::PathBuf;
+const DEFAULT_SLOT_DURATION: u8 = 2;
 
 #[derive(Clone, Debug)]
 pub struct ConfigurationBuilder {
@@ -65,7 +66,7 @@ impl ConfigurationBuilder {
             block0_hash: None,
             block0_consensus: ConsensusVersion::Bft,
             slots_per_epoch: NumberOfSlotsPerEpoch::new(100).unwrap(),
-            slot_duration: SlotDuration::new(1).unwrap(),
+            slot_duration: SlotDuration::new(DEFAULT_SLOT_DURATION).unwrap(),
             epoch_stability_depth: 2600u32.into(),
             linear_fees: LinearFee::new(0, 0, 0),
             consensus_genesis_praos_active_slot_coeff: ActiveSlotCoefficient::MAXIMUM,


### PR DESCRIPTION
CircleCI is a bit slow and this can cause forking inside a single node.
Let's try to increase the default slot time to 2s and hope this fixes the problem without increasing test times too much