### PR TITLE
refactor RemoteJormungandrBuilder move from &mut Self -> Self

### DIFF
--- a/testing/jormungandr-automation/src/jormungandr/process.rs
+++ b/testing/jormungandr-automation/src/jormungandr/process.rs
@@ -317,9 +317,9 @@ impl JormungandrProcess {
     }
 
     pub fn to_remote(&self) -> RemoteJormungandr {
-        let mut builder = RemoteJormungandrBuilder::new(self.alias.clone());
-        builder.with_rest(self.rest_socket_addr);
-        builder.build()
+        RemoteJormungandrBuilder::new(self.alias.clone())
+            .with_rest(self.rest_socket_addr)
+            .build()
     }
 
     pub fn steal_temp_dir(&mut self) -> Option<TestingDirectory> {

--- a/testing/jormungandr-automation/src/jormungandr/remote.rs
+++ b/testing/jormungandr-automation/src/jormungandr/remote.rs
@@ -175,35 +175,32 @@ impl RemoteJormungandrBuilder {
         }
     }
 
-    pub fn from_config(&mut self, node_config_path: PathBuf) -> &mut Self {
-        self.with_node_config(node_config_path);
+    pub fn from_config(mut self, node_config_path: PathBuf) -> Self {
+        self = self.with_node_config(node_config_path);
         let node_config = self.node_config.clone().unwrap();
 
         let rest_address = node_config.rest.listen;
-        self.with_rest(rest_address);
-
         let grpc_address = node_config.p2p.get_listen_addr().unwrap();
-        self.with_grpc(grpc_address.to_string());
-
-        self
+        self.with_rest(rest_address)
+            .with_grpc(grpc_address.to_string())
     }
 
-    pub fn with_rest(&mut self, address: SocketAddr) -> &mut Self {
+    pub fn with_rest(mut self, address: SocketAddr) -> Self {
         self.rest = Some(JormungandrRest::new(uri_from_socket_addr(address)));
         self
     }
 
-    pub fn with_grpc<S: Into<String>>(&mut self, address: S) -> &mut Self {
+    pub fn with_grpc<S: Into<String>>(mut self, address: S) -> Self {
         self.grpc = Some(JormungandrClient::from_address(&address.into()).unwrap());
         self
     }
 
-    pub fn with_logger(&mut self, mut process: Child) -> &mut Self {
+    pub fn with_logger(mut self, mut process: Child) -> Self {
         self.logger = Some(JormungandrLogger::new(process.stdout.take().unwrap()));
         self
     }
 
-    pub fn with_node_config(&mut self, node_config: PathBuf) -> &mut Self {
+    pub fn with_node_config(mut self, node_config: PathBuf) -> Self {
         self.node_config =
             Some(serde_yaml::from_str(&jortestkit::file::read_file(node_config)).unwrap());
         self

--- a/testing/jormungandr-automation/src/jormungandr/rest/mod.rs
+++ b/testing/jormungandr-automation/src/jormungandr/rest/mod.rs
@@ -66,6 +66,10 @@ impl JormungandrRest {
         }
     }
 
+    pub fn address(&self) -> String {
+        self.raw().uri()
+    }
+
     pub fn disable_logger(&mut self) {
         self.inner.disable_logger();
     }

--- a/testing/jormungandr-automation/src/jormungandr/rest/raw.rs
+++ b/testing/jormungandr-automation/src/jormungandr/rest/raw.rs
@@ -68,6 +68,10 @@ impl RawRest {
         }
     }
 
+    pub fn uri(&self) -> String {
+        self.uri.clone()
+    }
+
     pub fn rest_settings(&self) -> &RestSettings {
         &self.settings
     }

--- a/testing/mjolnir/src/mjolnir_lib/fragment/batch/adversary/all.rs
+++ b/testing/mjolnir/src/mjolnir_lib/fragment/batch/adversary/all.rs
@@ -65,9 +65,9 @@ impl AdversaryAll {
             self.faucet_key_file.clone(),
             Some(self.faucet_spending_counter.into()),
         );
-        let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
-        builder.with_rest(self.endpoint.parse().unwrap());
-        let remote_jormungandr = builder.build();
+        let remote_jormungandr = RemoteJormungandrBuilder::new("node".to_owned())
+            .with_rest(self.endpoint.parse().unwrap())
+            .build();
 
         let settings = remote_jormungandr.rest().settings().unwrap();
 

--- a/testing/mjolnir/src/mjolnir_lib/fragment/batch/adversary/votes_only.rs
+++ b/testing/mjolnir/src/mjolnir_lib/fragment/batch/adversary/votes_only.rs
@@ -74,9 +74,9 @@ impl VotesOnly {
         let block0 = get_block(&self.block0_path)?;
         let vote_plans = block0.vote_plans();
 
-        let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
-        builder.with_rest(self.endpoint.parse().unwrap());
-        let remote_jormungandr = builder.build();
+        let remote_jormungandr = RemoteJormungandrBuilder::new("node".to_owned())
+            .with_rest(self.endpoint.parse().unwrap())
+            .build();
 
         let settings = remote_jormungandr.rest().settings().unwrap();
 

--- a/testing/mjolnir/src/mjolnir_lib/fragment/batch/tx_only.rs
+++ b/testing/mjolnir/src/mjolnir_lib/fragment/batch/tx_only.rs
@@ -62,9 +62,9 @@ impl TxOnly {
             &self.faucet_key_file,
             Some(self.faucet_spending_counter.into()),
         );
-        let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
-        builder.with_rest(self.endpoint.parse().unwrap());
-        let remote_jormungandr = builder.build();
+        let remote_jormungandr = RemoteJormungandrBuilder::new("node".to_owned())
+            .with_rest(self.endpoint.parse().unwrap())
+            .build();
 
         let settings = remote_jormungandr.rest().settings().unwrap();
 
@@ -93,9 +93,9 @@ impl TxOnly {
             .shutdown_grace_period(Duration::from_secs(30))
             .build();
 
-        let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
-        builder.with_rest(self.endpoint.parse().unwrap());
-        let remote_jormungandr = builder.build();
+        let remote_jormungandr = RemoteJormungandrBuilder::new("node".to_owned())
+            .with_rest(self.endpoint.parse().unwrap())
+            .build();
         let status_provider = FragmentStatusProvider::new(remote_jormungandr);
 
         let stats =

--- a/testing/mjolnir/src/mjolnir_lib/fragment/standard/adversary/all.rs
+++ b/testing/mjolnir/src/mjolnir_lib/fragment/standard/adversary/all.rs
@@ -66,9 +66,9 @@ impl AllAdversary {
             self.faucet_key_file.clone(),
             Some(self.faucet_spending_counter.into()),
         );
-        let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
-        builder.with_rest(self.endpoint.parse().unwrap());
-        let remote_jormungandr = builder.build();
+        let remote_jormungandr = RemoteJormungandrBuilder::new("node".to_owned())
+            .with_rest(self.endpoint.parse().unwrap())
+            .build();
 
         let settings = remote_jormungandr.rest().settings().unwrap();
 

--- a/testing/mjolnir/src/mjolnir_lib/fragment/standard/adversary/votes_only.rs
+++ b/testing/mjolnir/src/mjolnir_lib/fragment/standard/adversary/votes_only.rs
@@ -72,9 +72,9 @@ impl VotesOnly {
         let block0 = get_block(&self.block0_path)?;
         let vote_plans = block0.vote_plans();
 
-        let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
-        builder.with_rest(self.endpoint.parse().unwrap());
-        let remote_jormungandr = builder.build();
+        let remote_jormungandr = RemoteJormungandrBuilder::new("node".to_owned())
+            .with_rest(self.endpoint.parse().unwrap())
+            .build();
 
         let settings = remote_jormungandr.rest().settings().unwrap();
 

--- a/testing/mjolnir/src/mjolnir_lib/fragment/standard/all.rs
+++ b/testing/mjolnir/src/mjolnir_lib/fragment/standard/all.rs
@@ -75,9 +75,9 @@ impl AllFragments {
             Some(self.faucet_spending_counter.into()),
         );
         let receiver = thor::Wallet::default();
-        let mut builder = RemoteJormungandrBuilder::new("node".to_string());
-        builder.with_rest(self.endpoint.parse().unwrap());
-        let remote_jormungandr = builder.build();
+        let remote_jormungandr = RemoteJormungandrBuilder::new("node".to_string())
+            .with_rest(self.endpoint.parse().unwrap())
+            .build();
 
         let rest = remote_jormungandr.rest().clone();
         let settings = rest.settings().unwrap();
@@ -133,9 +133,9 @@ impl AllFragments {
             .monitor(build_monitor(&self.progress_bar_mode))
             .shutdown_grace_period(Duration::from_secs(30))
             .build();
-        let mut builder = RemoteJormungandrBuilder::new("node".to_string());
-        builder.with_rest(self.endpoint.parse().unwrap());
-        let remote_jormungandr = builder.build();
+        let remote_jormungandr = RemoteJormungandrBuilder::new("node".to_string())
+            .with_rest(self.endpoint.parse().unwrap())
+            .build();
         let fragment_status_provider = FragmentStatusProvider::new(remote_jormungandr);
 
         let stats =

--- a/testing/mjolnir/src/mjolnir_lib/fragment/standard/tx_only.rs
+++ b/testing/mjolnir/src/mjolnir_lib/fragment/standard/tx_only.rs
@@ -64,9 +64,9 @@ impl TxOnly {
             self.faucet_key_file.clone(),
             Some(self.faucet_spending_counter.into()),
         );
-        let mut builder = RemoteJormungandrBuilder::new("node".to_owned());
-        builder.with_rest(self.endpoint.parse().unwrap());
-        let remote_jormungandr = builder.build();
+        let remote_jormungandr = RemoteJormungandrBuilder::new("node".to_owned())
+            .with_rest(self.endpoint.parse().unwrap())
+            .build();
 
         let settings = remote_jormungandr.rest().settings().unwrap();
 


### PR DESCRIPTION
Small refactoring for RemoteJormungandrBuilder. Migrated for not very convenient usage of builder methods:

`fn ___(&mut self, ...) -> &mut Self `

into 

`fn __(mut self) -> Self`