### PR TITLE
Applied fixes for other nightly tests.

### DIFF
--- a/testing/jormungandr-integration-tests/src/common/jcli/services/transaction_builder.rs
+++ b/testing/jormungandr-integration-tests/src/common/jcli/services/transaction_builder.rs
@@ -36,15 +36,6 @@ impl TransactionBuilder {
         PathBuf::from(self.staging_file().path())
     }
 
-    fn truncate_end_of_line(cert_content: &str) -> String {
-        let mut content = cert_content.to_string();
-        if content.ends_with('\n') {
-            let len = content.len();
-            content.truncate(len - 1);
-        }
-        content.trim().to_string()
-    }
-
     pub fn build_transaction_from_utxo(
         self,
         utxo: &UTxOInfo,


### PR DESCRIPTION
Fixed more issues with nightly tests as original connected with explorer load test revealed further issues.

- removed unused method in jcli test service 
- fix soak explorer test by adding expiry date to explorer soak test
- fix rest load tests by introducing split limit for RestRequestGen