### PR TITLE
[Testing Utils][5/6] move adversary module to loki project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,6 +2040,7 @@ dependencies = [
  "jortestkit",
  "json",
  "lazy_static",
+ "loki",
  "mjolnir",
  "parity-multiaddr",
  "poldercast",
@@ -2296,12 +2297,18 @@ version = "0.1.0"
 dependencies = [
  "chain-addr",
  "chain-core",
+ "chain-crypto",
  "chain-impl-mockchain",
  "jormungandr-lib",
  "jormungandr-testing-utils",
+ "parity-multiaddr",
+ "reqwest",
+ "serde",
  "serde_yaml",
  "structopt",
  "thiserror",
+ "tokio",
+ "warp",
 ]
 
 [[package]]

--- a/testing/jormungandr-integration-tests/Cargo.toml
+++ b/testing/jormungandr-integration-tests/Cargo.toml
@@ -20,6 +20,7 @@ chain-time      = { git = "https://github.com/input-output-hk/chain-libs.git", b
 chain-vote      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 jormungandr-lib = { path = "../../jormungandr-lib" }
 hersir = { path = "../hersir" }
+loki = { path = "../loki" }
 mjolnir = { path = "../mjolnir" }
 jormungandr-testing-utils = { path = "../jormungandr-testing-utils" }
 jortestkit = { git = "https://github.com/input-output-hk/jortestkit.git", branch = "master" }

--- a/testing/jormungandr-integration-tests/src/jormungandr/bft/block.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/bft/block.rs
@@ -7,10 +7,10 @@ use chain_impl_mockchain::{
 use hersir::builder::{Blockchain, NetworkBuilder, Node, SpawnParams, Topology};
 use jormungandr_lib::interfaces::SlotDuration;
 use jormungandr_testing_utils::testing::{
-    adversary::{block::BlockBuilder, process::AdversaryNodeBuilder},
     jormungandr::{ConfigurationBuilder, Starter},
     startup, FragmentBuilder,
 };
+use loki::{block::BlockBuilder, process::AdversaryNodeBuilder};
 
 #[test]
 /// Ensures that blocks with an incorrect signature are rejected by a BFT leader node

--- a/testing/jormungandr-integration-tests/src/jormungandr/block.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/block.rs
@@ -7,10 +7,10 @@ use chain_impl_mockchain::{
 };
 use jormungandr_lib::interfaces::SlotDuration;
 use jormungandr_testing_utils::testing::{
-    adversary::process::AdversaryNodeBuilder,
     jormungandr::{ConfigurationBuilder, LeadershipMode, Starter},
     startup, Block0ConfigurationBuilder,
 };
+use loki::process::AdversaryNodeBuilder;
 
 #[test]
 fn bft_block_with_incorrect_hash() {

--- a/testing/jormungandr-testing-utils/src/testing/mod.rs
+++ b/testing/jormungandr-testing-utils/src/testing/mod.rs
@@ -1,4 +1,3 @@
-pub mod adversary;
 pub mod asserts;
 pub mod block0;
 pub mod configuration;

--- a/testing/loki/Cargo.toml
+++ b/testing/loki/Cargo.toml
@@ -8,10 +8,20 @@ edition = "2021"
 
 [dependencies]
 chain-addr      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
+chain-crypto    = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
 chain-core      = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 jormungandr-testing-utils = { path = "../jormungandr-testing-utils" }
 jormungandr-lib = { path = "../../jormungandr-lib" }
+tokio = { version = "1.4", features = ["macros","rt","rt-multi-thread"] }
+multiaddr = { package = "parity-multiaddr", version = "0.11" }
 serde_yaml = "0.8.21"
-structopt = "0.3.25"
+serde = { version = "1.0", features = ["derive"] }
+structopt = "0.3.23"
 thiserror = "1.0"
+warp = "0.3"
+
+[dependencies.reqwest]
+version = "0.11"
+default-features = false
+features = ["blocking", "json", "rustls-tls"]

--- a/testing/loki/src/block.rs
+++ b/testing/loki/src/block.rs
@@ -1,4 +1,3 @@
-use crate::testing::startup;
 use chain_crypto::Ed25519;
 use chain_impl_mockchain::{
     block::{builder, Block, BlockDate, BlockVersion, Contents, Header},
@@ -8,6 +7,7 @@ use chain_impl_mockchain::{
     testing::{data::StakePool, TestGen},
 };
 use jormungandr_lib::crypto::key::SigningKey;
+use jormungandr_testing_utils::testing::startup;
 
 pub struct BlockBuilder {
     block_date: BlockDate,

--- a/testing/loki/src/lib.rs
+++ b/testing/loki/src/lib.rs
@@ -1,5 +1,5 @@
+pub mod args;
 pub mod block;
+pub mod error;
 pub mod process;
 pub mod rest;
-
-pub use process::AdversaryNode;

--- a/testing/loki/src/main.rs
+++ b/testing/loki/src/main.rs
@@ -1,14 +1,7 @@
-mod args;
-mod error;
-
-use args::Args;
 use chain_core::property::Deserialize;
 use chain_impl_mockchain::block::Block;
-use error::Error;
 use jormungandr_lib::interfaces::NodeSecret;
-use jormungandr_testing_utils::testing::adversary::{
-    process::AdversaryNodeBuilder, rest::AdversaryRest,
-};
+use loki::{args::Args, error::Error, process::AdversaryNodeBuilder, rest::AdversaryRest};
 use std::{fs::File, io::BufReader};
 use structopt::StructOpt;
 

--- a/testing/loki/src/process.rs
+++ b/testing/loki/src/process.rs
@@ -1,13 +1,3 @@
-use crate::testing::jormungandr::TestingDirectory;
-use crate::testing::node::grpc::{
-    client::MockClientError,
-    server::{
-        start_thread, MockBuilder, MockController, MockServerData as NodeData, ProtocolVersion,
-    },
-    JormungandrClient,
-};
-use crate::testing::node::NodeAlias;
-use crate::testing::{utils, FragmentSender, FragmentSenderSetup, SyncNode};
 use ::multiaddr::{Multiaddr, Protocol};
 use chain_impl_mockchain::{
     block::{Block, BlockDate},
@@ -18,6 +8,16 @@ use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{Block0Configuration, TrustedPeer},
 };
+use jormungandr_testing_utils::testing::jormungandr::TestingDirectory;
+use jormungandr_testing_utils::testing::node::NodeAlias;
+use jormungandr_testing_utils::testing::node::grpc::{
+    client::MockClientError,
+    server::{
+        start_thread, MockBuilder, MockController, MockServerData as NodeData, ProtocolVersion,
+    },
+    JormungandrClient,
+};
+use jormungandr_testing_utils::testing::{utils, FragmentSender, FragmentSenderSetup, SyncNode};
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, RwLock};

--- a/testing/loki/src/process.rs
+++ b/testing/loki/src/process.rs
@@ -9,7 +9,6 @@ use jormungandr_lib::{
     interfaces::{Block0Configuration, TrustedPeer},
 };
 use jormungandr_testing_utils::testing::jormungandr::TestingDirectory;
-use jormungandr_testing_utils::testing::node::NodeAlias;
 use jormungandr_testing_utils::testing::node::grpc::{
     client::MockClientError,
     server::{
@@ -17,6 +16,7 @@ use jormungandr_testing_utils::testing::node::grpc::{
     },
     JormungandrClient,
 };
+use jormungandr_testing_utils::testing::node::NodeAlias;
 use jormungandr_testing_utils::testing::{utils, FragmentSender, FragmentSenderSetup, SyncNode};
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};

--- a/testing/loki/src/rest/handlers.rs
+++ b/testing/loki/src/rest/handlers.rs
@@ -1,8 +1,9 @@
-use crate::testing::{adversary::block::BlockBuilder, startup, FragmentBuilder};
+use crate::block::BlockBuilder;
 use chain_impl_mockchain::{
     block::{Block, BlockDate, ContentsBuilder},
     chaintypes::ConsensusType,
 };
+use jormungandr_testing_utils::testing::{startup, FragmentBuilder};
 use reqwest::StatusCode;
 use std::net::SocketAddr;
 use warp::{reply::WithStatus, Reply};

--- a/testing/loki/src/rest/mod.rs
+++ b/testing/loki/src/rest/mod.rs
@@ -1,9 +1,10 @@
 mod handlers;
 
-use crate::testing::{adversary::AdversaryNode, configuration::get_available_port};
+use crate::process::AdversaryNode;
 use chain_crypto::Ed25519;
 use chain_impl_mockchain::{block::Header, testing::data::StakePool};
 use jormungandr_lib::crypto::{hash::Hash, key::SigningKey};
+use jormungandr_testing_utils::testing::configuration::get_available_port;
 use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,


### PR DESCRIPTION
5th Step from plan in issue; #3716 . Move leftovers in jormungandr utils to loki. So there is a single point of responsibility and code location for adversary node