### PR TITLE
update load metrics to use percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Add CORS config params: allowed headers and allowed methods.
 - Update REST API `/api/v0/account/{account_id}`, add new field with the token's state info.
 - Vote tally now uses the token in the voteplan instead of the native currency.
+- Remove `txPendingCnt` metric and related field in `node/stats`
+- Rename `txPendingTotalSize` to `mempoolTotalSize`
+- Add `mempoolUsageRatio` metric and related field in `node/stats` to track load on the mempool.
+- Change `blockContentSizeAvg` to represent information as a percentage of the block max size.
 
 ## Release 0.13.0
 

--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -631,9 +631,10 @@ paths:
                     type: string
                     format: date-time
                   blockContentSizeAvg:
-                    description: 'Moving average of the last 3 blocks size'
-                    type: integer
+                    description: 'Moving average of the last 3 blocks size as percentage of the block max size'
+                    type: number
                     minimum: 0
+                    maximum: 1
                   peerAvailableCnt:
                     description: Number of nodes that are available for p2p discovery and events propagation
                     type: integer
@@ -664,10 +665,11 @@ paths:
                     description: Number of transactions received by node
                     type: integer
                     minimum: 0
-                  txPending:
-                    description: Number of pending transactions in the mempool
-                    type: integer
+                  mempoolUsageRatio:
+                    description: Usage ratio of the mempool on a scale from 0 to 1
+                    type: number
                     minimum: 0
+                    maximum: 1
                   txPendingTotalSize:
                     description: Total size of pending transactions in the mempool
                     type: integer

--- a/jormungandr-lib/src/interfaces/stats.rs
+++ b/jormungandr-lib/src/interfaces/stats.rs
@@ -1,7 +1,7 @@
 use crate::time::SystemTime;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NodeStatsDto {
     pub version: String,
@@ -10,7 +10,7 @@ pub struct NodeStatsDto {
     pub stats: Option<NodeStats>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct NodeStats {
     pub block_recv_cnt: u64,
@@ -23,14 +23,14 @@ pub struct NodeStats {
     pub last_block_time: Option<SystemTime>,
     pub last_block_tx: u64,
     pub last_received_block_time: Option<SystemTime>,
-    pub block_content_size_avg: u32,
+    pub block_content_size_avg: f64,
     pub peer_available_cnt: usize,
     pub peer_connected_cnt: usize,
     pub peer_quarantined_cnt: usize,
     pub peer_total_cnt: usize,
     pub tx_recv_cnt: u64,
-    pub tx_pending: u64,
-    pub tx_pending_total_size: u64,
+    pub mempool_usage_ratio: f64,
+    pub mempool_total_size: u64,
     pub tx_rejected_cnt: u64,
     pub votes_cast: u64,
     pub uptime: Option<u64>,

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -310,9 +310,15 @@ impl Pool {
     }
 
     fn update_metrics(&self) {
-        self.metrics.set_tx_pending_cnt(self.pool.len());
+        let mempool_usage_ratio = match self.pool.max_entries() {
+            // a little arbitrary, but you could say the mempool is indeed full and it
+            // does not required any special logic somewhere else
+            0 => 1.0,
+            n => self.pool.len() as f64 / n as f64,
+        };
+        self.metrics.set_mempool_usage_ratio(mempool_usage_ratio);
         self.metrics
-            .set_tx_pending_total_size(self.pool.total_size_bytes());
+            .set_mempool_total_size(self.pool.total_size_bytes());
     }
 }
 
@@ -666,6 +672,10 @@ pub(super) mod internal {
 
         pub fn total_size_bytes(&self) -> usize {
             self.total_size_bytes
+        }
+
+        pub fn max_entries(&self) -> usize {
+            self.max_entries
         }
     }
 

--- a/jormungandr/src/metrics/backends/prometheus_exporter.rs
+++ b/jormungandr/src/metrics/backends/prometheus_exporter.rs
@@ -192,7 +192,6 @@ impl MetricsBackend for Prometheus {
     }
 
     fn set_mempool_usage_ratio(&self, ratio: f64) {
-        let ratio = ratio.try_into().unwrap();
         self.mempool_usage_ratio.set(ratio);
     }
 

--- a/jormungandr/src/metrics/backends/prometheus_exporter.rs
+++ b/jormungandr/src/metrics/backends/prometheus_exporter.rs
@@ -20,8 +20,8 @@ pub struct Prometheus {
 
     tx_recv_cnt: IntCounter,
     tx_rejected_cnt: IntCounter,
-    tx_pending_cnt: UIntGauge,
-    tx_pending_size_bytes_total: UIntGauge,
+    mempool_usage_ratio: Gauge,
+    mempool_size_bytes_total: UIntGauge,
     votes_casted_cnt: IntCounter,
     block_recv_cnt: IntCounter,
     peer_connected_cnt: UIntGauge,
@@ -79,12 +79,14 @@ impl Default for Prometheus {
 
         let tx_recv_cnt = IntCounter::new("txRecvCnt", "txRecvCnt").unwrap();
         registry.register(Box::new(tx_recv_cnt.clone())).unwrap();
-        let tx_pending_cnt = UIntGauge::new("txPending", "txPending").unwrap();
-        registry.register(Box::new(tx_pending_cnt.clone())).unwrap();
-        let tx_pending_size_bytes_total =
-            UIntGauge::new("txPendingSizeBytesTotal", "txPendingSizeBytesTotal").unwrap();
+        let mempool_usage_ratio = Gauge::new("mempoolUsageRatio", "mempoolUsageRatio").unwrap();
         registry
-            .register(Box::new(tx_pending_size_bytes_total.clone()))
+            .register(Box::new(mempool_usage_ratio.clone()))
+            .unwrap();
+        let mempool_size_bytes_total =
+            UIntGauge::new("mempoolSizeBytesTotal", "mempoolSizeBytesTotal").unwrap();
+        registry
+            .register(Box::new(mempool_size_bytes_total.clone()))
             .unwrap();
         let tx_rejected_cnt = IntCounter::new("txRejectedCnt", "txRejectedCnt").unwrap();
         registry
@@ -155,8 +157,8 @@ impl Default for Prometheus {
             registry,
             tx_recv_cnt,
             tx_rejected_cnt,
-            tx_pending_cnt,
-            tx_pending_size_bytes_total,
+            mempool_usage_ratio,
+            mempool_size_bytes_total,
             votes_casted_cnt,
             block_recv_cnt,
             peer_connected_cnt,
@@ -189,14 +191,14 @@ impl MetricsBackend for Prometheus {
         self.tx_rejected_cnt.inc_by(count);
     }
 
-    fn set_tx_pending_cnt(&self, count: usize) {
+    fn set_mempool_usage_ratio(&self, ratio: f64) {
         let count = count.try_into().unwrap();
-        self.tx_pending_cnt.set(count);
+        self.mempool_usage_ratio.set(count);
     }
 
-    fn set_tx_pending_total_size(&self, size: usize) {
+    fn set_mempool_total_size(&self, size: usize) {
         let size = size.try_into().unwrap();
-        self.tx_pending_size_bytes_total.set(size);
+        self.mempool_size_bytes_total.set(size);
     }
 
     fn add_block_recv_cnt(&self, count: usize) {

--- a/jormungandr/src/metrics/backends/prometheus_exporter.rs
+++ b/jormungandr/src/metrics/backends/prometheus_exporter.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 
 use arc_swap::ArcSwapOption;
 use prometheus::core::{AtomicU64, GenericGauge};
-use prometheus::{Encoder, IntCounter, Registry, TextEncoder};
+use prometheus::{Encoder, Gauge, IntCounter, Registry, TextEncoder};
 
 type UIntGauge = GenericGauge<AtomicU64>;
 
@@ -192,8 +192,8 @@ impl MetricsBackend for Prometheus {
     }
 
     fn set_mempool_usage_ratio(&self, ratio: f64) {
-        let count = count.try_into().unwrap();
-        self.mempool_usage_ratio.set(count);
+        let ratio = ratio.try_into().unwrap();
+        self.mempool_usage_ratio.set(ratio);
     }
 
     fn set_mempool_total_size(&self, size: usize) {

--- a/jormungandr/src/metrics/mod.rs
+++ b/jormungandr/src/metrics/mod.rs
@@ -9,8 +9,8 @@ pub mod backends;
 
 pub trait MetricsBackend {
     fn add_tx_recv_cnt(&self, count: usize);
-    fn set_tx_pending_cnt(&self, count: usize);
-    fn set_tx_pending_total_size(&self, size: usize);
+    fn set_mempool_usage_ratio(&self, ratio: f64);
+    fn set_mempool_total_size(&self, size: usize);
     fn add_tx_rejected_cnt(&self, count: usize);
     fn add_block_recv_cnt(&self, count: usize);
     fn add_peer_connected_cnt(&self, count: usize);
@@ -70,8 +70,8 @@ macro_rules! metrics_count_method {
 impl MetricsBackend for Metrics {
     metrics_count_method!(add_tx_recv_cnt);
     metrics_count_method!(add_tx_rejected_cnt);
-    metrics_count_method!(set_tx_pending_cnt);
-    metrics_count_method!(set_tx_pending_total_size);
+    metrics_method!(set_mempool_usage_ratio, f64);
+    metrics_count_method!(set_mempool_total_size);
     metrics_count_method!(add_block_recv_cnt);
     metrics_count_method!(add_peer_connected_cnt);
     metrics_count_method!(sub_peer_connected_cnt);

--- a/testing/jormungandr-automation/src/jormungandr/process.rs
+++ b/testing/jormungandr-automation/src/jormungandr/process.rs
@@ -171,6 +171,7 @@ impl JormungandrProcess {
             StartupVerificationMode::Rest => {
                 let output = self.rest().stats();
                 if let Err(err) = output {
+                    println!("{}", err);
                     return Err(StartupError::CannotGetRestStatus(err));
                 }
 

--- a/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
@@ -2,16 +2,13 @@ use assert_fs::{
     fixture::{PathChild, PathCreateDir},
     TempDir,
 };
-use chain_impl_mockchain::{
-    block::BlockDate, chaintypes::ConsensusVersion, fee::LinearFee, value::Value,
-};
+use chain_impl_mockchain::{block::BlockDate, chaintypes::ConsensusVersion, fee::LinearFee};
 use hersir::builder::wallet::template::builder::WalletTemplateBuilder;
 use hersir::builder::Blockchain;
 use hersir::builder::NetworkBuilder;
 use hersir::builder::Node;
 use hersir::builder::SpawnParams;
 use hersir::builder::Topology;
-use hersir::builder::WalletTemplate;
 use jormungandr_automation::jormungandr::FragmentNode;
 use jormungandr_lib::interfaces::{
     BlockDate as BlockDateDto, InitialUTxO, Mempool, PersistentLog, SlotDuration,
@@ -503,36 +500,30 @@ fn expired_fragment_should_be_rejected_by_passive_bft_node() {
 }
 
 #[test]
-/// Verifies `tx_pending` and `tx_pending_total_size` metrics reported by the node
+/// Verifies `tx_pending` and `mempool_total_size` metrics reported by the node
 fn pending_transaction_stats() {
-    const ALICE: &str = "Alice";
-    const BOB: &str = "Bob";
-    const LEADER: &str = "leader";
+    let bob = thor::Wallet::default();
+    let alice = thor::Wallet::default();
 
-    let mut controller = NetworkBuilder::default()
-        .topology(Topology::default().with_node(Node::new(LEADER)))
-        .wallet_template(WalletTemplate::new_account(
-            ALICE,
-            Value(100_000),
-            chain_addr::Discrimination::Test,
-        ))
-        .wallet_template(WalletTemplate::new_account(
-            BOB,
-            Value(100_000),
-            chain_addr::Discrimination::Test,
-        ))
-        .build()
-        .unwrap();
+    let mempool_max_entries = 1000;
 
-    let alice = controller.wallet(ALICE).unwrap();
-    let bob = controller.wallet(BOB).unwrap();
-
-    let leader = controller.spawn(SpawnParams::new(LEADER).leader()).unwrap();
+    let leader = startup::start_bft(
+        vec![&alice, &bob],
+        ConfigurationBuilder::new()
+            .with_block_content_max_size(256.into()) // This should only fit 1 transaction
+            .with_mempool(Mempool {
+                pool_max_entries: mempool_max_entries.into(),
+                log_max_entries: mempool_max_entries.into(),
+                persistent_log: None,
+            })
+            .with_log_level("debug".into()),
+    )
+    .unwrap();
 
     let stats = leader.rest().stats().unwrap().stats.unwrap();
 
-    assert_eq!(stats.tx_pending, 0);
-    assert_eq!(stats.tx_pending_total_size, 0);
+    assert_eq!(stats.mempool_usage_ratio, 0.0);
+    assert_eq!(stats.mempool_total_size, 0);
 
     let fragment_builder = FragmentBuilder::new(
         &leader.genesis_block_hash(),
@@ -561,8 +552,11 @@ fn pending_transaction_stats() {
         let stats = leader.rest().stats().unwrap().stats.unwrap();
 
         assert!(status.is_pending());
-        assert_eq!(pending_cnt, stats.tx_pending);
-        assert_eq!(pending_size, stats.tx_pending_total_size as usize);
+        assert_eq!(
+            pending_cnt as f64 / mempool_max_entries as f64,
+            stats.mempool_usage_ratio
+        );
+        assert_eq!(pending_size, stats.mempool_total_size as usize);
     }
 }
 

--- a/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/mempool.rs
@@ -516,7 +516,8 @@ fn pending_transaction_stats() {
                 log_max_entries: mempool_max_entries.into(),
                 persistent_log: None,
             })
-            .with_log_level("debug".into()),
+            .with_log_level("debug".into())
+            .with_slot_duration(30),
     )
     .unwrap();
 


### PR DESCRIPTION
Display load indicators as percentage and rename them for ease of use:
* `txPendingCnt (usize)`  -> `mempoolUsageRatio (f64)` so you don't need to know how big the mempool is to judge load
* `txPendingTotalSize (usize)` -> `mempoolTotalSize (usize)`
* `blockContentSizeAvg (usize)` -> `blockContentSizeAvg (f64)` for the same reason
 