### PR TITLE
fix NodeSecret struct, make evm_keys as Optional field

### DIFF
--- a/jormungandr/src/secure/mod.rs
+++ b/jormungandr/src/secure/mod.rs
@@ -34,7 +34,7 @@ pub struct NodeSecret {
     bft: Option<Bft>,
     genesis: Option<GenesisPraos>,
     #[cfg(feature = "evm")]
-    evm_keys: Vec<chain_evm::ethereum_types::H256>,
+    evm_keys: Option<Vec<chain_evm::ethereum_types::H256>>,
 }
 
 /// Node Secret's Public parts
@@ -74,8 +74,12 @@ impl NodeSecret {
     #[cfg(feature = "evm")]
     pub fn evm_keys(&self) -> Vec<chain_evm::util::Secret> {
         self.evm_keys
-            .iter()
-            .map(chain_evm::util::Secret::from_hash)
-            .collect()
+            .as_ref()
+            .map(|keys| {
+                keys.iter()
+                    .map(chain_evm::util::Secret::from_hash)
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }


### PR DESCRIPTION
This PR fixes following test `test_default_settings` for with the `evm` feature enabled.
The failure reason is that in test we are not correctly initiallizing NodeSecret file `evm_keys` array was missed.
So I have modified `NodeSecret` struct and made `evm_keys` an Optional field, so no needs to add explicitly empty vector into the NodeSecret file, we can just skip this field there.