### PR TITLE
fix peer available counter

### DIFF
--- a/jormungandr/src/metrics/backends/prometheus_exporter.rs
+++ b/jormungandr/src/metrics/backends/prometheus_exporter.rs
@@ -59,7 +59,8 @@ impl Prometheus {
             // hash value once again
             self.block_hash_value.store(None);
         }
-
+        self.peer_total_cnt
+            .set(self.peer_available_cnt.get() + self.peer_quarantined_cnt.get());
         let encoder = TextEncoder::new();
         let metric_families = self.registry.gather();
         let mut buffer = Vec::new();
@@ -204,25 +205,16 @@ impl MetricsBackend for Prometheus {
     fn add_peer_quarantined_cnt(&self, count: usize) {
         let count = count.try_into().unwrap();
         self.peer_quarantined_cnt.add(count);
-        self.peer_total_cnt.add(count);
     }
 
     fn sub_peer_quarantined_cnt(&self, count: usize) {
         let count = count.try_into().unwrap();
         self.peer_quarantined_cnt.sub(count);
-        self.peer_total_cnt.sub(count);
     }
 
-    fn add_peer_available_cnt(&self, count: usize) {
+    fn set_peer_available_cnt(&self, count: usize) {
         let count = count.try_into().unwrap();
-        self.peer_available_cnt.add(count);
-        self.peer_total_cnt.add(count);
-    }
-
-    fn sub_peer_available_cnt(&self, count: usize) {
-        let count = count.try_into().unwrap();
-        self.peer_available_cnt.sub(count);
-        self.peer_total_cnt.sub(count);
+        self.peer_available_cnt.set(count);
     }
 
     fn set_slot_start_time(&self, time: jormungandr_lib::time::SecondsSinceUnixEpoch) {

--- a/jormungandr/src/metrics/backends/simple_counter.rs
+++ b/jormungandr/src/metrics/backends/simple_counter.rs
@@ -144,12 +144,8 @@ impl MetricsBackend for SimpleCounter {
             .fetch_sub(count, Ordering::Relaxed);
     }
 
-    fn add_peer_available_cnt(&self, count: usize) {
-        self.peers_available_cnt.fetch_add(count, Ordering::Relaxed);
-    }
-
-    fn sub_peer_available_cnt(&self, count: usize) {
-        self.peers_available_cnt.fetch_sub(count, Ordering::Relaxed);
+    fn set_peer_available_cnt(&self, count: usize) {
+        self.peers_available_cnt.store(count, Ordering::Relaxed);
     }
 
     fn set_slot_start_time(&self, time: SecondsSinceUnixEpoch) {

--- a/jormungandr/src/metrics/mod.rs
+++ b/jormungandr/src/metrics/mod.rs
@@ -16,8 +16,7 @@ pub trait MetricsBackend {
     fn sub_peer_connected_cnt(&self, count: usize);
     fn add_peer_quarantined_cnt(&self, count: usize);
     fn sub_peer_quarantined_cnt(&self, count: usize);
-    fn add_peer_available_cnt(&self, count: usize);
-    fn sub_peer_available_cnt(&self, count: usize);
+    fn set_peer_available_cnt(&self, count: usize);
     fn set_slot_start_time(&self, time: SecondsSinceUnixEpoch);
     fn set_tip_block(&self, block: &Block, block_ref: &Ref);
 }
@@ -76,8 +75,7 @@ impl MetricsBackend for Metrics {
     metrics_count_method!(sub_peer_connected_cnt);
     metrics_count_method!(add_peer_quarantined_cnt);
     metrics_count_method!(sub_peer_quarantined_cnt);
-    metrics_count_method!(add_peer_available_cnt);
-    metrics_count_method!(sub_peer_available_cnt);
+    metrics_count_method!(set_peer_available_cnt);
     metrics_method!(set_slot_start_time, SecondsSinceUnixEpoch);
 
     fn set_tip_block(&self, block: &Block, block_ref: &Ref) {

--- a/testing/jormungandr-integration-tests/src/networking/p2p.rs
+++ b/testing/jormungandr-integration-tests/src/networking/p2p.rs
@@ -235,6 +235,7 @@ pub fn node_put_in_quarantine_nodes_which_are_not_whitelisted() {
     assert_are_in_quarantine(&server, vec![&client], "after starting client");
 }
 
+// PS: trusted as in poldercast-trusted, not trusted peer
 #[test]
 pub fn node_does_not_quarantine_trusted_node() {
     let mut network_controller = NetworkBuilder::default()
@@ -262,7 +263,7 @@ pub fn node_does_not_quarantine_trusted_node() {
     process_utils::sleep(20);
 
     // The server "forgets" the client but does not quarantine it
-    assert_node_stats(&server, 0, 0, 0, "before restarting client");
+    assert_node_stats(&server, 1, 0, 1, "before restarting client");
     assert_empty_quarantine(&server, "before restarting client");
 }
 


### PR DESCRIPTION


Getting an accurate list of all peers that could be selected by the node for gossip or even dissemination would require to construct a view each time. This operation is not incredibly heavy but it's also not negligible, as it needs to go through each layer, build a view, and update the position on the cache for each selected profile.

Since this is only needed for stats, an upper bound on that value can be obtained much cheaper, simply by looking at the number of peers which are known to the node, which is available through `list_available`. However, peers which have been lifted from quarantine and from which the node did not receive new gossips will only be contacted in extreme cases (https://github.com/input-output-hk/jormungandr/blob/6da38a90cf01212227ebb98df321a4b5001c8986/jormungandr/src/topology/process.rs#L105) and are not used in standard communication.

Anyway, If there's the need for a precise count, the view method is accessible even through the rest api.