### PR TITLE
make cli options public

### DIFF
--- a/jcli/src/jcli_lib/block/mod.rs
+++ b/jcli/src/jcli_lib/block/mod.rs
@@ -152,7 +152,6 @@ pub struct Common {
     pub output_file: Option<std::path::PathBuf>,
 }
 
-
 impl Common {
     pub fn open_output(&self) -> Result<impl Write, Error> {
         io::open_file_write(&self.output_file).map_err(|source| Error::OutputInvalid {

--- a/jcli/src/jcli_lib/block/mod.rs
+++ b/jcli/src/jcli_lib/block/mod.rs
@@ -114,7 +114,7 @@ pub struct Input {
     /// If not available the command will expect to read the configuration from
     /// the standard input.
     #[structopt(long = "input", parse(from_os_str), name = "FILE_INPUT")]
-    input_file: Option<std::path::PathBuf>,
+    pub input_file: Option<std::path::PathBuf>,
 }
 
 impl Input {
@@ -151,6 +151,7 @@ pub struct Common {
     #[structopt(long = "output", parse(from_os_str), name = "FILE_OUTPUT")]
     pub output_file: Option<std::path::PathBuf>,
 }
+
 
 impl Common {
     pub fn open_output(&self) -> Result<impl Write, Error> {


### PR DESCRIPTION
Makes `Input` have only public fields, so catalyst toolbox can access it