### PR TITLE
hersir: add defined_vote_plans to MonitorController

### DIFF
--- a/testing/hersir/src/controller/monitor/mod.rs
+++ b/testing/hersir/src/controller/monitor/mod.rs
@@ -9,6 +9,7 @@ use crate::style;
 use crate::utils::Dotifier;
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
+use chain_impl_mockchain::testing::scenario::template::VotePlanDef;
 use indicatif::{MultiProgress, ProgressBar};
 use jormungandr_automation::jormungandr::LeadershipMode;
 use jormungandr_automation::jormungandr::PersistenceMode;
@@ -174,6 +175,10 @@ impl MonitorController {
 
     pub fn settings(&self) -> &Settings {
         self.inner.settings()
+    }
+
+    pub fn defined_vote_plans(&self) -> Vec<VotePlanDef> {
+        self.inner.defined_vote_plans()
     }
 
     pub fn context(&self) -> &Context {


### PR DESCRIPTION
I think this is needed too, at least if what I did already in https://github.com/input-output-hk/vit-testing/pull/161 is indeed correct.