### PR TITLE
split explorer client from process guard

### DIFF
--- a/testing/hersir/src/controller/interactive/args/explorer.rs
+++ b/testing/hersir/src/controller/interactive/args/explorer.rs
@@ -31,7 +31,7 @@ impl ExplorerTip {
             .ok_or_else(|| {
                 InteractiveCommandError::UserError(format!("Node '{}' not found", self.alias))
             })?;
-        println!("{:#?}", node.explorer().last_block()?);
+        println!("{:#?}", node.explorer().client().last_block()?);
         Ok(())
     }
 }

--- a/testing/hersir/src/controller/monitor/node/mod.rs
+++ b/testing/hersir/src/controller/monitor/node/mod.rs
@@ -2,12 +2,12 @@
 
 mod legacy;
 
+use jormungandr_automation::jormungandr::ExplorerProcess;
 pub use legacy::LegacyNode;
 
 use crate::style;
 use chain_core::property::Fragment as _;
 use chain_impl_mockchain::fragment::{Fragment, FragmentId};
-use jormungandr_automation::jormungandr::Explorer;
 use jormungandr_automation::jormungandr::LogLevel;
 use jormungandr_automation::jormungandr::NodeAlias;
 pub use jormungandr_automation::jormungandr::{
@@ -169,7 +169,7 @@ impl Node {
         multiaddr::to_tcp_socket_addr(&self.process.p2p_public_address()).unwrap()
     }
 
-    pub fn explorer(&self) -> Explorer {
+    pub fn explorer(&self) -> ExplorerProcess {
         self.process.explorer()
     }
 

--- a/testing/jormungandr-automation/src/jormungandr/mod.rs
+++ b/testing/jormungandr-automation/src/jormungandr/mod.rs
@@ -16,7 +16,9 @@ pub use self::{
         get_available_port, Block0ConfigurationBuilder, ConfigurationBuilder, JormungandrParams,
         NodeConfigBuilder, SecretModelFactory, TestConfig,
     },
-    explorer::{compare_schema as compare_explorer_schema, Explorer, ExplorerError},
+    explorer::{
+        compare_schema as compare_explorer_schema, Explorer, ExplorerError, ExplorerProcess,
+    },
     fragment_node::{FragmentNode, FragmentNodeError, MemPoolCheck},
     legacy::{
         download_last_n_releases, get_jormungandr_bin, version_0_8_19, BackwardCompatibleRest,

--- a/testing/jormungandr-automation/src/jormungandr/process.rs
+++ b/testing/jormungandr-automation/src/jormungandr/process.rs
@@ -1,3 +1,4 @@
+use super::explorer::ExplorerProcess;
 use super::{starter::StartupError, JormungandrError};
 use crate::jcli::JCli;
 use crate::jormungandr::grpc::JormungandrClient;
@@ -5,8 +6,8 @@ use crate::jormungandr::NodeAlias;
 use crate::jormungandr::StartupVerificationMode;
 use crate::jormungandr::TestingDirectory;
 use crate::jormungandr::{
-    rest::uri_from_socket_addr, Explorer, JormungandrLogger, JormungandrRest,
-    JormungandrStateVerifier, TestConfig,
+    rest::uri_from_socket_addr, JormungandrLogger, JormungandrRest, JormungandrStateVerifier,
+    TestConfig,
 };
 use crate::jormungandr::{
     FragmentNode, FragmentNodeError, LogLevel, MemPoolCheck, RemoteJormungandr,
@@ -295,7 +296,7 @@ impl JormungandrProcess {
         self.child.id()
     }
 
-    pub fn explorer(&self) -> Explorer {
+    pub fn explorer(&self) -> ExplorerProcess {
         let mut p2p_public_address = self.p2p_public_address.clone();
         let port = match p2p_public_address.pop().unwrap() {
             multiaddr::Protocol::Tcp(port) => port,
@@ -307,7 +308,7 @@ impl JormungandrProcess {
             _ => todo!("only ipv4 supported for now"),
         };
 
-        Explorer::new(format!("http://{}:{}/", address, port), self.temp_dir())
+        ExplorerProcess::new(format!("http://{}:{}/", address, port), self.temp_dir())
     }
 
     pub fn to_trusted_peer(&self) -> TrustedPeer {

--- a/testing/jormungandr-integration-tests/src/jormungandr/explorer.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/explorer.rs
@@ -64,7 +64,8 @@ pub fn explorer_sanity_test() {
     let (jormungandr, initial_stake_pools) =
         startup::start_stake_pool(&[faucet.clone()], &[], &mut config).unwrap();
 
-    let explorer = jormungandr.explorer();
+    let explorer_process = jormungandr.explorer();
+    let explorer = explorer_process.client();
 
     let transaction = thor::FragmentBuilder::new(
         &jormungandr.genesis_block_hash(),

--- a/testing/jormungandr-integration-tests/src/jormungandr/explorer.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/explorer.rs
@@ -82,12 +82,12 @@ pub fn explorer_sanity_test() {
         .send(&transaction)
         .assert_in_block_with_wait(&wait);
 
-    transaction_by_id(&explorer, fragment_id);
-    blocks(&explorer, jormungandr.logger.get_created_blocks_hashes());
-    stake_pools(&explorer, initial_stake_pools.as_ref());
-    stake_pool(&explorer, initial_stake_pools.as_ref());
-    block_at_chain_length(&explorer, jormungandr.logger.get_created_blocks_hashes());
-    epoch(&explorer);
+    transaction_by_id(explorer, fragment_id);
+    blocks(explorer, jormungandr.logger.get_created_blocks_hashes());
+    stake_pools(explorer, initial_stake_pools.as_ref());
+    stake_pool(explorer, initial_stake_pools.as_ref());
+    block_at_chain_length(explorer, jormungandr.logger.get_created_blocks_hashes());
+    epoch(explorer);
 }
 
 fn transaction_by_id(explorer: &Explorer, fragment_id: FragmentId) {

--- a/testing/jormungandr-integration-tests/src/networking/explorer.rs
+++ b/testing/jormungandr-integration-tests/src/networking/explorer.rs
@@ -83,6 +83,7 @@ pub fn passive_node_explorer() {
 
     let transaction_id = passive
         .explorer()
+        .client()
         .transaction((*mem_pool_check.fragment_id()).into())
         .unwrap()
         .data

--- a/testing/jormungandr-integration-tests/src/networking/stake_pool/retire.rs
+++ b/testing/jormungandr-integration-tests/src/networking/stake_pool/retire.rs
@@ -79,7 +79,8 @@ pub fn retire_stake_pool_explorer() {
 
     time::wait_for_date(BlockDate::new(0, 30), leader_1.rest());
 
-    let explorer = leader_1.explorer();
+    let explorer_process = leader_1.explorer();
+    let explorer = explorer_process.client();
     let stake_pool_3 = controller.stake_pool(LEADER_3).unwrap().clone();
 
     let stake_pool_state_before = explorer

--- a/testing/jormungandr-integration-tests/src/non_functional/explorer.rs
+++ b/testing/jormungandr-integration-tests/src/non_functional/explorer.rs
@@ -2,7 +2,7 @@ use super::NodeStuckError;
 use crate::startup;
 use jormungandr_automation::{
     jcli::JCli,
-    jormungandr::{ConfigurationBuilder, JormungandrProcess},
+    jormungandr::{ConfigurationBuilder, ExplorerProcess, JormungandrProcess},
     testing::{
         benchmark_consumption, benchmark_endurance, Endurance, EnduranceBenchmarkRun, Thresholds,
     },
@@ -34,6 +34,7 @@ pub fn test_explorer_is_in_sync_with_node_for_15_minutes() {
             .with_kes_update_speed(KesUpdateSpeed::new(43200).unwrap()),
     )
     .unwrap();
+    let explorer_process = jormungandr.explorer();
 
     let output_value = 1_u64;
     let benchmark = benchmark_endurance("test_explorer_is_in_sync_with_node_for_15_minutes")
@@ -71,7 +72,7 @@ pub fn test_explorer_is_in_sync_with_node_for_15_minutes() {
             return;
         }
 
-        if let Err(err) = check_explorer_and_rest_are_in_sync(&jormungandr) {
+        if let Err(err) = check_explorer_and_rest_are_in_sync(&jormungandr, &explorer_process) {
             let message = format!("{:?}", err);
             finish_test_prematurely(message, benchmark);
             return;
@@ -100,11 +101,12 @@ fn finish_test_prematurely(error_message: String, benchmark: EnduranceBenchmarkR
 
 fn check_explorer_and_rest_are_in_sync(
     jormungandr: &JormungandrProcess,
+    explorer_process: &ExplorerProcess,
 ) -> Result<(), NodeStuckError> {
     let jcli: JCli = Default::default();
     let block_tip = Hash::from_str(&jcli.rest().v0().tip(&jormungandr.rest_uri())).unwrap();
 
-    let explorer = jormungandr.explorer();
+    let explorer = explorer_process.client();
     let last_block = explorer
         .last_block()
         .map_err(NodeStuckError::InternalExplorerError)?;
@@ -140,8 +142,9 @@ pub fn explorer_load_test() {
             .with_kes_update_speed(KesUpdateSpeed::new(43200).unwrap()),
     )
     .unwrap();
+    let explorer = jormungandr.explorer();
 
-    let mut request_gen = ExplorerRequestGen::new(jormungandr.explorer());
+    let mut request_gen = ExplorerRequestGen::new(explorer.client().clone());
     request_gen
         .do_setup(addresses.iter().map(|x| x.address().to_string()).collect())
         .unwrap();

--- a/testing/mjolnir/src/mjolnir_lib/explorer.rs
+++ b/testing/mjolnir/src/mjolnir_lib/explorer.rs
@@ -48,7 +48,7 @@ pub struct ExplorerLoadCommand {
 
 impl ExplorerLoadCommand {
     pub fn exec(&self) -> Result<(), ExplorerLoadCommandError> {
-        let mut explorer = Explorer::new(self.endpoint.clone(), None);
+        let mut explorer = Explorer::new(self.endpoint.clone());
         explorer.disable_logs();
         let mut request_gen = ExplorerRequestGen::new(explorer);
         request_gen.do_setup(Vec::new()).unwrap();


### PR DESCRIPTION
Instead of spawning the explorer process on `Explorer::new`, do it in a separate struct that functions as the guard to keep the process alive, and keep `Explorer` only as a thin wrapper around `GraphQlClient`.

With this, the client can be used with an already (for example, remote) existing instance.

I will rebase #3885 on top of this later.