### PR TITLE
Initialize a new RPC service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,15 +1325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "ethabi"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,9 +2346,9 @@ dependencies = [
  "futures",
  "hex",
  "http-zipkin",
- "hyper",
  "imhamt",
  "jormungandr-lib",
+ "jsonrpc-http-server",
  "keynesis",
  "lazy_static",
  "libc",
@@ -2392,7 +2383,6 @@ dependencies = [
  "tracing-subscriber 0.3.7",
  "versionisator",
  "warp",
- "warp-json-rpc",
 ]
 
 [[package]]
@@ -2599,6 +2589,55 @@ name = "json"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
+name = "jsonrpc-core"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
+dependencies = [
+ "futures",
+ "futures-executor",
+ "futures-util",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonrpc-http-server"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
+dependencies = [
+ "futures",
+ "hyper",
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log",
+ "net2",
+ "parking_lot",
+ "unicase",
+]
+
+[[package]]
+name = "jsonrpc-server-utils"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
+dependencies = [
+ "bytes",
+ "futures",
+ "globset",
+ "jsonrpc-core",
+ "lazy_static",
+ "log",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "unicase",
+]
 
 [[package]]
 name = "keccak"
@@ -2960,6 +2999,17 @@ dependencies = [
  "safemem",
  "tempfile",
  "twoway",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5434,24 +5484,6 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "warp-json-rpc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7267422020cd1544b9eb9d1a5e54128ccfd2e203a12b7f5eeec992d656c72fd8"
-dependencies = [
- "anyhow",
- "erased-serde",
- "futures",
- "http",
- "hyper",
- "lazycell",
- "log",
- "serde",
- "serde_json",
- "warp",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
 
 [[package]]
 name = "httpdate"
@@ -2110,9 +2110,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2123,7 +2123,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2355,6 +2355,7 @@ dependencies = [
  "futures",
  "hex",
  "http-zipkin",
+ "hyper",
  "imhamt",
  "jormungandr-lib",
  "keynesis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,9 @@ name = "beef"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bed554bd50246729a1ec158d08aa3235d1b69d94ad120ebe187e28894787e736"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -2405,7 +2408,7 @@ dependencies = [
  "http-zipkin",
  "imhamt",
  "jormungandr-lib",
- "jsonrpc-http-server",
+ "jsonrpsee-http-server",
  "keynesis",
  "lazy_static",
  "libc",
@@ -2648,52 +2651,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
-name = "jsonrpc-core"
-version = "18.0.0"
+name = "jsonrpsee-core"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
+checksum = "8066473754794e7784c61808d25d60dfb68e1025a625792a6a1bc680d1ab700a"
 dependencies = [
- "futures",
- "futures-executor",
+ "anyhow",
+ "arrayvec",
+ "async-trait",
+ "beef",
+ "futures-channel",
  "futures-util",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "jsonrpc-http-server"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
-dependencies = [
- "futures",
  "hyper",
- "jsonrpc-core",
- "jsonrpc-server-utils",
- "log",
- "net2",
- "parking_lot",
+ "jsonrpsee-types",
+ "parking_lot 0.12.0",
+ "rand 0.8.4",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-server"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee81d83b686966d6ba3b79f21bc71beedad9ec7e31c201fccff31ef0dd212e17"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "globset",
+ "hyper",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "lazy_static",
+ "serde_json",
+ "tokio",
+ "tracing",
  "unicase",
 ]
 
 [[package]]
-name = "jsonrpc-server-utils"
-version = "18.0.0"
+name = "jsonrpsee-types"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
+checksum = "fd42e08ae7f0de7b00319f723f7b06e2d461ab69bfa615a611fab5dec00b192e"
 dependencies = [
- "bytes",
- "futures",
- "globset",
- "jsonrpc-core",
- "lazy_static",
- "log",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "unicase",
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3050,17 +3061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "netstat2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3335,7 +3335,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -3350,6 +3360,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3684,7 +3707,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot",
+ "parking_lot 0.11.2",
  "protobuf",
  "thiserror",
 ]
@@ -4145,6 +4168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4507,7 +4536,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -4909,7 +4938,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -5682,6 +5711,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
+name = "erased-serde"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ethabi"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,6 +2391,7 @@ dependencies = [
  "tracing-subscriber 0.3.7",
  "versionisator",
  "warp",
+ "warp-json-rpc",
 ]
 
 [[package]]
@@ -5423,6 +5433,24 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "warp-json-rpc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7267422020cd1544b9eb9d1a5e54128ccfd2e203a12b7f5eeec992d656c72fd8"
+dependencies = [
+ "anyhow",
+ "erased-serde",
+ "futures",
+ "http",
+ "hyper",
+ "lazycell",
+ "log",
+ "serde",
+ "serde_json",
+ "warp",
 ]
 
 [[package]]

--- a/jormungandr-lib/src/interfaces/config/mod.rs
+++ b/jormungandr-lib/src/interfaces/config/mod.rs
@@ -7,6 +7,6 @@ pub use log::{Log, LogEntry, LogOutput};
 pub use mempool::{LogMaxEntries, Mempool, PersistentLog, PoolMaxEntries};
 pub use node::{
     Cors, CorsOrigin, LayersConfig, NodeConfig, NodeId, P2p, Policy, PreferredListConfig, Rest,
-    Tls, TopicsOfInterest, TrustedPeer,
+    Rpc, Tls, TopicsOfInterest, TrustedPeer,
 };
 pub use secret::{Bft, GenesisPraos, NodeSecret};

--- a/jormungandr-lib/src/interfaces/config/node.rs
+++ b/jormungandr-lib/src/interfaces/config/node.rs
@@ -21,6 +21,11 @@ pub struct Rest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Rpc {
+    pub listen: SocketAddr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct Tls {
     /// Path to server X.509 certificate chain file, must be PEM-encoded and contain at least 1 item

--- a/jormungandr-lib/src/interfaces/config/node.rs
+++ b/jormungandr-lib/src/interfaces/config/node.rs
@@ -23,7 +23,6 @@ pub struct Rest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Rpc {
     pub listen: SocketAddr,
-    pub threads: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/jormungandr-lib/src/interfaces/config/node.rs
+++ b/jormungandr-lib/src/interfaces/config/node.rs
@@ -295,6 +295,7 @@ pub struct NodeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage: Option<PathBuf>,
     pub rest: Rest,
+    pub rpc: Rpc,
     pub p2p: P2p,
     pub log: Option<Log>,
     pub mempool: Option<Mempool>,

--- a/jormungandr-lib/src/interfaces/config/node.rs
+++ b/jormungandr-lib/src/interfaces/config/node.rs
@@ -23,6 +23,7 @@ pub struct Rest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Rpc {
     pub listen: SocketAddr,
+    pub threads: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -57,11 +57,10 @@ tokio-util = { version = "0.6.0", features = ["time"] }
 tonic = "0.6"
 lru = "0.7"
 warp = { version = "0.3.2", features = ["tls"] }
-warp-json-rpc = { version = "0.3.0" }
-hyper = { version = "0.14.18" }
 serde_with = { version = "1.12", features = ["macros"] }
 http-zipkin = "0.3.0"
 prometheus = { version = "0.13", optional = true }
+jsonrpc-http-server = "18.0"
 
 [dependencies.reqwest]
 version = "0.11"

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -58,6 +58,7 @@ tonic = "0.6"
 lru = "0.7"
 warp = { version = "0.3.2", features = ["tls"] }
 warp-json-rpc = { version = "0.3.0" }
+hyper = { version = "0.14.18" }
 serde_with = { version = "1.12", features = ["macros"] }
 http-zipkin = "0.3.0"
 prometheus = { version = "0.13", optional = true }

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -57,6 +57,7 @@ tokio-util = { version = "0.6.0", features = ["time"] }
 tonic = "0.6"
 lru = "0.7"
 warp = { version = "0.3.2", features = ["tls"] }
+warp-json-rpc = { version = "0.3.0" }
 serde_with = { version = "1.12", features = ["macros"] }
 http-zipkin = "0.3.0"
 prometheus = { version = "0.13", optional = true }

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -60,7 +60,7 @@ warp = { version = "0.3.2", features = ["tls"] }
 serde_with = { version = "1.12", features = ["macros"] }
 http-zipkin = "0.3.0"
 prometheus = { version = "0.13", optional = true }
-jsonrpc-http-server = "18.0"
+jsonrpsee-http-server = "0.11.0"
 
 [dependencies.reqwest]
 version = "0.11"

--- a/jormungandr/src/lib.rs
+++ b/jormungandr/src/lib.rs
@@ -618,7 +618,7 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     init_os_signal_watchers(&mut services, cancellation_token.clone());
 
     let rest_context = match settings.rest.clone() {
-        Some(rest) => {
+        Some(rest_config) => {
             use tokio::sync::RwLock;
 
             let mut context = rest::Context::new();
@@ -628,15 +628,15 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
 
             let service_context = context.clone();
 
-            let rest = rest::Config {
-                listen: rest.listen,
-                tls: rest.tls,
-                cors: rest.cors,
+            let rest_config = rest::Config {
+                listen: rest_config.listen,
+                tls: rest_config.tls,
+                cors: rest_config.cors,
                 #[cfg(feature = "prometheus-metrics")]
                 enable_prometheus: settings.prometheus,
             };
 
-            let server_handler = rest::start_rest_server(rest, context.clone());
+            let server_handler = rest::start_rest_server(rest_config, context.clone());
             services.spawn_future("rest", |info| async move {
                 service_context.write().await.set_span(info.span().clone());
                 server_handler.await
@@ -646,9 +646,11 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
         None => None,
     };
 
-    if let Some(rpc) = settings.rpc.clone() {
-        let rpc = rpc::Config { listen: rpc.listen };
-        let server_handler = rpc::start_rpc_server(rpc);
+    if let Some(rpc_config) = settings.rpc.clone() {
+        let rpc_config = rpc::Config {
+            listen: rpc_config.listen,
+        };
+        let server_handler = rpc::start_rpc_server(rpc_config);
         services.spawn_future("rpc", |_| async move { server_handler.await });
     }
 

--- a/jormungandr/src/lib.rs
+++ b/jormungandr/src/lib.rs
@@ -646,13 +646,10 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
         None => None,
     };
 
-    match settings.rpc.clone() {
-        Some(rpc) => {
-            let rpc = rpc::Config { listen: rpc.listen };
-            let server_handler = rpc::start_rpc_server(rpc);
-            services.spawn_future("rpc", |_| async move { server_handler.await });
-        }
-        None => {}
+    if let Some(rpc) = settings.rpc.clone() {
+        let rpc = rpc::Config { listen: rpc.listen };
+        let server_handler = rpc::start_rpc_server(rpc);
+        services.spawn_future("rpc", |_| async move { server_handler.await });
     }
 
     // TODO: load network module here too (if needed)

--- a/jormungandr/src/lib.rs
+++ b/jormungandr/src/lib.rs
@@ -649,7 +649,6 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     if let Some(rpc_config) = settings.rpc.clone() {
         let rpc_config = rpc::Config {
             listen: rpc_config.listen,
-            threads: rpc_config.threads,
         };
         let server_handler = rpc::start_rpc_server(rpc_config);
         services.spawn_future("rpc", |_| async move { server_handler.await });

--- a/jormungandr/src/lib.rs
+++ b/jormungandr/src/lib.rs
@@ -649,6 +649,7 @@ fn initialize_node() -> Result<InitializedNode, start_up::Error> {
     if let Some(rpc_config) = settings.rpc.clone() {
         let rpc_config = rpc::Config {
             listen: rpc_config.listen,
+            threads: rpc_config.threads,
         };
         let server_handler = rpc::start_rpc_server(rpc_config);
         services.spawn_future("rpc", |_| async move { server_handler.await });

--- a/jormungandr/src/rpc/mod.rs
+++ b/jormungandr/src/rpc/mod.rs
@@ -1,25 +1,22 @@
-use futures::future;
-use std::{convert::Infallible, net::SocketAddr};
-use warp::Filter as _;
-use warp_json_rpc::Builder;
+use std::net::SocketAddr;
+
+use jsonrpc_http_server::jsonrpc_core::{IoHandler, Value};
+use jsonrpc_http_server::ServerBuilder;
 
 pub struct Config {
     pub listen: SocketAddr,
+    pub threads: usize,
 }
 
 pub async fn start_rpc_server(config: Config) {
     // it is initial dummy impl just for initialization rpc instance
-    let method = warp_json_rpc::filters::json_rpc()
-        .and(warp_json_rpc::filters::method("dummy"))
-        .and(warp_json_rpc::filters::params::<(isize, isize)>())
-        .map(|res: Builder, (lhs, rhs)| res.success(lhs + rhs).unwrap());
+    let mut io = IoHandler::default();
+    io.add_method("dummy", |_| async { Ok(Value::Null) });
 
-    let service = warp_json_rpc::service(method);
-    let serivce_fn =
-        hyper::service::make_service_fn(move |_| future::ok::<_, Infallible>(service.clone()));
-
-    hyper::Server::bind(&config.listen)
-        .serve(serivce_fn)
-        .await
+    let server = ServerBuilder::new(io)
+        .threads(config.threads)
+        .start_http(&config.listen)
         .unwrap();
+
+    server.wait();
 }

--- a/jormungandr/src/rpc/mod.rs
+++ b/jormungandr/src/rpc/mod.rs
@@ -1,0 +1,17 @@
+use std::net::SocketAddr;
+use warp::Filter as _;
+use warp_json_rpc::Builder;
+
+pub struct Config {
+    pub listen: SocketAddr,
+}
+
+pub async fn start_rpc_server(config: Config) {
+    // it is initial dummy impl just for initialization rpc instance
+    let method = warp_json_rpc::filters::json_rpc()
+        .and(warp_json_rpc::filters::method("dummy"))
+        .and(warp_json_rpc::filters::params::<(isize, isize)>())
+        .map(|res: Builder, (lhs, rhs)| res.success(lhs + rhs).unwrap());
+
+    warp::serve(method).bind(config.listen).await;
+}

--- a/jormungandr/src/rpc/mod.rs
+++ b/jormungandr/src/rpc/mod.rs
@@ -1,22 +1,22 @@
 use std::net::SocketAddr;
 
-use jsonrpc_http_server::jsonrpc_core::{IoHandler, Value};
-use jsonrpc_http_server::ServerBuilder;
+// use jsonrpsee::jsonrpc_core::{IoHandler, Value};
+// use jsonrpsee::ServerBuilder;
+use jsonrpsee_http_server::{HttpServerBuilder, RpcModule};
 
 pub struct Config {
     pub listen: SocketAddr,
-    pub threads: usize,
 }
 
 pub async fn start_rpc_server(config: Config) {
     // it is initial dummy impl just for initialization rpc instance
-    let mut io = IoHandler::default();
-    io.add_method("dummy", |_| async { Ok(Value::Null) });
-
-    let server = ServerBuilder::new(io)
-        .threads(config.threads)
-        .start_http(&config.listen)
+    let server = HttpServerBuilder::default()
+        .build(config.listen)
+        .await
         .unwrap();
 
-    server.wait();
+    let mut module = RpcModule::new(());
+    module.register_method("dummy", |_, _| Ok(())).unwrap();
+
+    server.start(module).unwrap().await
 }

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -76,6 +76,9 @@ pub struct RpcArguments {
     /// If not configured anywhere, defaults to RPC API being disabled
     #[structopt(long = "rpc-listen")]
     pub listen: Option<SocketAddr>,
+    /// RPC threads number of the server.
+    /// If not configured anywhere, default value will be established (DEFAULT_RPC_THREADS_AMOUNT = 1)
+    pub threads_num: Option<usize>,
 }
 
 #[derive(StructOpt, Debug)]
@@ -115,7 +118,7 @@ pub struct CommandLine {
     pub rest_arguments: RestArguments,
 
     #[structopt(flatten)]
-    pub rpc_arguments: RestArguments,
+    pub rpc_arguments: RpcArguments,
 
     #[structopt(flatten)]
     pub start_arguments: StartArguments,

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -71,6 +71,14 @@ pub struct RestArguments {
 }
 
 #[derive(StructOpt, Debug)]
+pub struct RpcArguments {
+    /// RPC API listening address.
+    /// If not configured anywhere, defaults to RPC API being disabled
+    #[structopt(long = "rpc-listen")]
+    pub listen: Option<SocketAddr>,
+}
+
+#[derive(StructOpt, Debug)]
 #[structopt(
     name = "jormungandr",
     setting = structopt::clap::AppSettings::ColoredHelp
@@ -105,6 +113,9 @@ pub struct CommandLine {
 
     #[structopt(flatten)]
     pub rest_arguments: RestArguments,
+
+    #[structopt(flatten)]
+    pub rpc_arguments: RestArguments,
 
     #[structopt(flatten)]
     pub start_arguments: StartArguments,

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -76,10 +76,6 @@ pub struct RpcArguments {
     /// If not configured anywhere, defaults to RPC API being disabled
     #[structopt(name = "rpc-listen")]
     pub listen: Option<SocketAddr>,
-    /// RPC threads number of the server.
-    /// If not configured anywhere, default value will be established (DEFAULT_RPC_THREADS_AMOUNT = 1)
-    #[structopt(name = "rpc-threads-num")]
-    pub threads_num: Option<usize>,
 }
 
 #[derive(StructOpt, Debug)]

--- a/jormungandr/src/settings/command_arguments.rs
+++ b/jormungandr/src/settings/command_arguments.rs
@@ -66,7 +66,7 @@ pub struct StartArguments {
 pub struct RestArguments {
     /// REST API listening address.
     /// If not configured anywhere, defaults to REST API being disabled
-    #[structopt(long = "rest-listen")]
+    #[structopt(name = "rest-listen")]
     pub listen: Option<SocketAddr>,
 }
 
@@ -74,10 +74,11 @@ pub struct RestArguments {
 pub struct RpcArguments {
     /// RPC API listening address.
     /// If not configured anywhere, defaults to RPC API being disabled
-    #[structopt(long = "rpc-listen")]
+    #[structopt(name = "rpc-listen")]
     pub listen: Option<SocketAddr>,
     /// RPC threads number of the server.
     /// If not configured anywhere, default value will be established (DEFAULT_RPC_THREADS_AMOUNT = 1)
+    #[structopt(name = "rpc-threads-num")]
     pub threads_num: Option<usize>,
 }
 

--- a/jormungandr/src/settings/start/config.rs
+++ b/jormungandr/src/settings/start/config.rs
@@ -4,7 +4,7 @@ use crate::{
     settings::LOG_FILTER_LEVEL_POSSIBLE_VALUES,
     topology::QuarantineConfig,
 };
-pub use jormungandr_lib::interfaces::{Cors, LayersConfig, Rest, Tls, TrustedPeer};
+pub use jormungandr_lib::interfaces::{Cors, LayersConfig, Rest, Rpc, Tls, TrustedPeer};
 use jormungandr_lib::{interfaces::Mempool, time::Duration};
 
 use multiaddr::Multiaddr;
@@ -29,6 +29,8 @@ pub struct Config {
     pub leadership: Leadership,
 
     pub rest: Option<Rest>,
+
+    pub rpc: Option<Rpc>,
 
     #[serde(default)]
     pub p2p: P2pConfig,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -139,13 +139,13 @@ impl RawSettings {
 
     fn rest_config(&self) -> Option<Rest> {
         let cmd_listen_opt = self.command_line.rest_arguments.listen;
-        let config_rest_opt = self.config.as_ref().and_then(|cfg| cfg.rest.as_ref());
+        let config_rest_opt = self.config.as_ref().and_then(|cfg| cfg.rest.clone());
         match (config_rest_opt, cmd_listen_opt) {
             (Some(config_rest), Some(cmd_listen)) => Some(Rest {
                 listen: cmd_listen,
-                ..config_rest.clone()
+                ..config_rest
             }),
-            (Some(config_rest), None) => Some(config_rest.clone()),
+            (Some(config_rest), None) => Some(config_rest),
             (None, Some(cmd_listen)) => Some(Rest {
                 listen: cmd_listen,
                 tls: None,
@@ -156,14 +156,20 @@ impl RawSettings {
     }
 
     fn rpc_config(&self) -> Option<Rpc> {
-        self.command_line.rpc_arguments.listen.map(|listen| {
-            let threads = self
-                .command_line
-                .rpc_arguments
-                .threads_num
-                .unwrap_or(DEFAULT_RPC_THREADS_AMOUNT);
-            Rpc { listen, threads }
-        })
+        let cmd_listen_opt = self.command_line.rpc_arguments.listen;
+        let config_rpc_opt = self.config.as_ref().and_then(|cfg| cfg.rpc.clone());
+        match (config_rpc_opt, cmd_listen_opt) {
+            (Some(config_rpc), Some(cmd_listen)) => Some(Rpc {
+                listen: cmd_listen,
+                ..config_rpc
+            }),
+            (Some(config_rpc), None) => Some(config_rpc),
+            (None, Some(cmd_listen)) => Some(Rpc {
+                listen: cmd_listen,
+                threads: DEFAULT_RPC_THREADS_AMOUNT,
+            }),
+            (None, None) => None,
+        }
     }
 
     /// Load the settings

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -25,6 +25,7 @@ const DEFAULT_LOG_SETTINGS_ENTRY: LogSettingsEntry = LogSettingsEntry {
     format: DEFAULT_LOG_FORMAT,
     output: DEFAULT_LOG_OUTPUT,
 };
+const DEFAULT_RPC_THREADS_AMOUNT: usize = 1;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -155,10 +156,14 @@ impl RawSettings {
     }
 
     fn rpc_config(&self) -> Option<Rpc> {
-        self.command_line
-            .rpc_arguments
-            .listen
-            .map(|listen| Rpc { listen })
+        self.command_line.rpc_arguments.listen.map(|listen| {
+            let threads = self
+                .command_line
+                .rpc_arguments
+                .threads_num
+                .unwrap_or(DEFAULT_RPC_THREADS_AMOUNT);
+            Rpc { listen, threads }
+        })
     }
 
     /// Load the settings

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -158,10 +158,7 @@ impl RawSettings {
         let cmd_listen_opt = self.command_line.rpc_arguments.listen;
         let config_rpc_opt = self.config.as_ref().and_then(|cfg| cfg.rpc.clone());
         match (config_rpc_opt, cmd_listen_opt) {
-            (Some(config_rpc), Some(cmd_listen)) => Some(Rpc {
-                listen: cmd_listen,
-                ..config_rpc
-            }),
+            (Some(_), Some(cmd_listen)) => Some(Rpc { listen: cmd_listen }),
             (Some(config_rpc), None) => Some(config_rpc),
             (None, Some(cmd_listen)) => Some(Rpc { listen: cmd_listen }),
             (None, None) => None,

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -155,11 +155,10 @@ impl RawSettings {
     }
 
     fn rpc_config(&self) -> Option<Rpc> {
-        let cmd_listen_opt = self.command_line.rpc_arguments.listen;
-        match cmd_listen_opt {
-            Some(cmd_listen) => Some(Rpc { listen: cmd_listen }),
-            None => None,
-        }
+        self.command_line
+            .rpc_arguments
+            .listen
+            .map(|listen| Rpc { listen })
     }
 
     /// Load the settings

--- a/jormungandr/src/settings/start/mod.rs
+++ b/jormungandr/src/settings/start/mod.rs
@@ -25,7 +25,6 @@ const DEFAULT_LOG_SETTINGS_ENTRY: LogSettingsEntry = LogSettingsEntry {
     format: DEFAULT_LOG_FORMAT,
     output: DEFAULT_LOG_OUTPUT,
 };
-const DEFAULT_RPC_THREADS_AMOUNT: usize = 1;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -164,10 +163,7 @@ impl RawSettings {
                 ..config_rpc
             }),
             (Some(config_rpc), None) => Some(config_rpc),
-            (None, Some(cmd_listen)) => Some(Rpc {
-                listen: cmd_listen,
-                threads: DEFAULT_RPC_THREADS_AMOUNT,
-            }),
+            (None, Some(cmd_listen)) => Some(Rpc { listen: cmd_listen }),
             (None, None) => None,
         }
     }

--- a/testing/jormungandr-automation/src/jormungandr/configuration/node_config_builder.rs
+++ b/testing/jormungandr-automation/src/jormungandr/configuration/node_config_builder.rs
@@ -2,8 +2,8 @@
 
 use jormungandr_lib::{
     interfaces::{
-        Cors, LayersConfig, Log, Mempool, NodeConfig, P2p, Policy, Rest, Tls, TopicsOfInterest,
-        TrustedPeer,
+        Cors, LayersConfig, Log, Mempool, NodeConfig, P2p, Policy, Rest, Rpc, Tls,
+        TopicsOfInterest, TrustedPeer,
     },
     time::Duration,
 };
@@ -15,11 +15,13 @@ pub struct NodeConfigBuilder {
     pub storage: Option<PathBuf>,
     pub log: Option<Log>,
     pub rest: Rest,
+    pub rpc: Rpc,
     pub p2p: P2p,
     pub mempool: Option<Mempool>,
 }
 
 const DEFAULT_HOST: &str = "127.0.0.1";
+const DEFAULT_RPC_THREADS_AMOUNT: usize = 1;
 
 impl Default for NodeConfigBuilder {
     fn default() -> Self {
@@ -31,6 +33,7 @@ impl NodeConfigBuilder {
     pub fn new() -> NodeConfigBuilder {
         let rest_port = super::get_available_port();
         let public_address_port = super::get_available_port();
+        let rpc_port = super::get_available_port();
         let grpc_public_address: Multiaddr =
             format!("/ip4/{}/tcp/{}", DEFAULT_HOST, public_address_port)
                 .parse()
@@ -43,6 +46,10 @@ impl NodeConfigBuilder {
                 listen: format!("{}:{}", DEFAULT_HOST, rest_port).parse().unwrap(),
                 tls: None,
                 cors: None,
+            },
+            rpc: Rpc {
+                listen: format!("{}:{}", DEFAULT_HOST, rpc_port).parse().unwrap(),
+                threads: 1,
             },
             p2p: P2p {
                 node_key_file: None,
@@ -121,6 +128,7 @@ impl NodeConfigBuilder {
             storage: self.storage.clone(),
             log: self.log.clone(),
             rest: self.rest.clone(),
+            rpc: self.rpc.clone(),
             p2p: self.p2p.clone(),
             mempool: self.mempool.clone(),
             bootstrap_from_trusted_peers: Some(!self.p2p.trusted_peers.is_empty()),

--- a/testing/jormungandr-automation/src/jormungandr/configuration/node_config_builder.rs
+++ b/testing/jormungandr-automation/src/jormungandr/configuration/node_config_builder.rs
@@ -49,7 +49,6 @@ impl NodeConfigBuilder {
             },
             rpc: Rpc {
                 listen: format!("{}:{}", DEFAULT_HOST, rpc_port).parse().unwrap(),
-                threads: 1,
             },
             p2p: P2p {
                 node_key_file: None,

--- a/testing/jormungandr-automation/src/jormungandr/legacy/config/configuration_builder.rs
+++ b/testing/jormungandr-automation/src/jormungandr/legacy/config/configuration_builder.rs
@@ -104,6 +104,7 @@ impl LegacyNodeConfigConverter {
                 cors: None,
                 tls: None,
             },
+            rpc: source.rpc.clone(),
             p2p: P2p {
                 trusted_peers,
                 public_address: source.p2p.public_address.clone(),
@@ -142,6 +143,7 @@ impl LegacyNodeConfigConverter {
                 cors: None,
                 tls: None,
             },
+            rpc: source.rpc.clone(),
             p2p: P2p {
                 trusted_peers,
                 public_address: source.p2p.public_address.clone(),
@@ -197,6 +199,7 @@ impl LegacyNodeConfigConverter {
                 cors: None,
                 tls: None,
             },
+            rpc: source.rpc.clone(),
             p2p: P2p {
                 trusted_peers,
                 public_address: source.p2p.public_address.clone(),

--- a/testing/jormungandr-automation/src/jormungandr/legacy/config/mod.rs
+++ b/testing/jormungandr-automation/src/jormungandr/legacy/config/mod.rs
@@ -5,7 +5,7 @@ pub use configuration_builder::{
     LegacyConfigConverter, LegacyConfigConverterError, LegacyNodeConfigConverter,
 };
 use jormungandr_lib::interfaces::{
-    LayersConfig, LogEntry, LogOutput, Mempool, Policy, Rest, TopicsOfInterest,
+    LayersConfig, LogEntry, LogOutput, Mempool, Policy, Rest, Rpc, TopicsOfInterest,
 };
 use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
@@ -73,6 +73,7 @@ pub struct NodeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage: Option<PathBuf>,
     pub rest: Rest,
+    pub rpc: Rpc,
     pub p2p: P2p,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log: Option<Log>,


### PR DESCRIPTION
Added initial RPC service initialization which will be used for the Ethereum JSON-API implementation.
Added two more dependencies:
- `jsonrpc`, [as for the server instance](https://github.com/paritytech/jsonrpc.git) 
