### PR TITLE
Add account RPC endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Bump libc from 0.2.117 to 0.2.124
 - Bump rand from 0.8.4 to 0.8.5
 - Add jcli option to generate and sign EVM mapping certificates.
+- Add new Ethreum RPC endpoints for the account handling: eth_getTransactionCount, eth_getBalance, eth_getCode, eth_getStorageAt
 
 ## Release 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Add new Ethreum RPC endpoints for getting block info: eth_getBlockByHash, eth_getBlockByNumber, eth_getBlockTransactionCountByHash, eth_getBlockTransactionCountByNumber, eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_blockNumber
 - Add new Ethreum RPC endpoints for transaction handling: eth_sendTransaction, eth_sendRawTransaction, eth_getTransactionByHash, eth_getTransactionByBlockHashAndIndex, eth_getTransactionByBlockNumberAndIndex, eth_getTransactionReceipt, eth_signTransaction, eth_estimateGas, eth_sign
 - Add new Ethreum RPC endpoints for getting chain info: eth_chainId, eth_syncing, eth_gasPrice, eth_protocolVersion
-- Add new Ethreum RPC endpoints for account handling: eth_getTransactionCount, eth_getBalance, eth_getCode, eth_getStorageAt
+- Add new Ethreum RPC endpoints for account handling: eth_accounts, eth_getTransactionCount, eth_getBalance, eth_getCode, eth_getStorageAt
 
 ## Release 0.13.0
 

--- a/jormungandr/src/jrpc/eth_account/logic.rs
+++ b/jormungandr/src/jrpc/eth_account/logic.rs
@@ -1,0 +1,18 @@
+use super::Error;
+use crate::context::Context;
+
+pub fn get_transaction_count(_context: &Context) -> Result<(), Error> {
+    Ok(())
+}
+
+pub fn get_balance(_context: &Context) -> Result<(), Error> {
+    Ok(())
+}
+
+pub fn get_code(_context: &Context) -> Result<(), Error> {
+    Ok(())
+}
+
+pub fn get_storage_at(_context: &Context) -> Result<(), Error> {
+    Ok(())
+}

--- a/jormungandr/src/jrpc/eth_account/logic.rs
+++ b/jormungandr/src/jrpc/eth_account/logic.rs
@@ -1,18 +1,44 @@
+use chain_evm::ethereum_types::{H160, H256, U256};
+
 use super::Error;
-use crate::context::Context;
+use crate::{
+    context::Context,
+    jrpc::eth_types::{block::Bytes, block_number::BlockNumber},
+};
 
-pub fn get_transaction_count(_context: &Context) -> Result<(), Error> {
-    Ok(())
+pub fn get_transaction_count(
+    _address: H160,
+    _block_number: BlockNumber,
+    _context: &Context,
+) -> Result<U256, Error> {
+    // TODO implement
+    Ok(0.into())
 }
 
-pub fn get_balance(_context: &Context) -> Result<(), Error> {
-    Ok(())
+pub fn get_balance(
+    _address: H160,
+    _block_number: BlockNumber,
+    _context: &Context,
+) -> Result<U256, Error> {
+    // TODO implement
+    Ok(0.into())
 }
 
-pub fn get_code(_context: &Context) -> Result<(), Error> {
-    Ok(())
+pub fn get_code(
+    _address: H160,
+    _block_number: BlockNumber,
+    _context: &Context,
+) -> Result<Bytes, Error> {
+    // TODO implement
+    Ok(Default::default())
 }
 
-pub fn get_storage_at(_context: &Context) -> Result<(), Error> {
-    Ok(())
+pub fn get_storage_at(
+    _address: H160,
+    _key: H256,
+    _block_number: BlockNumber,
+    _context: &Context,
+) -> Result<H256, Error> {
+    // TODO implement
+    Ok(H256::zero())
 }

--- a/jormungandr/src/jrpc/eth_account/logic.rs
+++ b/jormungandr/src/jrpc/eth_account/logic.rs
@@ -1,16 +1,16 @@
-use chain_evm::ethereum_types::{H160, H256, U256};
+use chain_evm::ethereum_types::{H160, H256};
 
 use super::Error;
 use crate::{
     context::Context,
-    jrpc::eth_types::{block_number::BlockNumber, bytes::Bytes},
+    jrpc::eth_types::{block_number::BlockNumber, bytes::Bytes, number::Number},
 };
 
 pub fn get_transaction_count(
     _address: H160,
     _block_number: BlockNumber,
     _context: &Context,
-) -> Result<U256, Error> {
+) -> Result<Number, Error> {
     // TODO implement
     Ok(0.into())
 }
@@ -19,7 +19,7 @@ pub fn get_balance(
     _address: H160,
     _block_number: BlockNumber,
     _context: &Context,
-) -> Result<U256, Error> {
+) -> Result<Number, Error> {
     // TODO implement
     Ok(0.into())
 }

--- a/jormungandr/src/jrpc/eth_account/logic.rs
+++ b/jormungandr/src/jrpc/eth_account/logic.rs
@@ -1,10 +1,14 @@
-use chain_evm::ethereum_types::{H160, H256};
-
 use super::Error;
 use crate::{
     context::Context,
     jrpc::eth_types::{block_number::BlockNumber, bytes::Bytes, number::Number},
 };
+use chain_evm::ethereum_types::{H160, H256};
+
+pub fn accounts(_context: &Context) -> Result<Vec<H160>, Error> {
+    // TODO implement
+    Ok(vec![H160::zero()])
+}
 
 pub fn get_transaction_count(
     _address: H160,

--- a/jormungandr/src/jrpc/eth_account/mod.rs
+++ b/jormungandr/src/jrpc/eth_account/mod.rs
@@ -11,6 +11,13 @@ pub fn eth_account_module(context: ContextLock) -> RpcModule<ContextLock> {
     let mut module = RpcModule::new(context);
 
     module
+        .register_async_method("eth_accounts", |_, context| async move {
+            let context = context.read().await;
+            logic::accounts(&context).map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
         .register_async_method("eth_getTransactionCount", |params, context| async move {
             let context = context.read().await;
             let (address, block_number) = params.parse()?;

--- a/jormungandr/src/jrpc/eth_account/mod.rs
+++ b/jormungandr/src/jrpc/eth_account/mod.rs
@@ -11,36 +11,37 @@ pub fn eth_account_module(context: ContextLock) -> RpcModule<ContextLock> {
     let mut module = RpcModule::new(context);
 
     module
-        .register_async_method("eth_getTransactionCount", |_params, context| async move {
+        .register_async_method("eth_getTransactionCount", |params, context| async move {
             let context = context.read().await;
-            // let (block_hash, full) = params.parse()?;
-            logic::get_transaction_count(&context)
+            let (address, block_number) = params.parse()?;
+            logic::get_transaction_count(address, block_number, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();
 
     module
-        .register_async_method("eth_getBalance", |_params, context| async move {
+        .register_async_method("eth_getBalance", |params, context| async move {
             let context = context.read().await;
-            // let (block_hash, full) = params.parse()?;
-            logic::get_balance(&context)
+            let (address, block_number) = params.parse()?;
+            logic::get_balance(address, block_number, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();
 
     module
-        .register_async_method("eth_getCode", |_params, context| async move {
+        .register_async_method("eth_getCode", |params, context| async move {
             let context = context.read().await;
-            // let (block_hash, full) = params.parse()?;
-            logic::get_code(&context).map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+            let (address, block_number) = params.parse()?;
+            logic::get_code(address, block_number, &context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();
 
     module
-        .register_async_method("eth_getStorageAt", |_params, context| async move {
+        .register_async_method("eth_getStorageAt", |params, context| async move {
             let context = context.read().await;
-            // let (block_hash, full) = params.parse()?;
-            logic::get_storage_at(&context)
+            let (address, key, block_number) = params.parse()?;
+            logic::get_storage_at(address, key, block_number, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();

--- a/jormungandr/src/jrpc/eth_account/mod.rs
+++ b/jormungandr/src/jrpc/eth_account/mod.rs
@@ -1,0 +1,49 @@
+use jsonrpsee_http_server::RpcModule;
+
+use crate::context::ContextLock;
+
+mod logic;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {}
+
+pub fn eth_account_module(context: ContextLock) -> RpcModule<ContextLock> {
+    let mut module = RpcModule::new(context);
+
+    module
+        .register_async_method("eth_getTransactionCount", |_params, context| async move {
+            let context = context.read().await;
+            // let (block_hash, full) = params.parse()?;
+            logic::get_transaction_count(&context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_getBalance", |_params, context| async move {
+            let context = context.read().await;
+            // let (block_hash, full) = params.parse()?;
+            logic::get_balance(&context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_getCode", |_params, context| async move {
+            let context = context.read().await;
+            // let (block_hash, full) = params.parse()?;
+            logic::get_code(&context).map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_getStorageAt", |_params, context| async move {
+            let context = context.read().await;
+            // let (block_hash, full) = params.parse()?;
+            logic::get_storage_at(&context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+}

--- a/jormungandr/src/jrpc/mod.rs
+++ b/jormungandr/src/jrpc/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "evm")]
+mod eth_account;
+#[cfg(feature = "evm")]
 mod eth_block_info;
 #[cfg(feature = "evm")]
 mod eth_chain_info;
@@ -29,7 +31,11 @@ pub async fn start_jrpc_server(config: Config, _context: ContextLock) {
             .unwrap();
 
         modules
-            .merge(eth_chain_info::eth_get_blocks_info_module(_context))
+            .merge(eth_chain_info::eth_get_blocks_info_module(_context.clone()))
+            .unwrap();
+
+        modules
+            .merge(eth_account::eth_account_module(_context))
             .unwrap();
     }
 


### PR DESCRIPTION
Add a dummy implementation for the bunch of the RPC endpoints.
The main goal to provide a correct signature of the RPC endpoints and correct data types for the arguments and return value.
Functionality for the endpoints will be added later.