### PR TITLE
CI: switch off the nightly release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,4 @@
 on:
-  schedule:
-    - cron: '0 3 * * *' # Nightly, run at 03:00 UTC
   push:
     tags:
       - 'v[0-9]+.*' # Release tags matching v*, i.e. v1.0, v20.15.10


### PR DESCRIPTION
This CI workflow has been failing for some time, and I get a notification every night, since apparently I'm still the "owner" of the workflow accordingly to some GitHub logic I cannot find the ends of.

There is no need to waste your GitHub Actions budget on this.