### PR TITLE
Improve Nix "stuff"

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,17 @@
 version: 2
 updates:
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: '00:00'
+      timezone: UTC
+    open-pull-requests-limit: 10
+    commit-message:
+        prefix: "chore"
+        include: "scope"
+
   - package-ecosystem: cargo
     directory: '/'
     schedule:

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,19 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v8

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 book
 /target
 /vendor
+/result
 .idea/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ book
 /target
 /vendor
 /result
-.idea/
-.vscode/
+/.idea/
+/.vscode/
+/.direnv/
+/.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -15,13 +15,49 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647605581,
+        "narHash": "sha256-56AaI1Zqgxuu+b8o3RbQBP2wtdn3/mQ23eLnkxOtHm8=",
+        "owner": "yusdacra",
+        "repo": "naersk",
+        "rev": "7882e303c4904664194236c921365b4d6b86b9bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "ref": "feat/cargolock-git-deps",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637595801,
-        "narHash": "sha256-LkIMwVFKCuEqidaUdg8uxwpESAXjsPo4oCz3eJ7RaRw=",
+        "lastModified": 1647297614,
+        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "263ef4cc4146c9fab808085487438c625d4426a9",
+        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
         "type": "github"
       },
       "original": {
@@ -34,7 +70,30 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647397753,
+        "narHash": "sha256-Q8HjnWFj+Gdx4ElvBiF99xhhZpeGdn1OZsGzyOrg7+Y=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dcc7af39185159fb2b8356bacca0473804a5b90e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -30,6 +30,26 @@
         "type": "github"
       }
     },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646480205,
+        "narHash": "sha256-kekOlTlu45vuK2L9nq8iVN17V3sB0WWPqTTW3a2SQG0=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "naersk": {
       "inputs": {
         "nixpkgs": [
@@ -70,6 +90,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
         "naersk": "naersk",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.lock
+++ b/flake.lock
@@ -15,21 +15,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -87,28 +72,54 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "naersk": "naersk",
         "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1647397753,
-        "narHash": "sha256-Q8HjnWFj+Gdx4ElvBiF99xhhZpeGdn1OZsGzyOrg7+Y=",
+        "lastModified": 1647570584,
+        "narHash": "sha256-wQ/xUt2yU+ncx0JQMMQDcFoWLY2xo0Vo5CxIGuxMdmY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "dcc7af39185159fb2b8356bacca0473804a5b90e",
+        "rev": "00ac40d23ec331be4fd143b8cd3e9142e3bcbe9b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1637595801,
@@ -18,23 +33,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1624650440,
-        "narHash": "sha256-BIwYENLvbSTNYdyeVJihwi7G6bXVGrPNoOgvJ1Z1SlY=",
-        "owner": "kreisys",
-        "repo": "flake-utils",
-        "rev": "026014b92b548ef130a7aebc84a3894f791370fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kreisys",
-        "repo": "flake-utils",
-        "type": "github"
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -81,12 +81,21 @@
 
         mkPackage = name: let
           pkgCargo = readTOML ./${name}/Cargo.toml;
+          cargoOptions =
+            [
+              "--package"
+              name
+            ]
+            ++ (pkgs.lib.optionals (name == "jormungandr") [
+              "--features"
+              "prometheus-metrics"
+            ]);
         in
           naersk-lib.buildPackage {
             root = gitignore.lib.gitignoreSource self;
 
-            cargoBuildOptions = x: x ++ ["-p" name];
-            cargoTestOptions = x: x ++ ["-p" name];
+            cargoBuildOptions = x: x ++ cargoOptions;
+            cargoTestOptions = x: x ++ cargoOptions;
 
             PROTOC = "${pkgs.protobuf}/bin/protoc";
             PROTOC_INCLUDE = "${pkgs.protobuf}/include";

--- a/flake.nix
+++ b/flake.nix
@@ -1,147 +1,177 @@
 {
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    utils.url = "github:kreisys/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
 
-  nixConfig = {
-    extra-substituters = [
-      "https://hydra.iohk.io"
+  nixConfig.extra-substituters =
+    [ "https://hydra.iohk.io"
       "https://vit-ops.cachix.org"
     ];
-    extra-trusted-public-keys = [
-      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+  nixConfig.extra-trusted-public-keys =
+    [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "vit-ops.cachix.org-1:LY84nIKdW7g1cvhJ6LsupHmGtGcKAlUXo+l1KByoDho="
     ];
-  };
 
-  outputs = { self, nixpkgs, utils }:
-    let
-      workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-      inherit (workspaceCargo.workspace) members;
-    in utils.lib.simpleFlake {
-      inherit nixpkgs;
-      systems = [ "x86_64-linux" "aarch64-linux" ];
-      preOverlays = [ ];
-      overlay = final: prev:
-        let inherit (prev) lib;
-        in (lib.listToAttrs (lib.forEach members (member:
-          lib.nameValuePair member (prev.rustPlatform.buildRustPackage {
-            inherit ((builtins.fromTOML
-              (builtins.readFile (./. + "/${member}/Cargo.toml"))).package)
-              name version;
-            src = ./.;
-            cargoSha256 = "sha256-80AmXP6zBuWweQXtHt9c8K9WrhrigF+CRv0reAuMvbM=";
-            nativeBuildInputs = with final; [ pkg-config protobuf rustfmt ];
-            buildInputs = with final; [ openssl ];
-            PROTOC = "${final.protobuf}/bin/protoc";
-            PROTOC_INCLUDE = "${final.protobuf}/include";
-          })))) // {
-            jormungandr-entrypoint = let
-              script = final.writeShellScriptBin "entrypoint" ''
-                set -exuo pipefail
+  outputs = { self
+            , nixpkgs
+            , flake-utils
+            }:
+    flake-utils.lib.eachSystem
+      [ flake-utils.lib.system.x86_64-linux
+        flake-utils.lib.system.aarch64-linux
+      ]
+      (system: 
+        let
+          readTOML = file: builtins.fromTOML (builtins.readFile file);
+          workspaceCargo = readTOML ./Cargo.toml;
 
-                ulimit -n 1024
-
-                nodeConfig="$NOMAD_TASK_DIR/node-config.json"
-                runConfig="$NOMAD_TASK_DIR/running.json"
-                runYaml="$NOMAD_TASK_DIR/running.yaml"
-                name="jormungandr"
-
-                chmod u+rwx -R "$NOMAD_TASK_DIR" || true
-
-                function convert () {
-                  chmod u+rwx -R "$NOMAD_TASK_DIR" || true
-                  cp "$nodeConfig" "$runConfig"
-                  remarshal --if json --of yaml "$runConfig" > "$runYaml"
-                }
-
-                if [ "$RESET" = "true" ]; then
-                  echo "RESET is given, will start from scratch..."
-                  rm -rf "$STORAGE_DIR"
-                elif [ -d "$STORAGE_DIR" ]; then
-                  echo "$STORAGE_DIR found, not restoring from backup..."
-                else
-                  echo "$STORAGE_DIR not found, restoring backup..."
-
-                  restic restore latest \
-                    --verbose=5 \
-                    --no-lock \
-                    --tag "$NAMESPACE" \
-                    --target / \
-                  || echo "couldn't restore backup, continue startup procedure..."
-                fi
-
-                set +x
-                echo "waiting for $REQUIRED_PEER_COUNT peers"
-                until [ "$(jq -e -r '.p2p.trusted_peers | length' < "$nodeConfig" || echo 0)" -ge $REQUIRED_PEER_COUNT ]; do
-                  sleep 1
-                done
-                set -x
-
-                convert
-
-                if [ -n "$PRIVATE" ]; then
-                  echo "Running with node with secrets..."
-                  exec jormungandr \
-                    --storage "$STORAGE_DIR" \
-                    --config "$NOMAD_TASK_DIR/running.yaml" \
-                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
-                    --secret $NOMAD_SECRETS_DIR/bft-secret.yaml \
-                    "$@" || true
-                else
-                  echo "Running with follower node..."
-                  exec jormungandr \
-                    --storage "$STORAGE_DIR" \
-                    --config "$NOMAD_TASK_DIR/running.yaml" \
-                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
-                    "$@" || true
-                fi
-              '';
-            in final.symlinkJoin {
-              name = "entrypoint";
-              paths = with final; [
-                jormungandr
-                script
-
-                bashInteractive
-                coreutils
-                curl
-                diffutils
-                fd
-                findutils
-                gnugrep
-                gnused
-                htop
-                jormungandr
-                jq
-                lsof
-                netcat
-                procps
-                remarshal
-                restic
-                ripgrep
-                strace
-                tcpdump
-                tmux
-                tree
-                utillinux
-                vim
-                yq
-              ];
-            };
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (import rust-overlay) ];
           };
 
-      packages = { jormungandr, jcli, jormungandr-entrypoint }@pkgs: pkgs;
+          mkPackage = name:
+            let
+              pkgCargo = readTOML ./${name}/Cargo.toml;
+            in
+            1;
 
-      devShell =
-        { mkShell, rustc, cargo, pkg-config, openssl, protobuf, rustfmt }:
-        mkShell {
-          PROTOC = "${protobuf}/bin/protoc";
-          PROTOC_INCLUDE = "${protobuf}/include";
-          buildInputs = [ rustc cargo pkg-config openssl protobuf rustfmt ];
-        };
+        in rec {
+          packages =
+            builtins.listToAttrs
+              (builtins.map
+                (name: { inherit name; value = mkPackage name; })
+                workspaceCargo.workspace.members);
+        }
+      );
 
-      hydraJobs = { jormungandr, jcli, jormungandr-entrypoint }@pkgs: pkgs;
-    };
-}
+#    let
+#      workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+#      inherit (workspaceCargo.workspace) members;
+#    in flake-utils.lib.simpleFlake {
+#      inherit self nixpkgs;
+#      systems = [  ];
+#      preOverlays = [ ];
+#      overlay = final: prev:
+#        let inherit (prev) lib;
+#        in (lib.listToAttrs (lib.forEach members (member:
+#          lib.nameValuePair member (prev.rustPlatform.buildRustPackage {
+#            inherit ((builtins.fromTOML
+#              (builtins.readFile (./. + "/${member}/Cargo.toml"))).package)
+#              name version;
+#            src = ./.;
+#            cargoSha256 = "sha256-80AmXP6zBuWweQXtHt9c8K9WrhrigF+CRv0reAuMvbM=";
+#            nativeBuildInputs = with final; [ pkg-config protobuf rustfmt ];
+#            buildInputs = with final; [ openssl ];
+#            PROTOC = "${final.protobuf}/bin/protoc";
+#            PROTOC_INCLUDE = "${final.protobuf}/include";
+#          })))) // {
+#            jormungandr-entrypoint = let
+#              script = final.writeShellScriptBin "entrypoint" ''
+#                set -exuo pipefail
+#
+#                ulimit -n 1024
+#
+#                nodeConfig="$NOMAD_TASK_DIR/node-config.json"
+#                runConfig="$NOMAD_TASK_DIR/running.json"
+#                runYaml="$NOMAD_TASK_DIR/running.yaml"
+#                name="jormungandr"
+#
+#                chmod u+rwx -R "$NOMAD_TASK_DIR" || true
+#
+#                function convert () {
+#                  chmod u+rwx -R "$NOMAD_TASK_DIR" || true
+#                  cp "$nodeConfig" "$runConfig"
+#                  remarshal --if json --of yaml "$runConfig" > "$runYaml"
+#                }
+#
+#                if [ "$RESET" = "true" ]; then
+#                  echo "RESET is given, will start from scratch..."
+#                  rm -rf "$STORAGE_DIR"
+#                elif [ -d "$STORAGE_DIR" ]; then
+#                  echo "$STORAGE_DIR found, not restoring from backup..."
+#                else
+#                  echo "$STORAGE_DIR not found, restoring backup..."
+#
+#                  restic restore latest \
+#                    --verbose=5 \
+#                    --no-lock \
+#                    --tag "$NAMESPACE" \
+#                    --target / \
+#                  || echo "couldn't restore backup, continue startup procedure..."
+#                fi
+#
+#                set +x
+#                echo "waiting for $REQUIRED_PEER_COUNT peers"
+#                until [ "$(jq -e -r '.p2p.trusted_peers | length' < "$nodeConfig" || echo 0)" -ge $REQUIRED_PEER_COUNT ]; do
+#                  sleep 1
+#                done
+#                set -x
+#
+#                convert
+#
+#                if [ -n "$PRIVATE" ]; then
+#                  echo "Running with node with secrets..."
+#                  exec jormungandr \
+#                    --storage "$STORAGE_DIR" \
+#                    --config "$NOMAD_TASK_DIR/running.yaml" \
+#                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
+#                    --secret $NOMAD_SECRETS_DIR/bft-secret.yaml \
+#                    "$@" || true
+#                else
+#                  echo "Running with follower node..."
+#                  exec jormungandr \
+#                    --storage "$STORAGE_DIR" \
+#                    --config "$NOMAD_TASK_DIR/running.yaml" \
+#                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
+#                    "$@" || true
+#                fi
+#              '';
+#            in final.symlinkJoin {
+#              name = "entrypoint";
+#              paths = with final; [
+#                jormungandr
+#                script
+#
+#                bashInteractive
+#                coreutils
+#                curl
+#                diffutils
+#                fd
+#                findutils
+#                gnugrep
+#                gnused
+#                htop
+#                jormungandr
+#                jq
+#                lsof
+#                netcat
+#                procps
+#                remarshal
+#                restic
+#                ripgrep
+#                strace
+#                tcpdump
+#                tmux
+#                tree
+#                utillinux
+#                vim
+#                yq
+#              ];
+#            };
+#          };
+#
+#      packages = { jormungandr, jcli, jormungandr-entrypoint }@pkgs: pkgs;
+#
+#      devShell =
+#        { mkShell, rustc, cargo, pkg-config, openssl, protobuf, rustfmt }:
+#        mkShell {
+#          PROTOC = "${protobuf}/bin/protoc";
+#          PROTOC_INCLUDE = "${protobuf}/include";
+#          buildInputs = [ rustc cargo pkg-config openssl protobuf rustfmt ];
+#        };
+#
+#      hydraJobs = { jormungandr, jcli, jormungandr-entrypoint }@pkgs: pkgs;
+#    };
+#}

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,7 @@
 
         jormungandr-entrypoint = let
           script =
-            pkgs.writeShellScriptBin "jormungandr-entrypoint"
+            pkgs.writeShellScriptBin "entrypoint"
             ''
               set -exuo pipefail
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,11 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.rust-overlay.url = "github:oxalica/rust-overlay";
   inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  #inputs.naersk.url = "github:nix-community/naersk";
+  # XXX: https://github.com/nix-community/naersk/pull/167
+  inputs.naersk.url = "github:yusdacra/naersk/feat/cargolock-git-deps";
+  inputs.naersk.inputs.nixpkgs.follows = "nixpkgs";
+  # TODO: use pre-commit-hooks
 
   nixConfig.extra-substituters =
     [ "https://hydra.iohk.io"
@@ -16,6 +21,8 @@
   outputs = { self
             , nixpkgs
             , flake-utils
+            , rust-overlay
+            , naersk
             }:
     flake-utils.lib.eachSystem
       [ flake-utils.lib.system.x86_64-linux
@@ -31,147 +38,162 @@
             overlays = [ (import rust-overlay) ];
           };
 
-          mkPackage = name:
-            let
-              pkgCargo = readTOML ./${name}/Cargo.toml;
-            in
-            1;
+          rust = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analysis"
+              "rustfmt-preview"
+              "clippy-preview"
+            ];
+          };
 
-        in rec {
-          packages =
+          naersk-lib = naersk.lib."${system}".override {
+            cargo = rust;
+            rustc = rust;
+          };
+
+          mkPackage = name:
+            let pkgCargo = readTOML ./${name}/Cargo.toml;
+            in
+              naersk-lib.buildPackage {
+                #src = self + "/${name}";
+                root = ./.;
+
+                cargoBuildOptions = x: x ++ [ "-p" name ];
+                cargoTestOptions = x: x ++ [ "-p" name ];
+
+                PROTOC = "${pkgs.protobuf}/bin/protoc";
+                PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+
+                nativeBuildInputs = with pkgs; [
+                  pkg-config
+                  protobuf
+                  rustfmt
+                ];
+
+                buildInputs = with pkgs; [
+                  openssl
+                ];
+              };
+
+          workspace =
             builtins.listToAttrs
               (builtins.map
                 (name: { inherit name; value = mkPackage name; })
-                workspaceCargo.workspace.members);
+                workspaceCargo.workspace.members
+              );
+
+          jormungandr-entrypoint =
+            let
+              script = pkgs.writeShellScriptBin "jormungandr-entrypoint"
+              ''
+                set -exuo pipefail
+
+                ulimit -n 1024
+
+                nodeConfig="$NOMAD_TASK_DIR/node-config.json"
+                runConfig="$NOMAD_TASK_DIR/running.json"
+                runYaml="$NOMAD_TASK_DIR/running.yaml"
+                name="jormungandr"
+
+                chmod u+rwx -R "$NOMAD_TASK_DIR" || true
+
+                function convert () {
+                  chmod u+rwx -R "$NOMAD_TASK_DIR" || true
+                  cp "$nodeConfig" "$runConfig"
+                  remarshal --if json --of yaml "$runConfig" > "$runYaml"
+                }
+
+                if [ "$RESET" = "true" ]; then
+                  echo "RESET is given, will start from scratch..."
+                  rm -rf "$STORAGE_DIR"
+                elif [ -d "$STORAGE_DIR" ]; then
+                  echo "$STORAGE_DIR found, not restoring from backup..."
+                else
+                  echo "$STORAGE_DIR not found, restoring backup..."
+
+                  restic restore latest \
+                    --verbose=5 \
+                    --no-lock \
+                    --tag "$NAMESPACE" \
+                    --target / \
+                  || echo "couldn't restore backup, continue startup procedure..."
+                fi
+
+                set +x
+                echo "waiting for $REQUIRED_PEER_COUNT peers"
+                until [ "$(jq -e -r '.p2p.trusted_peers | length' < "$nodeConfig" || echo 0)" -ge $REQUIRED_PEER_COUNT ]; do
+                  sleep 1
+                done
+                set -x
+
+                convert
+
+                if [ -n "$PRIVATE" ]; then
+                  echo "Running with node with secrets..."
+                  exec jormungandr \
+                    --storage "$STORAGE_DIR" \
+                    --config "$NOMAD_TASK_DIR/running.yaml" \
+                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
+                    --secret $NOMAD_SECRETS_DIR/bft-secret.yaml \
+                    "$@" || true
+                else
+                  echo "Running with follower node..."
+                  exec jormungandr \
+                    --storage "$STORAGE_DIR" \
+                    --config "$NOMAD_TASK_DIR/running.yaml" \
+                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
+                    "$@" || true
+                fi
+              '';
+            in pkgs.symlinkJoin {
+              name = "entrypoint";
+              paths = [ script workspace.jormungandr ] ++ (with pkgs; [
+                bashInteractive
+                coreutils
+                curl
+                diffutils
+                fd
+                findutils
+                gnugrep
+                gnused
+                htop
+                jq
+                lsof
+                netcat
+                procps
+                remarshal
+                restic
+                ripgrep
+                strace
+                tcpdump
+                tmux
+                tree
+                utillinux
+                vim
+                yq
+              ]);
+            };
+
+        in rec {
+          packages =
+            { inherit (workspace) jormungandr jcli;
+              inherit jormungandr-entrypoint;
+            };
+
+          devShell = pkgs.mkShell {
+            PROTOC = "${pkgs.protobuf}/bin/protoc";
+            PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+            buildInputs = [ rust ] ++ (with pkgs; [
+              pkg-config
+              openssl
+              protobuf
+            ]);
+          };
+
+          hydraJobs = packages;
+
+          # TODO: ciceroActions
         }
       );
-
-#    let
-#      workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-#      inherit (workspaceCargo.workspace) members;
-#    in flake-utils.lib.simpleFlake {
-#      inherit self nixpkgs;
-#      systems = [  ];
-#      preOverlays = [ ];
-#      overlay = final: prev:
-#        let inherit (prev) lib;
-#        in (lib.listToAttrs (lib.forEach members (member:
-#          lib.nameValuePair member (prev.rustPlatform.buildRustPackage {
-#            inherit ((builtins.fromTOML
-#              (builtins.readFile (./. + "/${member}/Cargo.toml"))).package)
-#              name version;
-#            src = ./.;
-#            cargoSha256 = "sha256-80AmXP6zBuWweQXtHt9c8K9WrhrigF+CRv0reAuMvbM=";
-#            nativeBuildInputs = with final; [ pkg-config protobuf rustfmt ];
-#            buildInputs = with final; [ openssl ];
-#            PROTOC = "${final.protobuf}/bin/protoc";
-#            PROTOC_INCLUDE = "${final.protobuf}/include";
-#          })))) // {
-#            jormungandr-entrypoint = let
-#              script = final.writeShellScriptBin "entrypoint" ''
-#                set -exuo pipefail
-#
-#                ulimit -n 1024
-#
-#                nodeConfig="$NOMAD_TASK_DIR/node-config.json"
-#                runConfig="$NOMAD_TASK_DIR/running.json"
-#                runYaml="$NOMAD_TASK_DIR/running.yaml"
-#                name="jormungandr"
-#
-#                chmod u+rwx -R "$NOMAD_TASK_DIR" || true
-#
-#                function convert () {
-#                  chmod u+rwx -R "$NOMAD_TASK_DIR" || true
-#                  cp "$nodeConfig" "$runConfig"
-#                  remarshal --if json --of yaml "$runConfig" > "$runYaml"
-#                }
-#
-#                if [ "$RESET" = "true" ]; then
-#                  echo "RESET is given, will start from scratch..."
-#                  rm -rf "$STORAGE_DIR"
-#                elif [ -d "$STORAGE_DIR" ]; then
-#                  echo "$STORAGE_DIR found, not restoring from backup..."
-#                else
-#                  echo "$STORAGE_DIR not found, restoring backup..."
-#
-#                  restic restore latest \
-#                    --verbose=5 \
-#                    --no-lock \
-#                    --tag "$NAMESPACE" \
-#                    --target / \
-#                  || echo "couldn't restore backup, continue startup procedure..."
-#                fi
-#
-#                set +x
-#                echo "waiting for $REQUIRED_PEER_COUNT peers"
-#                until [ "$(jq -e -r '.p2p.trusted_peers | length' < "$nodeConfig" || echo 0)" -ge $REQUIRED_PEER_COUNT ]; do
-#                  sleep 1
-#                done
-#                set -x
-#
-#                convert
-#
-#                if [ -n "$PRIVATE" ]; then
-#                  echo "Running with node with secrets..."
-#                  exec jormungandr \
-#                    --storage "$STORAGE_DIR" \
-#                    --config "$NOMAD_TASK_DIR/running.yaml" \
-#                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
-#                    --secret $NOMAD_SECRETS_DIR/bft-secret.yaml \
-#                    "$@" || true
-#                else
-#                  echo "Running with follower node..."
-#                  exec jormungandr \
-#                    --storage "$STORAGE_DIR" \
-#                    --config "$NOMAD_TASK_DIR/running.yaml" \
-#                    --genesis-block $NOMAD_TASK_DIR/block0.bin/block0.bin \
-#                    "$@" || true
-#                fi
-#              '';
-#            in final.symlinkJoin {
-#              name = "entrypoint";
-#              paths = with final; [
-#                jormungandr
-#                script
-#
-#                bashInteractive
-#                coreutils
-#                curl
-#                diffutils
-#                fd
-#                findutils
-#                gnugrep
-#                gnused
-#                htop
-#                jormungandr
-#                jq
-#                lsof
-#                netcat
-#                procps
-#                remarshal
-#                restic
-#                ripgrep
-#                strace
-#                tcpdump
-#                tmux
-#                tree
-#                utillinux
-#                vim
-#                yq
-#              ];
-#            };
-#          };
-#
-#      packages = { jormungandr, jcli, jormungandr-entrypoint }@pkgs: pkgs;
-#
-#      devShell =
-#        { mkShell, rustc, cargo, pkg-config, openssl, protobuf, rustfmt }:
-#        mkShell {
-#          PROTOC = "${protobuf}/bin/protoc";
-#          PROTOC_INCLUDE = "${protobuf}/include";
-#          buildInputs = [ rustc cargo pkg-config openssl protobuf rustfmt ];
-#        };
-#
-#      hydraJobs = { jormungandr, jcli, jormungandr-entrypoint }@pkgs: pkgs;
-#    };
-#}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,8 @@
   inputs.rust-overlay.url = "github:oxalica/rust-overlay";
   inputs.rust-overlay.inputs.flake-utils.follows = "flake-utils";
   inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
-  #inputs.naersk.url = "github:nix-community/naersk";
   # XXX: https://github.com/nix-community/naersk/pull/167
+  #inputs.naersk.url = "github:nix-community/naersk";
   inputs.naersk.url = "github:yusdacra/naersk/feat/cargolock-git-deps";
   inputs.naersk.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.gitignore.url = "github:hercules-ci/gitignore.nix";
+  inputs.gitignore.inputs.nixpkgs.follows = "nixpkgs";
   inputs.rust-overlay.url = "github:oxalica/rust-overlay";
   inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   #inputs.naersk.url = "github:nix-community/naersk";
@@ -21,6 +23,7 @@
   outputs = { self
             , nixpkgs
             , flake-utils
+            , gitignore
             , rust-overlay
             , naersk
             }:
@@ -56,8 +59,7 @@
             let pkgCargo = readTOML ./${name}/Cargo.toml;
             in
               naersk-lib.buildPackage {
-                #src = self + "/${name}";
-                root = ./.;
+                root = gitignore.lib.gitignoreSource self;
 
                 cargoBuildOptions = x: x ++ [ "-p" name ];
                 cargoTestOptions = x: x ++ [ "-p" name ];


### PR DESCRIPTION
This is - hopefully - an improvement for Nix integration.

One major issue we (me & @const-iohk) were trying to solve is the frequent problem with `cargoSha256` which had to be updated quite frequently. With this PR we hope that this is not going to be the case.

Apart from that we included few other improvements:

* Update github actions on a daily basis. 
* New github workflow that updates flake inputs weekly. 
* Use upstream [flake-utils](https://github.com/numtide/flake-utils) (no need to use the fork)
* Use [gitignore.nix](https://github.com/hercules-ci/gitignore.nix) to filter out not needed source files. That
* Use [direnv](https://direnv.net/) to automatically enter the nix development environment.
* Use [pre-commit.nix](https://github.com/cachix/pre-commit-hooks.nix/) to force rust and nix formatter.
* Use [rust-overlay](https://github.com/oxalica/rust-overlay) to follow latest stable rust compiler.
* Use [naersk](https://github.com/nix-community/naersk) to load cargo dependencies from Cargo.lock file. 


