### PR TITLE
Add transaction RPC endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,14 @@
 - Bump ed25519-bip32 from 0.4.0 to 0.4.1
 - Now the tally is incremental and is always available in the rest API. The
 - Add standalone explorer crate.
-- Add new Ethreum RPC endpoints for the getting block info: eth_getBlockByHash, eth_getBlockByNumber, eth_getBlockTransactionCountByHash, eth_getBlockTransactionCountByNumber, eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_blockNumber
 - Bump clap from 2.34.0 to 3.1.13
 - Bump time from 0.3.7 to 0.3.9
 - Bump libc from 0.2.117 to 0.2.124
 - Bump rand from 0.8.4 to 0.8.5
 - Add jcli option to generate and sign EVM mapping certificates.
-
+- Add new Ethreum RPC endpoints for the getting block info: eth_getBlockByHash, eth_getBlockByNumber, eth_getBlockTransactionCountByHash, eth_getBlockTransactionCountByNumber, eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_blockNumber
+- Add new Ethreum RPC endpoints for the transaction handling: eth_sendTransaction, eth_sendRawTransaction, eth_getTransactionByHash, eth_getTransactionByBlockHashAndIndex, eth_getTransactionByBlockNumberAndIndex, eth_getTransactionReceipt, eth_signTransaction, eth_estimateGas, eth_sign
+- Add new Ethreum RPC endpoints for the getting chain info: eth_chainId, eth_syncing, eth_gasPrice, eth_protocolVersion
 ## Release 0.13.0
 
 **New features:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@
 - Bump libc from 0.2.117 to 0.2.124
 - Bump rand from 0.8.4 to 0.8.5
 - Add jcli option to generate and sign EVM mapping certificates.
-- Add new Ethreum RPC endpoints for the getting block info: eth_getBlockByHash, eth_getBlockByNumber, eth_getBlockTransactionCountByHash, eth_getBlockTransactionCountByNumber, eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_blockNumber
-- Add new Ethreum RPC endpoints for the transaction handling: eth_sendTransaction, eth_sendRawTransaction, eth_getTransactionByHash, eth_getTransactionByBlockHashAndIndex, eth_getTransactionByBlockNumberAndIndex, eth_getTransactionReceipt, eth_signTransaction, eth_estimateGas, eth_sign
-- Add new Ethreum RPC endpoints for the getting chain info: eth_chainId, eth_syncing, eth_gasPrice, eth_protocolVersion
+- Add new Ethreum RPC endpoints for getting block info: eth_getBlockByHash, eth_getBlockByNumber, eth_getBlockTransactionCountByHash, eth_getBlockTransactionCountByNumber, eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_blockNumber
+- Add new Ethreum RPC endpoints for transaction handling: eth_sendTransaction, eth_sendRawTransaction, eth_getTransactionByHash, eth_getTransactionByBlockHashAndIndex, eth_getTransactionByBlockNumberAndIndex, eth_getTransactionReceipt, eth_signTransaction, eth_estimateGas, eth_sign
+- Add new Ethreum RPC endpoints for getting chain info: eth_chainId, eth_syncing, eth_gasPrice, eth_protocolVersion
 ## Release 0.13.0
 
 **New features:**

--- a/jormungandr/src/jrpc/eth_block_info/logic.rs
+++ b/jormungandr/src/jrpc/eth_block_info/logic.rs
@@ -1,9 +1,9 @@
 use super::Error;
 use crate::{
     context::Context,
-    jrpc::eth_types::{block::Block, block_number::BlockNumber},
+    jrpc::eth_types::{block::Block, block_number::BlockNumber, number::Number},
 };
-use chain_evm::ethereum_types::{H256, U256};
+use chain_evm::ethereum_types::H256;
 
 pub fn get_block_by_hash(
     _hash: H256,
@@ -16,17 +16,17 @@ pub fn get_block_by_hash(
 
 pub fn get_block_by_number(
     _number: BlockNumber,
-    _full: bool,
+    full: bool,
     _context: &Context,
 ) -> Result<Option<Block>, Error> {
     // TODO implement
-    Ok(Some(Block::default()))
+    Ok(Some(Block::build(full)))
 }
 
 pub fn get_transaction_count_by_hash(
     _hash: H256,
     _context: &Context,
-) -> Result<Option<U256>, Error> {
+) -> Result<Option<Number>, Error> {
     // TODO implement
     Ok(Some(0.into()))
 }
@@ -34,22 +34,22 @@ pub fn get_transaction_count_by_hash(
 pub fn get_transaction_count_by_number(
     _number: BlockNumber,
     _context: &Context,
-) -> Result<Option<U256>, Error> {
+) -> Result<Option<Number>, Error> {
     // TODO implement
     Ok(Some(0.into()))
 }
 
-pub fn get_uncle_count_by_hash(_: H256, _: &Context) -> Result<Option<U256>, Error> {
+pub fn get_uncle_count_by_hash(_: H256, _: &Context) -> Result<Option<Number>, Error> {
     // jormungandr block does not have any ethereum "uncles" so we allways return 0
     Ok(Some(0.into()))
 }
 
-pub fn get_uncle_count_by_number(_: BlockNumber, _: &Context) -> Result<Option<U256>, Error> {
+pub fn get_uncle_count_by_number(_: BlockNumber, _: &Context) -> Result<Option<Number>, Error> {
     // jormungandr block does not have any ethereum "uncles" so we allways return 0
     Ok(Some(0.into()))
 }
 
-pub fn get_block_number(_: &Context) -> Result<U256, Error> {
+pub fn get_block_number(_: &Context) -> Result<Number, Error> {
     // TODO implement
     Ok(0.into())
 }

--- a/jormungandr/src/jrpc/eth_block_info/mod.rs
+++ b/jormungandr/src/jrpc/eth_block_info/mod.rs
@@ -6,7 +6,7 @@ mod logic;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {}
 
-pub fn eth_get_blocks_info_module(context: ContextLock) -> RpcModule<ContextLock> {
+pub fn eth_block_info_module(context: ContextLock) -> RpcModule<ContextLock> {
     let mut module = RpcModule::new(context);
 
     module

--- a/jormungandr/src/jrpc/eth_chain_info/logic.rs
+++ b/jormungandr/src/jrpc/eth_chain_info/logic.rs
@@ -1,10 +1,12 @@
 use super::Error;
-use crate::{context::Context, jrpc::eth_types::sync::SyncStatus};
-use chain_evm::ethereum_types::{U256, U64};
+use crate::{
+    context::Context,
+    jrpc::eth_types::{number::Number, sync::SyncStatus},
+};
 
-pub fn get_chain_id(_context: &Context) -> Result<Option<U64>, Error> {
+pub fn get_chain_id(_context: &Context) -> Result<Number, Error> {
     // TODO implement
-    Ok(Some(0.into()))
+    Ok(0.into())
 }
 
 pub fn is_syncing(_context: &Context) -> Result<SyncStatus, Error> {
@@ -12,7 +14,7 @@ pub fn is_syncing(_context: &Context) -> Result<SyncStatus, Error> {
     Ok(SyncStatus::build())
 }
 
-pub fn get_gas_price(_context: &Context) -> Result<U256, Error> {
+pub fn get_gas_price(_context: &Context) -> Result<Number, Error> {
     // TODO implement
     Ok(0.into())
 }

--- a/jormungandr/src/jrpc/eth_chain_info/mod.rs
+++ b/jormungandr/src/jrpc/eth_chain_info/mod.rs
@@ -6,7 +6,7 @@ mod logic;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {}
 
-pub fn eth_get_blocks_info_module(context: ContextLock) -> RpcModule<ContextLock> {
+pub fn eth_chain_info_module(context: ContextLock) -> RpcModule<ContextLock> {
     let mut module = RpcModule::new(context);
 
     module

--- a/jormungandr/src/jrpc/eth_transaction/logic.rs
+++ b/jormungandr/src/jrpc/eth_transaction/logic.rs
@@ -6,7 +6,7 @@ use crate::{
         transaction::Transaction,
     },
 };
-use chain_evm::ethereum_types::H256;
+use chain_evm::ethereum_types::{H160, H256, H512, U256};
 
 pub fn send_transaction(_tx: Transaction, _context: &Context) -> Result<H256, Error> {
     // TODO implement
@@ -47,4 +47,19 @@ pub fn get_transaction_by_block_number_and_index(
 pub fn get_transaction_receipt(_hash: H256, _context: &Context) -> Result<Option<Receipt>, Error> {
     // TODO implement
     Ok(Some(Receipt::build()))
+}
+
+pub fn sign_transaction(_tx: Transaction, _context: &Context) -> Result<Bytes, Error> {
+    // TODO implement
+    Ok(Default::default())
+}
+
+pub fn estimate_gas(_tx: Transaction, _context: &Context) -> Result<U256, Error> {
+    // TODO implement
+    Ok(U256::zero())
+}
+
+pub fn sign(_address: H160, _message: Bytes, _context: &Context) -> Result<H512, Error> {
+    // TODO implement
+    Ok(H512::zero())
 }

--- a/jormungandr/src/jrpc/eth_transaction/logic.rs
+++ b/jormungandr/src/jrpc/eth_transaction/logic.rs
@@ -1,8 +1,33 @@
 use super::Error;
-use crate::{context::Context, jrpc::eth_types::transaction::Transaction};
+use crate::{
+    context::Context,
+    jrpc::eth_types::{bytes::Bytes, index::Index, transaction::Transaction},
+};
 use chain_evm::ethereum_types::H256;
 
 pub fn send_transaction(_tx: Transaction, _context: &Context) -> Result<H256, Error> {
     // TODO implement
     Ok(H256::zero())
+}
+
+pub fn send_raw_transaction(_raw_tx: Bytes, _context: &Context) -> Result<H256, Error> {
+    // TODO implement
+    Ok(H256::zero())
+}
+
+pub fn get_transaction_by_hash(
+    _hash: H256,
+    _context: &Context,
+) -> Result<Option<Transaction>, Error> {
+    // TODO implement
+    Ok(Some(Transaction::build()))
+}
+
+pub fn get_transaction_by_block_hash_and_index(
+    _hash: H256,
+    _index: Index,
+    _context: &Context,
+) -> Result<Option<Transaction>, Error> {
+    // TODO implement
+    Ok(Some(Transaction::build()))
 }

--- a/jormungandr/src/jrpc/eth_transaction/logic.rs
+++ b/jormungandr/src/jrpc/eth_transaction/logic.rs
@@ -2,11 +2,11 @@ use super::Error;
 use crate::{
     context::Context,
     jrpc::eth_types::{
-        block_number::BlockNumber, bytes::Bytes, index::Index, receipt::Receipt,
+        block_number::BlockNumber, bytes::Bytes, number::Number, receipt::Receipt,
         transaction::Transaction,
     },
 };
-use chain_evm::ethereum_types::{H160, H256, H512, U256};
+use chain_evm::ethereum_types::{H160, H256, H512};
 
 pub fn send_transaction(_tx: Transaction, _context: &Context) -> Result<H256, Error> {
     // TODO implement
@@ -28,7 +28,7 @@ pub fn get_transaction_by_hash(
 
 pub fn get_transaction_by_block_hash_and_index(
     _hash: H256,
-    _index: Index,
+    _index: Number,
     _context: &Context,
 ) -> Result<Option<Transaction>, Error> {
     // TODO implement
@@ -37,7 +37,7 @@ pub fn get_transaction_by_block_hash_and_index(
 
 pub fn get_transaction_by_block_number_and_index(
     _number: BlockNumber,
-    _index: Index,
+    _index: Number,
     _context: &Context,
 ) -> Result<Option<Transaction>, Error> {
     // TODO implement
@@ -54,9 +54,9 @@ pub fn sign_transaction(_tx: Transaction, _context: &Context) -> Result<Bytes, E
     Ok(Default::default())
 }
 
-pub fn estimate_gas(_tx: Transaction, _context: &Context) -> Result<U256, Error> {
+pub fn estimate_gas(_tx: Transaction, _context: &Context) -> Result<Number, Error> {
     // TODO implement
-    Ok(U256::zero())
+    Ok(0.into())
 }
 
 pub fn sign(_address: H160, _message: Bytes, _context: &Context) -> Result<H512, Error> {

--- a/jormungandr/src/jrpc/eth_transaction/logic.rs
+++ b/jormungandr/src/jrpc/eth_transaction/logic.rs
@@ -1,7 +1,10 @@
 use super::Error;
 use crate::{
     context::Context,
-    jrpc::eth_types::{bytes::Bytes, index::Index, transaction::Transaction},
+    jrpc::eth_types::{
+        block_number::BlockNumber, bytes::Bytes, index::Index, receipt::Receipt,
+        transaction::Transaction,
+    },
 };
 use chain_evm::ethereum_types::H256;
 
@@ -30,4 +33,18 @@ pub fn get_transaction_by_block_hash_and_index(
 ) -> Result<Option<Transaction>, Error> {
     // TODO implement
     Ok(Some(Transaction::build()))
+}
+
+pub fn get_transaction_by_block_number_and_index(
+    _number: BlockNumber,
+    _index: Index,
+    _context: &Context,
+) -> Result<Option<Transaction>, Error> {
+    // TODO implement
+    Ok(Some(Transaction::build()))
+}
+
+pub fn get_transaction_receipt(_hash: H256, _context: &Context) -> Result<Option<Receipt>, Error> {
+    // TODO implement
+    Ok(Some(Receipt::build()))
 }

--- a/jormungandr/src/jrpc/eth_transaction/logic.rs
+++ b/jormungandr/src/jrpc/eth_transaction/logic.rs
@@ -1,0 +1,8 @@
+use super::Error;
+use crate::{context::Context, jrpc::eth_types::transaction::Transaction};
+use chain_evm::ethereum_types::H256;
+
+pub fn send_transaction(_tx: Transaction, _context: &Context) -> Result<H256, Error> {
+    // TODO implement
+    Ok(H256::zero())
+}

--- a/jormungandr/src/jrpc/eth_transaction/mod.rs
+++ b/jormungandr/src/jrpc/eth_transaction/mod.rs
@@ -21,8 +21,8 @@ pub fn eth_transaction_module(context: ContextLock) -> RpcModule<ContextLock> {
     module
         .register_async_method("eth_sendRawTransaction", |params, context| async move {
             let context = context.read().await;
-            let tx = params.parse()?;
-            logic::send_transaction(tx, &context)
+            let raw_tx = params.parse()?;
+            logic::send_raw_transaction(raw_tx, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();
@@ -30,8 +30,8 @@ pub fn eth_transaction_module(context: ContextLock) -> RpcModule<ContextLock> {
     module
         .register_async_method("eth_getTransactionByHash", |params, context| async move {
             let context = context.read().await;
-            let tx = params.parse()?;
-            logic::send_transaction(tx, &context)
+            let hash = params.parse()?;
+            logic::get_transaction_by_hash(hash, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();
@@ -41,8 +41,8 @@ pub fn eth_transaction_module(context: ContextLock) -> RpcModule<ContextLock> {
             "eth_getTransactionByBlockHashAndIndex",
             |params, context| async move {
                 let context = context.read().await;
-                let tx = params.parse()?;
-                logic::send_transaction(tx, &context)
+                let (hash, index) = params.parse()?;
+                logic::get_transaction_by_block_hash_and_index(hash, index, &context)
                     .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
             },
         )

--- a/jormungandr/src/jrpc/eth_transaction/mod.rs
+++ b/jormungandr/src/jrpc/eth_transaction/mod.rs
@@ -70,19 +70,10 @@ pub fn eth_transaction_module(context: ContextLock) -> RpcModule<ContextLock> {
         .unwrap();
 
     module
-        .register_async_method("eth_sign", |params, context| async move {
-            let context = context.read().await;
-            let tx = params.parse()?;
-            logic::send_transaction(tx, &context)
-                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
-        })
-        .unwrap();
-
-    module
         .register_async_method("eth_signTransaction", |params, context| async move {
             let context = context.read().await;
             let tx = params.parse()?;
-            logic::send_transaction(tx, &context)
+            logic::sign_transaction(tx, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();
@@ -91,7 +82,16 @@ pub fn eth_transaction_module(context: ContextLock) -> RpcModule<ContextLock> {
         .register_async_method("eth_estimateGas", |params, context| async move {
             let context = context.read().await;
             let tx = params.parse()?;
-            logic::send_transaction(tx, &context)
+            logic::estimate_gas(tx, &context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_sign", |params, context| async move {
+            let context = context.read().await;
+            let (address, message) = params.parse()?;
+            logic::sign(address, message, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();

--- a/jormungandr/src/jrpc/eth_transaction/mod.rs
+++ b/jormungandr/src/jrpc/eth_transaction/mod.rs
@@ -1,0 +1,100 @@
+use crate::context::ContextLock;
+use jsonrpsee_http_server::RpcModule;
+
+mod logic;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {}
+
+pub fn eth_transaction_module(context: ContextLock) -> RpcModule<ContextLock> {
+    let mut module = RpcModule::new(context);
+
+    module
+        .register_async_method("eth_sendTransaction", |params, context| async move {
+            let context = context.read().await;
+            let tx = params.parse()?;
+            logic::send_transaction(tx, &context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_sendRawTransaction", |params, context| async move {
+            let context = context.read().await;
+            let tx = params.parse()?;
+            logic::send_transaction(tx, &context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_getTransactionByHash", |params, context| async move {
+            let context = context.read().await;
+            let tx = params.parse()?;
+            logic::send_transaction(tx, &context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method(
+            "eth_getTransactionByBlockHashAndIndex",
+            |params, context| async move {
+                let context = context.read().await;
+                let tx = params.parse()?;
+                logic::send_transaction(tx, &context)
+                    .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+            },
+        )
+        .unwrap();
+
+    module
+        .register_async_method(
+            "eth_getTransactionByBlockNumberAndIndex",
+            |params, context| async move {
+                let context = context.read().await;
+                let tx = params.parse()?;
+                logic::send_transaction(tx, &context)
+                    .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+            },
+        )
+        .unwrap();
+
+    module
+        .register_async_method("eth_getTransactionReceipt", |params, context| async move {
+            let context = context.read().await;
+            let tx = params.parse()?;
+            logic::send_transaction(tx, &context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_sign", |params, context| async move {
+            let context = context.read().await;
+            let tx = params.parse()?;
+            logic::send_transaction(tx, &context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_signTransaction", |params, context| async move {
+            let context = context.read().await;
+            let tx = params.parse()?;
+            logic::send_transaction(tx, &context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_estimateGas", |params, context| async move {
+            let context = context.read().await;
+            let tx = params.parse()?;
+            logic::send_transaction(tx, &context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+}

--- a/jormungandr/src/jrpc/eth_transaction/mod.rs
+++ b/jormungandr/src/jrpc/eth_transaction/mod.rs
@@ -53,8 +53,8 @@ pub fn eth_transaction_module(context: ContextLock) -> RpcModule<ContextLock> {
             "eth_getTransactionByBlockNumberAndIndex",
             |params, context| async move {
                 let context = context.read().await;
-                let tx = params.parse()?;
-                logic::send_transaction(tx, &context)
+                let (number, index) = params.parse()?;
+                logic::get_transaction_by_block_number_and_index(number, index, &context)
                     .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
             },
         )
@@ -63,8 +63,8 @@ pub fn eth_transaction_module(context: ContextLock) -> RpcModule<ContextLock> {
     module
         .register_async_method("eth_getTransactionReceipt", |params, context| async move {
             let context = context.read().await;
-            let tx = params.parse()?;
-            logic::send_transaction(tx, &context)
+            let hash = params.parse()?;
+            logic::get_transaction_receipt(hash, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();

--- a/jormungandr/src/jrpc/eth_types/block.rs
+++ b/jormungandr/src/jrpc/eth_types/block.rs
@@ -1,20 +1,6 @@
-use super::transaction::Transaction;
+use super::{bytes::Bytes, transaction::Transaction};
 use chain_evm::ethereum_types::{Bloom, H160, H256, U256};
 use serde::{Serialize, Serializer};
-
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct Bytes(Box<[u8]>);
-
-impl Serialize for Bytes {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut serialized = "0x".to_owned();
-        serialized.push_str(hex::encode(&self.0).as_str());
-        serializer.serialize_str(serialized.as_ref())
-    }
-}
 
 /// Block Transactions
 #[derive(Debug)]

--- a/jormungandr/src/jrpc/eth_types/block.rs
+++ b/jormungandr/src/jrpc/eth_types/block.rs
@@ -34,38 +34,38 @@ impl Serialize for BlockTransactions {
 #[serde(rename_all = "camelCase")]
 pub struct Header {
     /// Hash of the block
-    pub hash: H256,
+    hash: H256,
     /// Mix Hash of the block
-    pub mix_hash: H256,
+    mix_hash: H256,
     /// Nonce of the block,
-    pub nonce: U256,
+    nonce: U256,
     /// Hash of the parent
-    pub parent_hash: H256,
+    parent_hash: H256,
     /// Hash of the uncles
     #[serde(rename = "sha3Uncles")]
-    pub uncles_hash: H256,
+    uncles_hash: H256,
     /// Alias of `author`
-    pub miner: H160,
+    miner: H160,
     /// State root hash (same as transactions_root)
-    pub state_root: H256,
+    state_root: H256,
     /// Transactions root hash,
-    pub transactions_root: H256,
+    transactions_root: H256,
     /// Transactions receipts root hash
-    pub receipts_root: H256,
+    receipts_root: H256,
     /// Block number
-    pub number: U256,
+    number: U256,
     /// Gas Used
-    pub gas_used: U256,
+    gas_used: U256,
     /// Gas Limit
-    pub gas_limit: U256,
+    gas_limit: U256,
     /// Extra data
-    pub extra_data: Bytes,
+    extra_data: Bytes,
     /// Logs bloom
-    pub logs_bloom: Bloom,
+    logs_bloom: Bloom,
     /// Timestamp
-    pub timestamp: U256,
+    timestamp: U256,
     /// Difficulty
-    pub difficulty: Option<U256>,
+    difficulty: Option<U256>,
 }
 
 impl Header {
@@ -97,17 +97,17 @@ impl Header {
 pub struct Block {
     /// Header of the block
     #[serde(flatten)]
-    pub header: Header,
+    header: Header,
     /// Total difficulty
-    pub total_difficulty: U256,
+    total_difficulty: U256,
     /// Uncles' hashes
-    pub uncles: Vec<H256>,
+    uncles: Vec<H256>,
     /// Transactions
-    pub transactions: BlockTransactions,
+    transactions: BlockTransactions,
     /// Size in bytes
-    pub size: U256,
+    size: U256,
     /// Base Fee for post-EIP1559 blocks.
-    pub base_fee_per_gas: Option<U256>,
+    base_fee_per_gas: Option<U256>,
 }
 
 impl Block {

--- a/jormungandr/src/jrpc/eth_types/block.rs
+++ b/jormungandr/src/jrpc/eth_types/block.rs
@@ -1,5 +1,5 @@
-use super::{bytes::Bytes, transaction::Transaction};
-use chain_evm::ethereum_types::{Bloom, H160, H256, U256};
+use super::{bytes::Bytes, number::Number, transaction::Transaction};
+use chain_evm::ethereum_types::{Bloom, H160, H256};
 use serde::{Serialize, Serializer};
 
 /// Block Transactions
@@ -30,7 +30,7 @@ impl Serialize for BlockTransactions {
 }
 
 /// Block header representation.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, Default)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Header {
     /// Hash of the block
@@ -38,7 +38,7 @@ pub struct Header {
     /// Mix Hash of the block
     mix_hash: H256,
     /// Nonce of the block,
-    nonce: U256,
+    nonce: Number,
     /// Hash of the parent
     parent_hash: H256,
     /// Hash of the uncles
@@ -53,19 +53,19 @@ pub struct Header {
     /// Transactions receipts root hash
     receipts_root: H256,
     /// Block number
-    number: U256,
+    number: Number,
     /// Gas Used
-    gas_used: U256,
+    gas_used: Number,
     /// Gas Limit
-    gas_limit: U256,
+    gas_limit: Number,
     /// Extra data
     extra_data: Bytes,
     /// Logs bloom
     logs_bloom: Bloom,
     /// Timestamp
-    timestamp: U256,
+    timestamp: Number,
     /// Difficulty
-    difficulty: Option<U256>,
+    difficulty: Option<Number>,
 }
 
 impl Header {
@@ -73,41 +73,41 @@ impl Header {
         Self {
             hash: H256::zero(),
             mix_hash: H256::zero(),
-            nonce: U256::one(),
+            nonce: 1.into(),
             parent_hash: H256::zero(),
             uncles_hash: H256::zero(),
             miner: H160::zero(),
             state_root: H256::zero(),
             transactions_root: H256::zero(),
             receipts_root: H256::zero(),
-            number: U256::one(),
-            gas_used: U256::one(),
-            gas_limit: U256::one(),
+            number: 1.into(),
+            gas_used: 1.into(),
+            gas_limit: 1.into(),
             extra_data: Bytes::default(),
             logs_bloom: Bloom::zero(),
-            timestamp: U256::one(),
-            difficulty: Some(U256::one()),
+            timestamp: 1.into(),
+            difficulty: Some(1.into()),
         }
     }
 }
 
 /// Block representation
-#[derive(Debug, Serialize, Default)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Block {
     /// Header of the block
     #[serde(flatten)]
     header: Header,
     /// Total difficulty
-    total_difficulty: U256,
+    total_difficulty: Number,
     /// Uncles' hashes
     uncles: Vec<H256>,
     /// Transactions
     transactions: BlockTransactions,
     /// Size in bytes
-    size: U256,
+    size: Number,
     /// Base Fee for post-EIP1559 blocks.
-    base_fee_per_gas: Option<U256>,
+    base_fee_per_gas: Option<Number>,
 }
 
 impl Block {
@@ -121,11 +121,11 @@ impl Block {
 
         Self {
             header,
-            total_difficulty: U256::one(),
+            total_difficulty: 1.into(),
             uncles: Default::default(),
             transactions,
-            size: U256::one(),
-            base_fee_per_gas: Some(U256::one()),
+            size: 1.into(),
+            base_fee_per_gas: Some(1.into()),
         }
     }
 }

--- a/jormungandr/src/jrpc/eth_types/bytes.rs
+++ b/jormungandr/src/jrpc/eth_types/bytes.rs
@@ -65,13 +65,13 @@ mod tests {
     #[test]
     fn bytes_json_serde() {
         let bytes = Bytes([1, 2, 3, 4, 5, 69].into());
-        assert_eq!(serde_json::to_string(&bytes).unwrap(), "\"0x010203040545\"");
-        let decoded: Bytes = serde_json::from_str("\"0x010203040545\"").unwrap();
+        assert_eq!(serde_json::to_string(&bytes).unwrap(), r#""0x010203040545""#);
+        let decoded: Bytes = serde_json::from_str(r#""0x010203040545""#).unwrap();
         assert_eq!(decoded, bytes);
 
         let bytes = Bytes([].into());
-        assert_eq!(serde_json::to_string(&bytes).unwrap(), "\"0x\"");
-        let decoded: Bytes = serde_json::from_str("\"0x\"").unwrap();
+        assert_eq!(serde_json::to_string(&bytes).unwrap(), r#""0x""#);
+        let decoded: Bytes = serde_json::from_str(r#""0x""#).unwrap();
         assert_eq!(decoded, bytes);
     }
 }

--- a/jormungandr/src/jrpc/eth_types/bytes.rs
+++ b/jormungandr/src/jrpc/eth_types/bytes.rs
@@ -1,0 +1,77 @@
+use serde::{de::Error, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Bytes(Box<[u8]>);
+
+impl Serialize for Bytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serialized = "0x".to_owned();
+        serialized.push_str(hex::encode(&self.0).as_str());
+        serializer.serialize_str(serialized.as_ref())
+    }
+}
+
+impl<'a> Deserialize<'a> for Bytes {
+    fn deserialize<D>(deserializer: D) -> Result<Bytes, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_any(BytesVisitor)
+    }
+}
+
+struct BytesVisitor;
+
+impl<'a> Visitor<'a> for BytesVisitor {
+    type Value = Bytes;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a 0x-prefixed, hex-encoded vector of bytes")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if value.len() >= 2 && value.starts_with("0x") && value.len() % 2 == 0 {
+            Ok(Bytes(
+                hex::decode(&value[2..])
+                    .map_err(|e| Error::custom(format!("Invalid hex: {}", e)))?
+                    .into(),
+            ))
+        } else {
+            Err(Error::custom(
+                "Invalid bytes format. Expected a 0x-prefixed hex string with even length",
+            ))
+        }
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_str(value.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytes_json_serde() {
+        let bytes = Bytes([1, 2, 3, 4, 5, 69].into());
+        assert_eq!(serde_json::to_string(&bytes).unwrap(), "\"0x010203040545\"");
+        let decoded: Bytes = serde_json::from_str("\"0x010203040545\"").unwrap();
+        assert_eq!(decoded, bytes);
+
+        let bytes = Bytes([].into());
+        assert_eq!(serde_json::to_string(&bytes).unwrap(), "\"0x\"");
+        let decoded: Bytes = serde_json::from_str("\"0x\"").unwrap();
+        assert_eq!(decoded, bytes);
+    }
+}

--- a/jormungandr/src/jrpc/eth_types/bytes.rs
+++ b/jormungandr/src/jrpc/eth_types/bytes.rs
@@ -37,7 +37,7 @@ impl<'a> Visitor<'a> for BytesVisitor {
     where
         E: Error,
     {
-        if value.len() >= 2 && value.starts_with("0x") && value.len() % 2 == 0 {
+        if value.len() >= 2 && value.starts_with("0x") {
             Ok(Bytes(
                 hex::decode(&value[2..])
                     .map_err(|e| Error::custom(format!("Invalid hex: {}", e)))?
@@ -45,7 +45,7 @@ impl<'a> Visitor<'a> for BytesVisitor {
             ))
         } else {
             Err(Error::custom(
-                "Invalid bytes format. Expected a 0x-prefixed hex string with even length",
+                "Invalid bytes format. Expected a 0x-prefixed hex string",
             ))
         }
     }

--- a/jormungandr/src/jrpc/eth_types/bytes.rs
+++ b/jormungandr/src/jrpc/eth_types/bytes.rs
@@ -65,7 +65,10 @@ mod tests {
     #[test]
     fn bytes_json_serde() {
         let bytes = Bytes([1, 2, 3, 4, 5, 69].into());
-        assert_eq!(serde_json::to_string(&bytes).unwrap(), r#""0x010203040545""#);
+        assert_eq!(
+            serde_json::to_string(&bytes).unwrap(),
+            r#""0x010203040545""#
+        );
         let decoded: Bytes = serde_json::from_str(r#""0x010203040545""#).unwrap();
         assert_eq!(decoded, bytes);
 

--- a/jormungandr/src/jrpc/eth_types/index.rs
+++ b/jormungandr/src/jrpc/eth_types/index.rs
@@ -1,0 +1,72 @@
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer,
+};
+use std::fmt;
+
+/// Represents usize.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Index(u64);
+
+impl<'a> Deserialize<'a> for Index {
+    fn deserialize<D>(deserializer: D) -> Result<Index, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_any(IndexVisitor)
+    }
+}
+
+struct IndexVisitor;
+
+impl<'a> Visitor<'a> for IndexVisitor {
+    type Value = Index;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a hex-encoded or decimal index")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        match value {
+            _ if value.starts_with("0x") => u64::from_str_radix(&value[2..], 16)
+                .map(Index)
+                .map_err(|e| Error::custom(format!("Invalid index: {}", e))),
+            _ => value
+                .parse::<u64>()
+                .map(Index)
+                .map_err(|e| Error::custom(format!("Invalid index: {}", e))),
+        }
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_str(value.as_ref())
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(Index(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_deserialization() {
+        let s = r#"["0xa", "10", 42, "0x45"]"#;
+        let deserialized: Vec<Index> = serde_json::from_str(s).unwrap();
+        assert_eq!(
+            deserialized,
+            vec![Index(10), Index(10), Index(42), Index(69)]
+        );
+    }
+}

--- a/jormungandr/src/jrpc/eth_types/log.rs
+++ b/jormungandr/src/jrpc/eth_types/log.rs
@@ -1,0 +1,67 @@
+use super::bytes::Bytes;
+use chain_evm::ethereum_types::{H160, H256, U256};
+use serde::Serialize;
+
+/// Log
+#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Log {
+    /// Whether Log Type is Removed (Geth Compatibility Field)
+    removed: bool,
+    /// Log Index in Block
+    log_index: Option<U256>,
+    /// Transaction Index
+    transaction_index: Option<U256>,
+    /// Transaction Hash
+    transaction_hash: Option<H256>,
+    /// Block Hash
+    block_hash: Option<H256>,
+    /// Block Number
+    block_number: Option<U256>,
+    /// H160
+    address: Option<H160>,
+    /// Data
+    data: Option<Bytes>,
+    /// Topics
+    topics: Vec<H256>,
+}
+
+impl Log {
+    pub fn build() -> Self {
+        Self {
+            removed: true,
+            log_index: Some(U256::zero()),
+            transaction_index: Some(U256::zero()),
+            transaction_hash: Some(H256::zero()),
+            block_hash: Some(H256::zero()),
+            block_number: Some(U256::zero()),
+            address: Some(H160::zero()),
+            data: Some(Default::default()),
+            topics: Default::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receipt_json_serialize() {
+        let log = Log {
+            removed: true,
+            log_index: Some(U256::zero()),
+            transaction_index: Some(U256::zero()),
+            transaction_hash: Some(H256::zero()),
+            block_hash: Some(H256::zero()),
+            block_number: Some(U256::zero()),
+            address: Some(H160::zero()),
+            data: Some(Default::default()),
+            topics: Default::default(),
+        };
+        assert_eq!(
+            serde_json::to_string(&log).unwrap(),
+            r#"{"removed":true,"logIndex":"0x0","transactionIndex":"0x0","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x0","address":"0x0000000000000000000000000000000000000000","data":"0x","topics":[]}"#
+        );
+    }
+}

--- a/jormungandr/src/jrpc/eth_types/log.rs
+++ b/jormungandr/src/jrpc/eth_types/log.rs
@@ -1,23 +1,23 @@
-use super::bytes::Bytes;
-use chain_evm::ethereum_types::{H160, H256, U256};
+use super::{bytes::Bytes, number::Number};
+use chain_evm::ethereum_types::{H160, H256};
 use serde::Serialize;
 
 /// Log
-#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Log {
     /// Whether Log Type is Removed (Geth Compatibility Field)
     removed: bool,
     /// Log Index in Block
-    log_index: Option<U256>,
+    log_index: Option<Number>,
     /// Transaction Index
-    transaction_index: Option<U256>,
+    transaction_index: Option<Number>,
     /// Transaction Hash
     transaction_hash: Option<H256>,
     /// Block Hash
     block_hash: Option<H256>,
     /// Block Number
-    block_number: Option<U256>,
+    block_number: Option<Number>,
     /// H160
     address: Option<H160>,
     /// Data
@@ -30,11 +30,11 @@ impl Log {
     pub fn build() -> Self {
         Self {
             removed: true,
-            log_index: Some(U256::zero()),
-            transaction_index: Some(U256::zero()),
+            log_index: Some(1.into()),
+            transaction_index: Some(1.into()),
             transaction_hash: Some(H256::zero()),
             block_hash: Some(H256::zero()),
-            block_number: Some(U256::zero()),
+            block_number: Some(1.into()),
             address: Some(H160::zero()),
             data: Some(Default::default()),
             topics: Default::default(),
@@ -50,11 +50,11 @@ mod tests {
     fn receipt_json_serialize() {
         let log = Log {
             removed: true,
-            log_index: Some(U256::zero()),
-            transaction_index: Some(U256::zero()),
+            log_index: Some(0.into()),
+            transaction_index: Some(0.into()),
             transaction_hash: Some(H256::zero()),
             block_hash: Some(H256::zero()),
-            block_number: Some(U256::zero()),
+            block_number: Some(0.into()),
             address: Some(H160::zero()),
             data: Some(Default::default()),
             topics: Default::default(),

--- a/jormungandr/src/jrpc/eth_types/mod.rs
+++ b/jormungandr/src/jrpc/eth_types/mod.rs
@@ -1,8 +1,8 @@
 pub mod block;
 pub mod block_number;
 pub mod bytes;
-pub mod index;
 pub mod log;
+pub mod number;
 pub mod receipt;
 pub mod sync;
 pub mod transaction;

--- a/jormungandr/src/jrpc/eth_types/mod.rs
+++ b/jormungandr/src/jrpc/eth_types/mod.rs
@@ -2,5 +2,6 @@ pub mod block;
 pub mod block_number;
 pub mod bytes;
 pub mod index;
+pub mod receipt;
 pub mod sync;
 pub mod transaction;

--- a/jormungandr/src/jrpc/eth_types/mod.rs
+++ b/jormungandr/src/jrpc/eth_types/mod.rs
@@ -2,6 +2,7 @@ pub mod block;
 pub mod block_number;
 pub mod bytes;
 pub mod index;
+pub mod log;
 pub mod receipt;
 pub mod sync;
 pub mod transaction;

--- a/jormungandr/src/jrpc/eth_types/mod.rs
+++ b/jormungandr/src/jrpc/eth_types/mod.rs
@@ -1,5 +1,6 @@
 pub mod block;
 pub mod block_number;
 pub mod bytes;
+pub mod index;
 pub mod sync;
 pub mod transaction;

--- a/jormungandr/src/jrpc/eth_types/mod.rs
+++ b/jormungandr/src/jrpc/eth_types/mod.rs
@@ -1,4 +1,5 @@
 pub mod block;
 pub mod block_number;
+pub mod bytes;
 pub mod sync;
 pub mod transaction;

--- a/jormungandr/src/jrpc/eth_types/number.rs
+++ b/jormungandr/src/jrpc/eth_types/number.rs
@@ -1,15 +1,30 @@
 use serde::{
     de::{Error, Visitor},
-    Deserialize, Deserializer,
+    Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::fmt;
 
 /// Represents usize.
 #[derive(Debug, PartialEq, Eq)]
-pub struct Index(u64);
+pub struct Number(u64);
 
-impl<'a> Deserialize<'a> for Index {
-    fn deserialize<D>(deserializer: D) -> Result<Index, D::Error>
+impl From<u64> for Number {
+    fn from(val: u64) -> Self {
+        Self(val)
+    }
+}
+
+impl Serialize for Number {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(format!("{:#x}", self.0).as_str())
+    }
+}
+
+impl<'a> Deserialize<'a> for Number {
+    fn deserialize<D>(deserializer: D) -> Result<Number, D::Error>
     where
         D: Deserializer<'a>,
     {
@@ -20,7 +35,7 @@ impl<'a> Deserialize<'a> for Index {
 struct IndexVisitor;
 
 impl<'a> Visitor<'a> for IndexVisitor {
-    type Value = Index;
+    type Value = Number;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "a hex-encoded or decimal index")
@@ -32,11 +47,11 @@ impl<'a> Visitor<'a> for IndexVisitor {
     {
         match value {
             _ if value.starts_with("0x") => u64::from_str_radix(&value[2..], 16)
-                .map(Index)
+                .map(Number)
                 .map_err(|e| Error::custom(format!("Invalid index: {}", e))),
             _ => value
                 .parse::<u64>()
-                .map(Index)
+                .map(Number)
                 .map_err(|e| Error::custom(format!("Invalid index: {}", e))),
         }
     }
@@ -52,7 +67,7 @@ impl<'a> Visitor<'a> for IndexVisitor {
     where
         E: Error,
     {
-        Ok(Index(value))
+        Ok(Number(value))
     }
 }
 
@@ -63,10 +78,15 @@ mod tests {
     #[test]
     fn index_deserialization() {
         let s = r#"["0xa", "10", 42, "0x45"]"#;
-        let deserialized: Vec<Index> = serde_json::from_str(s).unwrap();
+        let deserialized: Vec<Number> = serde_json::from_str(s).unwrap();
         assert_eq!(
             deserialized,
-            vec![Index(10), Index(10), Index(42), Index(69)]
+            vec![Number(10), Number(10), Number(42), Number(69)]
+        );
+
+        assert_eq!(
+            serde_json::to_string(&vec![Number(10), Number(42), Number(69)]).unwrap(),
+            r#"["0xa", "0xa", "0x2a", "0x45"]"#
         );
     }
 }

--- a/jormungandr/src/jrpc/eth_types/receipt.rs
+++ b/jormungandr/src/jrpc/eth_types/receipt.rs
@@ -1,6 +1,8 @@
 use chain_evm::ethereum_types::{Bloom, H160, H256, U256, U64};
 use serde::Serialize;
 
+use super::log::Log;
+
 /// Receipt
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -24,8 +26,7 @@ pub struct Receipt {
     /// Contract address
     contract_address: Option<H160>,
     /// Logs
-    // TODO use Log type
-    logs: Vec<()>,
+    logs: Vec<Log>,
     /// Logs bloom
     logs_bloom: Bloom,
     /// State Root
@@ -52,11 +53,40 @@ impl Receipt {
             gas_used: U256::zero(),
             // This should be None if 'to' field has been set and vice versa
             contract_address: None,
-            logs: Default::default(),
+            logs: vec![Log::build()],
             logs_bloom: Default::default(),
             root: Some(H256::zero()),
             status: Some(U64::zero()),
             effective_gas_price: U256::zero(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receipt_json_serialize() {
+        let receipt = Receipt {
+            transaction_hash: H256::zero(),
+            transaction_index: U256::zero(),
+            block_hash: H256::zero(),
+            block_number: U256::zero(),
+            from: H160::zero(),
+            to: Some(H160::zero()),
+            cumulative_gas_used: U256::zero(),
+            gas_used: U256::zero(),
+            contract_address: Some(H160::zero()),
+            logs: Default::default(),
+            logs_bloom: Default::default(),
+            root: Some(H256::zero()),
+            status: Some(U64::zero()),
+            effective_gas_price: U256::zero(),
+        };
+        assert_eq!(
+            serde_json::to_string(&receipt).unwrap(),
+            r#"{"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x0","from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","cumulativeGasUsed":"0x0","gasUsed":"0x0","contractAddress":"0x0000000000000000000000000000000000000000","logs":[],"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","root":"0x0000000000000000000000000000000000000000000000000000000000000000","status":"0x0","effectiveGasPrice":"0x0"}"#
+        );
     }
 }

--- a/jormungandr/src/jrpc/eth_types/receipt.rs
+++ b/jormungandr/src/jrpc/eth_types/receipt.rs
@@ -1,0 +1,62 @@
+use chain_evm::ethereum_types::{Bloom, H160, H256, U256, U64};
+use serde::Serialize;
+
+/// Receipt
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Receipt {
+    /// Transaction Hash
+    transaction_hash: H256,
+    /// Transaction index
+    transaction_index: U256,
+    /// Block hash
+    block_hash: H256,
+    /// Block number
+    block_number: U256,
+    /// Sender
+    from: H160,
+    /// Recipient
+    to: Option<H160>,
+    /// Cumulative gas used
+    cumulative_gas_used: U256,
+    /// Gas used
+    gas_used: U256,
+    /// Contract address
+    contract_address: Option<H160>,
+    /// Logs
+    // TODO use Log type
+    logs: Vec<()>,
+    /// Logs bloom
+    logs_bloom: Bloom,
+    /// State Root
+    // EIP98 makes this optional field, if it's missing then skip serializing it
+    root: Option<H256>,
+    /// Status code
+    // Unknown after EIP98 rules, if it's missing then skip serializing it
+    status: Option<U64>,
+    /// Effective gas price.
+    // Pre-eip1559 this is just the gasprice. Post-eip1559 this is base fee + priority fee.
+    effective_gas_price: U256,
+}
+
+impl Receipt {
+    pub fn build() -> Self {
+        Self {
+            transaction_hash: H256::zero(),
+            transaction_index: U256::zero(),
+            block_hash: H256::zero(),
+            block_number: U256::zero(),
+            from: H160::zero(),
+            to: Some(H160::zero()),
+            cumulative_gas_used: U256::zero(),
+            gas_used: U256::zero(),
+            // This should be None if 'to' field has been set and vice versa
+            contract_address: None,
+            logs: Default::default(),
+            logs_bloom: Default::default(),
+            root: Some(H256::zero()),
+            status: Some(U64::zero()),
+            effective_gas_price: U256::zero(),
+        }
+    }
+}

--- a/jormungandr/src/jrpc/eth_types/receipt.rs
+++ b/jormungandr/src/jrpc/eth_types/receipt.rs
@@ -1,7 +1,7 @@
-use chain_evm::ethereum_types::{Bloom, H160, H256, U256, U64};
+use chain_evm::ethereum_types::{Bloom, H160, H256};
 use serde::Serialize;
 
-use super::log::Log;
+use super::{log::Log, number::Number};
 
 /// Receipt
 #[derive(Debug, Serialize)]
@@ -10,19 +10,19 @@ pub struct Receipt {
     /// Transaction Hash
     transaction_hash: H256,
     /// Transaction index
-    transaction_index: U256,
+    transaction_index: Number,
     /// Block hash
     block_hash: H256,
     /// Block number
-    block_number: U256,
+    block_number: Number,
     /// Sender
     from: H160,
     /// Recipient
     to: Option<H160>,
     /// Cumulative gas used
-    cumulative_gas_used: U256,
+    cumulative_gas_used: Number,
     /// Gas used
-    gas_used: U256,
+    gas_used: Number,
     /// Contract address
     contract_address: Option<H160>,
     /// Logs
@@ -34,30 +34,30 @@ pub struct Receipt {
     root: Option<H256>,
     /// Status code
     // Unknown after EIP98 rules, if it's missing then skip serializing it
-    status: Option<U64>,
+    status: Option<Number>,
     /// Effective gas price.
     // Pre-eip1559 this is just the gasprice. Post-eip1559 this is base fee + priority fee.
-    effective_gas_price: U256,
+    effective_gas_price: Number,
 }
 
 impl Receipt {
     pub fn build() -> Self {
         Self {
             transaction_hash: H256::zero(),
-            transaction_index: U256::zero(),
+            transaction_index: 1.into(),
             block_hash: H256::zero(),
-            block_number: U256::zero(),
+            block_number: 1.into(),
             from: H160::zero(),
             to: Some(H160::zero()),
-            cumulative_gas_used: U256::zero(),
-            gas_used: U256::zero(),
+            cumulative_gas_used: 1.into(),
+            gas_used: 1.into(),
             // This should be None if 'to' field has been set and vice versa
             contract_address: None,
             logs: vec![Log::build()],
             logs_bloom: Default::default(),
             root: Some(H256::zero()),
-            status: Some(U64::zero()),
-            effective_gas_price: U256::zero(),
+            status: Some(1.into()),
+            effective_gas_price: 1.into(),
         }
     }
 }
@@ -70,19 +70,19 @@ mod tests {
     fn receipt_json_serialize() {
         let receipt = Receipt {
             transaction_hash: H256::zero(),
-            transaction_index: U256::zero(),
+            transaction_index: 0.into(),
             block_hash: H256::zero(),
-            block_number: U256::zero(),
+            block_number: 0.into(),
             from: H160::zero(),
             to: Some(H160::zero()),
-            cumulative_gas_used: U256::zero(),
-            gas_used: U256::zero(),
+            cumulative_gas_used: 0.into(),
+            gas_used: 0.into(),
             contract_address: Some(H160::zero()),
             logs: Default::default(),
             logs_bloom: Default::default(),
             root: Some(H256::zero()),
-            status: Some(U64::zero()),
-            effective_gas_price: U256::zero(),
+            status: Some(0.into()),
+            effective_gas_price: 0.into(),
         };
         assert_eq!(
             serde_json::to_string(&receipt).unwrap(),

--- a/jormungandr/src/jrpc/eth_types/sync.rs
+++ b/jormungandr/src/jrpc/eth_types/sync.rs
@@ -61,7 +61,7 @@ mod tests {
         assert_eq!(serde_json::to_string(&ss_none).unwrap(), "false");
         assert_eq!(
             serde_json::to_string(&ss_info).unwrap(),
-            "{\"startingBlock\":\"0x0\",\"currentBlock\":\"0x0\",\"highestBlock\":\"0x0\"}"
+            r#"{"startingBlock":"0x0","currentBlock":"0x0","highestBlock":"0x0"}"#
         );
     }
 }

--- a/jormungandr/src/jrpc/eth_types/sync.rs
+++ b/jormungandr/src/jrpc/eth_types/sync.rs
@@ -6,11 +6,11 @@ use serde::{Serialize, Serializer};
 #[serde(rename_all = "camelCase")]
 pub struct SyncInfo {
     /// Starting block
-    pub starting_block: U256,
+    starting_block: U256,
     /// Current block
-    pub current_block: U256,
+    current_block: U256,
     /// Highest block seen so far
-    pub highest_block: U256,
+    highest_block: U256,
 }
 
 /// Sync status

--- a/jormungandr/src/jrpc/eth_types/sync.rs
+++ b/jormungandr/src/jrpc/eth_types/sync.rs
@@ -1,16 +1,17 @@
-use chain_evm::ethereum_types::U256;
 use serde::{Serialize, Serializer};
 
+use super::number::Number;
+
 /// Sync info
-#[derive(Default, Debug, Serialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncInfo {
     /// Starting block
-    starting_block: U256,
+    starting_block: Number,
     /// Current block
-    current_block: U256,
+    current_block: Number,
     /// Highest block seen so far
-    highest_block: U256,
+    highest_block: Number,
 }
 
 /// Sync status
@@ -26,9 +27,9 @@ pub enum SyncStatus {
 impl SyncStatus {
     pub fn build() -> Self {
         Self::Info(SyncInfo {
-            starting_block: U256::zero(),
-            current_block: U256::zero(),
-            highest_block: U256::zero(),
+            starting_block: 0.into(),
+            current_block: 0.into(),
+            highest_block: 0.into(),
         })
     }
 }
@@ -53,9 +54,9 @@ mod tests {
     fn sync_status_json_deserialize() {
         let ss_none = SyncStatus::None;
         let ss_info = SyncStatus::Info(SyncInfo {
-            starting_block: U256::zero(),
-            current_block: U256::zero(),
-            highest_block: U256::zero(),
+            starting_block: 0.into(),
+            current_block: 0.into(),
+            highest_block: 0.into(),
         });
 
         assert_eq!(serde_json::to_string(&ss_none).unwrap(), "false");

--- a/jormungandr/src/jrpc/eth_types/transaction.rs
+++ b/jormungandr/src/jrpc/eth_types/transaction.rs
@@ -1,9 +1,8 @@
+use super::bytes::Bytes;
 use chain_evm::ethereum_types::{H160, U256, U64};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-use super::block::Bytes;
-
-#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
     /// Nonce

--- a/jormungandr/src/jrpc/eth_types/transaction.rs
+++ b/jormungandr/src/jrpc/eth_types/transaction.rs
@@ -2,7 +2,7 @@ use super::bytes::Bytes;
 use chain_evm::ethereum_types::{H160, U256, U64};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
     /// Nonce
@@ -73,9 +73,9 @@ mod tests {
         };
         assert_eq!(
             serde_json::to_string(&transaction).unwrap(),
-            "{\"nonce\":\"0x0\",\"from\":\"0x0000000000000000000000000000000000000000\",\"to\":\"0x0000000000000000000000000000000000000000\",\"value\":\"0x0\",\"gas\":\"0x0\",\"input\":\"0x\",\"gasPrice\":\"0x0\",\"chainId\":\"0x0\",\"v\":\"0x0\",\"r\":\"0x0\",\"s\":\"0x0\",\"type\":\"0x0\"}"
+            r#"{"nonce":"0x0","from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","value":"0x0","gas":"0x0","input":"0x","gasPrice":"0x0","chainId":"0x0","v":"0x0","r":"0x0","s":"0x0","type":"0x0"}"#
         );
-        let decoded: Transaction = serde_json::from_str("{\"nonce\":\"0x0\",\"from\":\"0x0000000000000000000000000000000000000000\",\"to\":\"0x0000000000000000000000000000000000000000\",\"value\":\"0x0\",\"gas\":\"0x0\",\"input\":\"0x\",\"gasPrice\":\"0x0\",\"chainId\":\"0x0\",\"v\":\"0x0\",\"r\":\"0x0\",\"s\":\"0x0\",\"type\":\"0x0\"}").unwrap();
+        let decoded: Transaction = serde_json::from_str(r#"{"nonce":"0x0","from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","value":"0x0","gas":"0x0","input":"0x","gasPrice":"0x0","chainId":"0x0","v":"0x0","r":"0x0","s":"0x0","type":"0x0"}"#).unwrap();
         assert_eq!(decoded, transaction);
     }
 }

--- a/jormungandr/src/jrpc/eth_types/transaction.rs
+++ b/jormungandr/src/jrpc/eth_types/transaction.rs
@@ -1,52 +1,61 @@
-use super::bytes::Bytes;
-use chain_evm::ethereum_types::{H160, U256, U64};
+use super::{bytes::Bytes, number::Number};
+use chain_evm::ethereum_types::{H160, H256, U256};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
+    /// Block hash, null when pending
+    block_hash: Option<H256>,
+    /// Block number, null when pending
+    block_number: Option<Number>,
     /// Nonce
-    nonce: U256,
+    nonce: Number,
     /// Sender
     from: H160,
     /// Recipient
     to: Option<H160>,
     /// Transfered value
-    value: U256,
+    value: Number,
     /// Gas
-    gas: U256,
+    gas: Number,
     /// Data
     input: Bytes,
     /// Gas price
-    gas_price: U256,
+    gas_price: Number,
     /// The network id of the transaction, if any.
-    chain_id: Option<U64>,
+    chain_id: Option<Number>,
+    /// Transaction Index, null when pending
+    transaction_index: Option<Number>,
     /// The standardised V field of the signature.
-    v: U256,
+    v: Number,
     /// The R field of the signature.
     r: U256,
     /// The S field of the signature.
     s: U256,
     /// EIP-2718 type
     #[serde(rename = "type")]
-    transaction_type: U256,
+    transaction_type: Number,
 }
 
 impl Transaction {
     pub fn build() -> Self {
         Self {
-            nonce: U256::one(),
+            block_hash: None,
+            block_number: None,
+            nonce: 1.into(),
             from: H160::zero(),
             to: Some(H160::zero()),
-            value: U256::one(),
-            gas: U256::one(),
+            value: 1.into(),
+            gas: 1.into(),
             input: Default::default(),
-            gas_price: U256::one(),
-            chain_id: Some(U64::one()),
-            v: U256::one(),
+            gas_price: 1.into(),
+            chain_id: Some(1.into()),
+            transaction_index: None,
+            v: 1.into(),
             r: U256::one(),
             s: U256::one(),
-            transaction_type: U256::one(),
+            transaction_type: 1.into(),
         }
     }
 }
@@ -58,24 +67,28 @@ mod tests {
     #[test]
     fn transaction_json_serde() {
         let transaction = Transaction {
-            nonce: U256::zero(),
+            block_hash: None,
+            block_number: None,
+            nonce: 0.into(),
             from: H160::zero(),
             to: Some(H160::zero()),
-            value: U256::zero(),
-            gas: U256::zero(),
+            value: 0.into(),
+            gas: 0.into(),
             input: Default::default(),
-            gas_price: U256::zero(),
-            chain_id: Some(U64::zero()),
-            v: U256::zero(),
+            gas_price: 0.into(),
+            chain_id: Some(0.into()),
+            transaction_index: None,
+            v: 0.into(),
             r: U256::zero(),
             s: U256::zero(),
-            transaction_type: U256::zero(),
+            transaction_type: 0.into(),
         };
         assert_eq!(
             serde_json::to_string(&transaction).unwrap(),
-            r#"{"nonce":"0x0","from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","value":"0x0","gas":"0x0","input":"0x","gasPrice":"0x0","chainId":"0x0","v":"0x0","r":"0x0","s":"0x0","type":"0x0"}"#
+            r#"{"blockHash":null,"blockNumber":null,"nonce":"0x0","from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","value":"0x0","gas":"0x0","input":"0x","gasPrice":"0x0","chainId":"0x0","transactionIndex":null,"v":"0x0","r":"0x0","s":"0x0","type":"0x0"}"#
         );
-        let decoded: Transaction = serde_json::from_str(r#"{"nonce":"0x0","from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","value":"0x0","gas":"0x0","input":"0x","gasPrice":"0x0","chainId":"0x0","v":"0x0","r":"0x0","s":"0x0","type":"0x0"}"#).unwrap();
+        let decoded: Transaction = serde_json::from_str(r#"{"blockHash":null,"blockNumber":null,"nonce":"0x0","from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","value":"0x0","gas":"0x0","input":"0x","gasPrice":"0x0","chainId":"0x0","transactionIndex":null,"v":"0x0","r":"0x0","s":"0x0","type":"0x0"}"#
+    ).unwrap();
         assert_eq!(decoded, transaction);
     }
 }

--- a/jormungandr/src/jrpc/eth_types/transaction.rs
+++ b/jormungandr/src/jrpc/eth_types/transaction.rs
@@ -2,34 +2,34 @@ use super::bytes::Bytes;
 use chain_evm::ethereum_types::{H160, U256, U64};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
     /// Nonce
-    pub nonce: U256,
+    nonce: U256,
     /// Sender
-    pub from: H160,
+    from: H160,
     /// Recipient
-    pub to: Option<H160>,
+    to: Option<H160>,
     /// Transfered value
-    pub value: U256,
+    value: U256,
     /// Gas
-    pub gas: U256,
+    gas: U256,
     /// Data
-    pub input: Bytes,
+    input: Bytes,
     /// Gas price
-    pub gas_price: U256,
+    gas_price: U256,
     /// The network id of the transaction, if any.
-    pub chain_id: Option<U64>,
+    chain_id: Option<U64>,
     /// The standardised V field of the signature.
-    pub v: U256,
+    v: U256,
     /// The R field of the signature.
-    pub r: U256,
+    r: U256,
     /// The S field of the signature.
-    pub s: U256,
+    s: U256,
     /// EIP-2718 type
     #[serde(rename = "type")]
-    pub transaction_type: U256,
+    transaction_type: U256,
 }
 
 impl Transaction {

--- a/jormungandr/src/jrpc/eth_types/transaction.rs
+++ b/jormungandr/src/jrpc/eth_types/transaction.rs
@@ -17,8 +17,8 @@ pub struct Transaction {
     pub gas: U256,
     /// Data
     pub input: Bytes,
-    #[serde(rename = "gasPrice", skip_serializing_if = "Option::is_none")]
-    pub gas_price: Option<U256>,
+    /// Gas price
+    pub gas_price: U256,
     /// The network id of the transaction, if any.
     pub chain_id: Option<U64>,
     /// The standardised V field of the signature.
@@ -41,12 +41,41 @@ impl Transaction {
             value: U256::one(),
             gas: U256::one(),
             input: Default::default(),
-            gas_price: Some(U256::one()),
+            gas_price: U256::one(),
             chain_id: Some(U64::one()),
             v: U256::one(),
             r: U256::one(),
             s: U256::one(),
             transaction_type: U256::one(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transaction_json_serde() {
+        let transaction = Transaction {
+            nonce: U256::zero(),
+            from: H160::zero(),
+            to: Some(H160::zero()),
+            value: U256::zero(),
+            gas: U256::zero(),
+            input: Default::default(),
+            gas_price: U256::zero(),
+            chain_id: Some(U64::zero()),
+            v: U256::zero(),
+            r: U256::zero(),
+            s: U256::zero(),
+            transaction_type: U256::zero(),
+        };
+        assert_eq!(
+            serde_json::to_string(&transaction).unwrap(),
+            "{\"nonce\":\"0x0\",\"from\":\"0x0000000000000000000000000000000000000000\",\"to\":\"0x0000000000000000000000000000000000000000\",\"value\":\"0x0\",\"gas\":\"0x0\",\"input\":\"0x\",\"gasPrice\":\"0x0\",\"chainId\":\"0x0\",\"v\":\"0x0\",\"r\":\"0x0\",\"s\":\"0x0\",\"type\":\"0x0\"}"
+        );
+        let decoded: Transaction = serde_json::from_str("{\"nonce\":\"0x0\",\"from\":\"0x0000000000000000000000000000000000000000\",\"to\":\"0x0000000000000000000000000000000000000000\",\"value\":\"0x0\",\"gas\":\"0x0\",\"input\":\"0x\",\"gasPrice\":\"0x0\",\"chainId\":\"0x0\",\"v\":\"0x0\",\"r\":\"0x0\",\"s\":\"0x0\",\"type\":\"0x0\"}").unwrap();
+        assert_eq!(decoded, transaction);
     }
 }

--- a/jormungandr/src/jrpc/mod.rs
+++ b/jormungandr/src/jrpc/mod.rs
@@ -3,6 +3,8 @@ mod eth_block_info;
 #[cfg(feature = "evm")]
 mod eth_chain_info;
 #[cfg(feature = "evm")]
+mod eth_transaction;
+#[cfg(feature = "evm")]
 mod eth_types;
 
 use crate::context::ContextLock;
@@ -25,11 +27,15 @@ pub async fn start_jrpc_server(config: Config, _context: ContextLock) {
     #[cfg(feature = "evm")]
     {
         modules
-            .merge(eth_block_info::eth_get_blocks_info_module(_context.clone()))
+            .merge(eth_block_info::eth_block_info_module(_context.clone()))
             .unwrap();
 
         modules
-            .merge(eth_chain_info::eth_get_blocks_info_module(_context))
+            .merge(eth_chain_info::eth_chain_info_module(_context.clone()))
+            .unwrap();
+
+        modules
+            .merge(eth_transaction::eth_transaction_module(_context))
             .unwrap();
     }
 


### PR DESCRIPTION
Add a dummy implementation for the bunch of the RPC endpoints.
The main goal to provide a correct signature of the RPC endpoints and correct data types for the arguments and return value.
Functionality for the endpoints will be added later.