### PR TITLE
convert jormungandr to library crate + add criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
+ "futures",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -906,6 +907,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -2292,6 +2294,7 @@ dependencies = [
  "chain-storage",
  "chain-time",
  "chain-vote",
+ "criterion",
  "futures",
  "hex",
  "http-zipkin",

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -76,6 +76,12 @@ quickcheck_macros = "0.9"
 chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
 chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
 chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
+criterion = { version = "0.3", features = ["html_reports", "async_tokio"] }
+
+[[bench]]
+name = "rest_v0"
+harness = false
+
 
 [build-dependencies]
 versionisator = "1.0.2"

--- a/jormungandr/benches/rest_v0.rs
+++ b/jormungandr/benches/rest_v0.rs
@@ -1,0 +1,22 @@
+use criterion::black_box;
+use criterion::Criterion;
+use criterion::{criterion_group, criterion_main};
+use jormungandr::rest::v0::logic::get_message_logs;
+use jormungandr::rest::Context;
+use tokio::runtime::Runtime;
+
+fn tokio() -> Runtime {
+    Runtime::new().unwrap()
+}
+
+fn empty_context_get_message_logs(c: &mut Criterion) {
+    let context = Context::new();
+
+    c.bench_function("empty_context", |b| {
+        let f = || get_message_logs(black_box(&context));
+        b.to_async(tokio()).iter(f);
+    });
+}
+
+criterion_group!(benches, empty_context_get_message_logs);
+criterion_main!(benches);

--- a/jormungandr/src/bin/jormungandr.rs
+++ b/jormungandr/src/bin/jormungandr.rs
@@ -1,0 +1,3 @@
+fn main() {
+    jormungandr::main();
+}

--- a/jormungandr/src/lib.rs
+++ b/jormungandr/src/lib.rs
@@ -738,7 +738,8 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     })
 }
 
-fn main() {
+/// Main entrypoint for the `jormungandr` binary
+pub fn main() {
     use std::error::Error;
 
     if let Err(error) = start() {


### PR DESCRIPTION
Renames `jormungandr/src/main.rs` -> `lib.rs` to make public items available in integration tests (and benches)
Adds `jormungandr/src/bin/jormungandr.rs` to keep the binary target
Adds a preliminary benchmark for the rest endpoint in question. It's probably worth adding some transactions here as this test is currently pretty meaningless. I couldn't figure out how to generate a list of fake transactions