### PR TITLE
watch client implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   requiring any particular order between the transactions.
 - add new setting proposal expiration into the initial config/genesis
 - add feature for changing blockchain config during the network run. Add new certificates `UpdateProposal` and `UpdateVote`, updated `jcli` with these new transactions.
+- Add new grpc watch service implementation for external (non-node) clients.
 
 ## Release 0.13.0
 

--- a/jormungandr/src/blockchain/bootstrap.rs
+++ b/jormungandr/src/blockchain/bootstrap.rs
@@ -42,6 +42,7 @@ where
         blockchain.clone(),
         None,
         None,
+        None,
         Metrics::builder().build(),
     );
 

--- a/jormungandr/src/blockchain/storage.rs
+++ b/jormungandr/src/blockchain/storage.rs
@@ -141,6 +141,33 @@ impl Storage {
             .map_err(Into::into)
     }
 
+    pub fn get_parent(&self, header_hash: HeaderHash) -> Result<Option<HeaderHash>, Error> {
+        let block_info = match self.storage.get_block_info(header_hash.as_ref()) {
+            Ok(block_info) => block_info,
+            Err(_) => return Ok(None),
+        };
+
+        HeaderHash::deserialize(block_info.parent_id().as_ref())
+            .map_err(Error::Deserialize)
+            .map(Some)
+    }
+
+    pub fn is_ancestor(&self, a: HeaderHash, b: HeaderHash) -> bool {
+        self.storage
+            .is_ancestor(a.as_ref(), b.as_ref())
+            .map(|x| x.is_some())
+            .unwrap_or(false)
+    }
+
+    pub fn get_chain_length(&self, block_id: HeaderHash) -> Option<u32> {
+        let block_info = match self.storage.get_block_info(block_id.as_ref()) {
+            Ok(block_info) => block_info,
+            Err(_) => return None,
+        };
+
+        Some(block_info.chain_length())
+    }
+
     /// Return values:
     /// - `Ok(stream)` - `from` is ancestor of `to`, returns blocks between them
     /// - `Err(CannotIterate)` - `from` is not ancestor of `to`

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -627,5 +627,11 @@ pub enum ExplorerMsg {
     NewTip(HeaderHash),
 }
 
+/// Messages to the notifier task
+pub enum WatchMsg {
+    NewBlock(Block),
+    NewTip(Header),
+}
+
 #[cfg(test)]
 mod tests {}

--- a/jormungandr/src/main.rs
+++ b/jormungandr/src/main.rs
@@ -39,6 +39,7 @@ pub mod leadership;
 pub mod log;
 pub mod metrics;
 pub mod network;
+pub mod notifier;
 pub mod rest;
 pub mod secure;
 pub mod settings;
@@ -77,6 +78,7 @@ const NETWORK_TASK_QUEUE_LEN: usize = 64;
 const EXPLORER_TASK_QUEUE_LEN: usize = 32;
 const CLIENT_TASK_QUEUE_LEN: usize = 32;
 const TOPOLOGY_TASK_QUEUE_LEN: usize = 32;
+const NOTIFIER_TASK_QUEUE_LEN: usize = 32;
 const BOOTSTRAP_RETRY_WAIT: Duration = Duration::from_secs(5);
 
 fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::Error> {
@@ -148,12 +150,29 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
         }
     };
 
+    let (notifier_msgbox, notifier) = {
+        let (msgbox, queue) = async_msg::channel(NOTIFIER_TASK_QUEUE_LEN);
+
+        let blockchain_tip = blockchain_tip.clone();
+        let current_tip = block_on(async { blockchain_tip.get_ref().await.header().clone() });
+
+        let (client, message_processor) =
+            watch_client::WatchClient::new(current_tip, blockchain.clone());
+
+        services.spawn_future("notifier", move |info| async move {
+            message_processor.start(info, queue).await
+        });
+
+        (msgbox, client)
+    };
+
     {
         let blockchain = blockchain.clone();
         let blockchain_tip = blockchain_tip.clone();
         let network_msgbox = network_msgbox.clone();
         let fragment_msgbox = fragment_msgbox.clone();
         let explorer_msgbox = explorer.as_ref().map(|(msg_box, _context)| msg_box.clone());
+        let notifier_msgbox = notifier_msgbox.clone();
         // TODO: we should get this value from the configuration
         let block_cache_ttl: Duration = Duration::from_secs(120);
         let stats_counter = stats_counter.clone();
@@ -165,6 +184,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 network_msgbox,
                 fragment_msgbox,
                 explorer_msgbox,
+                watch_msgbox,
                 garbage_collection_interval: block_cache_ttl,
             };
             blockchain::start(task_data, info, block_queue)
@@ -206,6 +226,7 @@ fn start_services(bootstrapped_node: BootstrappedNode) -> Result<(), start_up::E
                 global_state,
                 input: network_queue,
                 channels,
+                notification_service: notifier,
             };
             network::start(params)
         });

--- a/jormungandr/src/watch_client.rs
+++ b/jormungandr/src/watch_client.rs
@@ -70,6 +70,10 @@ impl MessageProcessor {
                                     handle_sync_multiverse(from, &blockchain, &storage, &mut sink)
                                         .await
                                 {
+                                    tracing::warn!(
+                                        "sync multiverse call finished with error: {:?}",
+                                        e
+                                    );
                                     let _ = sink.feed(Err(e)).await;
                                 }
 

--- a/jormungandr/src/watch_client.rs
+++ b/jormungandr/src/watch_client.rs
@@ -1,0 +1,268 @@
+pub use crate::intercom::WatchMsg as Message;
+use crate::{
+    blockcfg::HeaderHash,
+    blockchain::{Blockchain, Storage},
+    intercom::{self, ReplyStream},
+    utils::async_msg::MessageQueue,
+};
+use crate::{
+    intercom::ReplyStreamHandle,
+    utils::{async_msg::MessageBox, task::TokioServiceInfo},
+};
+use chain_core::property::Deserialize;
+use chain_core::property::{Block as _, Serialize};
+use chain_impl_mockchain::header;
+use chain_network::grpc::watch::server::WatchService;
+use chain_network::{core::watch::server::Watch, grpc::watch::server};
+use chain_network::{
+    data::{Block, BlockIds, Header},
+    error::Code,
+};
+use futures::Stream;
+use futures::{
+    stream::{Map, MapErr},
+    SinkExt, StreamExt, TryStream, TryStreamExt,
+};
+use std::{collections::HashSet, sync::Arc};
+use tokio::sync::{broadcast, watch, Mutex};
+use tokio_stream::wrappers::{BroadcastStream, WatchStream};
+
+#[derive(Clone)]
+pub struct WatchClient {
+    tip_receiver: watch::Receiver<Header>,
+    block_sender: Arc<broadcast::Sender<Block>>,
+    request_tx: Arc<tokio::sync::Mutex<MessageBox<RequestMsg>>>,
+}
+
+pub struct MessageProcessor {
+    tip_sender: Arc<watch::Sender<Header>>,
+    block_sender: Arc<broadcast::Sender<Block>>,
+    requests: MessageQueue<RequestMsg>,
+    storage: Storage,
+    blockchain: Blockchain,
+}
+
+enum RequestMsg {
+    SyncMultiverse {
+        from: BlockIds,
+        handle: ReplyStreamHandle<Block>,
+    },
+}
+
+impl MessageProcessor {
+    pub async fn start(self, info: TokioServiceInfo, mut queue: MessageQueue<Message>) {
+        let storage = self.storage;
+        let requests = self.requests;
+        let blockchain = self.blockchain.clone();
+        info.spawn("watch client", async move {
+            requests
+                .for_each(|msg| async {
+                    match msg {
+                        RequestMsg::SyncMultiverse { from, handle } => {
+                            let mut sink = handle.start_sending();
+
+                            if let Err(e) =
+                                handle_sync_multiverse(from, &blockchain, &storage, &mut sink).await
+                            {
+                                let _ = sink.feed(Err(e)).await;
+                            }
+
+                            let _ = sink.close().await;
+                        }
+                    }
+                })
+                .await;
+        });
+
+        while let Some(input) = queue.next().await {
+            match input {
+                Message::NewBlock(block) => {
+                    let block_sender = Arc::clone(&self.block_sender);
+                    let block_id = block.id();
+                    info.spawn("notifier broadcast block", async move {
+                        if let Err(_err) =
+                            block_sender.send(Block::from_bytes(block.serialize_as_vec().unwrap()))
+                        {
+                            tracing::error!("notifier failed to broadcast block {}", block_id);
+                        }
+                    });
+                }
+                Message::NewTip(header) => {
+                    let tip_sender = Arc::clone(&self.tip_sender);
+                    info.spawn("notifier broadcast new tip", async move {
+                        if let Err(_err) = tip_sender.send(Header::from_bytes(
+                            header.serialize_as_vec().unwrap().as_ref(),
+                        )) {
+                            tracing::error!("notifier failed to broadcast tip {}", header.id());
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+impl WatchClient {
+    pub fn new(
+        current_tip: header::Header,
+        blockchain: Blockchain,
+    ) -> (WatchClient, MessageProcessor) {
+        let storage = blockchain.storage().clone();
+        let (tip_sender, tip_receiver) = watch::channel(Header::from_bytes(
+            current_tip.serialize_as_vec().unwrap().as_ref(),
+        ));
+
+        let (block_sender, _block_receiver) = broadcast::channel(16);
+
+        let tip_sender = Arc::new(tip_sender);
+        let block_sender = Arc::new(block_sender);
+
+        let (request_tx, requests) = crate::utils::async_msg::channel(16);
+
+        let client = WatchClient {
+            tip_receiver,
+            block_sender: Arc::clone(&block_sender),
+            request_tx: Arc::new(Mutex::new(request_tx)),
+        };
+
+        let message_processor = MessageProcessor {
+            tip_sender,
+            block_sender: Arc::clone(&block_sender),
+            storage,
+            blockchain,
+            requests,
+        };
+
+        (client, message_processor)
+    }
+
+    pub fn into_server(self) -> server::Server<Self> {
+        server::Server::new(WatchService::new(self))
+    }
+}
+
+type SubscriptionTryStream<S> =
+    MapErr<S, fn(<S as TryStream>::Error) -> chain_network::error::Error>;
+type SubscriptionStream<S> =
+    Map<S, fn(<S as Stream>::Item) -> Result<<S as Stream>::Item, chain_network::error::Error>>;
+
+#[tonic::async_trait]
+impl Watch for WatchClient {
+    type BlockSubscriptionStream = SubscriptionTryStream<BroadcastStream<Block>>;
+    type TipSubscriptionStream = SubscriptionStream<WatchStream<Header>>;
+    type SyncMultiverseStream = SubscriptionTryStream<ReplyStream<Block, intercom::Error>>;
+
+    async fn block_subscription(
+        &self,
+    ) -> Result<Self::BlockSubscriptionStream, chain_network::error::Error> {
+        let block_receiver = BroadcastStream::new(self.block_sender.subscribe());
+
+        // there are two possible errors for the block_receiver.
+        // one occurs when there are no more senders, but that won't happen here.
+        // the other is when the receiver is lagging.  I'm actually not sure
+        // what would be a sensible choice, so I just put some arbitrary error
+        // for now
+        let live_stream: SubscriptionTryStream<BroadcastStream<Block>> =
+            block_receiver.map_err(|e| chain_network::error::Error::new(Code::Internal, e));
+
+        Ok(live_stream)
+    }
+
+    async fn tip_subscription(
+        &self,
+    ) -> Result<Self::TipSubscriptionStream, chain_network::error::Error> {
+        let tip_receiver: SubscriptionStream<_> = WatchStream::new(self.tip_receiver.clone())
+            .map::<Result<Header, chain_network::error::Error>, _>(Ok);
+
+        Ok(tip_receiver)
+    }
+
+    async fn sync_multiverse(
+        &self,
+        from: BlockIds,
+    ) -> Result<Self::SyncMultiverseStream, chain_network::error::Error> {
+        let (handle, future) = intercom::stream_reply(32);
+
+        self.request_tx
+            .lock()
+            .await
+            .send(RequestMsg::SyncMultiverse { from, handle })
+            .await
+            .map_err(|e| chain_network::error::Error::new(Code::Unavailable, e))?;
+
+        let stream = future
+            .await
+            .map_err(|e| chain_network::error::Error::new(Code::Internal, e))?;
+
+        Ok(stream.map_err(|e| chain_network::error::Error::new(Code::Internal, e)))
+    }
+}
+
+async fn handle_sync_multiverse(
+    checkpoints: BlockIds,
+    blockchain: &Blockchain,
+    storage: &Storage,
+    sink: &mut intercom::ReplyStreamSink<Block>,
+) -> Result<(), intercom::Error> {
+    let mut checkpoints = checkpoints
+        .iter()
+        .map(|id| HeaderHash::deserialize(id.as_bytes()).map_err(intercom::Error::invalid_argument))
+        .collect::<Result<HashSet<_>, _>>()?;
+
+    let branches = blockchain.branches().branches().await;
+    let mut previous_branch = None;
+    let block0 = blockchain.block0();
+    for next_branch in branches {
+        let head_id = next_branch.header().id();
+
+        if let Some(prev) = previous_branch.replace(head_id) {
+            let lca = storage.find_common_ancestor(prev, head_id).unwrap();
+
+            checkpoints.insert(lca);
+        }
+
+        let ancestor = storage
+            // TODO: why does find_closest_ancestor need to own the
+            // Vec?
+            // it could be just impl Iterator I think
+            .find_closest_ancestor(checkpoints.iter().cloned().collect(), head_id)
+            .map_err(intercom::Error::failed)?
+            .map(|ancestor| ancestor.header_hash)
+            .unwrap_or(*block0);
+
+        checkpoints.remove(&ancestor);
+
+        let stream = storage
+            .stream_from_to(ancestor, head_id)
+            .map_err(intercom::Error::failed)?
+            .fuse();
+
+        futures::pin_mut!(stream);
+
+        let mut first_iter = true;
+
+        while let Some(block) = stream.next().await {
+            let block = block?;
+            // unless we are bootstrapping the whole chain, the client
+            // already has the 'from', either because it's one of the
+            // checkpoints or because we sent it before.
+            //
+            // (that is, if the `from` argument is inclusive, though, which
+            // I haven't checked)
+            if first_iter {
+                first_iter = false;
+                if &block.header().id() != block0 {
+                    continue;
+                }
+            }
+
+            let _ = sink
+                .send(Ok(chain_network::data::Block::from_bytes(
+                    block.serialize_as_vec().unwrap(),
+                )))
+                .await;
+        }
+    }
+
+    Ok(())
+}

--- a/jormungandr/src/watch_client.rs
+++ b/jormungandr/src/watch_client.rs
@@ -195,11 +195,9 @@ impl Watch for WatchClient {
 
         // there are two possible errors for the block_receiver.
         // one occurs when there are no more senders, but that won't happen here.
-        // the other is when the receiver is lagging.  I'm actually not sure
-        // what would be a sensible choice, so I just put some arbitrary error
-        // for now
+        // the other is when the receiver is lagging.
         let live_stream: SubscriptionTryStream<BroadcastStream<Block>> =
-            block_receiver.map_err(|e| chain_network::error::Error::new(Code::Internal, e));
+            block_receiver.map_err(|e| chain_network::error::Error::new(Code::Aborted, e));
 
         Ok(live_stream)
     }

--- a/jormungandr/src/watch_client.rs
+++ b/jormungandr/src/watch_client.rs
@@ -295,12 +295,6 @@ async fn handle_sync_multiverse(
         .map_err(intercom::Error::failed)?;
     }
 
-    checkpoints.sort_unstable();
-
-    // TODO: not sure if this is always true
-    const BLOCK0_CHAIN_LENGTH: u32 = 0;
-    let (lsb_chain_length, lsb) = checkpoints.pop().unwrap_or((BLOCK0_CHAIN_LENGTH, *block0));
-
     let mut known_unstable_blocks_by_client = HashSet::new();
 
     for (_, checkpoint) in checkpoints {

--- a/jormungandr/src/watch_client.rs
+++ b/jormungandr/src/watch_client.rs
@@ -321,6 +321,12 @@ async fn handle_sync_multiverse(
                 .get_parent(current)
                 .map_err(intercom::Error::failed_precondition)?
                 .ok_or_else(|| intercom::Error::aborted("reached block0"))?;
+
+            // current_length is not 0 because we know that current != lsb, and
+            //
+            // a) the chain lengths come from the storage, not the client.
+            // b) there should be only one block with a chain length of 0 in the storage.
+            current_length -= 1;
         }
     }
 

--- a/jormungandr/src/watch_client.rs
+++ b/jormungandr/src/watch_client.rs
@@ -310,8 +310,12 @@ async fn handle_sync_multiverse(
                 ));
             }
 
-        while current != lsb {
-            known_unstable_blocks_by_client.insert(current);
+            // if a block is in the set, then the predecesors should be also there (added by a
+            // previous iteration).
+            // and because this should be converging to the lsb then we can exit early.
+            if !known_unstable_blocks_by_client.insert(current) {
+                break;
+            }
 
             current = storage
                 .get_parent(current)

--- a/jormungandr/src/watch_client.rs
+++ b/jormungandr/src/watch_client.rs
@@ -297,14 +297,18 @@ async fn handle_sync_multiverse(
 
     let mut known_unstable_blocks_by_client = HashSet::new();
 
-    for (_, checkpoint) in checkpoints {
-        if !storage.is_ancestor(lsb, checkpoint) {
-            return Err(intercom::Error::invalid_argument(
-                "invalid from/checkpoints",
-            ));
-        }
-
+    for (checkpoint_length, checkpoint) in checkpoints {
         let mut current = checkpoint;
+        let mut current_length = checkpoint_length;
+
+        while current != lsb_id {
+            // this would mean the lsb is not an ancestor of the checkpoint
+            // which shouldn't happen.
+            if current_length < lsb_length {
+                return Err(intercom::Error::invalid_argument(
+                    "checkpoint is not a succesor of the last stable block",
+                ));
+            }
 
         while current != lsb {
             known_unstable_blocks_by_client.insert(current);

--- a/jormungandr/src/watch_client.rs
+++ b/jormungandr/src/watch_client.rs
@@ -247,7 +247,13 @@ async fn handle_sync_multiverse(
     let block0 = blockchain.block0();
 
     if checkpoints.is_empty() {
-        let block = storage.get(*block0).unwrap().unwrap();
+        let block = storage
+            .get(*block0)
+            .map_err(intercom::Error::failed)
+            .and_then(|maybe_block0| {
+                maybe_block0.ok_or_else(|| intercom::Error::failed("block0 not found in storage"))
+            })?;
+
         sink.send(Ok(chain_network::data::Block::from_bytes(
             block.serialize_as_vec().unwrap(),
         )))


### PR DESCRIPTION
implements https://github.com/input-output-hk/chain-libs/pull/652

the sync_multiverse algorithm may need some tweaks still.

also, I haven't tested this much, and only on a leader node.

besides that, the places where the `NewBlock` and `NewTip` are propagated basically duplicate the ones that the explorer currently uses. I'd prefer to remove them in a different PR, but I could do it here.