### PR TITLE
parallel spending counter in mjolnir

### DIFF
--- a/testing/mjolnir/src/mjolnir_lib/generators/batch_generator.rs
+++ b/testing/mjolnir/src/mjolnir_lib/generators/batch_generator.rs
@@ -85,7 +85,7 @@ impl<'a, S: SyncNode + Send> BatchFragmentGenerator<'a, S> {
                     self.split_marker = 1;
                 }
                 0
-            },
+            }
             i => i,
         }
     }

--- a/testing/mjolnir/src/mjolnir_lib/generators/batch_generator.rs
+++ b/testing/mjolnir/src/mjolnir_lib/generators/batch_generator.rs
@@ -1,5 +1,5 @@
-use chain_impl_mockchain::fragment::Fragment;
 use chain_impl_mockchain::fee::LinearFee;
+use chain_impl_mockchain::fragment::Fragment;
 use jormungandr_automation::jormungandr::RemoteJormungandr;
 use jormungandr_automation::testing::SyncNode;
 use jormungandr_lib::crypto::hash::Hash;

--- a/testing/mjolnir/src/mjolnir_lib/generators/batch_generator.rs
+++ b/testing/mjolnir/src/mjolnir_lib/generators/batch_generator.rs
@@ -1,5 +1,6 @@
-use chain_impl_mockchain::fee::LinearFee;
+use chain_impl_mockchain::accounting::account::SpendingCounterIncreasing;
 use chain_impl_mockchain::fragment::Fragment;
+use chain_impl_mockchain::{fee::LinearFee, testing::WitnessMode};
 use jormungandr_automation::jormungandr::RemoteJormungandr;
 use jormungandr_automation::testing::SyncNode;
 use jormungandr_lib::crypto::hash::Hash;
@@ -14,6 +15,7 @@ pub struct BatchFragmentGenerator<'a, S: SyncNode + Send> {
     fragment_sender: FragmentSender<'a, S>,
     rand: OsRng,
     split_marker: usize,
+    next_lane: usize,
     batch_size: u8,
 }
 
@@ -37,6 +39,7 @@ impl<'a, S: SyncNode + Send> BatchFragmentGenerator<'a, S> {
             rand: OsRng,
             jormungandr,
             split_marker: 0,
+            next_lane: 0,
             batch_size,
         }
     }
@@ -72,15 +75,23 @@ impl<'a, S: SyncNode + Send> BatchFragmentGenerator<'a, S> {
         self.wallets.append(&mut wallets);
     }
 
-    pub fn increment_split_marker(&mut self) {
-        self.split_marker += 1;
-        if self.split_marker >= self.wallets.len() - 1 {
-            self.split_marker = 1;
+    pub fn increment_split_markers(&mut self) {
+        self.next_lane += 1;
+        self.next_lane = match self.next_lane {
+            // If all lanes used, reset count and increment wallet
+            SpendingCounterIncreasing::LANES.. => {
+                self.split_marker += 1;
+                if self.split_marker >= self.wallets.len() - 1 {
+                    self.split_marker = 1;
+                }
+                0
+            },
+            i => i,
         }
     }
 
     pub fn generate_transaction(&mut self) -> Result<Fragment, RequestFailure> {
-        self.increment_split_marker();
+        self.increment_split_markers();
         let (senders, recievers) = self.wallets.split_at_mut(self.split_marker);
         let sender = senders.get_mut(senders.len() - 1).unwrap();
         let reciever = recievers.get(0).unwrap();
@@ -90,6 +101,9 @@ impl<'a, S: SyncNode + Send> BatchFragmentGenerator<'a, S> {
             &self.fragment_sender.fees(),
             self.fragment_sender.date(),
         )
+        .witness_mode(WitnessMode::Account {
+            lane: self.next_lane,
+        })
         .transaction(sender, reciever.address(), 1.into())
         .map_err(|e| RequestFailure::General(format!("{:?}", e)));
         sender.confirm_transaction();
@@ -144,6 +158,7 @@ impl<S: SyncNode + Send + Sync + Clone> RequestGenerator for BatchFragmentGenera
             fragment_sender: self.fragment_sender.clone(),
             rand: OsRng,
             split_marker: 1,
+            next_lane: 0,
             batch_size: self.batch_size(),
         };
         (self, Some(other))

--- a/testing/mjolnir/src/mjolnir_lib/generators/fragment_generator.rs
+++ b/testing/mjolnir/src/mjolnir_lib/generators/fragment_generator.rs
@@ -36,7 +36,6 @@ pub struct FragmentGenerator<'a, S: SyncNode + Send> {
     vote_plans_for_casting_count: usize,
 }
 
-
 impl<'a, S: SyncNode + Send> FragmentGenerator<'a, S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/testing/mjolnir/src/mjolnir_lib/generators/fragment_generator.rs
+++ b/testing/mjolnir/src/mjolnir_lib/generators/fragment_generator.rs
@@ -36,6 +36,7 @@ pub struct FragmentGenerator<'a, S: SyncNode + Send> {
     vote_plans_for_casting_count: usize,
 }
 
+
 impl<'a, S: SyncNode + Send> FragmentGenerator<'a, S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/testing/mjolnir/src/mjolnir_lib/generators/mod.rs
+++ b/testing/mjolnir/src/mjolnir_lib/generators/mod.rs
@@ -7,6 +7,7 @@ mod rest;
 mod status_provider;
 mod transaction_generator;
 mod vote_casts_generator;
+mod wallet_lane_iter;
 
 pub use adversary_generator::AdversaryFragmentGenerator;
 pub use adversary_vote_casts_generator::AdversaryVoteCastsGenerator;

--- a/testing/mjolnir/src/mjolnir_lib/generators/transaction_generator.rs
+++ b/testing/mjolnir/src/mjolnir_lib/generators/transaction_generator.rs
@@ -8,12 +8,14 @@ use rand_core::OsRng;
 use std::time::Instant;
 use thor::{BlockDateGenerator, FragmentSenderSetup};
 use thor::{FragmentSender, Wallet};
+
+use super::wallet_lane_iter::SplitLaneIter;
 pub struct TransactionGenerator<'a, S: SyncNode + Send> {
     wallets: Vec<Wallet>,
     jormungandr: RemoteJormungandr,
     fragment_sender: FragmentSender<'a, S>,
     rand: OsRng,
-    split_marker: usize,
+    split_lane: SplitLaneIter,
 }
 
 impl<'a, S: SyncNode + Send> TransactionGenerator<'a, S> {
@@ -34,7 +36,7 @@ impl<'a, S: SyncNode + Send> TransactionGenerator<'a, S> {
             ),
             rand: OsRng,
             jormungandr,
-            split_marker: 0,
+            split_lane: SplitLaneIter::new(),
         }
     }
 
@@ -69,21 +71,20 @@ impl<'a, S: SyncNode + Send> TransactionGenerator<'a, S> {
         self.wallets.append(&mut wallets);
     }
 
-    pub fn increment_split_marker(&mut self) {
-        self.split_marker += 1;
-        if self.split_marker >= self.wallets.len() - 1 {
-            self.split_marker = 1;
-        }
-    }
-
     pub fn send_transaction(&mut self) -> Result<FragmentId, RequestFailure> {
-        self.increment_split_marker();
-        let (senders, recievers) = self.wallets.split_at_mut(self.split_marker);
+        let (split_marker, witness_mode) = self.split_lane.next(self.wallets.len());
+        let (senders, recievers) = self.wallets.split_at_mut(split_marker);
         let sender = senders.get_mut(senders.len() - 1).unwrap();
         let reciever = recievers.get(0).unwrap();
 
         self.fragment_sender
-            .send_transaction(sender, reciever, &self.jormungandr, 1.into())
+            .send_transaction_with_witness_mode(
+                sender,
+                reciever.address(),
+                &self.jormungandr,
+                1.into(),
+                witness_mode,
+            )
             .map(|x| *x.fragment_id())
             .map_err(|e| RequestFailure::General(format!("{:?}", e)))
     }
@@ -110,7 +111,7 @@ impl<S: SyncNode + Send + Sync + Clone> RequestGenerator for TransactionGenerato
             jormungandr: self.jormungandr.clone_with_rest(),
             fragment_sender: self.fragment_sender.clone(),
             rand: OsRng,
-            split_marker: 1,
+            split_lane: SplitLaneIter::new(),
         };
         (self, Some(other))
     }

--- a/testing/mjolnir/src/mjolnir_lib/generators/wallet_lane_iter.rs
+++ b/testing/mjolnir/src/mjolnir_lib/generators/wallet_lane_iter.rs
@@ -1,0 +1,96 @@
+use chain_impl_mockchain::{accounting::account::SpendingCounterIncreasing, testing::WitnessMode};
+
+/// A wrapper for `Vec<Wallet>` that allows iteration over individual lanes of each wallet
+pub(super) struct SplitLaneIter {
+    split_marker: usize,
+    next_lane: usize,
+}
+
+impl SplitLaneIter {
+    pub fn new() -> Self {
+        Self {
+            split_marker: 1,
+            next_lane: 0,
+        }
+    }
+
+    /// Similar to `Iterator::next`, except it takes the length of the wallet vector each
+    /// iteration, since it can change
+    pub fn next(&mut self, wallet_count: usize) -> (usize, WitnessMode) {
+        self.next_lane += 1;
+        self.next_lane = match self.next_lane {
+            // If all lanes used, reset count and increment wallet
+            SpendingCounterIncreasing::LANES.. => {
+                self.split_marker += 1;
+                if self.split_marker >= wallet_count - 1 {
+                    self.split_marker = 1;
+                }
+                0
+            }
+            i => i,
+        };
+
+        (
+            self.split_marker,
+            WitnessMode::Account {
+                lane: self.next_lane,
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract_lane(mode: WitnessMode) -> usize {
+        match mode {
+            WitnessMode::Account { lane } => lane,
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn produces_elements_in_correct_order() {
+        let mut iter = SplitLaneIter {
+            next_lane: 0,
+            split_marker: 1,
+        };
+
+        let mut elements = vec![];
+        for _ in 0..24 {
+            let (index, mode) = iter.next(5);
+            elements.push((index, extract_lane(mode)));
+        }
+
+        assert_eq!(
+            elements,
+            vec![
+                (1, 1),
+                (1, 2),
+                (1, 3),
+                (1, 4),
+                (1, 5),
+                (1, 6),
+                (1, 7),
+                (2, 0),
+                (2, 1),
+                (2, 2),
+                (2, 3),
+                (2, 4),
+                (2, 5),
+                (2, 6),
+                (2, 7),
+                (3, 0),
+                (3, 1),
+                (3, 2),
+                (3, 3),
+                (3, 4),
+                (3, 5),
+                (3, 6),
+                (3, 7),
+                (1, 0),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Add parallel spending counter to mjolnir

It should cycle through the 8 lanes on a single wallet before moving onto the next wallet and repeating