### PR TITLE
test: added e2e test for merged vote plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
  "graphql_client",
  "hex",
  "humantime",
+ "jcli",
  "jormungandr-lib",
  "jortestkit",
  "json",

--- a/jcli/src/jcli_lib/vote/mod.rs
+++ b/jcli/src/jcli_lib/vote/mod.rs
@@ -14,6 +14,8 @@ mod committee;
 mod election_public_key;
 mod tally;
 
+pub use tally::MergedVotePlan;
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("I/O error")]

--- a/jcli/src/jcli_lib/vote/tally/mod.rs
+++ b/jcli/src/jcli_lib/vote/tally/mod.rs
@@ -3,6 +3,7 @@ mod decryption_shares;
 pub(crate) mod merge_results;
 
 use super::Error;
+pub use merge_results::MergedVotePlan;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]

--- a/testing/jormungandr-automation/Cargo.toml
+++ b/testing/jormungandr-automation/Cargo.toml
@@ -28,6 +28,7 @@ chain-evm       = { git = "https://github.com/input-output-hk/chain-libs.git", b
 cardano-legacy-address = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 typed-bytes = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 jormungandr-lib = { path = "../../jormungandr-lib" }
+jcli = { path = "../../jcli" }
 jortestkit = { git = "https://github.com/input-output-hk/jortestkit.git", branch = "master" }
 rand = "0.8"
 rand_core = "0.6"

--- a/testing/jormungandr-automation/src/jcli/api/votes/tally.rs
+++ b/testing/jormungandr-automation/src/jcli/api/votes/tally.rs
@@ -1,5 +1,6 @@
 use crate::jcli::command::votes::TallyCommand;
 use assert_cmd::assert::OutputAssertExt;
+use jcli_lib::vote::MergedVotePlan;
 use jortestkit::prelude::ProcessOutput;
 use std::path::Path;
 
@@ -67,5 +68,21 @@ impl Tally {
             .success()
             .get_output()
             .as_lossy_string()
+    }
+
+    pub fn merge_results<P: AsRef<Path>>(
+        self,
+        vote_plans: P,
+    ) -> Result<Vec<MergedVotePlan>, serde_json::Error> {
+        serde_json::from_str(
+            &self
+                .tally_command
+                .merge_results(vote_plans)
+                .build()
+                .assert()
+                .success()
+                .get_output()
+                .as_lossy_string(),
+        )
     }
 }

--- a/testing/jormungandr-automation/src/jcli/command/votes/tally.rs
+++ b/testing/jormungandr-automation/src/jcli/command/votes/tally.rs
@@ -60,4 +60,14 @@ impl TallyCommand {
         println!("{:?}", self.command);
         self.command
     }
+
+    pub fn merge_results<P: AsRef<Path>>(mut self, vote_plan_statuses: P) -> Self {
+        self.command
+            .arg("merge-results")
+            .arg("--vote-plans")
+            .arg(vote_plan_statuses.as_ref())
+            .arg("--output-format")
+            .arg("json");
+        self
+    }
 }

--- a/testing/jormungandr-automation/src/testing/vit/builder.rs
+++ b/testing/jormungandr-automation/src/testing/vit/builder.rs
@@ -1,7 +1,7 @@
 use chain_core::property::BlockDate as _;
 use chain_impl_mockchain::{
     block::BlockDate,
-    certificate::{Proposal, Proposals, VoteAction, VotePlan},
+    certificate::{ExternalProposalId, Proposal, Proposals, VoteAction, VotePlan},
     testing::VoteTestGen,
     tokens::identifier::TokenIdentifier,
     vote::{Options, PayloadType},
@@ -9,7 +9,7 @@ use chain_impl_mockchain::{
 use chain_vote::MemberPublicKey;
 use std::str::FromStr;
 pub struct VotePlanBuilder {
-    proposals_count: usize,
+    proposals_builder: ProposalsBuilder,
     action: VoteAction,
     payload: PayloadType,
     member_keys: Vec<MemberPublicKey>,
@@ -29,7 +29,7 @@ impl Default for VotePlanBuilder {
 impl VotePlanBuilder {
     pub fn new() -> Self {
         Self {
-            proposals_count: 3,
+            proposals_builder: ProposalsBuilder::default().with_count(3),
             options_size: 3,
             action: VoteAction::OffChain,
             payload: PayloadType::Public,
@@ -44,78 +44,70 @@ impl VotePlanBuilder {
         }
     }
 
-    pub fn proposals_count(&mut self, proposals_count: usize) -> &mut Self {
-        self.proposals_count = proposals_count;
+    pub fn proposals_count(mut self, proposals_count: usize) -> Self {
+        self.proposals_builder = self.proposals_builder.with_count(proposals_count);
         self
     }
 
-    pub fn action_type(&mut self, action: VoteAction) -> &mut Self {
+    pub fn proposals_external_ids(mut self, proposals_ids: Vec<ExternalProposalId>) -> Self {
+        self.proposals_builder = self.proposals_builder.with_ids(proposals_ids);
+        self
+    }
+
+    pub fn action_type(mut self, action: VoteAction) -> Self {
         self.action = action;
         self
     }
 
-    pub fn private(&mut self) -> &mut Self {
+    pub fn private(mut self) -> Self {
         self.payload = PayloadType::Private;
         self
     }
 
-    pub fn public(&mut self) -> &mut Self {
+    pub fn public(mut self) -> Self {
         self.payload = PayloadType::Public;
         self
     }
 
-    pub fn member_public_key(&mut self, key: MemberPublicKey) -> &mut Self {
+    pub fn member_public_key(mut self, key: MemberPublicKey) -> Self {
         self.member_keys.push(key);
         self
     }
 
-    pub fn member_public_keys(&mut self, keys: Vec<MemberPublicKey>) -> &mut Self {
+    pub fn member_public_keys(mut self, keys: Vec<MemberPublicKey>) -> Self {
         for key in keys {
-            self.member_public_key(key);
+            self = self.member_public_key(key);
         }
         self
     }
 
-    pub fn vote_start(&mut self, block_date: BlockDate) -> &mut Self {
+    pub fn vote_start(mut self, block_date: BlockDate) -> Self {
         self.vote_start = block_date;
         self
     }
 
-    pub fn tally_start(&mut self, block_date: BlockDate) -> &mut Self {
+    pub fn tally_start(mut self, block_date: BlockDate) -> Self {
         self.tally_start = block_date;
         self
     }
 
-    pub fn tally_end(&mut self, block_date: BlockDate) -> &mut Self {
+    pub fn tally_end(mut self, block_date: BlockDate) -> Self {
         self.tally_end = block_date;
         self
     }
 
-    pub fn voting_token(&mut self, voting_token: TokenIdentifier) -> &mut Self {
+    pub fn voting_token(mut self, voting_token: TokenIdentifier) -> Self {
         self.voting_token = voting_token;
         self
     }
 
-    pub fn options_size(&mut self, size: u8) -> &mut Self {
+    pub fn options_size(mut self, size: u8) -> Self {
         self.options_size = size;
         self
     }
 
-    pub fn build(&self) -> VotePlan {
-        let proposal_vec: Vec<Proposal> = std::iter::from_fn(|| {
-            Some(Proposal::new(
-                VoteTestGen::external_proposal_id(),
-                Options::new_length(self.options_size).unwrap(),
-                self.action.clone(),
-            ))
-        })
-        .take(self.proposals_count)
-        .collect();
-
-        let mut proposals = Proposals::new();
-        for proposal in proposal_vec {
-            let _ = proposals.push(proposal);
-        }
+    pub fn build(self) -> VotePlan {
+        let proposals = self.proposals_builder.build(self.options_size, self.action);
 
         VotePlan::new(
             self.vote_start,
@@ -124,7 +116,55 @@ impl VotePlanBuilder {
             proposals,
             self.payload,
             self.member_keys.clone(),
-            self.voting_token.clone(),
+            self.voting_token,
         )
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ProposalsBuilder {
+    count: usize,
+    external_ids: Vec<ExternalProposalId>,
+}
+
+impl ProposalsBuilder {
+    pub fn with_count(mut self, count: usize) -> Self {
+        self.count = count;
+        self
+    }
+
+    pub fn with_ids(mut self, external_ids: Vec<ExternalProposalId>) -> Self {
+        self.external_ids = external_ids;
+        self
+    }
+
+    pub fn build(self, options_size: u8, action: VoteAction) -> Proposals {
+        let proposals_vec: Vec<Proposal> = if !self.external_ids.is_empty() {
+            self.external_ids
+                .into_iter()
+                .map(|epi| {
+                    Proposal::new(
+                        epi,
+                        Options::new_length(options_size).unwrap(),
+                        action.clone(),
+                    )
+                })
+                .collect()
+        } else {
+            std::iter::from_fn(|| {
+                Some(Proposal::new(
+                    VoteTestGen::external_proposal_id(),
+                    Options::new_length(options_size).unwrap(),
+                    action.clone(),
+                ))
+            })
+            .take(self.count)
+            .collect()
+        };
+        let mut proposals = Proposals::new();
+        for proposal in proposals_vec {
+            let _ = proposals.push(proposal);
+        }
+        proposals
     }
 }

--- a/testing/jormungandr-integration-tests/src/jcli/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/mod.rs
@@ -3,5 +3,6 @@ pub mod certificate;
 pub mod genesis;
 pub mod key;
 pub mod rest;
+pub mod tally;
 pub mod transaction;
 pub mod update_proposal;

--- a/testing/jormungandr-integration-tests/src/jcli/tally/merge_results.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/tally/merge_results.rs
@@ -1,0 +1,192 @@
+use assert_fs::{fixture::PathChild, TempDir};
+use chain_core::property::BlockDate as _;
+use chain_impl_mockchain::{
+    header::BlockDate,
+    testing::VoteTestGen,
+    tokens::{identifier::TokenIdentifier as TokenIdentifierLib, minting_policy::MintingPolicy},
+    vote::Choice,
+};
+use jormungandr_automation::{
+    jcli::JCli,
+    jormungandr::{ConfigurationBuilder, Starter},
+    testing::{time::wait_for_epoch, VotePlanBuilder},
+};
+use jormungandr_lib::interfaces::{InitialToken, Tally, TallyResult, VotePlanStatus};
+use std::{collections::BTreeSet, path::Path, str::FromStr};
+use thor::{vote_plan_cert, FragmentSender, FragmentSenderSetup, Wallet};
+
+const INITIAL_FUND_PER_WALLET: u64 = 1_000_000;
+const SLOTS_PER_EPOCH: u32 = 10;
+const SLOT_DURATION: u8 = 4;
+
+#[test]
+pub fn merge_two_voteplans() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut alice = Wallet::default();
+    let mut bob = Wallet::default();
+
+    let minting_policy = MintingPolicy::new();
+
+    let first_token = TokenIdentifierLib::from_str(
+        "00000000000000000000000000000000000000000000000000000000.00000000",
+    )
+    .unwrap();
+
+    let second_token = TokenIdentifierLib::from_str(
+        "00000000000000000000000000000000000000000000000000000000.00000001",
+    )
+    .unwrap();
+
+    let proposal_external_id = VoteTestGen::external_proposal_id();
+    let vote_plan_statuses_file = temp_dir.child("vote_plan_status.json");
+
+    let first_vote_plan = VotePlanBuilder::new()
+        .proposals_external_ids(vec![proposal_external_id.clone()])
+        .vote_start(BlockDate::from_epoch_slot_id(0, 0))
+        .tally_start(BlockDate::from_epoch_slot_id(1, 0))
+        .tally_end(BlockDate::from_epoch_slot_id(2, 0))
+        .voting_token(first_token.clone())
+        .build();
+
+    let second_vote_plan = VotePlanBuilder::new()
+        .proposals_external_ids(vec![proposal_external_id.clone()])
+        .vote_start(BlockDate::from_epoch_slot_id(0, 0))
+        .tally_start(BlockDate::from_epoch_slot_id(1, 0))
+        .tally_end(BlockDate::from_epoch_slot_id(2, 0))
+        .voting_token(second_token.clone())
+        .build();
+
+    let vote_plan_certs: Vec<_> = vec![first_vote_plan.clone(), second_vote_plan.clone()]
+        .iter()
+        .map(|vp| {
+            vote_plan_cert(
+                &alice,
+                chain_impl_mockchain::block::BlockDate {
+                    epoch: 1,
+                    slot_id: 0,
+                },
+                vp,
+            )
+            .into()
+        })
+        .collect();
+
+    let wallets = [&alice, &bob];
+
+    let config = ConfigurationBuilder::new()
+        .with_funds(
+            wallets
+                .iter()
+                .map(|x| x.to_initial_fund(INITIAL_FUND_PER_WALLET))
+                .collect(),
+        )
+        .with_token(InitialToken {
+            token_id: first_token.into(),
+            policy: minting_policy.clone().into(),
+            to: vec![alice.to_initial_token(INITIAL_FUND_PER_WALLET)],
+        })
+        .with_token(InitialToken {
+            token_id: second_token.into(),
+            policy: minting_policy.into(),
+            to: vec![bob.to_initial_token(INITIAL_FUND_PER_WALLET)],
+        })
+        .with_committees(&[alice.to_committee_id()])
+        .with_slots_per_epoch(SLOTS_PER_EPOCH)
+        .with_certs(vote_plan_certs)
+        .with_slot_duration(SLOT_DURATION)
+        .build(&temp_dir);
+
+    let jormungandr = Starter::new()
+        .temp_dir(temp_dir)
+        .config(config)
+        .start()
+        .unwrap();
+
+    let transaction_sender = FragmentSender::new(
+        jormungandr.genesis_block_hash(),
+        jormungandr.fees(),
+        chain_impl_mockchain::block::BlockDate::first()
+            .next_epoch()
+            .into(),
+        FragmentSenderSetup::resend_3_times(),
+    );
+
+    transaction_sender
+        .send_vote_cast(
+            &mut alice,
+            &first_vote_plan,
+            0,
+            &Choice::new(0),
+            &jormungandr,
+        )
+        .unwrap();
+
+    transaction_sender
+        .send_vote_cast(
+            &mut bob,
+            &second_vote_plan,
+            0,
+            &Choice::new(0),
+            &jormungandr,
+        )
+        .unwrap();
+
+    wait_for_epoch(1, jormungandr.rest());
+
+    let transaction_sender =
+        transaction_sender.set_valid_until(chain_impl_mockchain::block::BlockDate {
+            epoch: 3,
+            slot_id: 0,
+        });
+
+    let vote_plan_statuses = jormungandr.rest().vote_plan_statuses().unwrap();
+
+    transaction_sender
+        .send_public_vote_tally(&mut alice, &first_vote_plan, &jormungandr)
+        .unwrap();
+
+    transaction_sender
+        .send_public_vote_tally(&mut alice, &second_vote_plan, &jormungandr)
+        .unwrap();
+
+    wait_for_epoch(2, jormungandr.rest());
+
+    write_vote_plan_statuses(vote_plan_statuses, vote_plan_statuses_file.path());
+
+    let merged_vote_plans = JCli::default()
+        .votes()
+        .tally()
+        .merge_results(vote_plan_statuses_file.path())
+        .unwrap();
+
+    let merged_vote_plan = merged_vote_plans.get(0).unwrap();
+    let mut ids: BTreeSet<jormungandr_lib::crypto::hash::Hash> = BTreeSet::new();
+    ids.insert(first_vote_plan.to_id().into());
+    ids.insert(second_vote_plan.to_id().into());
+
+    assert_eq!(merged_vote_plan.ids, ids);
+
+    let merged_proposal = merged_vote_plan.proposals.get(0).unwrap();
+    assert_eq!(merged_proposal.proposal_id, proposal_external_id.into());
+    assert_eq!(merged_proposal.votes_cast, 2);
+    assert_eq!(
+        merged_proposal.tally,
+        Tally::Public {
+            result: TallyResult {
+                options: 0..3,
+                results: vec![2000000, 0, 0]
+            }
+        }
+    );
+}
+
+pub fn write_vote_plan_statuses<P: AsRef<Path>>(vote_plan_statuses: Vec<VotePlanStatus>, path: P) {
+    use std::io::Write;
+    let mut file = std::fs::File::create(&path).unwrap();
+    file.write_all(
+        serde_json::to_string(&vote_plan_statuses)
+            .unwrap()
+            .as_bytes(),
+    )
+    .unwrap();
+}

--- a/testing/jormungandr-integration-tests/src/jcli/tally/mod.rs
+++ b/testing/jormungandr-integration-tests/src/jcli/tally/mod.rs
@@ -1,0 +1,1 @@
+pub mod merge_results;


### PR DESCRIPTION
Added e2e test for happy path when merging two voteplans. Idea behind the test was to create two voteplans with different tokens but the same proposal id (to simulate direct voter and reps separate votepans). we are excepting that outcome voteplan will contains proposal with votes count equal to sum of vote countes from separate voteplans