### PR TITLE
ignore retire_stake_pool_explorer until fix is provided

### DIFF
--- a/testing/jormungandr-integration-tests/src/networking/stake_pool/retire.rs
+++ b/testing/jormungandr-integration-tests/src/networking/stake_pool/retire.rs
@@ -18,7 +18,10 @@ const BOB: &str = "BOB";
 const CLARICE: &str = "CLARICE";
 const DAVID: &str = "DAVID";
 
+// FIX: there's a bug in our current handling of stake pool retirement
+// re-enable this test once we fix that
 #[test]
+#[ignore]
 pub fn retire_stake_pool_explorer() {
     let mut controller = NetworkBuilder::default()
         .topology(


### PR DESCRIPTION
The fix is going to take a while and we haven't committed to that yet. Disable the test in the meantime so that our CI is not polluted