### PR TITLE
Fix tracing-gelf, tracing-journald usage for the explorer crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,8 +229,8 @@ jobs:
         shell: bash
         run: |
           case '${{ matrix.config.os }}' in
-            ubuntu-latest)  features=systemd,gelf ;;
-            *)              features=gelf ;;
+            ubuntu-latest)  features=systemd ;;
+            *)
           esac
           echo "JORMUNGANDR_FEATURES=$features" >> $GITHUB_ENV
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,8 +2462,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-futures",
- "tracing-gelf",
- "tracing-journald",
  "tracing-subscriber",
  "versionisator",
  "warp",
@@ -5236,9 +5234,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-gelf"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef407d785989f789a53a00c9a6196735ef6e407ae2bb20e0282b3b9dc271f66"
+checksum = "d6d094204165dcfc9cffe7b2c22d98e4a7bc86f1e8a052c83c7c5442ee325bf4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5248,6 +5246,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
  "tracing-core",
  "tracing-futures",
  "tracing-subscriber",
@@ -5255,10 +5254,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-journald"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c35f4a6b4b2d00511aa9e17d4efc74d4c3ddc5a5416f58a5de25c30bfeb0307"
+checksum = "1ba49f4829f4e95702943ec6b2fad8936b369d20fa27036caf01329fb230e460"
 dependencies = [
+ "libc",
  "tracing-core",
  "tracing-subscriber",
 ]

--- a/explorer/Cargo.toml
+++ b/explorer/Cargo.toml
@@ -56,3 +56,5 @@ imhamt = {git = "https://github.com/input-output-hk/chain-libs.git", branch = "m
 [features]
 default = []
 evm = ["chain-impl-mockchain/evm", "jormungandr-lib/evm"]
+systemd = ["tracing-journald"]
+gelf = ["tracing-gelf"]

--- a/jormungandr/Cargo.toml
+++ b/jormungandr/Cargo.toml
@@ -46,9 +46,7 @@ time = { version = "0.3", features = ["macros"] }
 thiserror = "1.0.30"
 tracing = "0.1"
 tracing-futures = "0.2"
-tracing-gelf = { version = "0.6", optional = true }
 # TODO unpin this when cross for ARM targets is fixed: https://github.com/cross-rs/cross/pull/591
-tracing-journald = { version = "=0.2.0", optional = true }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json", "time"] }
 tracing-appender = "0.2"
 tokio = { version = "^1.15", features = ["rt-multi-thread", "time", "sync", "rt", "signal", "test-util"] }
@@ -94,7 +92,5 @@ with-bench = []
 codegen-rustfmt = ["chain-network/codegen-rustfmt"]
 integration-test = []
 soak-test = []
-systemd = ["tracing-journald"]
-gelf = ["tracing-gelf"]
 prometheus-metrics = ["prometheus"]
 evm = [ "chain-impl-mockchain/evm", "jormungandr-lib/evm" ]


### PR DESCRIPTION
Seems it was missed to move `tracing-gelf` and `tracing-journald` deps for the explorer crate.