### PR TITLE
add split limit for explorer load generator

### DIFF
--- a/testing/jormungandr-integration-tests/src/non_functional/explorer.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/explorer.rs
@@ -144,7 +144,7 @@ pub fn explorer_load_test() {
         .do_setup(addresses.iter().map(|x| x.address().to_string()).collect())
         .unwrap();
     let config = Configuration::duration(
-        100,
+        30,
         std::time::Duration::from_secs(60),
         100,
         Monitor::Progress(100),


### PR DESCRIPTION
We experienced some issues in `explorer_load_test` in nightly tests . When running test like below:
`cargo test --all-features explorer_load_test --release`
It causes:
```
thread '12' has overflowed its stack
fatal runtime error: stack overflow
```

I've try to debug it using gdb and got another:
```
Thread 65 "58" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fff77bfd700 (LWP 9734)]
0x0000555555753737 in rayon::iter::plumbing::bridge_unindexed_producer_consumer ()
```

Solution proposed by @Zeegomo was to limit number of splits for Explorer load generator