### PR TITLE
Reuse jormungandr process in scenario tests

### DIFF
--- a/testing/jormungandr-scenario-tests/src/example_scenarios.rs
+++ b/testing/jormungandr-scenario-tests/src/example_scenarios.rs
@@ -46,7 +46,7 @@ pub fn scenario_1(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
     let tip1 = node1.tip()?;
     std::thread::sleep(std::time::Duration::from_secs(1));
     node1.shutdown()?;
-    let _block = node2.block(&tip1.into_hash())?;
+    let _block = node2.rest().block(&tip1.into_hash())?;
 
     std::thread::sleep(std::time::Duration::from_secs(1));
 

--- a/testing/jormungandr-scenario-tests/src/interactive/args/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/mod.rs
@@ -1,5 +1,5 @@
-use crate::{legacy::LegacyNodeController, test::Result};
-use crate::{node::NodeController, scenario::Controller};
+use crate::{legacy::LegacyNode, test::Result};
+use crate::{node::Node, scenario::Controller};
 use chain_impl_mockchain::vote::Choice;
 use jormungandr_lib::interfaces::Value;
 use jormungandr_testing_utils::wallet::Wallet;
@@ -15,8 +15,8 @@ pub mod spawn;
 pub struct UserInteractionController {
     controller: Controller,
     wallets: Vec<Wallet>,
-    nodes: Vec<NodeController>,
-    legacy_nodes: Vec<LegacyNodeController>,
+    nodes: Vec<Node>,
+    legacy_nodes: Vec<LegacyNode>,
 }
 
 impl UserInteractionController {
@@ -38,18 +38,18 @@ impl UserInteractionController {
         &mut self.wallets
     }
 
-    pub fn nodes(&self) -> &[NodeController] {
+    pub fn nodes(&self) -> &[Node] {
         &self.nodes
     }
 
-    pub fn legacy_nodes(&self) -> &[LegacyNodeController] {
+    pub fn legacy_nodes(&self) -> &[LegacyNode] {
         &self.legacy_nodes
     }
 
-    pub fn legacy_nodes_mut(&mut self) -> &mut Vec<LegacyNodeController> {
+    pub fn legacy_nodes_mut(&mut self) -> &mut Vec<LegacyNode> {
         &mut self.legacy_nodes
     }
-    pub fn nodes_mut(&mut self) -> &mut Vec<NodeController> {
+    pub fn nodes_mut(&mut self) -> &mut Vec<Node> {
         &mut self.nodes
     }
 
@@ -221,10 +221,10 @@ pub enum InteractiveCommand {
     Send(send::Send),
 }
 
-fn do_for_all_alias<F: Fn(&NodeController), G: Fn(&LegacyNodeController)>(
+fn do_for_all_alias<F: Fn(&Node), G: Fn(&LegacyNode)>(
     alias: &Option<String>,
-    nodes: &[NodeController],
-    legacy_nodes: &[LegacyNodeController],
+    nodes: &[Node],
+    legacy_nodes: &[LegacyNode],
     f: F,
     g: G,
 ) {

--- a/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
@@ -1,5 +1,6 @@
 use super::{do_for_all_alias, UserInteractionController};
 use jormungandr_testing_utils::testing::node::{JormungandrLogger, LogLevel};
+use jormungandr_testing_utils::testing::FragmentNode;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -74,8 +75,8 @@ impl ActiveVotePlans {
             &self.alias,
             controller.nodes(),
             controller.legacy_nodes(),
-            |node| println!("{}: {:#?}", node.alias(), node.vote_plans()),
-            |node| println!("{}: {:#?}", node.alias(), node.vote_plans()),
+            |node| println!("{}: {:#?}", node.alias(), node.rest().vote_plan_statuses()),
+            |node| println!("{}: {:#?}", node.alias(), node.rest().vote_plan_statuses()),
         )
     }
 }
@@ -99,7 +100,7 @@ impl ShowStatus {
             controller.nodes(),
             controller.legacy_nodes(),
             |node| println!("{} is up", node.alias()),
-            |node| println!("{} is up", node.alias()),
+            |node| println!("{} is up", &node.alias()),
         )
     }
 }
@@ -117,7 +118,13 @@ impl ShowFragmentCount {
                     node.fragment_logs().unwrap().len()
                 )
             },
-            |node| println!("{}: {}", node.alias(), node.fragment_logs().unwrap().len()),
+            |node| {
+                println!(
+                    "{}: {}",
+                    node.alias(),
+                    node.rest().fragment_logs().unwrap().len()
+                )
+            },
         )
     }
 }
@@ -133,7 +140,7 @@ impl ShowFragments {
                 println!(
                     "{}: {:#?}",
                     node.alias(),
-                    node.fragment_logs().unwrap().len()
+                    node.rest().fragment_logs().unwrap().len()
                 )
             },
         )
@@ -150,7 +157,12 @@ impl ShowBlockHeight {
                 println!(
                     "{}: {:?}",
                     node.alias(),
-                    node.stats().unwrap().stats.unwrap().last_block_height
+                    node.rest()
+                        .stats()
+                        .unwrap()
+                        .stats
+                        .unwrap()
+                        .last_block_height
                 )
             },
             |node| {
@@ -182,8 +194,8 @@ impl ShowNodeStats {
             &self.alias,
             controller.nodes(),
             controller.legacy_nodes(),
-            |node| println!("{}: {:#?}", node.alias(), node.stats()),
-            |node| println!("{}: {:#?}", node.alias(), node.stats()),
+            |node| println!("{}: {:#?}", node.alias(), node.status()),
+            |node| println!("{}: {:#?}", node.alias(), node.status()),
         )
     }
 }
@@ -237,7 +249,7 @@ impl ShowLogs {
                 show_logs_for(
                     self.only_errors,
                     &self.contains,
-                    node.alias(),
+                    &node.alias(),
                     self.tail,
                     node.logger(),
                 )
@@ -246,7 +258,7 @@ impl ShowLogs {
                 show_logs_for(
                     self.only_errors,
                     &self.contains,
-                    node.alias(),
+                    &node.alias(),
                     self.tail,
                     node.logger(),
                 )

--- a/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
+++ b/testing/jormungandr-scenario-tests/src/interactive/args/show.rs
@@ -194,8 +194,8 @@ impl ShowNodeStats {
             &self.alias,
             controller.nodes(),
             controller.legacy_nodes(),
-            |node| println!("{}: {:#?}", node.alias(), node.status()),
-            |node| println!("{}: {:#?}", node.alias(), node.status()),
+            |node| println!("{}: {:#?}", node.alias(), node.rest().stats()),
+            |node| println!("{}: {:#?}", node.alias(), node.rest().stats()),
         )
     }
 }

--- a/testing/jormungandr-scenario-tests/src/legacy/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/legacy/mod.rs
@@ -1,5 +1,5 @@
 mod node;
 mod settings;
 
-pub use node::{LegacyNode, LegacyNodeController};
+pub use node::LegacyNode;
 pub use settings::LegacySettings;

--- a/testing/jormungandr-scenario-tests/src/lib.rs
+++ b/testing/jormungandr-scenario-tests/src/lib.rs
@@ -10,7 +10,7 @@ pub mod report;
 pub mod test;
 
 pub use jortestkit::console::style;
-pub use node::{Node, NodeBlock0, NodeController};
+pub use node::{Node, NodeBlock0};
 pub use programs::prepare_command;
 pub use scenario::{
     parse_progress_bar_mode_from_str,

--- a/testing/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -1,6 +1,5 @@
 use crate::node::SpawnBuilder;
 use crate::scenario::settings::Settings;
-use crate::Context;
 use crate::{
     legacy::LegacyNode,
     prepare_command,
@@ -43,7 +42,6 @@ use jormungandr_testing_utils::{
     wallet::Wallet,
     Version,
 };
-use rand_core::RngCore;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -386,7 +384,8 @@ impl Controller {
         let pb = ProgressBar::new_spinner();
         let pb = self.progress_bar.add(pb);
 
-        let mut spawn_builder = Self::legacy_spawn_builder(&self.context, &mut node_setting);
+        let mut spawn_builder: SpawnBuilder<_, LegacyNode> =
+            SpawnBuilder::new(&self.context, &mut node_setting);
         spawn_builder
             .path_to_jormungandr(jormungandr)
             .progress_bar(pb)
@@ -396,20 +395,6 @@ impl Controller {
             .working_dir(self.node_dir(params.get_alias()).path())
             .peristence_mode(params.get_persistence_mode());
         spawn_builder.build(version).map_err(Into::into)
-    }
-
-    fn legacy_spawn_builder<'a, R: RngCore>(
-        context: &'a Context<R>,
-        node_settings: &'a mut NodeSetting,
-    ) -> SpawnBuilder<'a, R, LegacyNode> {
-        SpawnBuilder::new(context, node_settings)
-    }
-
-    fn spawn_builder<'a, R: RngCore>(
-        context: &'a Context<R>,
-        node_settings: &'a mut NodeSetting,
-    ) -> SpawnBuilder<'a, R, Node> {
-        SpawnBuilder::new(context, node_settings)
     }
 
     pub fn spawn_node_custom(&mut self, params: SpawnParams) -> Result<Node> {
@@ -454,7 +439,8 @@ impl Controller {
         let pb = ProgressBar::new_spinner();
         let pb = self.progress_bar.add(pb);
 
-        let mut spawn_builder = Self::spawn_builder(&self.context, &mut node_setting);
+        let mut spawn_builder: SpawnBuilder<_, Node> =
+            SpawnBuilder::new(&self.context, &mut node_setting);
         spawn_builder
             .path_to_jormungandr(jormungandr)
             .progress_bar(pb)

--- a/testing/jormungandr-scenario-tests/src/scenario/controller.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/controller.rs
@@ -1,18 +1,19 @@
+use crate::node::SpawnBuilder;
 use crate::scenario::settings::Settings;
+use crate::Context;
 use crate::{
-    legacy::{LegacyNode, LegacyNodeController},
+    legacy::LegacyNode,
     prepare_command,
     scenario::{
         settings::{Dotifier, PrepareSettings},
         ContextChaCha, Error, ProgressBarMode, Result,
     },
-    style, Node, NodeBlock0, NodeController,
+    style, Node, NodeBlock0,
 };
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use chain_impl_mockchain::block::BlockDate;
 use chain_impl_mockchain::certificate::{VoteAction, VotePlan};
-use chain_impl_mockchain::header::HeaderId;
 use chain_impl_mockchain::ledger::governance::{
     ParametersGovernanceAction, TreasuryGovernanceAction,
 };
@@ -21,6 +22,7 @@ use chain_impl_mockchain::testing::scenario::template::{
 };
 use indicatif::{MultiProgress, ProgressBar};
 use jormungandr_lib::crypto::hash::Hash;
+use jormungandr_lib::interfaces::Block0Configuration;
 use jormungandr_lib::interfaces::Log;
 use jormungandr_lib::interfaces::LogEntry;
 use jormungandr_lib::interfaces::LogOutput;
@@ -41,6 +43,7 @@ use jormungandr_testing_utils::{
     wallet::Wallet,
     Version,
 };
+use rand_core::RngCore;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -63,7 +66,7 @@ pub struct Controller {
     working_directory: ChildPath,
 
     block0_file: PathBuf,
-    block0_hash: HeaderId,
+    block0: Block0Configuration,
 
     progress_bar: Arc<MultiProgress>,
     progress_bar_thread: Option<std::thread::JoinHandle<()>>,
@@ -178,18 +181,16 @@ impl Controller {
         use chain_core::property::Serialize as _;
 
         let block0 = settings.network_settings.block0.to_block();
-        let block0_hash = block0.header().hash();
-
         let block0_file = working_directory.child("block0.bin").path().into();
         let file = std::fs::File::create(&block0_file)?;
         block0.serialize(file)?;
         let progress_bar = Arc::new(MultiProgress::new());
 
         Ok(Controller {
+            block0: settings.network_settings.block0.clone(),
             settings,
             context,
             block0_file,
-            block0_hash,
             progress_bar,
             progress_bar_thread: None,
             working_directory,
@@ -320,7 +321,7 @@ impl Controller {
     pub fn start_monitor_resources(
         &mut self,
         info: &str,
-        nodes: Vec<&NodeController>,
+        nodes: Vec<&Node>,
     ) -> ConsumptionBenchmarkRun {
         benchmark_consumption(info.to_owned())
             .for_processes(nodes.iter().map(|x| x.as_named_process()).collect())
@@ -348,24 +349,22 @@ impl Controller {
         &mut self,
         params: SpawnParams,
         version: &Version,
-    ) -> Result<LegacyNodeController> {
-        let node_setting = if let Some(node_setting) =
-            self.settings.network_settings.nodes.get(params.get_alias())
-        {
-            node_setting
-        } else {
-            return Err(Error::NodeNotFound(params.get_alias().clone()));
-        };
-
-        let mut node_setting_overriden = node_setting.clone();
-        params.override_settings(&mut node_setting_overriden.config);
+    ) -> Result<LegacyNode> {
+        let mut node_setting = self
+            .settings
+            .network_settings
+            .nodes
+            .get(params.get_alias())
+            .ok_or_else(|| Error::NodeNotFound(params.get_alias().clone()))?
+            .clone();
+        params.override_settings(&mut node_setting.config);
 
         let log_file_path = self
             .node_dir(params.get_alias())
             .child("node.log")
             .path()
             .to_path_buf();
-        node_setting_overriden.config.log = Some(Log(LogEntry {
+        node_setting.config.log = Some(Log(LogEntry {
             format: "json".into(),
             level: params
                 .get_log_level()
@@ -376,7 +375,7 @@ impl Controller {
 
         let block0_setting = match params.get_leadership_mode() {
             LeadershipMode::Leader => NodeBlock0::File(self.block0_file.as_path().into()),
-            LeadershipMode::Passive => NodeBlock0::Hash(self.block0_hash),
+            LeadershipMode::Passive => NodeBlock0::Hash(self.block0.to_block().header().hash()),
         };
 
         let jormungandr = match &params.get_jormungandr() {
@@ -387,35 +386,48 @@ impl Controller {
         let pb = ProgressBar::new_spinner();
         let pb = self.progress_bar.add(pb);
 
-        let mut spawn_builder = LegacyNode::spawn(&self.context, &mut node_setting_overriden);
+        let mut spawn_builder = Self::legacy_spawn_builder(&self.context, &mut node_setting);
         spawn_builder
             .path_to_jormungandr(jormungandr)
             .progress_bar(pb)
             .alias(params.get_alias())
-            .block0(block0_setting)
+            .block0(self.block0.clone())
+            .block0_setting(block0_setting)
             .working_dir(self.node_dir(params.get_alias()).path())
             .peristence_mode(params.get_persistence_mode());
-        let node = spawn_builder.build(version)?;
-        Ok(node.controller())
+        spawn_builder.build(version).map_err(Into::into)
     }
 
-    pub fn spawn_node_custom(&mut self, params: SpawnParams) -> Result<NodeController> {
-        let node_setting = if let Some(node_setting) =
-            self.settings.network_settings.nodes.get(params.get_alias())
-        {
-            node_setting
-        } else {
-            return Err(Error::NodeNotFound(params.get_alias().clone()));
-        };
-        let mut node_setting_overriden = node_setting.clone();
-        params.override_settings(&mut node_setting_overriden.config);
+    fn legacy_spawn_builder<'a, R: RngCore>(
+        context: &'a Context<R>,
+        node_settings: &'a mut NodeSetting,
+    ) -> SpawnBuilder<'a, R, LegacyNode> {
+        SpawnBuilder::new(context, node_settings)
+    }
+
+    fn spawn_builder<'a, R: RngCore>(
+        context: &'a Context<R>,
+        node_settings: &'a mut NodeSetting,
+    ) -> SpawnBuilder<'a, R, Node> {
+        SpawnBuilder::new(context, node_settings)
+    }
+
+    pub fn spawn_node_custom(&mut self, params: SpawnParams) -> Result<Node> {
+        let mut node_setting = self
+            .settings
+            .network_settings
+            .nodes
+            .get(params.get_alias())
+            .ok_or_else(|| Error::NodeNotFound(params.get_alias().clone()))?
+            .clone();
+        params.override_settings(&mut node_setting.config);
 
         let log_file_path = self
             .node_dir(params.get_alias())
             .child("node.log")
             .path()
             .to_path_buf();
-        node_setting_overriden.config.log = Some(Log(LogEntry {
+        node_setting.config.log = Some(Log(LogEntry {
             format: "json".into(),
             level: params
                 .get_log_level()
@@ -425,13 +437,13 @@ impl Controller {
         }));
 
         // remove all id from trusted peers for current version
-        for trusted_peer in node_setting_overriden.config.p2p.trusted_peers.iter_mut() {
+        for trusted_peer in node_setting.config.p2p.trusted_peers.iter_mut() {
             trusted_peer.id = None;
         }
 
         let block0_setting = match params.get_leadership_mode() {
             LeadershipMode::Leader => NodeBlock0::File(self.block0_file.as_path().into()),
-            LeadershipMode::Passive => NodeBlock0::Hash(self.block0_hash),
+            LeadershipMode::Passive => NodeBlock0::Hash(self.block0.to_block().header().hash()),
         };
 
         let jormungandr = match &params.get_jormungandr() {
@@ -442,20 +454,20 @@ impl Controller {
         let pb = ProgressBar::new_spinner();
         let pb = self.progress_bar.add(pb);
 
-        let mut spawn_builder = Node::spawn(&self.context, &mut node_setting_overriden);
+        let mut spawn_builder = Self::spawn_builder(&self.context, &mut node_setting);
         spawn_builder
             .path_to_jormungandr(jormungandr)
             .progress_bar(pb)
             .alias(params.get_alias())
-            .block0(block0_setting)
+            .block0(self.block0.clone())
+            .block0_setting(block0_setting)
             .working_dir(self.node_dir(params.get_alias()).path())
             .peristence_mode(params.get_persistence_mode());
         if let Some(faketime) = params.get_faketime().take() {
             spawn_builder.faketime(faketime.clone());
         }
-        let node = spawn_builder.build()?;
 
-        Ok(node.controller())
+        spawn_builder.build().map_err(Into::into)
     }
 
     pub fn spawn_node(
@@ -463,7 +475,7 @@ impl Controller {
         node_alias: &str,
         leadership_mode: LeadershipMode,
         persistence_mode: PersistenceMode,
-    ) -> Result<NodeController> {
+    ) -> Result<Node> {
         self.spawn_node_custom(
             self.new_spawn_params(node_alias)
                 .leadership_mode(leadership_mode)
@@ -473,12 +485,12 @@ impl Controller {
 
     pub fn restart_node(
         &mut self,
-        node: NodeController,
+        node: Node,
         leadership_mode: LeadershipMode,
         persistence_mode: PersistenceMode,
-    ) -> Result<NodeController> {
+    ) -> Result<Node> {
         node.shutdown()?;
-        let new_node = self.spawn_node(node.alias(), leadership_mode, persistence_mode)?;
+        let new_node = self.spawn_node(&node.alias(), leadership_mode, persistence_mode)?;
         new_node.wait_for_bootstrap()?;
         Ok(new_node)
     }
@@ -509,7 +521,7 @@ impl Controller {
         let mut builder = FragmentSenderSetupBuilder::from(setup);
         let root_dir: PathBuf = PathBuf::from(self.working_directory().path());
         builder.dump_fragments_into(root_dir.join("fragments"));
-        let hash = Hash::from_hash(self.block0_hash);
+        let hash = Hash::from_hash(self.block0.to_block().header().hash());
 
         let blockchain_configuration = self
             .settings

--- a/testing/jormungandr-scenario-tests/src/test/features/leadership_log.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/leadership_log.rs
@@ -64,7 +64,7 @@ pub fn leader_restart_preserves_leadership_log(
 
     // logs during epoch 0 should be empty
     utils::assert(
-        !leader_2.leadership_log()?.is_empty(),
+        !leader_2.rest().leaders_log()?.is_empty(),
         "leadeship log should NOT be empty in current epoch",
     )?;
 
@@ -74,7 +74,7 @@ pub fn leader_restart_preserves_leadership_log(
 
     // logs during epoch 0 should be empty
     utils::assert(
-        !leader_2.leadership_log()?.is_empty(),
+        !leader_2.rest().leaders_log()?.is_empty(),
         "leadeship log should NOT be empty in new epoch",
     )?;
 

--- a/testing/jormungandr-scenario-tests/src/test/features/p2p/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/p2p/mod.rs
@@ -7,18 +7,14 @@ pub use connections::max_connections;
 pub use stats::p2p_stats_test;
 
 use crate::{
-    node::NodeController,
+    node::Node,
     test::{utils, Result},
 };
 
 use jormungandr_lib::interfaces::PeerRecord;
 
-pub fn assert_connected_cnt(
-    node: &NodeController,
-    peer_connected_cnt: usize,
-    info: &str,
-) -> Result<()> {
-    let stats = node.stats()?.stats.expect("empty stats");
+pub fn assert_connected_cnt(node: &Node, peer_connected_cnt: usize, info: &str) -> Result<()> {
+    let stats = node.rest().stats()?.stats.expect("empty stats");
     Ok(utils::assert_equals(
         &peer_connected_cnt,
         &stats.peer_connected_cnt.clone(),
@@ -27,14 +23,14 @@ pub fn assert_connected_cnt(
 }
 
 pub fn assert_node_stats(
-    node: &NodeController,
+    node: &Node,
     peer_available_cnt: usize,
     peer_quarantined_cnt: usize,
     peer_total_cnt: usize,
     info: &str,
 ) -> Result<()> {
     node.log_stats();
-    let stats = node.stats()?.stats.expect("empty stats");
+    let stats = node.rest().stats()?.stats.expect("empty stats");
     utils::assert_equals(
         &peer_available_cnt,
         &stats.peer_available_cnt.clone(),
@@ -55,12 +51,8 @@ pub fn assert_node_stats(
     Ok(())
 }
 
-pub fn assert_are_in_network_view(
-    node: &NodeController,
-    peers: Vec<&NodeController>,
-    info: &str,
-) -> Result<()> {
-    let network_view = node.p2p_view()?;
+pub fn assert_are_in_network_view(node: &Node, peers: Vec<&Node>, info: &str) -> Result<()> {
+    let network_view = node.rest().p2p_view()?;
     for peer in peers {
         utils::assert(
             network_view
@@ -76,12 +68,8 @@ pub fn assert_are_in_network_view(
     Ok(())
 }
 
-pub fn assert_are_not_in_network_view(
-    node: &NodeController,
-    peers: Vec<&NodeController>,
-    info: &str,
-) -> Result<()> {
-    let network_view = node.network_stats()?;
+pub fn assert_are_not_in_network_view(node: &Node, peers: Vec<&Node>, info: &str) -> Result<()> {
+    let network_view = node.rest().network_stats()?;
     for peer in peers {
         utils::assert(
             network_view
@@ -97,12 +85,8 @@ pub fn assert_are_not_in_network_view(
     Ok(())
 }
 
-pub fn assert_are_in_network_stats(
-    node: &NodeController,
-    peers: Vec<&NodeController>,
-    info: &str,
-) -> Result<()> {
-    let network_stats = node.network_stats()?;
+pub fn assert_are_in_network_stats(node: &Node, peers: Vec<&Node>, info: &str) -> Result<()> {
+    let network_stats = node.rest().network_stats()?;
     for peer in peers {
         utils::assert(
             network_stats.iter().any(|x| x.addr == Some(peer.address())),
@@ -116,12 +100,8 @@ pub fn assert_are_in_network_stats(
     Ok(())
 }
 
-pub fn assert_are_not_in_network_stats(
-    node: &NodeController,
-    peers: Vec<&NodeController>,
-    info: &str,
-) -> Result<()> {
-    let network_stats = node.network_stats()?;
+pub fn assert_are_not_in_network_stats(node: &Node, peers: Vec<&Node>, info: &str) -> Result<()> {
+    let network_stats = node.rest().network_stats()?;
     for peer in peers {
         utils::assert(
             !network_stats.iter().any(|x| x.addr == Some(peer.address())),
@@ -135,26 +115,18 @@ pub fn assert_are_not_in_network_stats(
     Ok(())
 }
 
-pub fn assert_are_available(
-    node: &NodeController,
-    peers: Vec<&NodeController>,
-    info: &str,
-) -> Result<()> {
-    let available_list = node.p2p_available()?;
+pub fn assert_are_available(node: &Node, peers: Vec<&Node>, info: &str) -> Result<()> {
+    let available_list = node.rest().p2p_available()?;
     assert_record_is_present(available_list, peers, "available", info)
 }
 
-pub fn assert_are_not_available(
-    node: &NodeController,
-    peers: Vec<&NodeController>,
-    info: &str,
-) -> Result<()> {
-    let available_list = node.p2p_available()?;
+pub fn assert_are_not_available(node: &Node, peers: Vec<&Node>, info: &str) -> Result<()> {
+    let available_list = node.rest().p2p_available()?;
     assert_record_is_present(available_list, peers, "available", info)
 }
 
-pub fn assert_empty_quarantine(node: &NodeController, info: &str) -> Result<()> {
-    let quarantine = node.p2p_quarantined()?;
+pub fn assert_empty_quarantine(node: &Node, info: &str) -> Result<()> {
+    let quarantine = node.rest().p2p_quarantined()?;
     Ok(utils::assert_equals(
         &vec![],
         &quarantine,
@@ -166,18 +138,14 @@ pub fn assert_empty_quarantine(node: &NodeController, info: &str) -> Result<()> 
     )?)
 }
 
-pub fn assert_are_in_quarantine(
-    node: &NodeController,
-    peers: Vec<&NodeController>,
-    info: &str,
-) -> Result<()> {
-    let available_list = node.p2p_quarantined()?;
+pub fn assert_are_in_quarantine(node: &Node, peers: Vec<&Node>, info: &str) -> Result<()> {
+    let available_list = node.rest().p2p_quarantined()?;
     assert_record_is_present(available_list, peers, "quarantine", info)
 }
 
 pub fn assert_record_is_present(
     peer_list: Vec<PeerRecord>,
-    peers: Vec<&NodeController>,
+    peers: Vec<&Node>,
     list_name: &str,
     info: &str,
 ) -> Result<()> {
@@ -199,7 +167,7 @@ pub fn assert_record_is_present(
 
 pub fn assert_record_is_not_present(
     peer_list: Vec<PeerRecord>,
-    peers: Vec<&NodeController>,
+    peers: Vec<&Node>,
     list_name: &str,
 ) -> Result<()> {
     for peer in peers {

--- a/testing/jormungandr-scenario-tests/src/test/features/p2p/stats.rs
+++ b/testing/jormungandr-scenario-tests/src/test/features/p2p/stats.rs
@@ -47,27 +47,27 @@ pub fn p2p_stats_test(mut context: Context<ChaChaRng>) -> Result<ScenarioResult>
     let info_before = "no peers for leader 1";
     utils::assert_equals(
         &vec![],
-        &leader1.network_stats()?,
+        &leader1.rest().network_stats()?,
         &format!("{} network_stats", info_before),
     )?;
     utils::assert_equals(
         &vec![],
-        &leader1.p2p_quarantined()?,
+        &leader1.rest().p2p_quarantined()?,
         &format!("{} p2p_quarantined", info_before),
     )?;
     utils::assert_equals(
         &vec![],
-        &leader1.p2p_non_public()?,
+        &leader1.rest().p2p_non_public()?,
         &format!("{} p2p_non_public", info_before),
     )?;
     utils::assert_equals(
         &vec![],
-        &leader1.p2p_available()?,
+        &leader1.rest().p2p_available()?,
         &format!("{} p2p_available", info_before),
     )?;
     utils::assert_equals(
         &vec![],
-        &leader1.p2p_view()?,
+        &leader1.rest().p2p_view()?,
         &format!("{} p2p_view", info_before),
     )?;
 

--- a/testing/jormungandr-scenario-tests/src/test/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/test/mod.rs
@@ -6,6 +6,7 @@ pub mod non_functional;
 pub mod utils;
 
 use jormungandr_lib::interfaces::FragmentStatus;
+use jormungandr_testing_utils::testing::jormungandr::StartupError;
 
 use std::time::Duration;
 
@@ -52,6 +53,11 @@ pub enum Error {
         node: String,
         status: FragmentStatus,
     },
+    #[error(transparent)]
+    Rest(#[from] jormungandr_testing_utils::testing::node::RestError),
+
+    #[error(transparent)]
+    Startup(#[from] StartupError),
 }
 
 pub type Result<T> = ::core::result::Result<T, Error>;

--- a/testing/jormungandr-scenario-tests/src/test/network/real.rs
+++ b/testing/jormungandr-scenario-tests/src/test/network/real.rs
@@ -8,7 +8,7 @@ use crate::{
         utils::{self, MeasurementReportInterval, SyncNode, SyncWaitParams},
         Result,
     },
-    Context, NodeController,
+    Context, Node as NodeController,
 };
 use jormungandr_testing_utils::testing::{
     network::{Blockchain, Topology, WalletTemplate},

--- a/testing/jormungandr-testing-utils/src/testing/adversary/process.rs
+++ b/testing/jormungandr-testing-utils/src/testing/adversary/process.rs
@@ -1,3 +1,4 @@
+use crate::testing::network::NodeAlias;
 use crate::testing::node::grpc::{
     client::MockClientError,
     server::{
@@ -68,8 +69,8 @@ impl AdversaryNode {
         )
     }
 
-    pub fn alias(&self) -> &str {
-        &self.alias
+    pub fn alias(&self) -> NodeAlias {
+        self.alias.to_string()
     }
 
     pub fn address(&self) -> SocketAddr {

--- a/testing/jormungandr-testing-utils/src/testing/fragments/adversary.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/adversary.rs
@@ -314,7 +314,7 @@ impl<'a, S: SyncNode + Send> AdversaryFragmentSender<'a, S> {
             FragmentStatus::Rejected { .. } => Ok(()),
             FragmentStatus::InABlock { date, block } => {
                 Err(AdversaryFragmentSenderError::FragmentNotRejected {
-                    alias: FragmentNode::alias(node).to_string(),
+                    alias: FragmentNode::alias(node),
                     date,
                     block,
                     logs: FragmentNode::log_content(node),

--- a/testing/jormungandr-testing-utils/src/testing/fragments/export.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/export.rs
@@ -108,7 +108,7 @@ impl FragmentExporter {
         let now: DateTime<Utc> = Utc::now();
         let alias = {
             if via.alias().is_empty() {
-                "jormungandr"
+                "jormungandr".to_string()
             } else {
                 via.alias()
             }
@@ -131,7 +131,7 @@ impl FragmentExporter {
         let now: DateTime<Utc> = Utc::now();
         let alias = {
             if via.alias().is_empty() {
-                "jormungandr"
+                "jormungandr".to_string()
             } else {
                 via.alias()
             }

--- a/testing/jormungandr-testing-utils/src/testing/fragments/node.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/node.rs
@@ -1,9 +1,9 @@
+use crate::testing::network::NodeAlias;
 use chain_impl_mockchain::fragment::{Fragment, FragmentId};
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{BlockDate, FragmentLog, FragmentsProcessingSummary},
 };
-
 use std::collections::HashMap;
 
 #[derive(custom_debug::Debug, thiserror::Error)]
@@ -50,7 +50,7 @@ impl FragmentNodeError {
 }
 
 pub trait FragmentNode {
-    fn alias(&self) -> &str;
+    fn alias(&self) -> NodeAlias;
     fn fragment_logs(&self) -> Result<HashMap<FragmentId, FragmentLog>, FragmentNodeError>;
     fn send_fragment(&self, fragment: Fragment) -> Result<MemPoolCheck, FragmentNodeError>;
     fn send_batch_fragments(

--- a/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/sender.rs
@@ -448,7 +448,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
             node,
         )? {
             FragmentStatus::Rejected { reason } => Err(FragmentSenderError::FragmentNotInBlock {
-                alias: FragmentNode::alias(node).to_string(),
+                alias: FragmentNode::alias(node),
                 reason,
                 logs: FragmentNode::log_content(node),
             }),
@@ -534,7 +534,7 @@ impl<'a, S: SyncNode + Send> FragmentSender<'a, S> {
 
         Err(FragmentSenderError::TooManyAttemptsFailed {
             attempts: self.setup.attempts_count(),
-            alias: FragmentNode::alias(node).to_string(),
+            alias: FragmentNode::alias(node),
         })
     }
 

--- a/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/setup.rs
@@ -1,5 +1,5 @@
 use super::FragmentNode;
-use crate::testing::SyncNode;
+use crate::testing::{network::NodeAlias, SyncNode};
 use std::fmt;
 use std::path::PathBuf;
 
@@ -14,11 +14,11 @@ impl<'a> fmt::Debug for VerifyStrategy<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             VerifyStrategy::AnyOf(nodes) => {
-                let aliases: Vec<String> = nodes.iter().map(|x| x.alias().to_string()).collect();
+                let aliases: Vec<String> = nodes.iter().map(|x| x.alias()).collect();
                 write!(f, "Any of {:?}", aliases)
             }
             VerifyStrategy::AllOf(nodes) => {
-                let aliases: Vec<String> = nodes.iter().map(|x| x.alias().to_string()).collect();
+                let aliases: Vec<String> = nodes.iter().map(|x| x.alias()).collect();
                 write!(f, "All of {:?}", aliases)
             }
             VerifyStrategy::Single(node) => write!(f, "{}", node.alias()),
@@ -101,7 +101,7 @@ pub struct DummySyncNode;
 use crate::testing::fragments::Hash;
 
 impl SyncNode for DummySyncNode {
-    fn alias(&self) -> &str {
+    fn alias(&self) -> NodeAlias {
         unimplemented!()
     }
 

--- a/testing/jormungandr-testing-utils/src/testing/fragments/verifier.rs
+++ b/testing/jormungandr-testing-utils/src/testing/fragments/verifier.rs
@@ -153,7 +153,7 @@ impl FragmentVerifier {
     ) -> Result<(), FragmentVerifierError> {
         if !status.is_in_a_block() {
             return Err(FragmentVerifierError::FragmentNotInBlock {
-                alias: node.alias().to_string(),
+                alias: node.alias(),
                 status,
                 logs: node.log_content(),
             });
@@ -167,7 +167,7 @@ impl FragmentVerifier {
     ) -> Result<(), FragmentVerifierError> {
         if !status.is_rejected() {
             return Err(FragmentVerifierError::FragmentNotRejected {
-                alias: node.alias().to_string(),
+                alias: node.alias(),
                 status,
                 logs: node.log_content(),
             });
@@ -197,7 +197,7 @@ impl FragmentVerifier {
         }
 
         Err(FragmentVerifierError::FragmentNotInMemPoolLogs {
-            alias: node.alias().to_string(),
+            alias: node.alias(),
             fragment_id: *check.fragment_id(),
             logs: node.log_content(),
         })
@@ -232,7 +232,7 @@ impl FragmentVerifier {
         Err(FragmentVerifierError::FragmentIsPendingForTooLong {
             fragment_id: *check.fragment_id(),
             timeout: Duration::from_secs(duration.as_secs() * max_try),
-            alias: node.alias().to_string(),
+            alias: node.alias(),
             logs: node.log_content(),
         })
     }
@@ -267,7 +267,7 @@ impl FragmentVerifier {
 
         Err(FragmentVerifierError::FragmentsArePendingForTooLong {
             timeout: Duration::from_secs(duration.as_secs() * max_try),
-            alias: node.alias().to_string(),
+            alias: node.alias(),
             logs: node.log_content(),
         })
     }

--- a/testing/jormungandr-testing-utils/src/testing/jormungandr/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/jormungandr/mod.rs
@@ -2,6 +2,7 @@ mod configuration_builder;
 pub mod process;
 pub mod starter;
 
+use crate::testing::network::NodeAlias;
 use crate::testing::{FragmentNode, FragmentNodeError, MemPoolCheck};
 use chain_core::property::Fragment as _;
 use chain_impl_mockchain::fragment::Fragment;
@@ -25,7 +26,7 @@ pub enum JormungandrError {
 }
 
 impl FragmentNode for JormungandrProcess {
-    fn alias(&self) -> &str {
+    fn alias(&self) -> NodeAlias {
         self.alias()
     }
     fn fragment_logs(&self) -> Result<HashMap<FragmentId, FragmentLog>, FragmentNodeError> {
@@ -38,7 +39,7 @@ impl FragmentNode for JormungandrProcess {
         self.rest().send_fragment(fragment.clone()).map_err(|e| {
             FragmentNodeError::CannotSendFragment {
                 reason: e.to_string(),
-                alias: self.alias().to_string(),
+                alias: self.alias(),
                 fragment_id: fragment.id(),
                 logs: self.log_content(),
             }
@@ -54,7 +55,7 @@ impl FragmentNode for JormungandrProcess {
             .send_fragment_batch(fragments.clone(), fail_fast)
             .map_err(|e| FragmentNodeError::CannotSendFragmentBatch {
                 reason: e.to_string(),
-                alias: self.alias().to_string(),
+                alias: self.alias(),
                 fragment_ids: fragments.iter().map(|x| x.id()).collect(),
                 logs: FragmentNode::log_content(self),
             })

--- a/testing/jormungandr-testing-utils/src/testing/jormungandr/process.rs
+++ b/testing/jormungandr-testing-utils/src/testing/jormungandr/process.rs
@@ -7,7 +7,7 @@ use crate::testing::{
         uri_from_socket_addr, Explorer, JormungandrLogger, JormungandrRest,
         JormungandrStateVerifier, LogLevel,
     },
-    utils, BlockDateGenerator, JormungandrParams, SyncNode, TestConfig,
+    utils, BlockDateGenerator, SyncNode, TestConfig,
 };
 use crate::testing::{
     FragmentChainSender, FragmentSender, FragmentSenderSetup, RemoteJormungandr,
@@ -53,22 +53,6 @@ pub struct JormungandrProcess {
 }
 
 impl JormungandrProcess {
-    pub(crate) fn from_config<Conf: TestConfig>(
-        child: Child,
-        params: &JormungandrParams<Conf>,
-        temp_dir: Option<TempDir>,
-        alias: String,
-    ) -> Result<Self, StartupError> {
-        let node_config = params.node_config();
-        Self::new(
-            child,
-            node_config,
-            params.block0_configuration().clone(),
-            temp_dir,
-            alias,
-        )
-    }
-
     pub fn new<Conf: TestConfig>(
         mut child: Child,
         node_config: &Conf,

--- a/testing/jormungandr-testing-utils/src/testing/jormungandr/starter/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/jormungandr/starter/mod.rs
@@ -381,9 +381,10 @@ where
     }
 
     fn start_async(self) -> Result<JormungandrProcess, StartupError> {
-        JormungandrProcess::from_config(
+        JormungandrProcess::new(
             self.start_process(),
-            &self.params,
+            self.params.node_config(),
+            self.params.block0_configuration().clone(),
             self.temp_dir,
             self.starter.alias.clone(),
         )
@@ -393,12 +394,15 @@ where
         let mut retry_counter = 1;
         loop {
             let process = self.start_process();
-            let mut jormungandr = JormungandrProcess::from_config(
+
+            let mut jormungandr = JormungandrProcess::new(
                 process,
-                &self.params,
+                self.params.node_config(),
+                self.params.block0_configuration().clone(),
                 self.temp_dir.take(),
                 self.starter.alias.clone(),
             )?;
+
             match (
                 jormungandr
                     .wait_for_bootstrap(&self.starter.verification_mode, self.starter.timeout),

--- a/testing/jormungandr-testing-utils/src/testing/node/legacy/rest.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/legacy/rest.rs
@@ -146,7 +146,7 @@ impl BackwardCompatibleRest {
         tip.parse().map_err(RestError::HashParseError)
     }
 
-    pub fn block(&self, header_hash: &HeaderId) -> Result<Vec<u8>, RestError> {
+    pub fn block_as_bytes(&self, header_hash: &HeaderId) -> Result<Vec<u8>, RestError> {
         let mut bytes = Vec::new();
         let mut resp = self.raw().block(header_hash)?;
         resp.copy_to(&mut bytes)?;

--- a/testing/jormungandr-testing-utils/src/testing/node/legacy/rest.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/legacy/rest.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use chain_core::property::Fragment as _;
 use chain_impl_mockchain::fragment::{Fragment, FragmentId};
+use chain_impl_mockchain::header::HeaderId;
 use jormungandr_lib::interfaces::{
     Address, FragmentStatus, FragmentsProcessingSummary, VotePlanId,
 };
@@ -143,6 +144,17 @@ impl BackwardCompatibleRest {
     pub fn tip(&self) -> Result<Hash, RestError> {
         let tip = self.raw().tip()?.text()?;
         tip.parse().map_err(RestError::HashParseError)
+    }
+
+    pub fn block(&self, header_hash: &HeaderId) -> Result<Vec<u8>, RestError> {
+        let mut bytes = Vec::new();
+        let mut resp = self.raw().block(header_hash)?;
+        resp.copy_to(&mut bytes)?;
+        Ok(bytes)
+    }
+
+    pub fn shutdown(&self) -> Result<String, reqwest::Error> {
+        self.raw().shutdown()?.text()
     }
 
     pub fn settings(&self) -> Result<String, reqwest::Error> {

--- a/testing/jormungandr-testing-utils/src/testing/node/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/mod.rs
@@ -12,7 +12,7 @@ pub use benchmark::*;
 pub use explorer::{Explorer, ExplorerError};
 pub use legacy::{
     download_last_n_releases, get_jormungandr_bin, version_0_12_0, version_0_13_0, version_0_8_19,
-    Version,
+    BackwardCompatibleRest, Version,
 };
 pub use logger::{JormungandrLogger, Level as LogLevel, LogEntry};
 pub use rest::{

--- a/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
+++ b/testing/jormungandr-testing-utils/src/testing/node/rest/raw.rs
@@ -5,6 +5,7 @@ use chain_core::property::Serialize;
 use chain_crypto::PublicKey;
 use chain_impl_mockchain::account;
 use chain_impl_mockchain::fragment::Fragment;
+use chain_impl_mockchain::header::HeaderId;
 use jormungandr_lib::interfaces::{Address, FragmentsBatch, VotePlanId};
 use jortestkit::process::Wait;
 use reqwest::{
@@ -198,6 +199,14 @@ impl RawRest {
 
     pub fn settings(&self) -> Result<Response, reqwest::Error> {
         self.get("settings")
+    }
+
+    pub fn shutdown(&self) -> Result<Response, reqwest::Error> {
+        self.get("shutdown")
+    }
+
+    pub fn block(&self, header_hash: &HeaderId) -> Result<Response, reqwest::Error> {
+        self.get(&format!("block/{}", header_hash))
     }
 
     pub fn fragment_logs(&self) -> Result<Response, reqwest::Error> {

--- a/testing/jormungandr-testing-utils/src/testing/remote.rs
+++ b/testing/jormungandr-testing-utils/src/testing/remote.rs
@@ -61,8 +61,8 @@ impl RemoteJormungandr {
 }
 
 impl SyncNode for RemoteJormungandr {
-    fn alias(&self) -> &str {
-        self.alias()
+    fn alias(&self) -> NodeAlias {
+        self.alias().to_string()
     }
 
     fn last_block_height(&self) -> u32 {
@@ -106,8 +106,8 @@ impl SyncNode for RemoteJormungandr {
 }
 
 impl FragmentNode for RemoteJormungandr {
-    fn alias(&self) -> &str {
-        self.alias()
+    fn alias(&self) -> NodeAlias {
+        self.alias().to_string()
     }
     fn fragment_logs(&self) -> Result<HashMap<FragmentId, FragmentLog>, FragmentNodeError> {
         self.rest()

--- a/testing/jormungandr-testing-utils/src/testing/sync/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/sync/mod.rs
@@ -39,13 +39,10 @@ pub fn ensure_node_is_in_sync_with_others(
 
     let other_nodes_records: Vec<SyncNodeRecord> = other_nodes
         .iter()
-        .map(|x| SyncNodeRecord::new(x.alias().to_string(), x.last_block_height()))
+        .map(|x| SyncNodeRecord::new(x.alias(), x.last_block_height()))
         .collect();
 
-    let target_node = SyncNodeRecord::new(
-        target_node.alias().to_string(),
-        target_node.last_block_height(),
-    );
+    let target_node = SyncNodeRecord::new(target_node.alias(), target_node.last_block_height());
 
     Err(SyncNodeError::TimeoutWhenSyncingTargetNode {
         target_node,

--- a/testing/jormungandr-testing-utils/src/testing/sync/node.rs
+++ b/testing/jormungandr-testing-utils/src/testing/sync/node.rs
@@ -1,9 +1,10 @@
+use crate::testing::network::NodeAlias;
 use jormungandr_lib::crypto::hash::Hash;
 use std::{fmt, time::Duration};
 use thiserror::Error;
 
 pub trait SyncNode {
-    fn alias(&self) -> &str;
+    fn alias(&self) -> NodeAlias;
     fn last_block_height(&self) -> u32;
     fn log_stats(&self);
     fn tip(&self) -> Hash;


### PR DESCRIPTION
First step to migrate scenario tests into standard cargo test and move cli capability to hersir. 

This PR is removing duplication between scenario tests and JormungandrProcess struct. It reuses JormungandrProcess and JormungandrRest structs for process management and interaction with the node. 

I made 3 commits just for reviewer convenience, since it's not easy to review this kind of work. After it's accepted I'll squash commits 