### PR TITLE
Fix CI fmt job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,8 +236,8 @@ jobs:
           path: ${{ runner.temp }}/jormungandr_*
           retention-days: 30
 
-  lints:
-    name: Lints
+  clippy:
+    name: Clippy
     needs: [cache_info, update_deps]
     runs-on: ubuntu-latest
     steps:
@@ -247,16 +247,10 @@ jobs:
           profile: minimal
           override: true
           default: true
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
 
       - name: Restore cargo registry index
         uses: actions/cache@v2
@@ -277,6 +271,28 @@ jobs:
         with:
           command: clippy
           args: --all-features --all-targets -- -D warnings
+
+  fmt:
+    name: Fmt
+    needs: [cache_info, update_deps]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          default: true
+          components: rustfmt
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
 
   test_coverage:
     name: Test Coverage

--- a/flake.lock
+++ b/flake.lock
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654953433,
-        "narHash": "sha256-TwEeh4r50NdWHFAHQSyjCk2cZxgwUfcCCAJOhPdXB28=",
+        "lastModified": 1655624069,
+        "narHash": "sha256-7g1zwTdp35GMTERnSzZMWJ7PG3QdDE8VOX3WsnOkAtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90cd5459a1fd707819b9a3fb9c852beaaac3b79a",
+        "rev": "0d68d7c857fe301d49cdcd56130e0beea4ecd5aa",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1655088497,
-        "narHash": "sha256-t8YdiQqG43uQKIB9BfjrmJauewFfpfZiT+Ts434CiCQ=",
+        "lastModified": 1655866083,
+        "narHash": "sha256-YETEUbdfj8iC19aGVgUeFU6T/pZO4uETEN9Nuhriv14=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cab0cb7f4dbbfa10cb3332da47726ed75861bfeb",
+        "rev": "dd556d5a2f75522187198a4869f3c3a9d1aa62f7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655624069,
-        "narHash": "sha256-7g1zwTdp35GMTERnSzZMWJ7PG3QdDE8VOX3WsnOkAtM=",
+        "lastModified": 1655807518,
+        "narHash": "sha256-5YV29Ry/DpAJc/0Hc/+ISVBAjwHpJvAkeKkcUG5lWsc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d68d7c857fe301d49cdcd56130e0beea4ecd5aa",
+        "rev": "a72d7811be1162dd6804c4e36e5402d76fb6e921",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652714503,
-        "narHash": "sha256-qQKVEfDe5FqvGgkZtg5Pc491foeiDPIOeycHMqnPDps=",
+        "lastModified": 1655906603,
+        "narHash": "sha256-wwyJc0VPm7NQlQRspMrFFQQak1hHJwRfcNgGTL2onDA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "521a524771a8e93caddaa0ac1d67d03766a8b0b3",
+        "rev": "b7a131d06a23b02ab8eaa12d249d282f3590cbf9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -48,8 +48,8 @@
           overlays = [(import rust-overlay)];
         };
 
-        rust = let
-          _rust = pkgs.rust-bin.stable.latest.default.override {
+        mkRust = {channel ? "stable"}: let
+          _rust = pkgs.rust-bin.${channel}.latest.default.override {
             extensions = [
               "rust-src"
               "rust-analysis"
@@ -75,9 +75,12 @@
             '';
           };
 
+        rust-stable = mkRust {channel = "stable";};
+        rust-nightly = mkRust {channel = "nightly";};
+
         naersk-lib = naersk.lib."${system}".override {
-          cargo = rust;
-          rustc = rust;
+          cargo = mkRust "stable";
+          rustc = mkRust "stable";
         };
 
         mkPackage = name: let
@@ -228,7 +231,7 @@
             };
             rustfmt = {
               enable = true;
-              entry = pkgs.lib.mkForce "${rust}/bin/cargo-fmt fmt +nightly -- --check --color always";
+              entry = pkgs.lib.mkForce "${rust-nightly}/bin/cargo-fmt fmt -- --check --color always";
             };
           };
         };
@@ -246,7 +249,7 @@
           PROTOC = "${pkgs.protobuf}/bin/protoc";
           PROTOC_INCLUDE = "${pkgs.protobuf}/include";
           buildInputs =
-            [rust]
+            [rust-stable]
             ++ (with pkgs; [
               pkg-config
               openssl

--- a/flake.nix
+++ b/flake.nix
@@ -79,8 +79,8 @@
         rust-nightly = mkRust {channel = "nightly";};
 
         naersk-lib = naersk.lib."${system}".override {
-          cargo = mkRust "stable";
-          rustc = mkRust "stable";
+          cargo = rust-stable;
+          rustc = rust-stable;
         };
 
         mkPackage = name: let

--- a/flake.nix
+++ b/flake.nix
@@ -228,7 +228,7 @@
             };
             rustfmt = {
               enable = true;
-              entry = pkgs.lib.mkForce "${rust}/bin/cargo-fmt fmt -- --check --color always";
+              entry = pkgs.lib.mkForce "${rust}/bin/cargo-fmt fmt +nightly -- --check --color always";
             };
           };
         };

--- a/testing/jormungandr-integration-tests/src/networking/p2p/quarantine.rs
+++ b/testing/jormungandr-integration-tests/src/networking/p2p/quarantine.rs
@@ -84,14 +84,16 @@ pub fn node_does_not_quarantine_whitelisted_node() {
                 // The client broadcast a different ip address from the one it's actually
                 // listening to, so that client_2 will fail connection
                 .public_address("/ip4/127.0.0.1/tcp/80".parse().unwrap())
-                .listen_address(Some(
-                    network_controller
-                        .node_config(CLIENT)
-                        .unwrap()
-                        .p2p
-                        .get_listen_addr()
-                        .unwrap(),
-                )),
+                .listen_address(
+                    Some(
+                        network_controller
+                            .node_config(CLIENT)
+                            .unwrap()
+                            .p2p
+                            .get_listen_addr()
+                            .unwrap(),
+                    ),
+                ),
         )
         .unwrap();
 
@@ -131,14 +133,16 @@ pub fn node_put_in_quarantine_nodes_which_are_not_whitelisted() {
                 // The client broadcast a different ip address from the one it's actually
                 // listening to, so that client_2 will fail connection and put it in quarantine
                 .public_address("/ip4/127.0.0.1/tcp/80".parse().unwrap())
-                .listen_address(Some(
-                    network_controller
-                        .node_config(CLIENT)
-                        .unwrap()
-                        .p2p
-                        .get_listen_addr()
-                        .unwrap(),
-                )),
+                .listen_address(
+                    Some(
+                        network_controller
+                            .node_config(CLIENT)
+                            .unwrap()
+                            .p2p
+                            .get_listen_addr()
+                            .unwrap(),
+                    ),
+                ),
         )
         .unwrap();
 
@@ -154,14 +158,16 @@ pub fn node_put_in_quarantine_nodes_which_are_not_whitelisted() {
                 // The client broadcast a different ip address from the one it's actually
                 // listening to, so that client will fail connection and put it in quarantine
                 .public_address("/ip4/127.0.0.1/tcp/810".parse().unwrap())
-                .listen_address(Some(
-                    network_controller
-                        .node_config(CLIENT_2)
-                        .unwrap()
-                        .p2p
-                        .get_listen_addr()
-                        .unwrap(),
-                )),
+                .listen_address(
+                    Some(
+                        network_controller
+                            .node_config(CLIENT_2)
+                            .unwrap()
+                            .p2p
+                            .get_listen_addr()
+                            .unwrap(),
+                    ),
+                ),
         )
         .unwrap();
 


### PR DESCRIPTION
As we are using `rustfmt.toml` with the predefined rules for `fmt` which only works on the `nightly` toolchain, so also need our CI job.