### PR TITLE
Validate server id is the expect one when connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate server id is the expected one during gRPC handshake
 - fix incorrect keys bech32 HRP by always using the ones provided by the library
 - update REST API: add new endpoint AccountVotes (`/api/v1/votes/plan/account-votes/{account_id}`)
 - Support parallel lanes in spending counters on account outputs. This allows

--- a/jormungandr/src/network/mod.rs
+++ b/jormungandr/src/network/mod.rs
@@ -474,7 +474,7 @@ fn connect_and_propagate(
     let cf = async move {
         let conn_state = ConnectionState::new(state.clone(), &peer, Span::current());
         tracing::info!("connecting to peer");
-        let (handle, connecting) = client::connect(conn_state, channels.clone());
+        let (handle, connecting) = client::connect(conn_state, channels.clone(), id);
         state.peers.add_connecting(id, addr, handle, options).await;
         match connecting.await {
             Err(e) => {


### PR DESCRIPTION
This would be better done in a network refactor which is currently in the backlog but not high priority. 
Since this change has some advantage when dealing with restarting nodes let's add a simple temporary check for it.