### PR TITLE
Add new /v1/account-votes-all endpoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add /v1/account-votes-all endpoint to return the list of proposals a user has voted for
+- Remove /v1/account-votes-count endpoint
 - Validate server id is the expected one during gRPC handshake
 - fix incorrect keys bech32 HRP by always using the ones provided by the library
 - update REST API: add new endpoint AccountVotes (`/api/v1/votes/plan/account-votes/{account_id}`)

--- a/doc/api/v1.yaml
+++ b/doc/api/v1.yaml
@@ -309,9 +309,9 @@ paths:
                       items:
                         type: integer
 
-  /api/v1/votes/plan/accounts-votes-count:
+  /api/v1/votes/plan/accounts-votes-all:
     get:
-      description: Get count of submitted and accepted ballots per account
+      description: Get submitted and accepted ballots per every account
       tags:
         - vote
       responses:
@@ -326,8 +326,12 @@ paths:
                     type: string
                     description: hex encoded account identifier
                   text:
-                    type: integer
-                    description: total votes casted
+                    type: array
+                    items:
+                      type: string
+                      description: Hex-encoded proposal id
+                      pattern: '[0-9a-f]{64}'
+                    description: ids of the proposals a user has voted for
 
 components:
   schemas:

--- a/jormungandr/src/rest/v1/handlers.rs
+++ b/jormungandr/src/rest/v1/handlers.rs
@@ -65,9 +65,9 @@ pub async fn get_account_votes(
         .map(|r| warp::reply::json(&r))
 }
 
-pub async fn get_accounts_votes_count(context: ContextLock) -> Result<impl Reply, Rejection> {
+pub async fn get_accounts_votes_all(context: ContextLock) -> Result<impl Reply, Rejection> {
     let context = context.read().await;
-    logic::get_accounts_votes_count(&context)
+    logic::get_accounts_votes_all(&context)
         .await
         .map_err(warp::reject::custom)
         .map(|r| warp::reply::json(&r))

--- a/jormungandr/src/rest/v1/logic.rs
+++ b/jormungandr/src/rest/v1/logic.rs
@@ -203,11 +203,13 @@ pub async fn get_account_votes(
     .await
 }
 
-pub async fn get_accounts_votes_count(context: &Context) -> Result<HashMap<String, u64>, Error> {
+pub async fn get_accounts_votes_all(
+    context: &Context,
+) -> Result<HashMap<String, Vec<AccountVotes>>, Error> {
     let span = span!(parent: context.span()?, Level::TRACE, "get_accounts_votes", request = "get_accounts_votes");
 
     async {
-        let mut result = HashMap::new();
+        let mut result = HashMap::<String, HashMap<VotePlanId, Vec<u8>>>::new();
         for vote_plan in context
             .blockchain_tip()?
             .get_ref()
@@ -216,19 +218,36 @@ pub async fn get_accounts_votes_count(context: &Context) -> Result<HashMap<Strin
             .active_vote_plans()
             .into_iter()
         {
-            for status in vote_plan.proposals.into_iter() {
+            for (i, status) in vote_plan.proposals.into_iter().enumerate() {
                 for (account, _) in status.votes.iter() {
-                    *result
+                    result
                         .entry(
                             UnspecifiedAccountIdentifier::from_single_account(account.clone())
                                 .encode_hex(),
                         )
-                        .or_insert(0) += 1;
+                        .or_default()
+                        .entry(vote_plan.id.clone().into())
+                        .or_default()
+                        .push(i.try_into().expect("too many proposals in voteplan"));
                 }
             }
         }
 
-        Ok(result)
+        Ok(result
+            .into_iter()
+            .map(|(account, votes)| {
+                (
+                    account,
+                    votes
+                        .into_iter()
+                        .map(|(vote_plan_id, votes)| AccountVotes {
+                            vote_plan_id,
+                            votes,
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect())
     }
     .instrument(span)
     .await

--- a/jormungandr/src/rest/v1/mod.rs
+++ b/jormungandr/src/rest/v1/mod.rs
@@ -47,10 +47,10 @@ pub fn filter(
         .and(with_context.clone())
         .and_then(handlers::get_account_votes);
 
-    let votes_count = warp::path!("votes" / "plan" / "accounts-votes-count")
+    let votes_count = warp::path!("votes" / "plan" / "accounts-votes-all")
         .and(warp::get())
         .and(with_context)
-        .and_then(handlers::get_accounts_votes_count);
+        .and_then(handlers::get_accounts_votes_all);
 
     let routes = fragments.or(votes_with_plan).or(votes).or(votes_count);
 

--- a/testing/jormungandr-automation/src/jormungandr/legacy/rest.rs
+++ b/testing/jormungandr-automation/src/jormungandr/legacy/rest.rs
@@ -84,8 +84,8 @@ impl BackwardCompatibleRest {
         Ok(response_text)
     }
 
-    pub fn account_votes_count(&self) -> Result<String, reqwest::Error> {
-        let response_text = self.raw().account_votes_count()?.text()?;
+    pub fn account_votes_all(&self) -> Result<String, reqwest::Error> {
+        let response_text = self.raw().account_votes_all()?.text()?;
         self.print_response_text(&response_text);
         Ok(response_text)
     }

--- a/testing/jormungandr-automation/src/jormungandr/rest/mod.rs
+++ b/testing/jormungandr-automation/src/jormungandr/rest/mod.rs
@@ -134,9 +134,8 @@ impl JormungandrRest {
             .map_err(RestError::CannotDeserialize)
     }
 
-    pub fn account_votes_count(&self) -> Result<HashMap<String, u64>, RestError> {
-        serde_json::from_str(&self.inner.account_votes_count()?)
-            .map_err(RestError::CannotDeserialize)
+    pub fn account_votes_all(&self) -> Result<HashMap<String, Vec<AccountVotes>>, RestError> {
+        serde_json::from_str(&self.inner.account_votes_all()?).map_err(RestError::CannotDeserialize)
     }
 
     pub fn account_votes_with_plan_id(

--- a/testing/jormungandr-automation/src/jormungandr/rest/raw.rs
+++ b/testing/jormungandr-automation/src/jormungandr/rest/raw.rs
@@ -200,9 +200,9 @@ impl RawRest {
         self.get(&request)
     }
 
-    pub fn account_votes_count(&self) -> Result<Response, reqwest::Error> {
+    pub fn account_votes_all(&self) -> Result<Response, reqwest::Error> {
         self.client
-            .get(&self.path(ApiVersion::V1, "votes/plan/accounts-votes-count"))
+            .get(&self.path(ApiVersion::V1, "votes/plan/accounts-votes-all"))
             .send()
     }
 

--- a/testing/jormungandr-integration-tests/src/jormungandr/rest/v1/votes.rs
+++ b/testing/jormungandr-integration-tests/src/jormungandr/rest/v1/votes.rs
@@ -315,22 +315,24 @@ pub fn list_cast_votes_count() {
             votes: vec![0, 1, 2],
         }],
     );
-    expected_votes_count.insert(
-        bob.public_key_bech32(),
-        vec![
-            AccountVotes {
-                vote_plan_id: vote_plan_2.to_id().into(),
-                votes: vec![0],
-            },
-            AccountVotes {
-                vote_plan_id: vote_plan_1.to_id().into(),
-                votes: vec![1, 2],
-            },
-        ],
-    );
+    let mut votes = vec![
+        AccountVotes {
+            vote_plan_id: vote_plan_2.to_id().into(),
+            votes: vec![0],
+        },
+        AccountVotes {
+            vote_plan_id: vote_plan_1.to_id().into(),
+            votes: vec![1, 2],
+        },
+    ];
 
-    assert_eq!(
-        jormungandr.rest().account_votes_all().unwrap(),
-        expected_votes_count
-    );
+    // sort votes by voteplan to ensure consistent results
+    votes.sort_by_key(|v| v.vote_plan_id);
+    expected_votes_count.insert(bob.public_key_bech32(), votes);
+
+    let mut res = jormungandr.rest().account_votes_all().unwrap();
+    for v in res.values_mut() {
+        v.sort_by_key(|v| v.vote_plan_id)
+    }
+    assert_eq!(res, expected_votes_count);
 }


### PR DESCRIPTION
Remove /v1/account-votes-count endpoint and add new /v1/account-votes-all
to return the full list of proposals a user has voted for instead
of just the count.

This is going to be needed for a few rewards distribution but it's
likely going to result in a lot of data and should thus be
restricted and/or not made publicly available.