### PR TITLE
Add get chain info RPC endpoints

### DIFF
--- a/jormungandr/src/jrpc/eth_block_info/mod.rs
+++ b/jormungandr/src/jrpc/eth_block_info/mod.rs
@@ -1,15 +1,10 @@
-use crate::{blockchain::StorageError, context::ContextLock};
+use crate::context::ContextLock;
 use jsonrpsee_http_server::RpcModule;
 
 mod logic;
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error(transparent)]
-    ContextError(#[from] crate::context::Error),
-    #[error(transparent)]
-    Storage(#[from] StorageError),
-}
+pub enum Error {}
 
 pub fn eth_get_blocks_info_module(context: ContextLock) -> RpcModule<ContextLock> {
     let mut module = RpcModule::new(context);

--- a/jormungandr/src/jrpc/eth_chain_info/logic.rs
+++ b/jormungandr/src/jrpc/eth_chain_info/logic.rs
@@ -1,0 +1,23 @@
+use super::Error;
+use crate::{context::Context, jrpc::eth_types::sync::SyncStatus};
+use chain_evm::ethereum_types::{U256, U64};
+
+pub fn get_chain_id(_context: &Context) -> Result<Option<U64>, Error> {
+    // TODO implement
+    Ok(Some(0.into()))
+}
+
+pub fn is_syncing(_context: &Context) -> Result<SyncStatus, Error> {
+    // TODO implement
+    Ok(SyncStatus::build())
+}
+
+pub fn get_gas_price(_context: &Context) -> Result<U256, Error> {
+    // TODO implement
+    Ok(0.into())
+}
+
+pub fn get_protocol_verion(_context: &Context) -> Result<u64, Error> {
+    // TODO implement
+    Ok(0)
+}

--- a/jormungandr/src/jrpc/eth_chain_info/mod.rs
+++ b/jormungandr/src/jrpc/eth_chain_info/mod.rs
@@ -1,0 +1,45 @@
+use crate::context::ContextLock;
+use jsonrpsee_http_server::RpcModule;
+
+mod logic;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {}
+
+pub fn eth_get_blocks_info_module(context: ContextLock) -> RpcModule<ContextLock> {
+    let mut module = RpcModule::new(context);
+
+    module
+        .register_async_method("eth_chainId", |_, context| async move {
+            let context = context.read().await;
+            logic::get_chain_id(&context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_syncing", |_, context| async move {
+            let context = context.read().await;
+            logic::is_syncing(&context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_gasPrice", |_, context| async move {
+            let context = context.read().await;
+            logic::get_gas_price(&context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_protocolVersion", |_, context| async move {
+            let context = context.read().await;
+            logic::get_protocol_verion(&context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+}

--- a/jormungandr/src/jrpc/eth_types/mod.rs
+++ b/jormungandr/src/jrpc/eth_types/mod.rs
@@ -1,3 +1,4 @@
 pub mod block;
 pub mod block_number;
+pub mod sync;
 pub mod transaction;

--- a/jormungandr/src/jrpc/eth_types/sync.rs
+++ b/jormungandr/src/jrpc/eth_types/sync.rs
@@ -59,6 +59,9 @@ mod tests {
         });
 
         assert_eq!(serde_json::to_string(&ss_none).unwrap(), "false");
-        assert_eq!(serde_json::to_string(&ss_info).unwrap(), "{\"startingBlock\":\"0x0\",\"currentBlock\":\"0x0\",\"highestBlock\":\"0x0\"}");
+        assert_eq!(
+            serde_json::to_string(&ss_info).unwrap(),
+            "{\"startingBlock\":\"0x0\",\"currentBlock\":\"0x0\",\"highestBlock\":\"0x0\"}"
+        );
     }
 }

--- a/jormungandr/src/jrpc/eth_types/sync.rs
+++ b/jormungandr/src/jrpc/eth_types/sync.rs
@@ -1,0 +1,72 @@
+use chain_evm::ethereum_types::U256;
+use serde::{Serialize, Serializer};
+
+/// Sync info
+#[derive(Default, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncInfo {
+    /// Starting block
+    pub starting_block: U256,
+    /// Current block
+    pub current_block: U256,
+    /// Highest block seen so far
+    pub highest_block: U256,
+    /// Warp sync snapshot chunks total.
+    pub warp_chunks_amount: Option<U256>,
+    /// Warp sync snpashot chunks processed.
+    pub warp_chunks_processed: Option<U256>,
+}
+
+/// Sync status
+#[derive(Debug, PartialEq, Eq)]
+pub enum SyncStatus {
+    /// Info when syncing
+    Info(SyncInfo),
+    /// Not syncing
+    #[allow(dead_code)]
+    None,
+}
+
+impl SyncStatus {
+    pub fn build() -> Self {
+        Self::Info(SyncInfo {
+            starting_block: U256::zero(),
+            current_block: U256::zero(),
+            highest_block: U256::zero(),
+            warp_chunks_amount: Some(U256::zero()),
+            warp_chunks_processed: Some(U256::zero()),
+        })
+    }
+}
+
+impl Serialize for SyncStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            SyncStatus::Info(ref info) => info.serialize(serializer),
+            SyncStatus::None => false.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_status_json_deserialize() {
+        let ss_none = SyncStatus::None;
+        let ss_info = SyncStatus::Info(SyncInfo {
+            starting_block: U256::zero(),
+            current_block: U256::zero(),
+            highest_block: U256::zero(),
+            warp_chunks_amount: Some(U256::zero()),
+            warp_chunks_processed: Some(U256::zero()),
+        });
+
+        assert_eq!(serde_json::to_string(&ss_none).unwrap(), "false");
+        assert_eq!(serde_json::to_string(&ss_info).unwrap(), "{\"startingBlock\":\"0x0\",\"currentBlock\":\"0x0\",\"highestBlock\":\"0x0\",\"warpChunksAmount\":\"0x0\",\"warpChunksProcessed\":\"0x0\"}");
+    }
+}

--- a/jormungandr/src/jrpc/eth_types/sync.rs
+++ b/jormungandr/src/jrpc/eth_types/sync.rs
@@ -11,10 +11,6 @@ pub struct SyncInfo {
     pub current_block: U256,
     /// Highest block seen so far
     pub highest_block: U256,
-    /// Warp sync snapshot chunks total.
-    pub warp_chunks_amount: Option<U256>,
-    /// Warp sync snpashot chunks processed.
-    pub warp_chunks_processed: Option<U256>,
 }
 
 /// Sync status
@@ -33,8 +29,6 @@ impl SyncStatus {
             starting_block: U256::zero(),
             current_block: U256::zero(),
             highest_block: U256::zero(),
-            warp_chunks_amount: Some(U256::zero()),
-            warp_chunks_processed: Some(U256::zero()),
         })
     }
 }
@@ -62,11 +56,9 @@ mod tests {
             starting_block: U256::zero(),
             current_block: U256::zero(),
             highest_block: U256::zero(),
-            warp_chunks_amount: Some(U256::zero()),
-            warp_chunks_processed: Some(U256::zero()),
         });
 
         assert_eq!(serde_json::to_string(&ss_none).unwrap(), "false");
-        assert_eq!(serde_json::to_string(&ss_info).unwrap(), "{\"startingBlock\":\"0x0\",\"currentBlock\":\"0x0\",\"highestBlock\":\"0x0\",\"warpChunksAmount\":\"0x0\",\"warpChunksProcessed\":\"0x0\"}");
+        assert_eq!(serde_json::to_string(&ss_info).unwrap(), "{\"startingBlock\":\"0x0\",\"currentBlock\":\"0x0\",\"highestBlock\":\"0x0\"}");
     }
 }

--- a/jormungandr/src/jrpc/mod.rs
+++ b/jormungandr/src/jrpc/mod.rs
@@ -23,14 +23,15 @@ pub async fn start_jrpc_server(config: Config, _context: ContextLock) {
     let mut modules = RpcModule::new(());
 
     #[cfg(feature = "evm")]
-    modules
-        .merge(eth_block_info::eth_get_blocks_info_module(_context.clone()))
-        .unwrap();
+    {
+        modules
+            .merge(eth_block_info::eth_get_blocks_info_module(_context.clone()))
+            .unwrap();
 
-    #[cfg(feature = "evm")]
-    modules
-        .merge(eth_chain_info::eth_get_blocks_info_module(_context))
-        .unwrap();
+        modules
+            .merge(eth_chain_info::eth_get_blocks_info_module(_context))
+            .unwrap();
+    }
 
     server.start(modules).unwrap().await
 }

--- a/jormungandr/src/jrpc/mod.rs
+++ b/jormungandr/src/jrpc/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "evm")]
 mod eth_block_info;
 #[cfg(feature = "evm")]
+mod eth_chain_info;
+#[cfg(feature = "evm")]
 mod eth_types;
 
 use crate::context::ContextLock;
@@ -22,7 +24,12 @@ pub async fn start_jrpc_server(config: Config, _context: ContextLock) {
 
     #[cfg(feature = "evm")]
     modules
-        .merge(eth_block_info::eth_get_blocks_info_module(_context))
+        .merge(eth_block_info::eth_get_blocks_info_module(_context.clone()))
+        .unwrap();
+
+    #[cfg(feature = "evm")]
+    modules
+        .merge(eth_chain_info::eth_get_blocks_info_module(_context))
         .unwrap();
 
     server.start(modules).unwrap().await


### PR DESCRIPTION
Add a dummy implementation for the bunch of the RPC endpoints.
The main goal to provide a correct signature of the RPC endpoints and correct data types for the arguments and return value.
Functionality for the endpoints will be added later.