### PR TITLE
graphql: add total_count to Block::transactions

### DIFF
--- a/jormungandr/src/explorer/graphql/mod.rs
+++ b/jormungandr/src/explorer/graphql/mod.rs
@@ -546,7 +546,9 @@ impl Block {
         last: Option<i32>,
         before: Option<String>,
         after: Option<String>,
-    ) -> FieldResult<Connection<IndexCursor, Transaction, EmptyFields, EmptyFields>> {
+    ) -> FieldResult<
+        Connection<IndexCursor, Transaction, ConnectionFields<TransactionCount>, EmptyFields>,
+    > {
         let explorer_block = self
             .fetch_explorer_block(&extract_context(context).await.db)
             .await?;
@@ -588,8 +590,13 @@ impl Block {
                 };
 
                 let (range, page_meta) = compute_interval(boundaries, pagination_arguments)?;
-                let mut connection =
-                    Connection::new(page_meta.has_previous_page, page_meta.has_next_page);
+                let mut connection = Connection::with_additional_fields(
+                    page_meta.has_previous_page,
+                    page_meta.has_next_page,
+                    ConnectionFields {
+                        total_count: page_meta.total_count,
+                    },
+                );
 
                 let edges = match range {
                     PaginationInterval::Empty => vec![],


### PR DESCRIPTION
for some reason this query doesn't add the total_count field, and
although it is working now, it will cause a panic with async-graphql
2.11 because there are two different `TransactionConnection`

