### PR TITLE
Update chain-libs for parallel spending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - fix incorrect keys bech32 HRP by always using the ones provided by the library
 - update REST API: add new endpoint AccountVotes (/api/v1/votes/plan/account-votes/{account_id})
+- Support parallel lanes in spending counters on account outputs. This allows
+  submitting transactions that can spend from the same account without
+  requiring any particular order between the transactions.
 
 ## Release 0.13.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "cbor_event",
  "chain-ser",
@@ -489,7 +489,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "bech32 0.8.1",
  "chain-core",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "chain-ser",
 ]
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "bech32 0.8.1",
  "cryptoxide",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "cardano-legacy-address",
  "chain-addr",
@@ -563,29 +563,29 @@ dependencies = [
 [[package]]
 name = "chain-network"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "async-trait",
  "chain-crypto",
  "futures",
  "http-body",
  "pin-project",
- "prost 0.9.0",
+ "prost",
  "rand_core 0.6.3",
  "thiserror",
  "tonic",
- "tonic-build 0.6.0",
+ "tonic-build",
 ]
 
 [[package]]
 name = "chain-ser"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "criterion",
  "data-pile",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "chain-core",
  "chain-ser",
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "chain-vote"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "cfg-if 1.0.0",
  "chain-core",
@@ -1163,12 +1163,6 @@ dependencies = [
  "redox_syscall",
  "winapi",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fixedbitset"
@@ -1785,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 dependencies = [
  "thiserror",
 ]
@@ -1973,7 +1967,7 @@ dependencies = [
  "parity-multiaddr",
  "poldercast",
  "predicates 2.0.2",
- "prost 0.9.0",
+ "prost",
  "rand 0.8.4",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
@@ -2106,7 +2100,7 @@ dependencies = [
  "parity-multiaddr",
  "poldercast",
  "predicates 2.0.2",
- "prost 0.9.0",
+ "prost",
  "qrcodegen",
  "quircs",
  "rand 0.8.4",
@@ -2128,7 +2122,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-build 0.5.2",
+ "tonic-build",
  "tracing",
  "tracing-subscriber",
  "typed-bytes",
@@ -2713,21 +2707,11 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset 0.2.0",
- "indexmap",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
- "fixedbitset 0.4.0",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -2986,40 +2970,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
-dependencies = [
- "bytes",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
-dependencies = [
- "bytes",
- "heck",
- "itertools",
- "log",
- "multimap",
- "petgraph 0.5.1",
- "prost 0.8.0",
- "prost-types 0.8.0",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3034,25 +2990,12 @@ dependencies = [
  "lazy_static",
  "log",
  "multimap",
- "petgraph 0.6.0",
- "prost 0.9.0",
- "prost-types 0.9.0",
+ "petgraph",
+ "prost",
+ "prost-types",
  "regex",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
 ]
 
 [[package]]
@@ -3070,22 +3013,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
-dependencies = [
- "bytes",
- "prost 0.8.0",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost 0.9.0",
+ "prost",
 ]
 
 [[package]]
@@ -3736,7 +3669,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 
 [[package]]
 name = "spin"
@@ -4202,8 +4135,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4216,24 +4149,12 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
-dependencies = [
- "proc-macro2 1.0.28",
- "prost-build 0.8.0",
- "quote 1.0.9",
- "syn 1.0.74",
-]
-
-[[package]]
-name = "tonic-build"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88358bb1dcfeb62dcce85c63006cafb964b7be481d522b7e09589d4d1e718d2a"
 dependencies = [
  "proc-macro2 1.0.28",
- "prost-build 0.9.0",
+ "prost-build",
  "quote 1.0.9",
  "syn 1.0.74",
 ]
@@ -4448,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#e54aac5c700f396ee842b38a91c8fd35deeae6d7"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ff7b7653392f4c2e30e77b47f53dce33ee3e7543"
 
 [[package]]
 name = "typenum"

--- a/jcli/src/jcli_lib/transaction/simplified.rs
+++ b/jcli/src/jcli_lib/transaction/simplified.rs
@@ -224,7 +224,7 @@ pub fn make_transaction(
         &WitnessType::Account,
         &block0_hash,
         &transaction_sign_data_hash,
-        Some(SpendingCounter::from(account_state.counter())),
+        Some(SpendingCounter::from(account_state.counters()[0])),
         &secret_key,
     )?;
 

--- a/jormungandr-lib/src/interfaces/account_state.rs
+++ b/jormungandr-lib/src/interfaces/account_state.rs
@@ -87,7 +87,7 @@ impl LastRewards {
 pub struct AccountState {
     delegation: DelegationType,
     value: Value,
-    counter: u32,
+    counters: Vec<u32>,
     last_rewards: LastRewards,
 }
 
@@ -107,12 +107,13 @@ impl AccountState {
         &self.value
     }
 
-    /// the transaction counter. This is used as part of the parameter when adding
-    /// a new account input to a transaction.
+    /// The transaction counters for spending lanes.
+    /// A counter in one of the existing lanes is used as part of the parameter
+    /// when adding a new account input to a transaction.
     ///
     #[inline]
-    pub fn counter(&self) -> u32 {
-        self.counter
+    pub fn counters(&self) -> Vec<u32> {
+        self.counters.clone()
     }
 
     /// the last rewards transfered to account
@@ -147,7 +148,12 @@ impl<E> From<account::AccountState<E>> for AccountState {
         AccountState {
             delegation: account.delegation().clone().into(),
             value: account.value().into(),
-            counter: account.get_counter(),
+            counters: account
+                .spending
+                .get_valid_counters()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
             last_rewards: account.last_rewards.into(),
         }
     }
@@ -158,7 +164,12 @@ impl<'a, E> From<&'a account::AccountState<E>> for AccountState {
         AccountState {
             delegation: account.delegation().clone().into(),
             value: account.value().into(),
-            counter: account.get_counter(),
+            counters: account
+                .spending
+                .get_valid_counters()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
             last_rewards: account.last_rewards.clone().into(),
         }
     }

--- a/jormungandr-lib/src/interfaces/transaction_witness.rs
+++ b/jormungandr-lib/src/interfaces/transaction_witness.rs
@@ -161,7 +161,7 @@ mod test {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
             match u8::arbitrary(g) % 3 {
                 0 => Witness::Utxo(Arbitrary::arbitrary(g)).into(),
-                1 => Witness::Account(Arbitrary::arbitrary(g)).into(),
+                1 => Witness::Account(Arbitrary::arbitrary(g), Arbitrary::arbitrary(g)).into(),
                 2 => {
                     use crate::crypto::key::KeyPair;
                     use chain_crypto::Ed25519Bip32;

--- a/jormungandr/src/explorer/indexing.rs
+++ b/jormungandr/src/explorer/indexing.rs
@@ -373,7 +373,7 @@ impl ExplorerTransaction {
             .map(|i| i.to_enum())
             .zip(witnesses)
             .filter_map(|input_with_witness| match input_with_witness {
-                (InputEnum::AccountInput(id, value), Witness::Account(_)) => {
+                (InputEnum::AccountInput(id, value), Witness::Account(_, _)) => {
                     let kind = chain_addr::Kind::Account(
                         id.to_single_account()
                             .expect("the input to be validated")
@@ -382,7 +382,7 @@ impl ExplorerTransaction {
                     let address = ExplorerAddress::New(Address(context.discrimination, kind));
                     Some(ExplorerInput { address, value })
                 }
-                (InputEnum::AccountInput(id, value), Witness::Multisig(_)) => {
+                (InputEnum::AccountInput(id, value), Witness::Multisig(_, _)) => {
                     let kind = chain_addr::Kind::Multisig(
                         id.to_multi_account()
                             .as_ref()

--- a/testing/jormungandr-integration-tests/src/networking/testnet.rs
+++ b/testing/jormungandr-integration-tests/src/networking/testnet.rs
@@ -140,7 +140,7 @@ fn create_actor_account(private_key: &str, jormungandr: &JormungandrProcess) -> 
         .rest()
         .v0()
         .account_stats(actor_account.address().to_string(), jormungandr.rest_uri());
-    Wallet::from_existing_account(private_key, Some(account_state.counter()))
+    Wallet::from_existing_account(private_key, Some(account_state.counters()[0]))
 }
 
 fn bootstrap_current(testnet_config: TestnetConfig, network_alias: &str) {

--- a/testing/jormungandr-scenario-tests/src/test/non_functional/desync.rs
+++ b/testing/jormungandr-scenario-tests/src/test/non_functional/desync.rs
@@ -77,9 +77,11 @@ pub fn bft_forks(mut context: Context<ChaChaRng>) -> Result<ScenarioResult> {
             (transaction_amount + i).into(),
         )?;
         let state = leader_1.rest().account_state(&alice).unwrap();
+        // The fragment sender currently only uses the counter in lane 0
+        let updated_counter = state.counters()[0];
         if let Wallet::Account(account) = &alice {
             let counter: u32 = account.internal_counter().into();
-            if counter < state.counter() {
+            if counter < updated_counter {
                 alice.confirm_transaction();
             }
         }

--- a/testing/jormungandr-testing-utils/Cargo.toml
+++ b/testing/jormungandr-testing-utils/Cargo.toml
@@ -78,4 +78,4 @@ default = []
 property-test-api = [ ]
 
 [build-dependencies]
-tonic-build = "0.5"
+tonic-build = "0.6"


### PR DESCRIPTION
Initial adaptation for chain-impl-mockchain API changes for independent
spending counters lanes.
Also tonic and prost versions were updated.