### PR TITLE
add token minting for ExternalWalletTemplate

### DIFF
--- a/jormungandr-lib/src/interfaces/mint_token.rs
+++ b/jormungandr-lib/src/interfaces/mint_token.rs
@@ -52,7 +52,7 @@ impl<'de> Deserialize<'de> for TokenName {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Hash, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TokenIdentifier(identifier::TokenIdentifier);
 
 impl From<identifier::TokenIdentifier> for TokenIdentifier {

--- a/jormungandr-lib/src/interfaces/mod.rs
+++ b/jormungandr-lib/src/interfaces/mod.rs
@@ -57,6 +57,7 @@ pub use self::fragments_processing_summary::{
 };
 pub use self::leadership_log::{LeadershipLog, LeadershipLogId, LeadershipLogStatus};
 pub use self::linear_fee::{LinearFeeDef, PerCertificateFeeDef, PerVoteCertificateFeeDef};
+pub use self::mint_token::TokenIdentifier;
 pub use self::old_address::OldAddress;
 pub use self::peer_stats::{PeerRecord, PeerStats, Subscription};
 pub use self::ratio::{ParseRatioError, Ratio};

--- a/testing/hersir/src/builder/wallet/template/external.rs
+++ b/testing/hersir/src/builder/wallet/template/external.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
+
 use chain_impl_mockchain::value::Value;
-use jormungandr_lib::interfaces::ValueDef;
+use jormungandr_lib::interfaces::{TokenIdentifier, ValueDef};
 use serde::Deserialize;
 use thor::WalletAlias;
 
@@ -11,15 +13,22 @@ pub struct ExternalWalletTemplate {
     address: String,
     #[serde(with = "ValueDef")]
     value: Value,
+    tokens: HashMap<TokenIdentifier, u64>,
 }
 
 impl ExternalWalletTemplate {
     #[inline]
-    pub fn new<S: Into<WalletAlias>>(alias: S, value: Value, address: String) -> Self {
+    pub fn new<S: Into<WalletAlias>>(
+        alias: S,
+        value: Value,
+        address: String,
+        tokens: HashMap<TokenIdentifier, u64>,
+    ) -> Self {
         Self {
             alias: alias.into(),
             value,
             address,
+            tokens,
         }
     }
 
@@ -29,6 +38,10 @@ impl ExternalWalletTemplate {
 
     pub fn address(&self) -> &str {
         &self.address
+    }
+
+    pub fn tokens(&self) -> &HashMap<TokenIdentifier, u64> {
+        &self.tokens
     }
 
     pub fn alias(&self) -> WalletAlias {


### PR DESCRIPTION
since the block0 snapshot is built with this code, it's necessary to be able to set tokens for `ExternalWalletTemplate`.

it may be better to group all addresses by token (since `to` is a `Vec<Destination>`), but I'm actually not sure it makes any difference in the final binary.