### PR TITLE
Add miner RPC endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 - Add new Ethreum RPC endpoints for getting block info: eth_getBlockByHash, eth_getBlockByNumber, eth_getBlockTransactionCountByHash, eth_getBlockTransactionCountByNumber, eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_blockNumber
 - Add new Ethreum RPC endpoints for transaction handling: eth_sendTransaction, eth_sendRawTransaction, eth_getTransactionByHash, eth_getTransactionByBlockHashAndIndex, eth_getTransactionByBlockNumberAndIndex, eth_getTransactionReceipt, eth_signTransaction, eth_estimateGas, eth_sign
 - Add new Ethreum RPC endpoints for getting chain info: eth_chainId, eth_syncing, eth_gasPrice, eth_protocolVersion
+- Add new Ethreum RPC mining endpoints: eth_mining, eth_hashrate, eth_getWork, eth_submitWork, eth_submitHashrate
+
 ## Release 0.13.0
 
 **New features:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Add new Ethreum RPC endpoints for getting block info: eth_getBlockByHash, eth_getBlockByNumber, eth_getBlockTransactionCountByHash, eth_getBlockTransactionCountByNumber, eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_blockNumber
 - Add new Ethreum RPC endpoints for transaction handling: eth_sendTransaction, eth_sendRawTransaction, eth_getTransactionByHash, eth_getTransactionByBlockHashAndIndex, eth_getTransactionByBlockNumberAndIndex, eth_getTransactionReceipt, eth_signTransaction, eth_estimateGas, eth_sign
 - Add new Ethreum RPC endpoints for getting chain info: eth_chainId, eth_syncing, eth_gasPrice, eth_protocolVersion
-- Add new Ethreum RPC mining endpoints: eth_mining, eth_hashrate, eth_getWork, eth_submitWork, eth_submitHashrate
+- Add new Ethreum RPC mining endpoints: eth_mining, eth_coinbase, eth_hashrate, eth_getWork, eth_submitWork, eth_submitHashrate
 
 ## Release 0.13.0
 

--- a/jormungandr/src/jrpc/eth_miner/logic.rs
+++ b/jormungandr/src/jrpc/eth_miner/logic.rs
@@ -1,4 +1,9 @@
-use crate::{context::Context, jrpc::eth_types::number::Number};
+use chain_evm::ethereum_types::{H256, H64};
+
+use crate::{
+    context::Context,
+    jrpc::eth_types::{number::Number, work::Work},
+};
 
 use super::Error;
 
@@ -12,17 +17,22 @@ pub fn hashrate(_context: &Context) -> Result<Number, Error> {
     Ok(0.into())
 }
 
-pub fn get_work(_context: &Context) -> Result<(), Error> {
+pub fn get_work(_context: &Context) -> Result<Work, Error> {
     // TODO implement
-    Ok(())
+    Ok(Work::build())
 }
 
-pub fn submit_work(_context: &Context) -> Result<(), Error> {
+pub fn submit_work(
+    _nonce: H64,
+    _pow_hash: H256,
+    _mix_digest: H256,
+    _context: &Context,
+) -> Result<bool, Error> {
     // TODO implement
-    Ok(())
+    Ok(true)
 }
 
-pub fn submit_hashrate(_context: &Context) -> Result<(), Error> {
+pub fn submit_hashrate(_hash_rate: H256, _id: H256, _context: &Context) -> Result<bool, Error> {
     // TODO implement
-    Ok(())
+    Ok(true)
 }

--- a/jormungandr/src/jrpc/eth_miner/logic.rs
+++ b/jormungandr/src/jrpc/eth_miner/logic.rs
@@ -1,4 +1,4 @@
-use chain_evm::ethereum_types::{H256, H64};
+use chain_evm::ethereum_types::{H160, H256, H64};
 
 use crate::{
     context::Context,
@@ -10,6 +10,11 @@ use super::Error;
 pub fn mining(_context: &Context) -> Result<bool, Error> {
     // TODO implement
     Ok(true)
+}
+
+pub fn coinbase(_context: &Context) -> Result<H160, Error> {
+    // TODO implement
+    Ok(H160::zero())
 }
 
 pub fn hashrate(_context: &Context) -> Result<Number, Error> {

--- a/jormungandr/src/jrpc/eth_miner/logic.rs
+++ b/jormungandr/src/jrpc/eth_miner/logic.rs
@@ -9,7 +9,7 @@ use super::Error;
 
 pub fn mining(_context: &Context) -> Result<bool, Error> {
     // TODO implement
-    Ok(true.into())
+    Ok(true)
 }
 
 pub fn hashrate(_context: &Context) -> Result<Number, Error> {

--- a/jormungandr/src/jrpc/eth_miner/logic.rs
+++ b/jormungandr/src/jrpc/eth_miner/logic.rs
@@ -1,15 +1,15 @@
-use crate::context::Context;
+use crate::{context::Context, jrpc::eth_types::number::Number};
 
 use super::Error;
 
-pub fn mining(_context: &Context) -> Result<(), Error> {
+pub fn mining(_context: &Context) -> Result<bool, Error> {
     // TODO implement
-    Ok(())
+    Ok(true.into())
 }
 
-pub fn hashrate(_context: &Context) -> Result<(), Error> {
+pub fn hashrate(_context: &Context) -> Result<Number, Error> {
     // TODO implement
-    Ok(())
+    Ok(0.into())
 }
 
 pub fn get_work(_context: &Context) -> Result<(), Error> {

--- a/jormungandr/src/jrpc/eth_miner/logic.rs
+++ b/jormungandr/src/jrpc/eth_miner/logic.rs
@@ -1,0 +1,28 @@
+use crate::context::Context;
+
+use super::Error;
+
+pub fn mining(_context: &Context) -> Result<(), Error> {
+    // TODO implement
+    Ok(())
+}
+
+pub fn hashrate(_context: &Context) -> Result<(), Error> {
+    // TODO implement
+    Ok(())
+}
+
+pub fn get_work(_context: &Context) -> Result<(), Error> {
+    // TODO implement
+    Ok(())
+}
+
+pub fn submit_work(_context: &Context) -> Result<(), Error> {
+    // TODO implement
+    Ok(())
+}
+
+pub fn submit_hashrate(_context: &Context) -> Result<(), Error> {
+    // TODO implement
+    Ok(())
+}

--- a/jormungandr/src/jrpc/eth_miner/mod.rs
+++ b/jormungandr/src/jrpc/eth_miner/mod.rs
@@ -31,17 +31,19 @@ pub fn eth_miner_module(context: ContextLock) -> RpcModule<ContextLock> {
         .unwrap();
 
     module
-        .register_async_method("eth_submitWork", |_, context| async move {
+        .register_async_method("eth_submitWork", |params, context| async move {
             let context = context.read().await;
-            logic::submit_work(&context)
+            let (nonce, pow_hash, mix_digest) = params.parse()?;
+            logic::submit_work(nonce, pow_hash, mix_digest, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();
 
     module
-        .register_async_method("eth_submitHashrate", |_, context| async move {
+        .register_async_method("eth_submitHashrate", |params, context| async move {
             let context = context.read().await;
-            logic::submit_hashrate(&context)
+            let (hash_rate, id) = params.parse()?;
+            logic::submit_hashrate(hash_rate, id, &context)
                 .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
         })
         .unwrap();

--- a/jormungandr/src/jrpc/eth_miner/mod.rs
+++ b/jormungandr/src/jrpc/eth_miner/mod.rs
@@ -17,6 +17,13 @@ pub fn eth_miner_module(context: ContextLock) -> RpcModule<ContextLock> {
         .unwrap();
 
     module
+        .register_async_method("eth_coinbase", |_, context| async move {
+            let context = context.read().await;
+            logic::coinbase(&context).map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
         .register_async_method("eth_hashrate", |_, context| async move {
             let context = context.read().await;
             logic::hashrate(&context).map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))

--- a/jormungandr/src/jrpc/eth_miner/mod.rs
+++ b/jormungandr/src/jrpc/eth_miner/mod.rs
@@ -1,0 +1,49 @@
+use crate::context::ContextLock;
+use jsonrpsee_http_server::RpcModule;
+
+mod logic;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {}
+
+pub fn eth_miner_module(context: ContextLock) -> RpcModule<ContextLock> {
+    let mut module = RpcModule::new(context);
+
+    module
+        .register_async_method("eth_mining", |_, context| async move {
+            let context = context.read().await;
+            logic::mining(&context).map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_hashrate", |_, context| async move {
+            let context = context.read().await;
+            logic::hashrate(&context).map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_getWork", |_, context| async move {
+            let context = context.read().await;
+            logic::get_work(&context).map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_submitWork", |_, context| async move {
+            let context = context.read().await;
+            logic::submit_work(&context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+
+    module
+        .register_async_method("eth_submitHashrate", |_, context| async move {
+            let context = context.read().await;
+            logic::submit_hashrate(&context)
+                .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))
+        })
+        .unwrap();
+    module
+}

--- a/jormungandr/src/jrpc/eth_types/mod.rs
+++ b/jormungandr/src/jrpc/eth_types/mod.rs
@@ -6,3 +6,4 @@ pub mod number;
 pub mod receipt;
 pub mod sync;
 pub mod transaction;
+pub mod work;

--- a/jormungandr/src/jrpc/eth_types/work.rs
+++ b/jormungandr/src/jrpc/eth_types/work.rs
@@ -1,7 +1,7 @@
 use chain_evm::ethereum_types::H256;
+use serde::{Serialize, Serializer};
 
-/// The result of an `eth_getWork` call: it differs based on an option
-/// whether to send the block number.
+/// Work
 #[derive(Debug, PartialEq, Eq)]
 pub struct Work {
     /// The proof-of-work hash.
@@ -10,6 +10,42 @@ pub struct Work {
     pub seed_hash: H256,
     /// The target.
     pub target: H256,
-    /// The block number: this isn't always stored.
-    pub number: Option<u64>,
+}
+
+impl Work {
+    pub fn build() -> Self {
+        Self {
+            pow_hash: H256::zero(),
+            seed_hash: H256::zero(),
+            target: H256::zero(),
+        }
+    }
+}
+
+impl Serialize for Work {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        vec![self.pow_hash, self.seed_hash, self.target].serialize(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn work_serialize() {
+        let work = Work {
+            pow_hash: H256::zero(),
+            seed_hash: H256::zero(),
+            target: H256::zero(),
+        };
+
+        assert_eq!(
+            serde_json::to_string(&work).unwrap(),
+            r#"["0x0000000000000000000000000000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000000000000000000000000000"]"#
+        );
+    }
 }

--- a/jormungandr/src/jrpc/eth_types/work.rs
+++ b/jormungandr/src/jrpc/eth_types/work.rs
@@ -1,0 +1,15 @@
+use chain_evm::ethereum_types::H256;
+
+/// The result of an `eth_getWork` call: it differs based on an option
+/// whether to send the block number.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Work {
+    /// The proof-of-work hash.
+    pub pow_hash: H256,
+    /// The seed hash.
+    pub seed_hash: H256,
+    /// The target.
+    pub target: H256,
+    /// The block number: this isn't always stored.
+    pub number: Option<u64>,
+}

--- a/jormungandr/src/jrpc/mod.rs
+++ b/jormungandr/src/jrpc/mod.rs
@@ -3,6 +3,8 @@ mod eth_block_info;
 #[cfg(feature = "evm")]
 mod eth_chain_info;
 #[cfg(feature = "evm")]
+mod eth_miner;
+#[cfg(feature = "evm")]
 mod eth_transaction;
 #[cfg(feature = "evm")]
 mod eth_types;
@@ -35,7 +37,11 @@ pub async fn start_jrpc_server(config: Config, _context: ContextLock) {
             .unwrap();
 
         modules
-            .merge(eth_transaction::eth_transaction_module(_context))
+            .merge(eth_transaction::eth_transaction_module(_context.clone()))
+            .unwrap();
+
+        modules
+            .merge(eth_miner::eth_miner_module(_context))
             .unwrap();
     }
 


### PR DESCRIPTION
Add a dummy implementation for the bunch of the RPC endpoints.
The main goal to provide a correct signature of the RPC endpoints and correct data types for the arguments and return value.
Functionality for the endpoints will be added later.