### PR TITLE
Improve tip update

### DIFF
--- a/jormungandr/src/blockchain/branch.rs
+++ b/jormungandr/src/blockchain/branch.rs
@@ -1,160 +1,25 @@
 use crate::blockchain::Ref;
-use futures::stream::{FuturesUnordered, StreamExt};
 use std::sync::Arc;
-use tokio::sync::RwLock;
-
-#[derive(Clone)]
-pub struct Branches {
-    inner: Arc<RwLock<BranchesData>>,
-}
-
-struct BranchesData {
-    branches: Vec<Branch>,
-}
-
-#[derive(Clone)]
-pub struct Branch {
-    inner: Arc<RwLock<BranchData>>,
-}
 
 /// the data that is contained in a branch
-struct BranchData {
+#[derive(Clone)]
+pub struct Branch {
     /// reference to the block where the branch points to
     reference: Arc<Ref>,
 }
 
-impl Default for Branches {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Branches {
-    pub fn new() -> Self {
-        Branches {
-            inner: Arc::new(RwLock::new(BranchesData {
-                branches: Vec::new(),
-            })),
-        }
-    }
-
-    pub async fn add(&mut self, branch: Branch) {
-        let mut guard = self.inner.write().await;
-        guard.add(branch);
-    }
-
-    pub async fn apply_or_create(&mut self, candidate: Arc<Ref>) -> Branch {
-        let maybe_branch = self.apply(Arc::clone(&candidate)).await;
-        match maybe_branch {
-            Some(branch) => branch,
-            None => {
-                let maybe_exists = self
-                    .branches()
-                    .await
-                    .into_iter()
-                    .find(|branch| branch.hash() == candidate.hash());
-
-                if let Some(branch) = maybe_exists {
-                    return Branch::new(branch);
-                }
-                self.create(candidate).await
-            }
-        }
-    }
-
-    pub async fn branches(&self) -> Vec<Arc<Ref>> {
-        let guard = self.inner.read().await;
-        guard.branches().await
-    }
-
-    async fn apply(&mut self, candidate: Arc<Ref>) -> Option<Branch> {
-        let mut guard = self.inner.write().await;
-        guard.apply(candidate).await
-    }
-
-    async fn create(&mut self, candidate: Arc<Ref>) -> Branch {
-        let branch = Branch::new(candidate);
-        self.add(branch.clone()).await;
-        branch
-    }
-}
-
-impl BranchesData {
-    fn add(&mut self, branch: Branch) {
-        self.branches.push(branch)
-    }
-
-    async fn apply(&mut self, candidate: Arc<Ref>) -> Option<Branch> {
-        let (value, _) = self
-            .branches
-            .iter_mut()
-            .map(|branch| branch.continue_with(Arc::clone(&candidate)))
-            .collect::<FuturesUnordered<_>>()
-            .filter_map(|updated| Box::pin(async move { updated }))
-            .into_future()
-            .await;
-        value
-    }
-
-    async fn branches(&self) -> Vec<Arc<Ref>> {
-        self.branches
-            .iter()
-            .map(|b| b.get_ref())
-            // this is done so that inner futures are only polled when they generate wake-up notifications
-            .collect::<FuturesUnordered<_>>()
-            .collect()
-            .await
-    }
-}
-
 impl Branch {
-    pub fn new(reference: Arc<Ref>) -> Self {
-        Branch {
-            inner: Arc::new(RwLock::new(BranchData::new(reference))),
-        }
-    }
-
-    pub async fn get_ref(&self) -> Arc<Ref> {
-        let guard = self.inner.read().await;
-        guard.reference()
-    }
-
-    pub async fn update_ref(&mut self, new_ref: Arc<Ref>) -> Arc<Ref> {
-        let mut guard = self.inner.write().await;
-        guard.update(new_ref)
-    }
-
-    async fn continue_with(&mut self, candidate: Arc<Ref>) -> Option<Self> {
-        let mut guard = self.inner.write().await;
-        if guard.continue_with(candidate) {
-            Some(self.clone())
-        } else {
-            None
-        }
-    }
-}
-
-impl BranchData {
     /// create the branch data with the current `last_updated` to
     /// the current time this function was called
-    fn new(reference: Arc<Ref>) -> Self {
-        BranchData { reference }
+    pub fn new(reference: Arc<Ref>) -> Self {
+        Branch { reference }
     }
 
-    fn update(&mut self, reference: Arc<Ref>) -> Arc<Ref> {
-        std::mem::replace(&mut self.reference, reference)
-    }
-
-    fn reference(&self) -> Arc<Ref> {
+    pub fn get_ref(&self) -> Arc<Ref> {
         Arc::clone(&self.reference)
     }
 
-    fn continue_with(&mut self, candidate: Arc<Ref>) -> bool {
-        if self.reference.hash() == candidate.block_parent_hash() {
-            let _parent = self.update(candidate);
-            true
-        } else {
-            false
-        }
+    pub fn into_ref(self) -> Arc<Ref> {
+        self.reference
     }
 }

--- a/jormungandr/src/blockchain/process.rs
+++ b/jormungandr/src/blockchain/process.rs
@@ -29,7 +29,7 @@ use std::{sync::Arc, time::Duration};
 type PullHeadersScheduler = FireForgetScheduler<HeaderHash, Address, Checkpoints>;
 type GetNextBlockScheduler = FireForgetScheduler<HeaderHash, Address, ()>;
 
-const TIP_UPDATE_QUEUE_SIZE: usize = 5;
+const TIP_UPDATE_QUEUE_SIZE: usize = 10;
 
 const DEFAULT_TIMEOUT_PROCESS_LEADERSHIP: u64 = 5;
 const DEFAULT_TIMEOUT_PROCESS_ANNOUNCEMENT: u64 = 5;
@@ -416,7 +416,7 @@ async fn process_block_announcement(
         PreCheckedHeader::MissingParent { header, .. } => {
             tracing::debug!("block is missing a locally stored parent");
             let to = header.hash();
-            let from = blockchain.get_checkpoints(blockchain_tip.branch()).await;
+            let from = blockchain.get_checkpoints(&blockchain_tip.branch().await);
             pull_headers_scheduler
                 .schedule(to, node_id, from)
                 .unwrap_or_else(move |err| {

--- a/jormungandr/src/blockchain/storage.rs
+++ b/jormungandr/src/blockchain/storage.rs
@@ -107,6 +107,15 @@ impl Storage {
             .map_err(Into::into)
     }
 
+    pub fn get_branches(&self) -> Result<Vec<HeaderHash>, Error> {
+        Ok(self
+            .storage
+            .get_tips_ids()?
+            .into_iter()
+            .map(|branch| HeaderHash::deserialize(branch.as_ref()).map_err(Error::Deserialize))
+            .collect::<Result<Vec<_>, Error>>()?)
+    }
+
     pub fn get_blocks_by_chain_length(&self, chain_length: u32) -> Result<Vec<Block>, Error> {
         self.storage
             .get_blocks_by_chain_length(chain_length)

--- a/jormungandr/src/blockchain/storage.rs
+++ b/jormungandr/src/blockchain/storage.rs
@@ -108,12 +108,11 @@ impl Storage {
     }
 
     pub fn get_branches(&self) -> Result<Vec<HeaderHash>, Error> {
-        Ok(self
-            .storage
+        self.storage
             .get_tips_ids()?
             .into_iter()
             .map(|branch| HeaderHash::deserialize(branch.as_ref()).map_err(Error::Deserialize))
-            .collect::<Result<Vec<_>, Error>>()?)
+            .collect::<Result<Vec<_>, Error>>()
     }
 
     pub fn get_blocks_by_chain_length(&self, chain_length: u32) -> Result<Vec<Block>, Error> {

--- a/jormungandr/src/blockchain/tip.rs
+++ b/jormungandr/src/blockchain/tip.rs
@@ -230,7 +230,7 @@ impl TipUpdater {
         let storage = blockchain.storage();
 
         let best_branch = branches.into_iter().map(Branch::into_ref).max_by(|a, b| {
-            match chain_selection::compare_against(storage, &a, &b) {
+            match chain_selection::compare_against(storage, a, b) {
                 ComparisonResult::PreferCurrent => Ordering::Greater,
                 ComparisonResult::PreferCandidate => Ordering::Less,
             }

--- a/jormungandr/src/explorer/mod.rs
+++ b/jormungandr/src/explorer/mod.rs
@@ -265,8 +265,8 @@ impl ExplorerDb {
             })
             .await?;
 
-        for branch in blockchain.branches().branches().await.iter() {
-            let mut hash = branch.hash();
+        for branch in blockchain.branches().await.map_err(Box::new)?.iter() {
+            let mut hash = branch.get_ref().hash();
             let mut blocks = vec![];
             loop {
                 if db.get_block(&hash).await.is_some() {

--- a/jormungandr/src/network/bootstrap.rs
+++ b/jormungandr/src/network/bootstrap.rs
@@ -100,7 +100,7 @@ pub async fn bootstrap_from_peer(
             break Ok(());
         }
 
-        let checkpoints = blockchain.get_checkpoints(tip.branch()).await;
+        let checkpoints = blockchain.get_checkpoints(&tip.branch().await);
         let checkpoints = net_data::block::try_ids_from_iter(checkpoints).unwrap();
 
         let remote_tip = BlockId::try_from(remote_tip.as_ref()).unwrap();


### PR DESCRIPTION
Port of https://github.com/input-output-hk/jormungandr/pull/3740 to master


Looking at the recent failures in the perf env, it seems like one of the problems is that reprocessing the tip takes a lot of time and the actual tip falls behind.

This happens for two reasons:
* We maintain a list of branches at the node level in a best effort non ideal way:
    This can result in a lot of unnecessary branches (as in considering a branch a non-leaf block) in certain edge cases. As a consequence, the reprocessing step will have a lot of useless branches to consider.
    In addition, Branch currently looks like it's meant to be updated and kept track of, but I argue this is not very useful.
    What does it mean to follow a branch? In the event of a fork, which path should it follow?
    The only exception is to follow the tip, as diverging blocks can be discriminated precisely by means of the chain selection rule.
    I'm not sure why we handle it this way (and I'm to blame for this as well, as I did recent work on it), but the storage already keeps track of existing branches in a reliable way and I suggest to use that information.
* Reprocessing the tip is done in the same loop as the standard tip update.
    To avoid blocking the loop, calculate the best branch in another task and only serialize this single ref as if it was coming from the blockchain
