### PR TITLE
Revert "rename max_client_connections"

### DIFF
--- a/doc/configuration/network.md
+++ b/doc/configuration/network.md
@@ -102,7 +102,7 @@ Use the CA certificate with `jcli`.
     typical settings for a non mining node: `"normal"`. For a stakepool: `"high"`.
 - `max_connections`: the maximum number of P2P connections this node should
     maintain. If not specified, an internal limit is used by default `[default: 256]`
-- `max_inbound_connections`: the maximum number of client P2P connections this
+- `max_client_connections`: the maximum number of client P2P connections this
     node should keep open. `[default: 192]`
 - `policy`: (optional) set the setting for the policy module
   - `quarantine_duration` set the time to leave a node in quarantine before allowing

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -214,8 +214,8 @@ impl GlobalState {
     // established
     fn num_clients_to_bump(&self) -> usize {
         let count = self.client_count().saturating_add(1);
-        if count > self.config.max_inbound_connections {
-            count - self.config.max_inbound_connections
+        if count > self.config.max_client_connections {
+            count - self.config.max_client_connections
         } else {
             0
         }

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -89,8 +89,7 @@ pub struct P2pConfig {
 
     /// Limit on the number of simultaneous client connections.
     /// If not specified, an internal default limit is used.
-    #[serde(alias = "max_client_connections")]
-    pub max_inbound_connections: Option<usize>,
+    pub max_client_connections: Option<usize>,
 
     /// This setting is not used and is left for backward compatibility.
     pub max_connections_threshold: Option<usize>,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -347,9 +347,9 @@ fn generate_network(
         max_connections: p2p
             .max_connections
             .unwrap_or(network::DEFAULT_MAX_CONNECTIONS),
-        max_inbound_connections: p2p
-            .max_inbound_connections
-            .unwrap_or(network::DEFAULT_MAX_INBOUND_CONNECTIONS),
+        max_client_connections: p2p
+            .max_client_connections
+            .unwrap_or(network::DEFAULT_MAX_CLIENT_CONNECTIONS),
         timeout: std::time::Duration::from_secs(15),
         allow_private_addresses: p2p.allow_private_addresses,
         gossip_interval: p2p
@@ -366,13 +366,13 @@ fn generate_network(
         skip_bootstrap,
     };
 
-    if network.max_inbound_connections > network.max_connections {
+    if network.max_client_connections > network.max_connections {
         tracing::warn!(
-            "p2p.max_inbound_connections is larger than p2p.max_connections, decreasing from {} to {}",
-            network.max_inbound_connections,
+            "p2p.max_client_connections is larger than p2p.max_connections, decreasing from {} to {}",
+            network.max_client_connections,
             network.max_connections
         );
-        network.max_inbound_connections = network.max_connections;
+        network.max_client_connections = network.max_connections;
     }
 
     Ok(network)

--- a/jormungandr/src/settings/start/network.rs
+++ b/jormungandr/src/settings/start/network.rs
@@ -45,7 +45,7 @@ pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
 
 /// The limit on the number of simultaneous P2P client connections
 /// used unless the corresponding configuration option is specified.
-pub const DEFAULT_MAX_INBOUND_CONNECTIONS: usize = 192;
+pub const DEFAULT_MAX_CLIENT_CONNECTIONS: usize = 192;
 
 /// The default timeout for connections
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -74,7 +74,7 @@ pub struct Configuration {
     pub max_connections: usize,
 
     /// Maximum allowed number of client connections.
-    pub max_inbound_connections: usize,
+    pub max_client_connections: usize,
 
     /// the default value for the timeout for inactive connection
     pub timeout: Duration,


### PR DESCRIPTION
This is a bit confusing. I find the current name for this option misleading and the old one more representative, but apparently it was changed for the same reason (i.e make the name more reflective of what it does) in https://github.com/input-output-hk/jormungandr/pull/1960 and this is simply a revert of that commit.

Speaking with Dariusz it seemed like we might be interested in this option, so I'm simply renaming it here.

Please comment if you have any other solution or missing piece of information.