### PR TITLE
Fix network setup - remove auto adding all nodes as leaders

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/block.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/block.rs
@@ -66,11 +66,11 @@ fn block_with_wrong_leader() {
     const LEADER_1: &str = "Abbott";
     const LEADER_2: &str = "Costello";
 
-    let mut blockchain_config = Blockchain::default();
-    blockchain_config.set_consensus(ConsensusVersion::Bft);
-    blockchain_config.set_slot_duration(SlotDuration::new(10).unwrap());
-    blockchain_config.add_leader(LEADER_1);
-    blockchain_config.add_leader(LEADER_2);
+    let blockchain_config = Blockchain::default()
+        .with_consensus(ConsensusVersion::Bft)
+        .with_slot_duration(SlotDuration::new(10).unwrap())
+        .with_leader(LEADER_1)
+        .with_leader(LEADER_2);
 
     let mut controller = NetworkBuilder::default()
         .blockchain_config(blockchain_config)

--- a/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
@@ -510,6 +510,7 @@ fn pending_transaction_stats() {
             Value(100_000),
             chain_addr::Discrimination::Test,
         ))
+        .blockchain_config(Blockchain::default().with_leader(LEADER))
         .wallet_template(WalletTemplate::new_account(
             BOB,
             Value(100_000),
@@ -571,10 +572,11 @@ fn avg_block_size_stats() {
     const STABILITY_SLOTS: usize = 3; // Number of slots we expect `block_content_size_avg` to stay the same for
     let linear_fee = LinearFee::new(0, 0, 0);
 
-    let mut blockchain = Blockchain::default();
-    blockchain.set_slot_duration(SlotDuration::new(SLOT_DURATION_SECS).unwrap());
-    blockchain.set_linear_fee(linear_fee);
-    blockchain.set_block_content_max_size(200.into()); // This should only fit one transaction
+    let blockchain = Blockchain::default()
+        .with_slot_duration(SlotDuration::new(SLOT_DURATION_SECS).unwrap())
+        .with_linear_fee(linear_fee)
+        .with_leader(LEADER)
+        .with_block_content_max_size(200.into()); // This should only fit one transaction
 
     let mut controller = NetworkBuilder::default()
         .blockchain_config(blockchain)

--- a/testing/jormungandr-integration-tests/src/networking/communication.rs
+++ b/testing/jormungandr-integration-tests/src/networking/communication.rs
@@ -1,3 +1,4 @@
+use jormungandr_testing_utils::testing::network::Blockchain;
 use jormungandr_testing_utils::testing::network::{
     builder::NetworkBuilder, wallet::template::builder::WalletTemplateBuilder,
 };
@@ -18,6 +19,7 @@ pub fn two_nodes_communication() {
                 .with_node(Node::new(LEADER))
                 .with_node(Node::new(PASSIVE).with_trusted_peer(LEADER)),
         )
+        .blockchain_config(Blockchain::default().with_leader(LEADER))
         .wallet_template(
             WalletTemplateBuilder::new(ALICE)
                 .with(1_000_000)

--- a/testing/jormungandr-integration-tests/src/networking/mod.rs
+++ b/testing/jormungandr-integration-tests/src/networking/mod.rs
@@ -1,4 +1,3 @@
 pub mod communication;
 pub mod p2p;
-pub mod stats;
 pub mod testnet;

--- a/testing/jormungandr-integration-tests/src/networking/p2p.rs
+++ b/testing/jormungandr-integration-tests/src/networking/p2p.rs
@@ -600,6 +600,11 @@ fn max_bootstrap_attempts() {
                 .with_node(Node::new(SERVER))
                 .with_node(Node::new(CLIENT).with_trusted_peer(SERVER)),
         )
+        .blockchain_config(
+            Blockchain::default()
+                .with_leader(SERVER)
+                .with_leader(CLIENT),
+        )
         .build()
         .unwrap();
 

--- a/testing/jormungandr-integration-tests/src/networking/p2p.rs
+++ b/testing/jormungandr-integration-tests/src/networking/p2p.rs
@@ -1,3 +1,4 @@
+use jormungandr_testing_utils::testing::network::Blockchain;
 use jormungandr_testing_utils::testing::{
     jormungandr::process::JormungandrProcess,
     network::{
@@ -130,6 +131,11 @@ pub fn node_whitelist_itself() {
                 .with_node(Node::new(SERVER))
                 .with_node(Node::new(CLIENT).with_trusted_peer(SERVER)),
         )
+        .blockchain_config(
+            Blockchain::default()
+                .with_leader(SERVER)
+                .with_leader(CLIENT),
+        )
         .wallet_template(
             WalletTemplateBuilder::new(ALICE)
                 .with(1_000_000)
@@ -170,6 +176,11 @@ pub fn node_does_not_quarantine_whitelisted_node() {
             Topology::default()
                 .with_node(Node::new(SERVER))
                 .with_node(Node::new(CLIENT).with_trusted_peer(SERVER)),
+        )
+        .blockchain_config(
+            Blockchain::default()
+                .with_leader(SERVER)
+                .with_leader(CLIENT),
         )
         .wallet_template(
             WalletTemplateBuilder::new(ALICE)
@@ -225,6 +236,11 @@ pub fn node_put_in_quarantine_nodes_which_are_not_whitelisted() {
                 .with_node(Node::new(SERVER))
                 .with_node(Node::new(CLIENT).with_trusted_peer(SERVER)),
         )
+        .blockchain_config(
+            Blockchain::default()
+                .with_leader(SERVER)
+                .with_leader(CLIENT),
+        )
         .wallet_template(
             WalletTemplateBuilder::new(ALICE)
                 .with(1_000_000)
@@ -276,6 +292,11 @@ pub fn node_does_not_quarantine_trusted_node() {
                 .with_node(Node::new(SERVER))
                 .with_node(Node::new(CLIENT).with_trusted_peer(SERVER)),
         )
+        .blockchain_config(
+            Blockchain::default()
+                .with_leader(SERVER)
+                .with_leader(CLIENT),
+        )
         .wallet_template(
             WalletTemplateBuilder::new(ALICE)
                 .with(1_000_000)
@@ -318,6 +339,11 @@ pub fn node_trust_itself() {
             Topology::default()
                 .with_node(Node::new(SERVER))
                 .with_node(Node::new(CLIENT).with_trusted_peer(SERVER)),
+        )
+        .blockchain_config(
+            Blockchain::default()
+                .with_leader(SERVER)
+                .with_leader(CLIENT),
         )
         .wallet_template(
             WalletTemplateBuilder::new(ALICE)
@@ -362,6 +388,11 @@ fn gossip_interval() {
             Topology::default()
                 .with_node(Node::new(SERVER))
                 .with_node(Node::new(CLIENT).with_trusted_peer(SERVER)),
+        )
+        .blockchain_config(
+            Blockchain::default()
+                .with_leader(SERVER)
+                .with_leader(CLIENT),
         )
         .wallet_template(
             WalletTemplateBuilder::new(ALICE)
@@ -423,6 +454,11 @@ fn network_stuck_check() {
                 .with_node(Node::new(SERVER))
                 .with_node(Node::new(CLIENT).with_trusted_peer(SERVER)),
         )
+        .blockchain_config(
+            Blockchain::default()
+                .with_leader(SERVER)
+                .with_leader(CLIENT),
+        )
         .build()
         .unwrap();
 
@@ -473,6 +509,12 @@ pub fn topics_of_interest_influences_node_sync_ability() {
                 .with_node(Node::new(SERVER))
                 .with_node(Node::new(FAST_CLIENT).with_trusted_peer(SERVER))
                 .with_node(Node::new(SLOW_CLIENT).with_trusted_peer(SERVER)),
+        )
+        .blockchain_config(
+            Blockchain::default()
+                .with_leader(SERVER)
+                .with_leader(FAST_CLIENT)
+                .with_leader(SLOW_CLIENT),
         )
         .wallet_template(
             WalletTemplateBuilder::new(ALICE)

--- a/testing/jormungandr-scenario-tests/src/scenario/mod.rs
+++ b/testing/jormungandr-scenario-tests/src/scenario/mod.rs
@@ -97,15 +97,15 @@ macro_rules! prepare_scenario {
         )*
         builder = builder.topology(topology);
 
-        let mut blockchain = crate::scenario::Blockchain::default();
-        blockchain.set_consensus(crate::scenario::ConsensusVersion::$blockchain_consensus);
-        blockchain.set_consensus_genesis_praos_active_slot_coeff(crate::scenario::ActiveSlotCoefficient::new(crate::scenario::Milli::from_millis(700)).unwrap());
-        blockchain.set_slots_per_epoch(crate::scenario::NumberOfSlotsPerEpoch::new($slots_per_epoch).unwrap());
-        blockchain.set_slot_duration(crate::scenario::SlotDuration::new($slot_duration).unwrap());
+        let mut blockchain = crate::scenario::Blockchain::default()
+            .with_consensus(crate::scenario::ConsensusVersion::$blockchain_consensus)
+            .with_consensus_genesis_praos_active_slot_coeff(crate::scenario::ActiveSlotCoefficient::new(crate::scenario::Milli::from_millis(700)).unwrap())
+            .with_slots_per_epoch(crate::scenario::NumberOfSlotsPerEpoch::new($slots_per_epoch).unwrap())
+            .with_slot_duration(crate::scenario::SlotDuration::new($slot_duration).unwrap());
 
         $(
             let node_leader = $node_leader.to_owned();
-            blockchain.add_leader(node_leader);
+            blockchain = blockchain.with_leader(node_leader);
         )*
 
         $(
@@ -140,7 +140,7 @@ macro_rules! prepare_scenario {
                     panic!("unknown wallet type");
                 }
             };
-            blockchain.add_wallet(wallet);
+            blockchain = blockchain.with_wallet(wallet);
         )*
 
         $(

--- a/testing/jormungandr-scenario-tests/src/test/network/real.rs
+++ b/testing/jormungandr-scenario-tests/src/test/network/real.rs
@@ -48,17 +48,17 @@ fn prepare_real_scenario(
     let mut builder = ControllerBuilder::new(title);
     let mut topology = Topology::default().with_node(Node::new(CORE_NODE));
 
-    let mut blockchain = Blockchain::default();
-    blockchain.set_consensus(consensus);
-    blockchain.set_slot_duration(SlotDuration::new(1).unwrap());
-    blockchain.set_consensus_genesis_praos_active_slot_coeff(
-        ActiveSlotCoefficient::new(Milli::from_millis(700)).unwrap(),
-    );
+    let mut blockchain = Blockchain::default()
+        .with_consensus(consensus)
+        .with_slot_duration(SlotDuration::new(1).unwrap())
+        .with_consensus_genesis_praos_active_slot_coeff(
+            ActiveSlotCoefficient::new(Milli::from_millis(700)).unwrap(),
+        );
 
     for i in 0..relay_nodes_count {
         let relay_name = relay_name(i + 1);
         topology = topology.with_node(Node::new(&relay_name).with_trusted_peer(CORE_NODE));
-        blockchain.add_leader(relay_name);
+        blockchain = blockchain.with_leader(relay_name);
     }
 
     let mut leader_counter = 1;
@@ -71,7 +71,7 @@ fn prepare_real_scenario(
             let leader_name = leader_name(leader_counter);
             topology = topology.with_node(Node::new(&leader_name).with_trusted_peer(&relay_name));
 
-            blockchain.add_leader(leader_name);
+            blockchain = blockchain.with_leader(leader_name);
 
             leader_counter += 1;
         }
@@ -80,7 +80,7 @@ fn prepare_real_scenario(
             let legacy_name = legacy_name(legacy_nodes_counter);
             topology = topology.with_node(Node::new(&legacy_name).with_trusted_peer(&relay_name));
 
-            blockchain.add_leader(legacy_name);
+            blockchain = blockchain.with_leader(legacy_name);
 
             legacy_nodes_counter += 1;
         }
@@ -89,7 +89,7 @@ fn prepare_real_scenario(
     builder = builder.topology(topology);
 
     // adds all nodes as leaders
-    blockchain.add_leader(CORE_NODE);
+    blockchain = blockchain.with_leader(CORE_NODE);
 
     for i in 1..leader_counter {
         let initial_wallet_name = wallet_name(i);
@@ -99,7 +99,7 @@ fn prepare_real_scenario(
             blockchain.discrimination(),
         );
         *wallet.delegate_mut() = Some(leader_name(i).to_owned());
-        blockchain.add_wallet(wallet);
+        blockchain = blockchain.with_wallet(wallet);
     }
 
     for i in 1..legacy_nodes_counter {
@@ -110,7 +110,7 @@ fn prepare_real_scenario(
             blockchain.discrimination(),
         );
         *wallet.delegate_mut() = Some(legacy_name(i).to_owned());
-        blockchain.add_wallet(wallet);
+        blockchain = blockchain.with_wallet(wallet);
     }
 
     builder.blockchain(blockchain)

--- a/testing/jormungandr-testing-utils/src/testing/network/blockchain.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network/blockchain.rs
@@ -57,75 +57,91 @@ impl Blockchain {
         self.block0_date
     }
 
-    pub fn set_block0_date(&mut self, block0_date: SecondsSinceUnixEpoch) {
+    pub fn with_block0_date(mut self, block0_date: SecondsSinceUnixEpoch) -> Self {
         self.block0_date = block0_date;
+        self
     }
 
     pub fn block_content_max_size(&self) -> &BlockContentMaxSize {
         &self.block_content_max_size
     }
 
-    pub fn set_block_content_max_size(&mut self, block_content_max_size: BlockContentMaxSize) {
+    pub fn with_block_content_max_size(
+        mut self,
+        block_content_max_size: BlockContentMaxSize,
+    ) -> Self {
         self.block_content_max_size = block_content_max_size;
+        self
     }
 
     pub fn committees(&self) -> Vec<WalletAlias> {
         self.committees.clone()
     }
 
-    pub fn set_committes(&mut self, committees: Vec<WalletAlias>) {
+    pub fn with_committes(mut self, committees: Vec<WalletAlias>) -> Self {
         self.committees = committees;
+        self
     }
 
-    pub fn add_committee<S: Into<NodeAlias>>(&mut self, alias: S) {
+    pub fn with_committee<S: Into<NodeAlias>>(mut self, alias: S) -> Self {
         self.committees.push(alias.into());
+        self
     }
 
     pub fn consensus(&self) -> &ConsensusVersion {
         &self.consensus
     }
 
-    pub fn set_consensus(&mut self, consensus: ConsensusVersion) {
+    pub fn with_consensus(mut self, consensus: ConsensusVersion) -> Self {
         self.consensus = consensus;
+        self
     }
 
     pub fn consensus_genesis_praos_active_slot_coeff(&self) -> &ActiveSlotCoefficient {
         &self.consensus_genesis_praos_active_slot_coeff
     }
 
-    pub fn set_consensus_genesis_praos_active_slot_coeff(&mut self, coeff: ActiveSlotCoefficient) {
+    pub fn with_consensus_genesis_praos_active_slot_coeff(
+        mut self,
+        coeff: ActiveSlotCoefficient,
+    ) -> Self {
         self.consensus_genesis_praos_active_slot_coeff = coeff;
+        self
     }
 
     pub fn discrimination(&self) -> Discrimination {
         self.discrimination
     }
 
-    pub fn set_discrimination(&mut self, discrimination: Discrimination) {
+    pub fn with_discrimination(mut self, discrimination: Discrimination) -> Self {
         self.discrimination = discrimination;
+        self
     }
 
     pub fn external_committees(&self) -> Vec<CommitteeIdDef> {
         self.external_committees.clone()
     }
 
-    pub fn set_external_committees(&mut self, external_committees: Vec<CommitteeIdDef>) {
+    pub fn with_external_committees(mut self, external_committees: Vec<CommitteeIdDef>) -> Self {
         self.external_committees = external_committees;
+        self
     }
 
-    pub fn add_external_committee(&mut self, committee: CommitteeIdDef) {
+    pub fn with_external_committee(mut self, committee: CommitteeIdDef) -> Self {
         self.external_committees.push(committee);
+        self
     }
 
     pub fn external_consensus_leader_ids(&self) -> Vec<ConsensusLeaderId> {
         self.external_consensus_leader_ids.clone()
     }
 
-    pub fn set_external_consensus_leader_ids(
-        &mut self,
+    pub fn with_external_consensus_leader_ids(
+        mut self,
         external_consensus_leader_ids: Vec<ConsensusLeaderId>,
-    ) {
+    ) -> Self {
         self.external_consensus_leader_ids = external_consensus_leader_ids;
+        self
     }
 
     pub fn has_external_consensus_leader_ids(&self) -> bool {
@@ -136,8 +152,9 @@ impl Blockchain {
         self.external_wallets.clone()
     }
 
-    pub fn set_external_wallets(&mut self, external_wallets: Vec<ExternalWalletTemplate>) {
+    pub fn with_external_wallets(mut self, external_wallets: Vec<ExternalWalletTemplate>) -> Self {
         self.external_wallets = external_wallets;
+        self
     }
 
     pub fn kes_update_speed(&self) -> &KesUpdateSpeed {
@@ -148,62 +165,69 @@ impl Blockchain {
         self.leaders.iter()
     }
 
-    pub fn add_leader<S: Into<NodeAlias>>(&mut self, alias: S) {
-        self.leaders.push(alias.into())
+    pub fn with_leader<S: Into<NodeAlias>>(mut self, alias: S) -> Self {
+        self.leaders.push(alias.into());
+        self
     }
 
     pub fn linear_fee(&self) -> LinearFee {
         self.linear_fee
     }
 
-    pub fn set_linear_fee(&mut self, linear_fee: LinearFee) {
+    pub fn with_linear_fee(mut self, linear_fee: LinearFee) -> Self {
         self.linear_fee = linear_fee;
+        self
     }
 
     pub fn slot_duration(&self) -> &SlotDuration {
         &self.slot_duration
     }
 
-    pub fn set_slot_duration(&mut self, slot_duration: SlotDuration) {
+    pub fn with_slot_duration(mut self, slot_duration: SlotDuration) -> Self {
         self.slot_duration = slot_duration;
+        self
     }
 
     pub fn slots_per_epoch(&self) -> &NumberOfSlotsPerEpoch {
         &self.slots_per_epoch
     }
 
-    pub fn set_slots_per_epoch(&mut self, slots_per_epoch: NumberOfSlotsPerEpoch) {
+    pub fn with_slots_per_epoch(mut self, slots_per_epoch: NumberOfSlotsPerEpoch) -> Self {
         self.slots_per_epoch = slots_per_epoch;
+        self
     }
 
     pub fn tx_max_expiry_epochs(&self) -> Option<u8> {
         self.tx_max_expiry_epochs
     }
 
-    pub fn set_tx_max_expiry_epochs(&mut self, tx_max_expiry_epochs: Option<u8>) {
+    pub fn with_tx_max_expiry_epochs(mut self, tx_max_expiry_epochs: Option<u8>) -> Self {
         self.tx_max_expiry_epochs = tx_max_expiry_epochs;
+        self
     }
 
     pub fn vote_plans(&self) -> HashMap<VotePlanKey, VotePlan> {
         self.vote_plans.clone()
     }
 
-    pub fn add_vote_plan(
-        &mut self,
+    pub fn with_vote_plan(
+        mut self,
         alias: String,
         owner_alias: String,
         vote_plan_template: VotePlan,
-    ) {
+    ) -> Self {
         self.vote_plans
             .insert(VotePlanKey { alias, owner_alias }, vote_plan_template);
+        self
     }
 
     pub fn wallets(&self) -> impl Iterator<Item = &WalletTemplate> {
         self.wallets.values()
     }
 
-    pub fn add_wallet(&mut self, wallet: WalletTemplate) {
+    pub fn with_wallet(mut self, wallet: WalletTemplate) -> Self {
         self.wallets.insert(wallet.alias().clone(), wallet);
+        self
     }
 }
 

--- a/testing/jormungandr-testing-utils/src/testing/network/builder.rs
+++ b/testing/jormungandr-testing-utils/src/testing/network/builder.rs
@@ -88,13 +88,8 @@ impl NetworkBuilder {
         let seed = Seed::generate(rand::rngs::OsRng);
         let mut random = Random::new(seed);
 
-        for alias in nodes.keys() {
-            let leader: NodeAlias = alias.into();
-            self.blockchain.add_leader(leader);
-        }
-
         for wallet in &self.wallet_templates {
-            self.blockchain.add_wallet(wallet.clone());
+            self.blockchain = self.blockchain.with_wallet(wallet.clone());
         }
 
         self.notify_all(Event::new("building block0.."));


### PR DESCRIPTION
I noticed that in jormungandr utils we are adding all knowns leaders to consensus_leader_ids settings in blockchain. I think this should be done in level above, because it can silently expand leaders count. I learnt that when testing update proposals and was suprised that i have 7 leaders (while i should have 3). Thus removing this code and we need to keep in mind that we should define leaders explicitly 