### PR TITLE
[Tests] Adversary node

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/server_tests.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/server_tests.rs
@@ -10,12 +10,10 @@ pub fn wrong_protocol() {
     let setup = setup::server::default();
 
     let block0 = setup.server.block0_configuration().to_block();
-    let genesis_hash = setup.server.genesis_block_hash().into_hash();
 
     let mock_controller = MockBuilder::new()
         .with_port(setup.mock_port)
-        .with_genesis_hash(genesis_hash)
-        .with_tip(block0.header().clone())
+        .with_genesis_block(block0)
         .with_protocol_version(ProtocolVersion::Bft)
         .build();
 
@@ -44,13 +42,11 @@ pub fn wrong_genesis_hash() {
 
     let block0 = setup.server.block0_configuration().to_block();
 
-    let mock_controller = MockBuilder::new()
+    let mut mock_controller = MockBuilder::new()
         .with_port(setup.mock_port)
-        // little hack, we need tip header to be the same of the server so that we can complete bootstrap
-        .with_tip(block0.header().clone())
         .with_protocol_version(ProtocolVersion::GenesisPraos)
         .build();
-
+    mock_controller.set_tip_block(&block0);
     setup.wait_server_online();
 
     let mock_result = mock_controller.finish_and_verify_that(|mock_verifier| {
@@ -80,12 +76,10 @@ pub fn handshake_ok() {
     let setup = setup::server::default();
 
     let block0 = setup.server.block0_configuration().to_block();
-    let genesis_hash = setup.server.genesis_block_hash().into_hash();
 
     let mock_controller = MockBuilder::new()
         .with_port(setup.mock_port)
-        .with_genesis_hash(genesis_hash)
-        .with_tip(block0.header().clone())
+        .with_genesis_block(block0)
         .with_protocol_version(ProtocolVersion::GenesisPraos)
         .build();
 

--- a/testing/jormungandr-testing-utils/src/bin/mock_server_app.rs
+++ b/testing/jormungandr-testing-utils/src/bin/mock_server_app.rs
@@ -1,19 +1,32 @@
-use chain_core::property::FromStr;
-use chain_impl_mockchain::key::Hash;
-use jormungandr_testing_utils::testing::node::grpc::server::{header, MockBuilder};
+use chain_impl_mockchain::{
+    header::BlockDate,
+    testing::{GenesisPraosBlockBuilder, StakePoolBuilder},
+};
+use chain_time::{Epoch, TimeEra};
+use jormungandr_testing_utils::testing::node::grpc::server::MockBuilder;
 use std::env;
 
 fn main() {
-    let tip_parent =
-        Hash::from_str("1c3ad65daec5ccb157b439ecd5e8d0574e389077cc672dd2a256ab1af8e6a463").unwrap();
-
     let args: Vec<String> = env::args().collect();
     let port: u16 = args[1].parse().unwrap();
 
     let mut mock_controller = MockBuilder::new().with_port(port).build();
 
     std::thread::sleep(std::time::Duration::from_secs(60));
-    mock_controller.set_tip(header(30, &tip_parent));
+
+    let stake_pool = StakePoolBuilder::new().build();
+    let time_era = TimeEra::new(0u64.into(), Epoch(0u32), 30);
+
+    let block = GenesisPraosBlockBuilder::new()
+        .with_parent_id(mock_controller.genesis_hash())
+        .with_date(BlockDate {
+            epoch: 0,
+            slot_id: 1,
+        })
+        .with_chain_length(1.into())
+        .build(&stake_pool, &time_era);
+
+    mock_controller.set_tip_block(&block);
     std::thread::sleep(std::time::Duration::from_secs(60));
     mock_controller.stop();
 }

--- a/testing/jormungandr-testing-utils/src/testing/adversary/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/adversary/mod.rs
@@ -1,0 +1,3 @@
+pub mod process;
+
+pub use process::AdversaryNode;

--- a/testing/jormungandr-testing-utils/src/testing/adversary/process.rs
+++ b/testing/jormungandr-testing-utils/src/testing/adversary/process.rs
@@ -1,0 +1,210 @@
+use crate::testing::node::grpc::{
+    client::MockClientError,
+    server::{
+        start_thread, MockBuilder, MockController, MockServerData as NodeData, ProtocolVersion,
+    },
+    JormungandrClient,
+};
+use crate::testing::{utils, FragmentSender, FragmentSenderSetup, SyncNode};
+
+use ::multiaddr::{Multiaddr, Protocol};
+use assert_fs::TempDir;
+use chain_impl_mockchain::{
+    block::{Block, BlockDate},
+    fee::LinearFee,
+    header::Header,
+};
+use jormungandr_lib::{
+    crypto::hash::Hash,
+    interfaces::{Block0Configuration, TrustedPeer},
+};
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, RwLock};
+
+/// An adversary-controlled node, which can deviate in every way
+/// from the blockchain protocol.
+///
+/// It uses the same node-to-node gRPC interface as Jormungandr (although not complete)
+/// so that it's able to communicate with other nodes, but the rest
+/// interface and the general way of controlling its behavior might be different.
+///
+/// In the future, we may be interested in this node being interchangeable with
+/// JormungandrProcess in terms of functionalities, but we start from what is
+/// currently needed.
+pub struct AdversaryNode {
+    temp_dir: Option<TempDir>,
+    alias: String,
+    node_data: Arc<RwLock<NodeData>>,
+    server: Option<MockController>,
+    open_client_connections: HashMap<SocketAddr, JormungandrClient>,
+}
+
+impl AdversaryNode {
+    pub(crate) fn new(
+        temp_dir: Option<TempDir>,
+        alias: String,
+        node_data: Arc<RwLock<NodeData>>,
+        server: Option<MockController>,
+    ) -> Self {
+        AdversaryNode {
+            temp_dir,
+            alias,
+            server,
+            node_data,
+            open_client_connections: HashMap::new(),
+        }
+    }
+
+    pub fn fragment_sender<'a, S: SyncNode + Send>(
+        &self,
+        setup: FragmentSenderSetup<'a, S>,
+    ) -> FragmentSender<'a, S> {
+        FragmentSender::new(
+            self.genesis_block_hash(),
+            self.fees(),
+            BlockDate::first().next_epoch().into(),
+            setup,
+        )
+    }
+
+    pub fn alias(&self) -> &str {
+        &self.alias
+    }
+
+    pub fn address(&self) -> SocketAddr {
+        self.node_data.read().unwrap().profile().address()
+    }
+
+    pub fn fees(&self) -> LinearFee {
+        self.block0_configuration()
+            .blockchain_configuration
+            .linear_fees
+    }
+
+    pub fn genesis_block_hash(&self) -> Hash {
+        (*self.node_data.read().unwrap().genesis_hash()).into()
+    }
+
+    pub fn block0_configuration(&self) -> Block0Configuration {
+        Block0Configuration::from_block(&self.node_data.read().unwrap().genesis_block()).unwrap()
+    }
+
+    fn p2p_public_addr(&self) -> SocketAddr {
+        self.node_data.read().unwrap().profile().address()
+    }
+
+    pub fn to_trusted_peer(&self) -> TrustedPeer {
+        let mut address = Multiaddr::empty();
+        match self.address().ip() {
+            IpAddr::V4(ip) => address.push(Protocol::Ip4(ip)),
+            IpAddr::V6(ip) => address.push(Protocol::Ip6(ip)),
+        }
+        address.push(Protocol::Tcp(self.p2p_public_addr().port()));
+        TrustedPeer { address, id: None }
+    }
+
+    pub fn steal_temp_dir(&mut self) -> Option<TempDir> {
+        self.temp_dir.take()
+    }
+
+    pub fn send_block_to_peer(
+        &mut self,
+        peer: SocketAddr,
+        block: Block,
+    ) -> Result<(), MockClientError> {
+        let client = self
+            .open_client_connections
+            .entry(peer)
+            .or_insert_with(|| JormungandrClient::new(peer));
+        client.upload_blocks(block)
+    }
+
+    pub fn send_header_to_peer(
+        &mut self,
+        peer: SocketAddr,
+        header: Header,
+    ) -> Result<(), MockClientError> {
+        let client = self
+            .open_client_connections
+            .entry(peer)
+            .or_insert_with(|| JormungandrClient::new(peer));
+        client.push_headers(header)
+    }
+
+    pub fn builder(genesis_block: Block) -> AdversaryNodeBuilder {
+        AdversaryNodeBuilder::new(genesis_block)
+    }
+}
+
+impl Drop for AdversaryNode {
+    fn drop(&mut self) {
+        if let Some(controller) = self.server.take() {
+            controller.stop();
+        }
+
+        utils::persist_dir_on_panic(self.temp_dir.take(), Vec::new())
+    }
+}
+
+pub struct AdversaryNodeBuilder {
+    alias: String,
+    temp_dir: Option<TempDir>,
+    server_enabled: bool,
+    protocol_version: ProtocolVersion,
+    genesis_block: Block,
+}
+
+impl AdversaryNodeBuilder {
+    /// As a limitation of the current implementation, the adversary node is not able to
+    /// bootstrap from peers and as such always need the full block0 to be able to function properly
+    pub fn new(genesis_block: Block) -> Self {
+        Self {
+            alias: String::new(),
+            temp_dir: None,
+            server_enabled: false,
+            protocol_version: ProtocolVersion::Bft,
+            genesis_block,
+        }
+    }
+
+    pub fn with_alias(self, alias: String) -> Self {
+        Self { alias, ..self }
+    }
+
+    pub fn with_temp_dir(self, temp_dir: TempDir) -> Self {
+        Self {
+            temp_dir: Some(temp_dir),
+            ..self
+        }
+    }
+
+    pub fn with_server_enabled(self) -> Self {
+        Self {
+            server_enabled: true,
+            ..self
+        }
+    }
+
+    pub fn with_protocol_version(self, protocol_version: ProtocolVersion) -> Self {
+        Self {
+            protocol_version,
+            ..self
+        }
+    }
+
+    pub fn build(self) -> AdversaryNode {
+        let data = MockBuilder::new()
+            .with_protocol_version(self.protocol_version)
+            .with_genesis_block(self.genesis_block)
+            .build_data();
+
+        let controller = if self.server_enabled {
+            Some(start_thread(data.clone()))
+        } else {
+            None
+        };
+
+        AdversaryNode::new(self.temp_dir, self.alias, data, controller)
+    }
+}

--- a/testing/jormungandr-testing-utils/src/testing/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/mod.rs
@@ -1,3 +1,4 @@
+pub mod adversary;
 pub mod asserts;
 pub mod block0;
 pub mod configuration;
@@ -13,6 +14,7 @@ pub mod startup;
 pub mod storage;
 pub mod sync;
 pub mod transaction_utils;
+mod utils;
 pub mod verify;
 pub mod vit;
 pub mod witness;

--- a/testing/jormungandr-testing-utils/src/testing/node/grpc/server/controller.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/grpc/server/controller.rs
@@ -1,5 +1,9 @@
 use super::{MockExitCode, MockLogger, MockServerData, MockVerifier, ProtocolVersion};
-use chain_impl_mockchain::{block::Header, key::Hash};
+use chain_core::property::Serialize;
+use chain_impl_mockchain::{
+    block::{Block, Header},
+    key::Hash,
+};
 use std::sync::RwLock;
 use std::{
     sync::Arc,
@@ -10,7 +14,7 @@ use std::{
 pub struct MockController {
     verifier: MockVerifier,
     stop_signal: tokio::sync::oneshot::Sender<()>,
-    data: Arc<RwLock<MockServerData>>,
+    pub data: Arc<RwLock<MockServerData>>,
     port: u16,
 }
 
@@ -52,9 +56,23 @@ impl MockController {
         }
     }
 
-    pub fn set_tip(&mut self, tip: Header) {
-        let mut data = self.data.write().unwrap();
-        *data.tip_mut() = tip;
+    /// block_id must refer to a valid block already in the storage
+    pub fn set_tip(&mut self, tip: &Header) {
+        let data = self.data.write().unwrap();
+        data.set_tip(tip.serialize_as_vec().as_ref().unwrap())
+            .unwrap();
+    }
+
+    pub fn set_tip_block(&mut self, tip: &Block) {
+        let data = self.data.write().unwrap();
+        data.put_block(tip).unwrap();
+        data.set_tip(tip.header().hash().serialize_as_vec().as_ref().unwrap())
+            .unwrap();
+    }
+
+    pub fn genesis_hash(&self) -> Hash {
+        let data = self.data.read().unwrap();
+        *data.genesis_hash()
     }
 
     pub fn set_genesis(&mut self, tip: Hash) {

--- a/testing/jormungandr-testing-utils/src/testing/node/grpc/server/data.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/grpc/server/data.rs
@@ -1,11 +1,15 @@
 use super::ProtocolVersion;
+use chain_core::{
+    mempack::{ReadBuf, ReadError, Readable},
+    property::Serialize,
+};
 use chain_crypto::{Ed25519, KeyPair, PublicKey, Signature, Verification};
 use chain_impl_mockchain::{
-    block::{BlockDate, Header},
+    block::{self, Block, BlockDate, ContentsBuilder, Header},
+    header::BlockVersion,
     key::Hash,
-    testing::{GenesisPraosBlockBuilder, StakePoolBuilder},
 };
-use chain_time::{Epoch, TimeEra};
+use chain_storage::{BlockInfo, BlockStore};
 use rand::Rng;
 use std::net::SocketAddr;
 
@@ -13,30 +17,41 @@ const AUTH_NONCE_LEN: usize = 32;
 
 pub struct MockServerData {
     genesis_hash: Hash,
-    tip: Header,
     protocol: ProtocolVersion,
     keypair: KeyPair<Ed25519>,
     profile: poldercast::Profile,
     auth_nonce: [u8; AUTH_NONCE_LEN],
+    storage: BlockStore,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Storage(#[from] chain_storage::Error),
+    #[error(transparent)]
+    Read(#[from] ReadError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 impl MockServerData {
+    const TIP_TAG: &'static str = "tip";
     pub fn new(
         genesis_hash: Hash,
-        tip: Header,
         protocol: ProtocolVersion,
         addr: SocketAddr,
+        storage: BlockStore,
     ) -> Self {
         let keypair = KeyPair::generate(&mut rand::thread_rng());
         let topology_key = keynesis::key::ed25519::SecretKey::new(&mut rand::thread_rng());
         let profile = poldercast::Profile::new(addr, &topology_key);
         Self {
             genesis_hash,
-            tip,
             protocol,
             keypair,
             profile,
             auth_nonce: [0; AUTH_NONCE_LEN],
+            storage,
         }
     }
 
@@ -44,8 +59,45 @@ impl MockServerData {
         &self.genesis_hash
     }
 
-    pub fn tip(&self) -> &Header {
-        &self.tip
+    pub fn get_block(&self, header_id: Hash) -> Result<Block, Error> {
+        Ok(Block::read(&mut ReadBuf::from(
+            self.storage()
+                .get_block(header_id.as_ref())
+                .unwrap()
+                .as_ref(),
+        ))?)
+    }
+
+    pub fn genesis_block(&self) -> Block {
+        self.get_block(self.genesis_hash)
+            .expect("genesis block should always be valid")
+    }
+
+    pub fn tip(&self) -> Result<Header, Error> {
+        let header_id = self
+            .storage
+            .get_tag(Self::TIP_TAG)?
+            .ok_or(chain_storage::Error::BlockNotFound)?;
+
+        Ok(self
+            .get_block(Hash::read(&mut ReadBuf::from(header_id.as_ref())).unwrap())?
+            .header()
+            .clone())
+    }
+
+    /// block_id must refer to a valid block already in the storage
+    pub fn set_tip(&self, block_id: &[u8]) -> Result<(), Error> {
+        Ok(self.storage.put_tag(Self::TIP_TAG, block_id)?)
+    }
+
+    pub fn put_block(&self, block: &Block) -> Result<(), Error> {
+        let id = block.header().hash().serialize_as_vec()?;
+        let parent_id = block.header().block_parent_hash().serialize_as_vec()?;
+        let chain_length = block.header().chain_length().into();
+        let block_info = BlockInfo::new(id, parent_id, chain_length);
+        Ok(self
+            .storage()
+            .put_block(&block.serialize_as_vec()?, block_info)?)
     }
 
     pub fn profile(&self) -> &poldercast::Profile {
@@ -70,6 +122,13 @@ impl MockServerData {
         &self.auth_nonce
     }
 
+    /// Raw access to the storage. Can be used to play with raw bytes sequences
+    /// or get around validations of domain objects, for example to mimic a malicous
+    /// adversary
+    pub fn storage(&self) -> &BlockStore {
+        &self.storage
+    }
+
     pub fn validate_peer_node_id(&self, node_id: &[u8], signature: &[u8]) -> bool {
         let public_key = PublicKey::<Ed25519>::from_binary(node_id).expect("invalid node ID");
         let signature =
@@ -84,27 +143,24 @@ impl MockServerData {
         &mut self.genesis_hash
     }
 
-    pub fn tip_mut(&mut self) -> &mut Header {
-        &mut self.tip
-    }
-
     pub fn protocol_mut(&mut self) -> &mut ProtocolVersion {
         &mut self.protocol
     }
 }
 
-pub fn header(slots_per_epochs: u32, parent_id: &Hash) -> Header {
-    let stake_pool = StakePoolBuilder::new().build();
-
-    let time_era = TimeEra::new(0u64.into(), Epoch(0u32), slots_per_epochs);
-
-    let block = GenesisPraosBlockBuilder::new()
-        .with_parent_id(*parent_id)
-        .with_date(BlockDate {
-            epoch: 0,
-            slot_id: 1,
-        })
-        .with_chain_length(1.into())
-        .build(&stake_pool, &time_era);
-    block.header().clone()
+pub fn block0() -> Block {
+    block::builder(
+        BlockVersion::Genesis,
+        ContentsBuilder::new().into(),
+        |hdr| {
+            Ok::<_, ()>(
+                hdr.set_genesis()
+                    .set_date(BlockDate::first())
+                    .into_unsigned_header()
+                    .expect("internal error cannot build unsigned block")
+                    .generalize(),
+            )
+        },
+    )
+    .expect("internal error: block builder cannot return error")
 }

--- a/testing/jormungandr-testing-utils/src/testing/utils.rs
+++ b/testing/jormungandr-testing-utils/src/testing/utils.rs
@@ -1,0 +1,35 @@
+use assert_fs::TempDir;
+use fs_extra::dir::{move_dir, CopyOptions};
+use std::thread::panicking;
+
+pub fn persist_dir_on_panic(temp_dir: Option<TempDir>, additional_contents: Vec<(&str, &str)>) {
+    if panicking() {
+        let logs_dir = match tempfile::Builder::new().prefix("jormungandr_").tempdir() {
+            Ok(dir) => dir.into_path(),
+            Err(e) => {
+                eprintln!("Could not create logs dir: {}", e);
+                return;
+            }
+        };
+
+        println!(
+            "persisting node temp_dir after panic: {}",
+            logs_dir.display()
+        );
+
+        if let Some(dir) = temp_dir {
+            let options = CopyOptions {
+                content_only: true,
+                ..Default::default()
+            };
+            move_dir(dir.path(), &logs_dir, &options)
+                .map(|_| ())
+                .unwrap_or_else(|e| eprintln!("Could not move files to new dir: {}", e));
+        }
+
+        for (filename, content) in additional_contents {
+            std::fs::write(logs_dir.join(filename), content)
+                .unwrap_or_else(|e| eprint!("Could not write {} to disk: {}", filename, e));
+        }
+    }
+}


### PR DESCRIPTION
* improve mock gRPC server capabilities by adding a storage. This allows the server to respond with meaningful info to incoming queries, and access to raw storage bytes can be used to inject invalid data and test behavior of connected peers.
* Add a stub for an `AdversaryNode` with the same gRPC interface as the node


Draft until https://github.com/input-output-hk/jormungandr/pull/3623 is merged