### PR TITLE
refactor(rm fragment expiry filter): fragment generator

### DIFF
--- a/jormungandr-lib/src/interfaces/fragments_processing_summary.rs
+++ b/jormungandr-lib/src/interfaces/fragments_processing_summary.rs
@@ -13,7 +13,6 @@ pub enum FragmentRejectionReason {
     FragmentInvalid,
     PreviousFragmentInvalid,
     PoolOverflow,
-    FragmentExpired,
     FragmentValidForTooLong,
 }
 

--- a/jormungandr/src/fragment/pool.rs
+++ b/jormungandr/src/fragment/pool.rs
@@ -109,21 +109,6 @@ impl Pool {
             return Err(FragmentRejectionReason::FragmentAlreadyInLog);
         }
 
-        if let Some(valid_until) = get_transaction_expiry_date(fragment) {
-            use chain_impl_mockchain::ledger::check::{valid_transaction_date, TxValidityError};
-            match valid_transaction_date(ledger_settings, valid_until, block_date) {
-                Ok(_) => {}
-                Err(TxValidityError::TransactionExpired) => {
-                    tracing::debug!("fragment is expired at the time of receiving");
-                    return Err(FragmentRejectionReason::FragmentExpired);
-                }
-                Err(TxValidityError::TransactionValidForTooLong) => {
-                    tracing::debug!("fragment is valid for too long");
-                    return Err(FragmentRejectionReason::FragmentValidForTooLong);
-                }
-            }
-        }
-
         if !is_fragment_valid(fragment) {
             tracing::debug!("fragment is invalid, not including to the pool");
             return Err(FragmentRejectionReason::FragmentInvalid);


### PR DESCRIPTION
Remove fragment expiry filter

![Screenshot from 2023-10-25 12-10-51](https://github.com/input-output-hk/jormungandr/assets/60357579/f596bf55-d434-4084-9992-5acf0ce26e60)

@kukkok3 will this break the tests? Not sure what the protocol for modifying this stack is? 