### PR TITLE
Improve tip update [catalyst-fund7]

### DIFF
--- a/jormungandr/src/blockchain/branch.rs
+++ b/jormungandr/src/blockchain/branch.rs
@@ -1,160 +1,25 @@
 use crate::blockchain::Ref;
-use futures::stream::{FuturesUnordered, StreamExt};
 use std::sync::Arc;
-use tokio::sync::RwLock;
-
-#[derive(Clone)]
-pub struct Branches {
-    inner: Arc<RwLock<BranchesData>>,
-}
-
-struct BranchesData {
-    branches: Vec<Branch>,
-}
-
-#[derive(Clone)]
-pub struct Branch {
-    inner: Arc<RwLock<BranchData>>,
-}
 
 /// the data that is contained in a branch
-struct BranchData {
+#[derive(Clone)]
+pub struct Branch {
     /// reference to the block where the branch points to
     reference: Arc<Ref>,
 }
 
-impl Default for Branches {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Branches {
-    pub fn new() -> Self {
-        Branches {
-            inner: Arc::new(RwLock::new(BranchesData {
-                branches: Vec::new(),
-            })),
-        }
-    }
-
-    pub async fn add(&mut self, branch: Branch) {
-        let mut guard = self.inner.write().await;
-        guard.add(branch);
-    }
-
-    pub async fn apply_or_create(&mut self, candidate: Arc<Ref>) -> Branch {
-        let maybe_branch = self.apply(Arc::clone(&candidate)).await;
-        match maybe_branch {
-            Some(branch) => branch,
-            None => {
-                let maybe_exists = self
-                    .branches()
-                    .await
-                    .into_iter()
-                    .find(|branch| branch.hash() == candidate.hash());
-
-                if let Some(branch) = maybe_exists {
-                    return Branch::new(branch);
-                }
-                self.create(candidate).await
-            }
-        }
-    }
-
-    pub async fn branches(&self) -> Vec<Arc<Ref>> {
-        let guard = self.inner.read().await;
-        guard.branches().await
-    }
-
-    async fn apply(&mut self, candidate: Arc<Ref>) -> Option<Branch> {
-        let mut guard = self.inner.write().await;
-        guard.apply(candidate).await
-    }
-
-    async fn create(&mut self, candidate: Arc<Ref>) -> Branch {
-        let branch = Branch::new(candidate);
-        self.add(branch.clone()).await;
-        branch
-    }
-}
-
-impl BranchesData {
-    fn add(&mut self, branch: Branch) {
-        self.branches.push(branch)
-    }
-
-    async fn apply(&mut self, candidate: Arc<Ref>) -> Option<Branch> {
-        let (value, _) = self
-            .branches
-            .iter_mut()
-            .map(|branch| branch.continue_with(Arc::clone(&candidate)))
-            .collect::<FuturesUnordered<_>>()
-            .filter_map(|updated| Box::pin(async move { updated }))
-            .into_future()
-            .await;
-        value
-    }
-
-    async fn branches(&self) -> Vec<Arc<Ref>> {
-        self.branches
-            .iter()
-            .map(|b| b.get_ref())
-            // this is done so that inner futures are only polled when they generate wake-up notifications
-            .collect::<FuturesUnordered<_>>()
-            .collect()
-            .await
-    }
-}
-
 impl Branch {
-    pub fn new(reference: Arc<Ref>) -> Self {
-        Branch {
-            inner: Arc::new(RwLock::new(BranchData::new(reference))),
-        }
-    }
-
-    pub async fn get_ref(&self) -> Arc<Ref> {
-        let guard = self.inner.read().await;
-        guard.reference()
-    }
-
-    pub async fn update_ref(&mut self, new_ref: Arc<Ref>) -> Arc<Ref> {
-        let mut guard = self.inner.write().await;
-        guard.update(new_ref)
-    }
-
-    async fn continue_with(&mut self, candidate: Arc<Ref>) -> Option<Self> {
-        let mut guard = self.inner.write().await;
-        if guard.continue_with(candidate) {
-            Some(self.clone())
-        } else {
-            None
-        }
-    }
-}
-
-impl BranchData {
     /// create the branch data with the current `last_updated` to
     /// the current time this function was called
-    fn new(reference: Arc<Ref>) -> Self {
-        BranchData { reference }
+    pub fn new(reference: Arc<Ref>) -> Self {
+        Branch { reference }
     }
 
-    fn update(&mut self, reference: Arc<Ref>) -> Arc<Ref> {
-        std::mem::replace(&mut self.reference, reference)
-    }
-
-    fn reference(&self) -> Arc<Ref> {
+    pub fn get_ref(&self) -> Arc<Ref> {
         Arc::clone(&self.reference)
     }
 
-    fn continue_with(&mut self, candidate: Arc<Ref>) -> bool {
-        if self.reference.hash() == candidate.block_parent_hash() {
-            let _parent = self.update(candidate);
-            true
-        } else {
-            false
-        }
+    pub fn into_ref(self) -> Arc<Ref> {
+        self.reference
     }
 }

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -29,7 +29,7 @@ use std::{sync::Arc, time::Duration};
 type PullHeadersScheduler = FireForgetScheduler<HeaderHash, Address, Checkpoints>;
 type GetNextBlockScheduler = FireForgetScheduler<HeaderHash, Address, ()>;
 
-const TIP_UPDATE_QUEUE_SIZE: usize = 5;
+const TIP_UPDATE_QUEUE_SIZE: usize = 10;
 
 const DEFAULT_TIMEOUT_PROCESS_LEADERSHIP: u64 = 5;
 const DEFAULT_TIMEOUT_PROCESS_ANNOUNCEMENT: u64 = 5;
@@ -399,7 +399,7 @@ async fn process_block_announcement(
         PreCheckedHeader::MissingParent { header, .. } => {
             tracing::debug!("block is missing a locally stored parent");
             let to = header.hash();
-            let from = blockchain.get_checkpoints(blockchain_tip.branch()).await;
+            let from = blockchain.get_checkpoints(&blockchain_tip.branch().await);
             pull_headers_scheduler
                 .schedule(to, node_id, from)
                 .unwrap_or_else(move |err| {

--- a/jormungandr/src/blockchain/storage.rs
+++ b/jormungandr/src/blockchain/storage.rs
@@ -107,6 +107,15 @@ impl Storage {
             .map_err(Into::into)
     }
 
+    pub fn get_branches(&self) -> Result<Vec<HeaderHash>, Error> {
+        Ok(self
+            .storage
+            .get_tips_ids()?
+            .into_iter()
+            .map(|branch| HeaderHash::deserialize(branch.as_ref()).map_err(Error::Deserialize))
+            .collect::<Result<Vec<_>, Error>>()?)
+    }
+
     pub fn get_blocks_by_chain_length(&self, chain_length: u32) -> Result<Vec<Block>, Error> {
         self.storage
             .get_blocks_by_chain_length(chain_length)

--- a/jormungandr/src/blockchain/tip.rs
+++ b/jormungandr/src/blockchain/tip.rs
@@ -10,15 +10,18 @@ use crate::{
 };
 use chain_core::property::{Block as _, Fragment as _};
 use chain_impl_mockchain::block::Block;
+use futures::prelude::*;
 use jormungandr_lib::interfaces::FragmentStatus;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use tokio::time::MissedTickBehavior;
-
-use futures::prelude::*;
+use tracing::instrument;
 
 use std::time::Duration;
 
-const BRANCH_REPROCESSING_INTERVAL: Duration = Duration::from_secs(60);
+// no point in updating again the tip if the old one was not processed
+const INTERNAL_TIP_UPDATE_QUEUE_SIZE: usize = 1;
+const BRANCH_REPROCESSING_INTERVAL: Duration = Duration::from_secs(120);
 
 /// Handles updates to the tip.
 /// Only one of this structs should be active at any given time.
@@ -48,17 +51,24 @@ impl TipUpdater {
         }
     }
 
-    pub async fn run(&mut self, mut input: MessageQueue<Arc<Ref>>) {
+    pub async fn run(&mut self, input: MessageQueue<Arc<Ref>>) {
         let mut reprocessing_interval = tokio::time::interval(BRANCH_REPROCESSING_INTERVAL);
         reprocessing_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        let (internal_mbox, internal_queue) = async_msg::channel(INTERNAL_TIP_UPDATE_QUEUE_SIZE);
+        let mut stream = futures::stream::select(input, internal_queue);
         loop {
             tokio::select! {
-                Some(candidate) = input.next() => {
+                Some(candidate) = stream.next() => {
                     self.process_new_ref(candidate).await.unwrap_or_else(|e| tracing::error!("could not process new ref:` {}", e))
                 }
 
                 _ = reprocessing_interval.tick() => {
-                    self.reprocess_tip().await.unwrap_or_else(|e| tracing::error!("could not reprocess tip:` {}", e))
+                    let current_tip = self.tip.get_ref().await;
+                    let blockchain = self.blockchain.clone();
+                    let mbox = internal_mbox.clone();
+                    // Spawn this in a new task so that it does not block updates to the tip
+                    tokio::spawn(Self::reprocess_tip(blockchain, current_tip, mbox));
                 }
 
             }
@@ -93,12 +103,7 @@ impl TipUpdater {
             .storage()
             .put_tag(MAIN_BRANCH_TAG, candidate_hash)?;
 
-        let branch = self
-            .blockchain
-            .branches_mut()
-            .apply_or_create(candidate)
-            .await;
-        self.tip.swap(branch).await;
+        self.tip.update_ref(candidate).await;
         Ok(())
     }
 
@@ -123,33 +128,28 @@ impl TipUpdater {
     /// process a new candidate block on top of the blockchain, this function may:
     ///
     /// * update the current tip if the candidate's parent is the current tip;
-    /// * update a branch if the candidate parent is that branch's tip;
-    /// * create a new branch if none of the above;
     ///
     /// If the current tip is not the one being updated we will then trigger
     /// chain selection after updating that other branch as it may be possible that
     /// this branch just became more interesting for the current consensus algorithm.
+    #[instrument(level = "debug", skip(self, candidate), fields(candidate = %candidate.header().description()))]
     pub async fn process_new_ref(&mut self, candidate: Arc<Ref>) -> Result<(), Error> {
         let candidate_hash = candidate.hash();
         let storage = self.blockchain.storage();
         let tip_ref = self.tip.get_ref().await;
-        let block = storage
-            .get(candidate_hash)?
-            .ok_or(storage::Error::BlockNotFound)?;
 
         match chain_selection::compare_against(storage, &tip_ref, &candidate) {
             ComparisonResult::PreferCurrent => {
                 tracing::info!(
-                    "create new branch with tip {} | current-tip {}",
+                    "rejecting candidate {} for the tip {}",
                     candidate.header().description(),
                     tip_ref.header().description(),
                 );
-                self.blockchain
-                    .branches_mut()
-                    .apply_or_create(candidate.clone())
-                    .await;
             }
             ComparisonResult::PreferCandidate => {
+                let block = storage
+                    .get(candidate_hash)?
+                    .ok_or(storage::Error::BlockNotFound)?;
                 let tip_hash = tip_ref.hash();
                 if tip_hash == candidate.block_parent_hash() {
                     tracing::info!(
@@ -202,52 +202,69 @@ impl TipUpdater {
         Ok(())
     }
 
-    /// this function will re-process the tip against the different branches
+    /// this function will re-process the tip against the different branches.
     /// this is because a branch may have become more interesting with time
     /// moving forward and branches may have been dismissed
-    async fn reprocess_tip(&mut self) -> Result<(), Error> {
-        let branches: Vec<Arc<Ref>> = self.blockchain.branches().branches().await;
-        let tip_as_ref = self.tip.get_ref().await;
+    #[instrument(level = "debug", skip_all, fields(current_tip = %tip.header().description()))]
+    async fn reprocess_tip(
+        blockchain: Blockchain,
+        tip: Arc<Ref>,
+        mut mbox: MessageBox<Arc<Ref>>,
+    ) -> Result<(), Error> {
+        use std::cmp::Ordering;
+        let branches = blockchain.branches().await?;
+        let storage = blockchain.storage();
 
-        let others = branches
-            .iter()
-            .filter(|r| !Arc::ptr_eq(r, &tip_as_ref))
-            .collect::<Vec<_>>();
+        let best_branch = branches.into_iter().map(Branch::into_ref).max_by(|a, b| {
+            match chain_selection::compare_against(storage, &a, &b) {
+                ComparisonResult::PreferCurrent => Ordering::Greater,
+                ComparisonResult::PreferCandidate => Ordering::Less,
+            }
+        });
 
-        for other in others {
-            self.process_new_ref(Arc::clone(other)).await?
+        if let Some(new_tip) = best_branch {
+            if !Arc::ptr_eq(&tip, &new_tip) {
+                tracing::info!(
+                    "branch reprocessing found {} as the new best tip",
+                    new_tip.header().description()
+                );
+                mbox.try_send(new_tip).unwrap_or_else(|e| {
+                    tracing::error!(
+                        "{}: unable to send reprocessed tip for update, is the node overloaded?",
+                        e
+                    )
+                });
+            } else {
+                tracing::debug!("reprocessing concluded, current tip is still the best branch");
+            }
+        } else {
+            tracing::warn!("no branches found in the storage");
         }
-
         Ok(())
     }
 }
 
 #[derive(Clone)]
 pub struct Tip {
-    branch: Branch,
+    branch: Arc<RwLock<Branch>>,
 }
 
 impl Tip {
     pub(super) fn new(branch: Branch) -> Self {
-        Tip { branch }
+        Tip {
+            branch: Arc::new(RwLock::new(branch)),
+        }
     }
 
     pub async fn get_ref(&self) -> Arc<Ref> {
-        self.branch.get_ref().await
+        self.branch.read().await.get_ref()
     }
 
-    async fn update_ref(&mut self, new_ref: Arc<Ref>) -> Arc<Ref> {
-        self.branch.update_ref(new_ref).await
+    async fn update_ref(&mut self, new_ref: Arc<Ref>) {
+        *self.branch.write().await = Branch::new(new_ref);
     }
 
-    async fn swap(&mut self, mut branch: Branch) {
-        let mut tip_branch = self.branch.clone();
-        let tr = self.branch.get_ref().await;
-        let br = branch.update_ref(tr).await;
-        tip_branch.update_ref(br).await;
-    }
-
-    pub fn branch(&self) -> &Branch {
-        &self.branch
+    pub async fn branch(&self) -> Branch {
+        (*self.branch.read().await).clone()
     }
 }

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -265,8 +265,8 @@ impl ExplorerDb {
             })
             .await?;
 
-        for branch in blockchain.branches().branches().await.iter() {
-            let mut hash = branch.hash();
+        for branch in blockchain.branches().await.map_err(Box::new)?.iter() {
+            let mut hash = branch.get_ref().hash();
             let mut blocks = vec![];
             loop {
                 if db.get_block(&hash).await.is_some() {

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -100,7 +100,7 @@ pub async fn bootstrap_from_peer(
             break Ok(());
         }
 
-        let checkpoints = blockchain.get_checkpoints(tip.branch()).await;
+        let checkpoints = blockchain.get_checkpoints(&tip.branch().await);
         let checkpoints = net_data::block::try_ids_from_iter(checkpoints).unwrap();
 
         let remote_tip = BlockId::try_from(remote_tip.as_ref()).unwrap();


### PR DESCRIPTION
Looking at the recent failures in the perf env, it seems like one of the problems is that reprocessing the tip takes a lot of time and the actual tip falls behind.

This happens for two reasons:
* **We maintain a list of branches at the node level in a best effort _non ideal_ way:** 
This can result in a lot of unnecessary branches (as in considering a branch a non-leaf block) in certain edge cases. As a consequence, the reprocessing step will have a lot of useless branches to consider.
In addition, `Branch` currently looks like it's meant to be updated and kept track of, but I argue this is not very useful. 
What does it mean to follow a branch? In the event of a fork, which path should it follow?
The only exception is to follow the tip, as diverging blocks can be discriminated precisely by means of the chain selection rule.

    I'm not sure why we handle it this way (and I'm to blame for this as well, as I did recent work on it), but the storage already keeps track of existing branches in a reliable way and I suggest to use that information.

* **Reprocessing the tip is done in the same loop as the standard tip update**.
To avoid blocking the loop, calculate the best branch in another task and only serialize this single ref as if it was coming from the blockchain

PS: Will need to port this to master as well