### PR TITLE
[Test] Stabilize grpc client tests

### DIFF
--- a/testing/jormungandr-integration-tests/src/jormungandr/grpc/setup.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/grpc/setup.rs
@@ -56,9 +56,8 @@ pub mod client {
         let server = Starter::new()
             .temp_dir(dir)
             .config(config.clone())
-            .start_async()
+            .start()
             .unwrap();
-        std::thread::sleep(Duration::from_secs(4));
         let attached_config = Config::attach_to_local_node(config.get_p2p_listen_port());
         let client = attached_config.client();
         let watch_client = attached_config.watch_client();


### PR DESCRIPTION
An attempt to stabilize two problematic tests. Increased slot duration to decrease block production rate. Added fail-over for tip hash comparison and decreased number of iterations. Also i think that start_async is not needed as we wait 4 seconds any ways.