### PR TITLE
Parallel spending counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - add feature for changing blockchain config during the network run. Add new certificates `UpdateProposal` and `UpdateVote`, updated `jcli` with these new transactions.
 - Add new grpc watch service implementation for external (non-node) clients.
 - update explorer, add new GraphQL objects as `UpdateProposal`, `UpdateVote`, `ConfigParam` etc.
+- Add jcli option to specify a spending counter lane in a user-friendly way
 
 ## Release 0.13.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
  "cbor_event",
  "chain-ser",
@@ -489,7 +489,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
  "bech32 0.8.1",
  "chain-core",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
  "chain-ser",
 ]
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
  "bech32 0.8.1",
  "cryptoxide",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
  "cardano-legacy-address",
  "chain-addr",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "chain-network"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
  "async-trait",
  "chain-crypto",
@@ -580,12 +580,12 @@ dependencies = [
 [[package]]
 name = "chain-ser"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
  "criterion",
  "data-pile",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
  "chain-core",
  "chain-ser",
@@ -610,9 +610,9 @@ dependencies = [
 [[package]]
 name = "chain-vote"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "chain-core",
  "chain-crypto",
  "const_format",
@@ -1827,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 dependencies = [
  "thiserror",
 ]
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 
 [[package]]
 name = "spin"
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#95d1883f318538f924f65f1a3a282ec5b9ed446f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#995eac86c61bc19da2e74b5b49fa3a7f63300485"
 
 [[package]]
 name = "typenum"

--- a/jcli/src/jcli_lib/transaction/mk_witness.rs
+++ b/jcli/src/jcli_lib/transaction/mk_witness.rs
@@ -33,7 +33,7 @@ pub struct MkWitness {
     #[structopt(long = "genesis-block-hash", parse(try_from_str))]
     pub genesis_block_hash: HeaderId,
 
-    /// value is mandatory is `--type=account' It is the counter value for
+    /// value is mandatory if `--type=account`. It is the counter value for
     /// every time the account is being utilized.
     #[structopt(long = "account-spending-counter")]
     pub account_spending_counter: Option<u32>,

--- a/jcli/src/jcli_lib/transaction/mk_witness.rs
+++ b/jcli/src/jcli_lib/transaction/mk_witness.rs
@@ -7,6 +7,7 @@ use chain_core::property::Serialize as _;
 use chain_impl_mockchain::key::EitherEd25519SecretKey;
 use chain_impl_mockchain::{
     account::SpendingCounter,
+    accounting::account::spending::SpendingCounterIncreasing,
     header::HeaderId,
     transaction::{TransactionSignDataHash, Witness},
 };
@@ -32,10 +33,16 @@ pub struct MkWitness {
     #[structopt(long = "genesis-block-hash", parse(try_from_str))]
     pub genesis_block_hash: HeaderId,
 
-    /// value is mandatory is `--type=account' It is the counter for
+    /// value is mandatory is `--type=account' It is the counter value for
     /// every time the account is being utilized.
     #[structopt(long = "account-spending-counter")]
     pub account_spending_counter: Option<u32>,
+
+    /// lane to use for the spending counter. Each lane has an independent
+    /// spending counter value.
+    /// If unsure, leave blank and lane 0 will be used
+    #[structopt(long)]
+    pub account_spending_counter_lane: Option<usize>,
 
     /// the file path to the file to read the signing key from.
     /// If omitted it will be read from the standard input.
@@ -64,11 +71,24 @@ impl std::str::FromStr for WitnessType {
 impl MkWitness {
     pub fn exec(self) -> Result<(), Error> {
         let secret_key = read_ed25519_secret_key_from_file(&self.secret)?;
+        let sc = self
+            .account_spending_counter
+            .map(|counter| {
+                let lane = self.account_spending_counter_lane.unwrap_or_default();
+                if lane > SpendingCounterIncreasing::LANES {
+                    return Err(Error::MakeWitnessAccountInvalidCounterLane {
+                        max: SpendingCounterIncreasing::LANES,
+                        actual: lane,
+                    });
+                }
+                Ok(SpendingCounter::new(lane, counter))
+            })
+            .transpose()?;
         let witness = make_witness(
             &self.witness_type,
             &self.genesis_block_hash,
             &self.sign_data_hash,
-            self.account_spending_counter.map(SpendingCounter::from),
+            sc,
             &secret_key,
         )?;
         self.write_witness(&witness)

--- a/jcli/src/jcli_lib/transaction/mod.rs
+++ b/jcli/src/jcli_lib/transaction/mod.rs
@@ -183,6 +183,8 @@ pub enum Error {
     InfoExpectedSingleAccount,
     #[error("making account witness requires passing spending counter")]
     MakeWitnessAccountCounterMissing,
+    #[error("invalid account spending counter lane: max {max}, actual {actual}")]
+    MakeWitnessAccountInvalidCounterLane { max: usize, actual: usize },
     #[error("transaction type doesn't need payload authentification")]
     TxDoesntNeedPayloadAuth,
     #[error("transaction type need payload authentification")]

--- a/testing/jormungandr-integration-tests/src/networking/testnet.rs
+++ b/testing/jormungandr-integration-tests/src/networking/testnet.rs
@@ -140,7 +140,7 @@ fn create_actor_account(private_key: &str, jormungandr: &JormungandrProcess) -> 
         .rest()
         .v0()
         .account_stats(actor_account.address().to_string(), jormungandr.rest_uri());
-    Wallet::from_existing_account(private_key, Some(account_state.counters()[0]))
+    Wallet::from_existing_account(private_key, Some(account_state.counters()[0].into()))
 }
 
 fn bootstrap_current(testnet_config: TestnetConfig, network_alias: &str) {

--- a/testing/jormungandr-testing-utils/src/testing/jcli/api/transaction.rs
+++ b/testing/jormungandr-testing-utils/src/testing/jcli/api/transaction.rs
@@ -4,7 +4,7 @@ use crate::wallet::Wallet;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::TempDir;
 use chain_core::property::Deserialize;
-use chain_impl_mockchain::{fee::LinearFee, fragment::Fragment};
+use chain_impl_mockchain::{account::SpendingCounter, fee::LinearFee, fragment::Fragment};
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{BlockDate, LegacyUTxO, UTxOInfo, Value},
@@ -173,7 +173,7 @@ impl Transaction {
                 &witness.block_hash.to_hex(),
                 &witness.transaction_id.to_hex(),
                 &witness.addr_type,
-                witness.spending_account_counter,
+                witness.account_spending_counter,
                 &witness.file,
                 &witness.private_key_path,
             )
@@ -188,7 +188,7 @@ impl Transaction {
                 &witness.block_hash.to_hex(),
                 &witness.transaction_id.to_hex(),
                 &witness.addr_type,
-                witness.spending_account_counter,
+                witness.account_spending_counter,
                 &witness.file,
                 &witness.private_key_path,
             )
@@ -211,7 +211,7 @@ impl Transaction {
                 genesis_hash,
                 &account.signing_key().to_bech32_str(),
                 "account",
-                Some(account.internal_counter().into()),
+                Some(account.internal_counter()),
                 staging_file,
             ),
             Wallet::UTxO(utxo) => self.create_witness_from_key(
@@ -239,7 +239,7 @@ impl Transaction {
         genesis_hash: Hash,
         private_key: &str,
         addr_type: &str,
-        spending_key: Option<u32>,
+        spending_counter: Option<SpendingCounter>,
         staging_file: P,
     ) -> Witness {
         let transaction_id = self.id(staging_file);
@@ -249,7 +249,7 @@ impl Transaction {
             &transaction_id,
             addr_type,
             private_key,
-            spending_key,
+            spending_counter,
         )
     }
 

--- a/testing/jormungandr-testing-utils/src/testing/jcli/command/transaction.rs
+++ b/testing/jormungandr-testing-utils/src/testing/jcli/command/transaction.rs
@@ -1,4 +1,4 @@
-use chain_impl_mockchain::fee::LinearFee;
+use chain_impl_mockchain::{account::SpendingCounter, fee::LinearFee};
 use std::path::Path;
 use std::process::Command;
 
@@ -108,12 +108,11 @@ impl TransactionCommand {
         block0_hash: &str,
         tx_id: &str,
         addr_type: &str,
-        spending_account_counter: Option<u32>,
+        account_spending_counter: Option<SpendingCounter>,
         witness_file: P,
         witness_key: Q,
     ) -> Self {
-        let spending_counter = spending_account_counter.unwrap_or(0);
-
+        let spending_counter = account_spending_counter.unwrap_or_else(SpendingCounter::zero);
         self.command
             .arg("make-witness")
             .arg("--genesis-block-hash")
@@ -123,7 +122,9 @@ impl TransactionCommand {
             .arg(&tx_id)
             .arg(witness_file.as_ref())
             .arg("--account-spending-counter")
-            .arg(spending_counter.to_string())
+            .arg(spending_counter.unlaned_counter().to_string())
+            .arg("--account-spending-counter-lane")
+            .arg(spending_counter.lane().to_string())
             .arg(witness_key.as_ref());
         self
     }

--- a/testing/jormungandr-testing-utils/src/testing/jcli/services/transaction_builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/jcli/services/transaction_builder.rs
@@ -5,7 +5,7 @@ use crate::wallet::Wallet;
 use assert_fs::fixture::ChildPath;
 use assert_fs::{prelude::*, TempDir};
 use chain_core::property::Deserialize;
-use chain_impl_mockchain::{fee::LinearFee, fragment::Fragment};
+use chain_impl_mockchain::{account::SpendingCounter, fee::LinearFee, fragment::Fragment};
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::BlockDate,
@@ -199,7 +199,7 @@ impl TransactionBuilder {
         &mut self,
         private_key: &str,
         transaction_type: &str,
-        spending_key: Option<u32>,
+        spending_key: Option<SpendingCounter>,
     ) -> &mut Self {
         let witness = self.create_witness_from_key(private_key, transaction_type, spending_key);
         self.seal_with_witness(&witness);
@@ -230,7 +230,7 @@ impl TransactionBuilder {
             Wallet::Account(account) => self.create_witness_from_key(
                 &account.signing_key().to_bech32_str(),
                 "account",
-                Some(account.internal_counter().into()),
+                Some(account.internal_counter()),
             ),
             Wallet::UTxO(utxo) => {
                 self.create_witness_from_key(&utxo.last_signing_key().to_bech32_str(), "utxo", None)
@@ -247,7 +247,7 @@ impl TransactionBuilder {
         &self,
         private_key: &str,
         addr_type: &str,
-        spending_key: Option<u32>,
+        spending_key: Option<SpendingCounter>,
     ) -> Witness {
         let transaction_id = self.transaction_id();
         Witness::new(
@@ -260,7 +260,11 @@ impl TransactionBuilder {
         )
     }
 
-    pub fn create_witness_default(&self, addr_type: &str, spending_key: Option<u32>) -> Witness {
+    pub fn create_witness_default(
+        &self,
+        addr_type: &str,
+        spending_key: Option<SpendingCounter>,
+    ) -> Witness {
         let private_key = self.jcli.key().generate_default();
         self.create_witness_from_key(&private_key, addr_type, spending_key)
     }

--- a/testing/jormungandr-testing-utils/src/testing/witness.rs
+++ b/testing/jormungandr-testing-utils/src/testing/witness.rs
@@ -1,17 +1,17 @@
+use chain_impl_mockchain::account::SpendingCounter;
 use jormungandr_lib::crypto::hash::Hash;
-use serde_derive::{Deserialize, Serialize};
 
 use assert_fs::fixture::PathChild;
 use assert_fs::prelude::*;
 use std::path::PathBuf;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 pub struct Witness {
     pub block_hash: Hash,
     pub transaction_id: Hash,
     pub addr_type: String,
     pub private_key_path: PathBuf,
-    pub spending_account_counter: Option<u32>,
+    pub account_spending_counter: Option<SpendingCounter>,
     pub file: PathBuf,
 }
 
@@ -22,7 +22,7 @@ impl Witness {
         transaction_id: &Hash,
         addr_type: &str,
         private_key: &str,
-        spending_account_counter: Option<u32>,
+        account_spending_counter: Option<SpendingCounter>,
     ) -> Witness {
         Witness {
             block_hash: *block_hash,
@@ -30,7 +30,7 @@ impl Witness {
             addr_type: addr_type.to_string(),
             private_key_path: write_witness_key(temp_dir, private_key),
             file: temp_dir.child("witness").path().into(),
-            spending_account_counter,
+            account_spending_counter,
         }
     }
 }

--- a/testing/jormungandr-testing-utils/src/wallet/account.rs
+++ b/testing/jormungandr-testing-utils/src/wallet/account.rs
@@ -1,7 +1,8 @@
 use crate::testing::FragmentBuilderError;
 use chain_addr::Discrimination;
 use chain_impl_mockchain::{
-    account,
+    account::SpendingCounter,
+    accounting::account::SpendingCounterIncreasing,
     fee::{FeeAlgorithm, LinearFee},
     transaction::{
         Balance, Input, InputOutputBuilder, Payload, PayloadSlice, TransactionSignDataHash,
@@ -29,7 +30,7 @@ pub struct Wallet {
 
     /// the counter as we know of this value needs to be in sync
     /// with what is in the blockchain
-    internal_counter: account::SpendingCounter,
+    internal_counters: SpendingCounterIncreasing,
 
     discrimination: Discrimination,
 }
@@ -44,18 +45,23 @@ impl Wallet {
         Wallet {
             signing_key,
             identifier,
-            internal_counter: account::SpendingCounter::zero(),
+            internal_counters: SpendingCounterIncreasing::default(),
             discrimination,
         }
     }
 
-    pub fn from_existing_account(bech32_str: &str, spending_counter: Option<u32>) -> Self {
+    pub fn from_existing_account(
+        bech32_str: &str,
+        spending_counter: Option<SpendingCounter>,
+    ) -> Self {
         let signing_key = SigningKey::from_bech32_str(bech32_str).expect("bad bech32");
         let identifier = signing_key.identifier();
         Wallet {
             signing_key,
             identifier,
-            internal_counter: spending_counter.unwrap_or(0).into(),
+            internal_counters: SpendingCounterIncreasing::new_from_counter(
+                spending_counter.unwrap_or_else(|| SpendingCounter::zero()),
+            ),
             discrimination: Discrimination::Test,
         }
     }
@@ -68,22 +74,31 @@ impl Wallet {
         self.identifier().to_address(self.discrimination).into()
     }
 
-    pub fn set_counter(&mut self, value: u32) {
-        self.internal_counter = account::SpendingCounter::from(value);
+    pub fn set_counter(&mut self, counter: SpendingCounter) {
+        let mut counters = self.internal_counters.get_valid_counters();
+        counters[counter.lane()] = counter;
+        self.internal_counters = SpendingCounterIncreasing::new_from_counters(counters).unwrap();
     }
 
-    pub fn increment_counter(&mut self) {
-        let v: u32 = self.internal_counter.into();
-        self.internal_counter = account::SpendingCounter::from(v + 1);
+    pub fn increment_counter(&mut self, lane: usize) {
+        self.internal_counters
+            .next_verify(self.internal_counters.get_valid_counters()[lane])
+            .unwrap();
     }
 
-    pub fn decrement_counter(&mut self) {
-        let v: u32 = self.internal_counter.into();
-        self.internal_counter = account::SpendingCounter::from(v - 1);
+    pub fn decrement_counter(&mut self, lane: usize) {
+        self.set_counter(SpendingCounter::from(
+            <u32>::from(self.internal_counters()[lane]) - 1,
+        ))
     }
 
-    pub fn internal_counter(&self) -> account::SpendingCounter {
-        self.internal_counter
+    /// Use the default counter
+    pub fn internal_counter(&self) -> SpendingCounter {
+        self.internal_counters.get_valid_counter()
+    }
+
+    pub fn internal_counters(&self) -> Vec<SpendingCounter> {
+        self.internal_counters.get_valid_counters()
     }
 
     pub fn stake_key(&self) -> UnspecifiedAccountIdentifier {
@@ -106,7 +121,7 @@ impl Wallet {
         Witness::new_account(
             &(*block0_hash).into_hash(),
             signing_data,
-            self.internal_counter(),
+            self.internal_counters.get_valid_counter(),
             |d| self.signing_key().as_ref().sign(d),
         )
     }

--- a/testing/jormungandr-testing-utils/src/wallet/account.rs
+++ b/testing/jormungandr-testing-utils/src/wallet/account.rs
@@ -60,7 +60,7 @@ impl Wallet {
             signing_key,
             identifier,
             internal_counters: SpendingCounterIncreasing::new_from_counter(
-                spending_counter.unwrap_or_else(|| SpendingCounter::zero()),
+                spending_counter.unwrap_or_else(SpendingCounter::zero),
             ),
             discrimination: Discrimination::Test,
         }

--- a/testing/jormungandr-testing-utils/src/wallet/mod.rs
+++ b/testing/jormungandr-testing-utils/src/wallet/mod.rs
@@ -63,6 +63,8 @@ pub enum WalletError {
     InvalidBech32Key { expected: String, actual: String },
 }
 
+const DEFAULT_LANE: usize = 0;
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum Wallet {
@@ -81,7 +83,7 @@ impl Wallet {
 
     pub fn import_account<P: AsRef<Path>>(
         secret_key_file: P,
-        spending_counter: Option<u32>,
+        spending_counter: Option<SpendingCounter>,
     ) -> Wallet {
         let bech32_str = jortestkit::file::read_file(secret_key_file);
         Wallet::Account(account::Wallet::from_existing_account(
@@ -102,7 +104,7 @@ impl Wallet {
 
     pub fn from_existing_account(
         signing_key_bech32: &str,
-        spending_counter: Option<u32>,
+        spending_counter: Option<SpendingCounter>,
     ) -> Wallet {
         Wallet::Account(account::Wallet::from_existing_account(
             signing_key_bech32,
@@ -270,14 +272,14 @@ impl Wallet {
 
     pub fn confirm_transaction(&mut self) {
         match self {
-            Wallet::Account(account) => account.increment_counter(),
+            Wallet::Account(account) => account.increment_counter(DEFAULT_LANE),
             _ => unimplemented!(),
         }
     }
 
     pub fn decrement_counter(&mut self) {
         match self {
-            Wallet::Account(account) => account.decrement_counter(),
+            Wallet::Account(account) => account.decrement_counter(DEFAULT_LANE),
             _ => unimplemented!(),
         }
     }
@@ -469,7 +471,7 @@ impl Wallet {
         ))
     }
 
-    pub fn update_counter(&mut self, counter: u32) {
+    pub fn update_counter(&mut self, counter: SpendingCounter) {
         if let Wallet::Account(account) = self {
             account.set_counter(counter)
         }

--- a/testing/mjolnir/src/mjolnir_app/fragment/batch/adversary/all.rs
+++ b/testing/mjolnir/src/mjolnir_app/fragment/batch/adversary/all.rs
@@ -66,7 +66,7 @@ impl AdversaryAll {
         let title = "adversary load transactions";
         let mut faucet = Wallet::import_account(
             self.faucet_key_file.clone(),
-            Some(self.faucet_spending_counter),
+            Some(self.faucet_spending_counter.into()),
         );
         let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
         builder.with_rest(self.endpoint.parse().unwrap());

--- a/testing/mjolnir/src/mjolnir_app/fragment/batch/adversary/votes_only.rs
+++ b/testing/mjolnir/src/mjolnir_app/fragment/batch/adversary/votes_only.rs
@@ -71,7 +71,7 @@ impl VotesOnly {
         let title = "adversary load transactions";
         let faucet = Wallet::import_account(
             self.faucet_key_file.clone(),
-            Some(self.faucet_spending_counter),
+            Some(self.faucet_spending_counter.into()),
         );
         let block0 = get_block(&self.block0_path)?;
         let vote_plans = block0.vote_plans();

--- a/testing/mjolnir/src/mjolnir_app/fragment/batch/tx_only.rs
+++ b/testing/mjolnir/src/mjolnir_app/fragment/batch/tx_only.rs
@@ -61,8 +61,10 @@ pub struct TxOnly {
 
 impl TxOnly {
     pub fn exec(&self) -> Result<(), MjolnirError> {
-        let mut faucet =
-            Wallet::import_account(&self.faucet_key_file, Some(self.faucet_spending_counter));
+        let mut faucet = Wallet::import_account(
+            &self.faucet_key_file,
+            Some(self.faucet_spending_counter.into()),
+        );
         let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
         builder.with_rest(self.endpoint.parse().unwrap());
         let remote_jormungandr = builder.build();

--- a/testing/mjolnir/src/mjolnir_app/fragment/standard/adversary/all.rs
+++ b/testing/mjolnir/src/mjolnir_app/fragment/standard/adversary/all.rs
@@ -67,7 +67,7 @@ impl AllAdversary {
         let title = "adversary load transactions";
         let mut faucet = Wallet::import_account(
             self.faucet_key_file.clone(),
-            Some(self.faucet_spending_counter),
+            Some(self.faucet_spending_counter.into()),
         );
         let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
         builder.with_rest(self.endpoint.parse().unwrap());

--- a/testing/mjolnir/src/mjolnir_app/fragment/standard/adversary/votes_only.rs
+++ b/testing/mjolnir/src/mjolnir_app/fragment/standard/adversary/votes_only.rs
@@ -71,7 +71,7 @@ impl VotesOnly {
         let title = "adversary load transactions";
         let faucet = Wallet::import_account(
             self.faucet_key_file.clone(),
-            Some(self.faucet_spending_counter),
+            Some(self.faucet_spending_counter.into()),
         );
         let block0 = get_block(&self.block0_path)?;
         let vote_plans = block0.vote_plans();

--- a/testing/mjolnir/src/mjolnir_app/fragment/standard/all.rs
+++ b/testing/mjolnir/src/mjolnir_app/fragment/standard/all.rs
@@ -73,8 +73,10 @@ pub struct AllFragments {
 impl AllFragments {
     pub fn exec(&self) -> Result<(), MjolnirError> {
         let title = "all fragment load test";
-        let faucet =
-            Wallet::import_account(&self.faucet_key_file, Some(self.faucet_spending_counter));
+        let faucet = Wallet::import_account(
+            &self.faucet_key_file,
+            Some(self.faucet_spending_counter.into()),
+        );
         let receiver = startup::create_new_account_address();
         let mut builder = RemoteJormungandrBuilder::new("node".to_string());
         builder.with_rest(self.endpoint.parse().unwrap());

--- a/testing/mjolnir/src/mjolnir_app/fragment/standard/tx_only.rs
+++ b/testing/mjolnir/src/mjolnir_app/fragment/standard/tx_only.rs
@@ -66,7 +66,7 @@ impl TxOnly {
         let title = "standard load only transactions";
         let mut faucet = Wallet::import_account(
             self.faucet_key_file.clone(),
-            Some(self.faucet_spending_counter),
+            Some(self.faucet_spending_counter.into()),
         );
         let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
         builder.with_rest(self.endpoint.parse().unwrap());


### PR DESCRIPTION
Add jcli option to specify a spending counter lane in a user-friendly way.

I've also added basic parallel spending counter capability to tests, while still using lane 0 as the default in the test wallet.

I wanted to add tests to ensure the new command is working but I've noticed witness tests are not even compiled right now and have fallen behind. Will fix this and add tests for this command in another PR