### PR TITLE
p2p id rework - remove redundant conn

### DIFF
--- a/jormungandr-lib/src/crypto/key.rs
+++ b/jormungandr-lib/src/crypto/key.rs
@@ -414,6 +414,12 @@ impl<A: AsymmetricKey> From<SecretKey<A>> for SigningKey<A> {
     }
 }
 
+impl<A: AsymmetricKey> From<SigningKey<A>> for SecretKey<A> {
+    fn from(key: SigningKey<A>) -> Self {
+        key.0
+    }
+}
+
 impl<A: AsymmetricPublicKey> From<PublicKey<A>> for Identifier<A> {
     fn from(key: PublicKey<A>) -> Self {
         Identifier(key)

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -243,7 +243,7 @@ impl Process {
                     hash = %header.hash(),
                     parent = %header.parent_id(),
                     date = %header.block_date(),
-                    peer = ?node_id
+                    %node_id
                 );
                 let _enter = span.enter();
                 tracing::debug!("received block announcement from network");

--- a/jormungandr/src/intercom.rs
+++ b/jormungandr/src/intercom.rs
@@ -3,7 +3,7 @@ use crate::blockcfg::{
 };
 use crate::blockchain::{Checkpoints, LeadershipBlock, StorageError};
 use crate::fragment::selection::FragmentSelectionAlgorithmParams;
-use crate::network::p2p::{comm::PeerInfo, Address};
+use crate::network::p2p::comm::PeerInfo;
 use crate::topology::{Gossips, NodeId, Peer, PeerInfo as TopologyPeerInfo, View};
 use crate::utils::async_msg::{self, MessageBox, MessageQueue};
 use chain_impl_mockchain::fragment::Contents as FragmentContents;
@@ -579,7 +579,7 @@ pub enum BlockMsg {
     /// A trusted Block has been received from the leadership task
     LeadershipBlock(Box<LeadershipBlock>),
     /// A untrusted block Header has been received from the network task
-    AnnouncedBlock(Box<Header>, Address),
+    AnnouncedBlock(Box<Header>, NodeId),
     /// A stream of untrusted blocks has been received from the network task.
     NetworkBlocks(RequestStreamHandle<Block, ()>),
     /// The stream of headers for missing chain blocks has been received
@@ -601,9 +601,9 @@ pub enum PropagateMsg {
 pub enum NetworkMsg {
     Propagate(Box<PropagateMsg>),
     GetBlocks(Vec<HeaderHash>),
-    GetNextBlock(Address, HeaderHash),
+    GetNextBlock(NodeId, HeaderHash),
     PullHeaders {
-        node_address: Address,
+        node_id: NodeId,
         from: Checkpoints,
         to: HeaderHash,
     },

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -80,7 +80,6 @@ pub fn connect(state: ConnectionState, channels: Channels) -> (ConnectHandle, Co
         .map_err(ConnectError::Subscription)?;
         let inbound = InboundSubscriptions {
             peer_id,
-            peer_addr: peer.connection,
             block_events: block_sub,
             fragments: fragment_sub,
             gossip: gossip_sub,

--- a/jormungandr/src/network/client/connect.rs
+++ b/jormungandr/src/network/client/connect.rs
@@ -55,7 +55,7 @@ pub fn connect(state: ConnectionState, channels: Channels) -> (ConnectHandle, Co
         //TODO: check id is the expected one
         let peer_id = validate_peer_auth(hr.auth, &nonce)?;
 
-        tracing::debug!(node_id = ?peer_id, "authenticated server peer node");
+        tracing::debug!(node_id = %peer_id, "authenticated server peer node");
 
         // Send client authentication
         let auth = keypair.sign(&hr.nonce);

--- a/jormungandr/src/network/client/mod.rs
+++ b/jormungandr/src/network/client/mod.rs
@@ -7,10 +7,7 @@ use super::{
         self,
         client::{BlockSubscription, FragmentSubscription, GossipSubscription},
     },
-    p2p::{
-        comm::{OutboundSubscription, PeerComms},
-        Address,
-    },
+    p2p::comm::{OutboundSubscription, PeerComms},
     subscription::{BlockAnnouncementProcessor, Direction, FragmentProcessor, GossipProcessor},
     Channels, GlobalStateR,
 };
@@ -107,7 +104,6 @@ impl Client {
 
 struct InboundSubscriptions {
     pub peer_id: NodeId,
-    pub peer_addr: Address,
     pub block_events: BlockSubscription,
     pub fragments: FragmentSubscription,
     pub gossip: GossipSubscription,
@@ -154,7 +150,7 @@ impl Progress {
 }
 
 impl Client {
-    #[instrument(skip_all, level = "debug", fields(peer_addr = %self.inbound.peer_addr, id = %self.inbound.peer_id))]
+    #[instrument(skip_all, level = "debug")]
     fn process_block_event(&mut self, cx: &mut Context<'_>) -> Poll<Result<ProcessingOutcome, ()>> {
         use self::ProcessingOutcome::*;
         // Drive sending of a message to block task to clear the buffered
@@ -245,7 +241,7 @@ impl Client {
         Ok(Continue).into()
     }
 
-    #[instrument(skip_all, level = "debug", fields(peer_addr = %self.inbound.peer_addr, id = %self.inbound.peer_id))]
+    #[instrument(skip_all, level = "debug")]
     fn upload_blocks(&mut self, block_ids: BlockIds) -> Result<(), ()> {
         if block_ids.is_empty() {
             tracing::info!("peer has sent an empty block solicitation");
@@ -295,7 +291,7 @@ impl Client {
         Ok(())
     }
 
-    #[instrument(skip_all, level = "debug", fields(peer_addr = %self.inbound.peer_addr, id = %self.inbound.peer_id))]
+    #[instrument(skip_all, level = "debug")]
     fn push_missing_headers(&mut self, req: ChainPullRequest) -> Result<(), ()> {
         let from = req.from.decode().map_err(|e| {
             tracing::info!(
@@ -347,7 +343,7 @@ impl Client {
         Ok(())
     }
 
-    #[instrument(skip_all, level = "debug", fields(peer_addr = %self.inbound.peer_addr, id = %self.inbound.peer_id))]
+    #[instrument(skip_all, level = "debug")]
     fn pull_headers(&mut self, req: ChainPullRequest) {
         let mut block_box = self.block_sink.message_box();
 
@@ -393,7 +389,7 @@ impl Client {
         );
     }
 
-    #[instrument(skip_all, level = "debug", fields(peer_addr = %self.inbound.peer_addr, id = %self.inbound.peer_id))]
+    #[instrument(skip_all, level = "debug")]
     fn solicit_blocks(&mut self, block_ids: BlockIds) {
         let mut block_box = self.block_sink.message_box();
         let (handle, sink, _) = intercom::stream_request(buffer_sizes::inbound::BLOCKS);
@@ -438,7 +434,7 @@ impl Client {
         );
     }
 
-    #[instrument(skip_all, level = "debug", fields(peer_addr = %self.inbound.peer_addr, id = %self.inbound.peer_id, direction = "in"))]
+    #[instrument(skip_all, level = "debug", fields(direction = "in"))]
     fn process_fragments(&mut self, cx: &mut Context<'_>) -> Poll<Result<ProcessingOutcome, ()>> {
         use self::ProcessingOutcome::*;
         let mut fragment_sink = Pin::new(&mut self.fragment_sink);
@@ -472,7 +468,7 @@ impl Client {
         }
     }
 
-    #[instrument(skip_all, level = "debug", fields(peer_addr = %self.inbound.peer_addr, id = %self.inbound.peer_id, direction = "in"))]
+    #[instrument(skip_all, level = "debug", fields(direction = "in"))]
     fn process_gossip(&mut self, cx: &mut Context<'_>) -> Poll<Result<ProcessingOutcome, ()>> {
         use self::ProcessingOutcome::*;
         let mut gossip_sink = Pin::new(&mut self.gossip_sink);

--- a/jormungandr/src/network/convert.rs
+++ b/jormungandr/src/network/convert.rs
@@ -1,6 +1,6 @@
 use crate::blockcfg::{Block, Fragment, Header, HeaderId};
 use crate::intercom;
-use crate::topology::{Gossip, Gossips};
+use crate::topology::{Gossip, Gossips, NodeId};
 use chain_core::mempack::{ReadBuf, Readable};
 use chain_core::property::{Deserialize, Serialize};
 use chain_network::data as net_data;
@@ -94,6 +94,13 @@ impl Decode for net_data::gossip::Node {
     }
 }
 
+impl Decode for net_data::NodeId {
+    type Object = NodeId;
+    fn decode(self) -> Result<Self::Object, Error> {
+        NodeId::try_from(self.as_bytes()).map_err(|e| Error::new(Code::InvalidArgument, e))
+    }
+}
+
 impl<T, N> Encode for Vec<T>
 where
     T: Encode<NetworkData = N>,
@@ -158,5 +165,13 @@ impl Encode for Gossips {
             .collect::<Vec<net_data::gossip::Node>>()
             .into_boxed_slice();
         net_data::gossip::Gossip { nodes }
+    }
+}
+
+impl Encode for NodeId {
+    type NetworkData = net_data::NodeId;
+
+    fn encode(&self) -> Self::NetworkData {
+        net_data::NodeId::try_from(self.as_ref().as_ref()).unwrap()
     }
 }

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -176,7 +176,8 @@ impl GlobalState {
         rand::thread_rng().fill(&mut rng_seed);
         let mut prng = ChaChaRng::from_seed(rng_seed);
 
-        let keypair = NodeKeyPair::generate(&mut prng);
+        //TODO: move this to a secure enclave
+        let keypair = NodeKeyPair::from(config.node_key);
 
         GlobalState {
             block0_hash,

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -531,7 +531,9 @@ impl Peers {
         F: FnOnce([u8; NONCE_LEN]) -> Result<(), Error>,
     {
         let mut map = self.inner().await;
-        map.complete_handshake(peer_addr, id, verify)
+        map.complete_handshake(peer_addr, id, verify)?;
+        tracing::debug!(addr = %peer_addr, %id, "authenticated client peer node");
+        Ok(())
     }
 
     pub async fn client_id(&self, peer_addr: Address) -> Option<NodeId> {

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -1,5 +1,6 @@
 mod peer_map;
 use super::Address;
+use crate::metrics::Metrics;
 use crate::network::{client::ConnectHandle, security_params::NONCE_LEN};
 use crate::topology::NodeId;
 use chain_network::data::block::{BlockEvent, ChainPullRequest};
@@ -465,9 +466,9 @@ pub struct Peers {
 }
 
 impl Peers {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new(capacity: usize, stats_counter: Metrics) -> Self {
         Peers {
-            mutex: Mutex::new(PeerMap::new(capacity)),
+            mutex: Mutex::new(PeerMap::new(capacity, stats_counter)),
         }
     }
 

--- a/jormungandr/src/network/p2p/comm.rs
+++ b/jormungandr/src/network/p2p/comm.rs
@@ -524,7 +524,7 @@ impl Peers {
     pub async fn server_complete_handshake(&self, peer_addr: Address, id: NodeId) {
         tracing::debug!(
             peer_addr = %peer_addr,
-            node_id = ?id,
+            node_id = %id,
             "authenticated client peer node"
         );
         let mut map = self.inner().await;
@@ -533,7 +533,7 @@ impl Peers {
         } else {
             tracing::warn!(
                 %peer_addr,
-                ?id,
+                %id,
                 "peer is not known to the node, was the handshake procedure skipped?",
             );
         }
@@ -690,7 +690,7 @@ impl Peers {
     pub async fn solicit_blocks_peer(&self, peer: &NodeId, hashes: BlockIds) {
         let span = debug_span!(
             "block solicitation",
-            ?peer,
+            %peer,
             peer_addr = tracing::field::Empty,
             hashes = %format!("[{}]", hashes.iter().map(hex::encode).collect::<Vec<_>>().join(", "))
         );
@@ -724,7 +724,7 @@ impl Peers {
     pub async fn pull_headers(&self, peer: &NodeId, from: BlockIds, to: BlockId) {
         let span = debug_span!(
             "pull_header",
-            ?peer,
+            %peer,
             peer_addr = tracing::field::Empty,
             from = %format!("[{}]", from.iter().map(hex::encode).collect::<Vec<_>>().join(", ")),
             to = %hex::encode(to)
@@ -749,7 +749,7 @@ impl Peers {
                 None => {
                     // TODO: connect and request on demand, or select another peer?
                     tracing::info!(
-                        peer = ?peer,
+                        peer = %peer,
                         "peer not available to pull headers from"
                     );
                 }

--- a/jormungandr/src/network/p2p/comm/peer_map.rs
+++ b/jormungandr/src/network/p2p/comm/peer_map.rs
@@ -17,7 +17,7 @@ use rand::Rng;
 /// and ids is needed to handle subscriptions. However, this is subject to ip spoofing
 /// attacks and should not be used in an open network.
 pub struct ClientAuth {
-    // Avoid keeping open handshakes forever
+    // Limit the number of in progress handshakes to prevent SYN flood-like resource exhaustion attacks
     in_progress: LruCache<Address, [u8; NONCE_LEN]>,
     established: LinkedHashMap<Address, NodeId>,
 }
@@ -32,7 +32,7 @@ impl Default for ClientAuth {
 }
 
 impl ClientAuth {
-    const DEFAULT_OPEN_HANDSHAKED_LIMIT: usize = 32;
+    const DEFAULT_OPEN_HANDSHAKED_LIMIT: usize = 128;
 
     pub fn generate_auth_nonce(&mut self, addr: Address) -> [u8; NONCE_LEN] {
         let mut nonce = [0u8; NONCE_LEN];

--- a/jormungandr/src/network/p2p/mod.rs
+++ b/jormungandr/src/network/p2p/mod.rs
@@ -1,14 +1,12 @@
 /// This module is responsible for handling active peers and communication in a p2p setting.
 /// It takes care of managing connections with said peers and sending messages to them.
 /// The topology task is instead responsible for the discovery of active peers.
-///
-/// FIXME: Topology and peers have indipendent representation of a external node.
-/// At the moment, topology and peers each use a different ID for node identification
-/// but since those are not checked, each layers ignore the other one's IDs.
-/// Ideally, peers should request a proof-of-possession of the key used to
-/// authenticate gossips when connecting and viceversa.
-/// Leaving this to when we will introduce identity verification, since requirements
-/// are likely to change.
 pub mod comm;
 
+/// At the logical level, every peer is identified by its public key, and this is the only
+/// info exposed in the external interface.
+/// However, keeping the remote address of the peer is needed for some features, namely
+/// debugging and server side authentication of requests.
+/// In addition, keep in mind the address here is not always the public address included in the
+/// gossip, as it may be an ephemeral address used by a connected client.
 pub type Address = std::net::SocketAddr;

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -61,7 +61,7 @@ pub struct Configuration {
 
     pub public_address: Option<Address>,
 
-    // Secret key used to authenticate gossips, the public part is used as an identifier of the node
+    // Secret key used to authenticate communications, the public part is used as an identifier of the node
     pub node_key: SigningKey<Ed25519>,
 
     /// list of trusted addresses

--- a/jormungandr/src/topology/layers/preferred_list.rs
+++ b/jormungandr/src/topology/layers/preferred_list.rs
@@ -40,7 +40,7 @@ impl PreferredListLayer {
             peers: config
                 .peers
                 .iter()
-                .map(|peer| (peer.addr, peer.id.clone()))
+                .map(|peer| (peer.addr, peer.id))
                 .collect(),
             current_peers: HashSet::new(),
             prng,

--- a/jormungandr/src/topology/mod.rs
+++ b/jormungandr/src/topology/mod.rs
@@ -7,6 +7,7 @@ use jormungandr_lib::time::SystemTime;
 use serde::Serialize;
 use serde::Serializer;
 use std::convert::{TryFrom, TryInto};
+use std::fmt;
 use std::hash::{Hash, Hasher};
 
 mod gossip;
@@ -72,6 +73,12 @@ impl TryFrom<&[u8]> for NodeId {
             PublicKey::<Ed25519>::from_binary(bytes)
                 .map(jormungandr_lib::interfaces::NodeId::from)?,
         ))
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/jormungandr/src/topology/mod.rs
+++ b/jormungandr/src/topology/mod.rs
@@ -6,7 +6,7 @@ use jormungandr_lib::interfaces::Subscription;
 use jormungandr_lib::time::SystemTime;
 use serde::Serialize;
 use serde::Serializer;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
 
 mod gossip;
@@ -47,7 +47,7 @@ pub mod limits {
 }
 
 /// Unique identifier of a node in the topology
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct NodeId(keynesis::key::ed25519::PublicKey);
 
 impl From<jormungandr_lib::interfaces::NodeId> for NodeId {
@@ -60,6 +60,18 @@ impl From<jormungandr_lib::interfaces::NodeId> for NodeId {
 impl From<NodeId> for jormungandr_lib::interfaces::NodeId {
     fn from(node_id: NodeId) -> jormungandr_lib::interfaces::NodeId {
         jormungandr_lib::interfaces::NodeId::from_hex(&node_id.0.to_string()).unwrap()
+    }
+}
+
+impl TryFrom<&[u8]> for NodeId {
+    type Error = chain_crypto::PublicKeyError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        use chain_crypto::{Ed25519, PublicKey};
+        Ok(Self::from(
+            PublicKey::<Ed25519>::from_binary(bytes)
+                .map(jormungandr_lib::interfaces::NodeId::from)?,
+        ))
     }
 }
 

--- a/jormungandr/src/topology/quarantine.rs
+++ b/jormungandr/src/topology/quarantine.rs
@@ -76,16 +76,16 @@ impl ReportRecords {
         if self.report_whitelist.contains(&node.address()) {
             tracing::debug!(
                 node = %node.address(),
-                id=?node.id(),
+                id=%node.id(),
                 "quarantine whitelists prevents this node from being reported",
             );
             ReportNodeStatus::Ok
         } else if self.report_grace.contains(&node.id()) {
-            tracing::trace!(node = %node.address(), id=?node.id(), "not reporting node in grace list");
+            tracing::trace!(node = %node.address(), id=%node.id(), "not reporting node in grace list");
             ReportNodeStatus::Ok
         } else {
             let mut peer_info = PeerInfo::from(node);
-            tracing::debug!(node = %peer_info.address, id=?peer_info.id, ?self.report_duration, "reporting node");
+            tracing::debug!(node = %peer_info.address, id=%peer_info.id, ?self.report_duration, "reporting node");
             // If we'll handle report reasons other that a connectivity issue in the future, we may want to
             // demote a peer all the way down to dirty in case of a serious violation.
             topology.remove_peer(peer_info.id.as_ref());
@@ -102,7 +102,7 @@ impl ReportRecords {
             // nodes again after some time if we haven't heard from them sooner (and avoid network splits).
             if topology.peers().dirty().contains(peer_info.id.as_ref()) {
                 peer_info.quarantined = Some(SystemTime::now().into());
-                tracing::debug!(node = %peer_info.address, id=?peer_info.id, "node has been quarantined");
+                tracing::debug!(node = %peer_info.address, id=%peer_info.id, "node has been quarantined");
                 result = ReportNodeStatus::Quarantine;
             }
 

--- a/jormungandr/src/topology/quarantine.rs
+++ b/jormungandr/src/topology/quarantine.rs
@@ -107,7 +107,7 @@ impl ReportRecords {
             }
 
             self.report_records.put(
-                peer_info.id.clone(),
+                peer_info.id,
                 ReportRecord {
                     peer_info,
                     report_time: Instant::now(),

--- a/jormungandr/src/topology/topology.rs
+++ b/jormungandr/src/topology/topology.rs
@@ -209,7 +209,7 @@ impl P2pTopology {
     }
 
     /// register a strike against the given peer
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip_all, level = "debug", fields(%node_id))]
     pub fn report_node(&mut self, node_id: &NodeId) {
         if let Some(node) = self.topology.get(node_id.as_ref()).cloned() {
             let result = self

--- a/jormungandr/src/topology/topology.rs
+++ b/jormungandr/src/topology/topology.rs
@@ -152,7 +152,7 @@ impl P2pTopology {
         for gossip in gossips {
             let peer = Profile::from_gossip(gossip);
             let peer_id = NodeId(peer.id());
-            tracing::trace!(node = %peer.address(), "received peer from gossip");
+            tracing::trace!(addr = %peer.address(), %peer_id, "received peer from incoming gossip");
             if self.topology.add_peer(peer) {
                 self.quarantine.record_new_gossip(&peer_id);
                 self.stats_counter

--- a/testing/jormungandr-integration-tests/src/networking/p2p/quarantine.rs
+++ b/testing/jormungandr-integration-tests/src/networking/p2p/quarantine.rs
@@ -11,6 +11,7 @@ use jormungandr_testing_utils::testing::network::SpawnParams;
 use jormungandr_testing_utils::testing::network::Topology;
 
 const CLIENT: &str = "CLIENT";
+const CLIENT_2: &str = "CLIENT_2";
 const SERVER: &str = "SERVER";
 
 const ALICE: &str = "ALICE";
@@ -101,7 +102,7 @@ pub fn node_does_not_quarantine_whitelisted_node() {
         .spawn(SpawnParams::new(CLIENT_2).policy(policy).in_memory())
         .unwrap();
 
-    process_utils::sleep(20);
+    utils::wait(20);
 
     assert_node_stats(&client2, 2, 0, 2, "after starting client2");
     assert_empty_quarantine(&client2, "after starting client2");
@@ -143,7 +144,7 @@ pub fn node_put_in_quarantine_nodes_which_are_not_whitelisted() {
     assert_node_stats(&server, 1, 0, 1, "before starting client2");
     assert_empty_quarantine(&server, "before starting client2");
 
-    process_utils::sleep(20);
+    utils::wait(20);
 
     let client2 = network_controller
         .spawn(
@@ -163,7 +164,7 @@ pub fn node_put_in_quarantine_nodes_which_are_not_whitelisted() {
         )
         .unwrap();
 
-    process_utils::sleep(20);
+    utils::wait(20);
 
     assert_node_stats(&client2, 1, 1, 2, "after starting client2");
     assert_are_in_quarantine(&client2, vec![&client], "after starting client2");
@@ -202,13 +203,13 @@ pub fn node_does_not_quarantine_trusted_node() {
         .spawn(SpawnParams::new(CLIENT).in_memory())
         .unwrap();
 
-    process_utils::sleep(5);
+    utils::wait(5);
 
     assert_node_stats(&server, 1, 0, 1, "before stopping client");
     assert_empty_quarantine(&server, "before stopping client");
 
     client.shutdown();
-    process_utils::sleep(20);
+    utils::wait(20);
 
     // The server "forgets" the client but does not quarantine it
     assert_node_stats(&server, 1, 0, 1, "before restarting client");


### PR DESCRIPTION
### Why
The aim of this PR is mainly to simplify the way we handle p2p connections and remove redundant communications.

Before this, addresses were used as identifiers, which led to a node being present twice in the peers, once as a server and once as a client. In addition, messages were only propagated from a client to a server, even though we have quite some code that is supposed to handle incoming messages for a client (note we use bidirectional streams) which was left unused. Not only was that inefficient (maintain two active connections when that is not needed), it also made understanding flow of information more difficult.

Last but not least, addresses can be forged and we can't use that alone to authenticate messages.

### Changes
I propose with this PR to change the identifier of a node in the p2p layer to the public key used in the topology. From the high level perspective of message dissemination, this hides the fact that a node is a client or a server in the particular protocol used, and avoid having two connections to the same node.

In addition, unify the node id used during the handshake procedure to use the topology key pair. That identifier was only used to avoid propagating the same information to the same node more than once, and we can now reuse the id we already have from topology to do so. 

Furthermore, this can be used to authenticate the peer we're connecting to and is the first step for reliable authentication of messages.

Peer promotion on the server side does not happen right after the handshake but only after the first gossip message is received, to accommodate peers that do not wish to participate in the full dissemination protocol (e.g. private nodes, full wallets, ...).

### Future improvements
At this initial stage we are mainly interested in performance since the network is private and no external users have access to the deployment.
Nonetheless, there is still room for improvements, mainly in the security part like:
 * reliable authentication (ip spoofing works after the initial handshake)
 * proper key handling
 * id-based quarantine whitelist
 * id-based trusted peers

I'm thinking of moving most of the handshake procedure / connection handling to the underlying network layer, something like a tls connection but using tower services. 

Also, we should port this change to chain-network as well, but for that I was waiting for a complete design of the handshake/connections procedure.

### Test

Since this stress code that was previously unused, we should take extra care of testing this PR in detail